### PR TITLE
Advance matrix-stats section 4 cleanup

### DIFF
--- a/KIMI.md
+++ b/KIMI.md
@@ -69,7 +69,7 @@ grep -n "Object " src/main/groovy/**/*.groovy | grep -v "Object>" | grep -v "imp
 grep -L "@CompileStatic" src/main/groovy/**/*.groovy | grep -v test
 ```
 
-- [ ] All production classes have `@CompileStatic`
+- [ ] All production classes have `@CompileStatic` unless the build script sets it to compile statically per default (e.g. in matrix-stats).
 - [ ] Only use `@CompileDynamic` when explicitly justified
 
 ---
@@ -649,6 +649,8 @@ When reviewing charting code:
 # Find potential issues
 grep -rn "TODO\|FIXME\|XXX" src/main/groovy/  # Unresolved items
 grep -rn "throw new RuntimeException" src/main/groovy/  # Should be specific type
+
+# Not in matrix-stats as all classes are compiled statically per default in that module
 find src/main/groovy -name "*.groovy" -exec grep -L "@CompileStatic" {} \;  # Missing annotation
 
 # Test semantic edge cases (add to test file temporarily)

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/DensityStat.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/DensityStat.groovy
@@ -44,13 +44,13 @@ class DensityStat {
       }
 
       KernelDensity kde = new KernelDensity(values, kdeParams)
-      double[] xVals = kde.getX()
-      double[] densityVals = kde.getDensity()
+      List<BigDecimal> xVals = kde.getX()
+      List<BigDecimal> densityVals = kde.getDensity()
       LayerData template = bucket.first()
-      for (int i = 0; i < xVals.length; i++) {
+      for (int i = 0; i < xVals.size(); i++) {
         LayerData datum = new LayerData(
-            x: xVals[i] as BigDecimal,
-            y: densityVals[i] as BigDecimal,
+            x: xVals[i],
+            y: densityVals[i],
             color: template?.color,
             fill: template?.fill,
             group: template?.group,

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/YDensityStat.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/YDensityStat.groovy
@@ -40,21 +40,21 @@ class YDensityStat {
       }
 
       KernelDensity kde = new KernelDensity(values, kdeParams)
-      double[] yVals = kde.getX()
-      double[] densityVals = kde.getDensity()
+      List<BigDecimal> yVals = kde.getX()
+      List<BigDecimal> densityVals = kde.getDensity()
       LayerData template = bucket.first()
 
-      for (int i = 0; i < yVals.length; i++) {
+      for (int i = 0; i < yVals.size(); i++) {
         LayerData datum = new LayerData(
             x: centerX,
-            y: yVals[i] as BigDecimal,
+            y: yVals[i],
             color: template?.color,
             fill: template?.fill,
             group: template?.group,
             rowIndex: -1
         )
         datum.meta.centerX = centerX
-        datum.meta.density = densityVals[i] as BigDecimal
+        datum.meta.density = densityVals[i]
         result << datum
       }
     }

--- a/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/stat/GgStat.groovy
+++ b/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/stat/GgStat.groovy
@@ -1368,10 +1368,10 @@ class GgStat {
     groups.each { groupKey, values ->
       if (values.size() >= 2) {
         KernelDensity kde = new KernelDensity(values, kdeParams)
-        double[] xVals = kde.getX()
-        double[] densityVals = kde.getDensity()
+        List<BigDecimal> xVals = kde.getX()
+        List<BigDecimal> densityVals = kde.getDensity()
 
-        for (int i = 0; i < xVals.length; i++) {
+        for (int i = 0; i < xVals.size(); i++) {
           allRows << [
               x: xVals[i],
               density: densityVals[i],

--- a/matrix-stats/README.md
+++ b/matrix-stats/README.md
@@ -160,7 +160,8 @@ Grid<BigDecimal> inverseGrid = Linalg.inverse(grid)
 assert inverseGrid[0, 0] == 0.6
 
 def svd = Linalg.svd(grid)
-assert svd.singularValues.length == 2
+assert svd.singularValues.size() == 2
+assert svd.reconstruct()[0, 0] == 3.0
 ```
 
 ## Interpolation

--- a/matrix-stats/req/v2.4.0-idiomaticGroovy.md
+++ b/matrix-stats/req/v2.4.0-idiomaticGroovy.md
@@ -303,6 +303,41 @@ Implemented:
 
 Depends on: PR 2 (shared utilities consolidation)
 
+Current progress in this PR slice:
+
+4.0.1 [x] Reshape the remaining public `linalg` decomposition result surface.
+- `SvdResult` now exposes:
+  - `Matrix u`
+  - `Matrix vt`
+  - `List<BigDecimal> singularValues`
+  - `Matrix sigma()`
+  - `Matrix reconstruct()`
+- The public constructor now accepts idiomatic `Matrix` and numeric-list inputs instead of primitive arrays.
+
+4.0.2 [x] Clean up the first normality result-object band to establish the section 4 migration pattern.
+- Updated:
+  - `JarqueBera`
+  - `Lilliefors`
+  - `ShapiroWilk`
+  - `ShapiroFrancia`
+  - `CramerVonMises`
+- Public scalar results in these classes now use `BigDecimal`.
+- Public significance-level parameters in the touched APIs now use `Number`.
+- Removed primitive public overloads from:
+  - `JarqueBera`
+  - `ShapiroWilk`
+  - `ShapiroFrancia`
+
+4.0.3 [x] Add or update focused tests for the current section 4 slice.
+- Added:
+  - `matrix-stats/src/test/groovy/normality/JarqueBeraTest.groovy`
+- Updated:
+  - `matrix-stats/src/test/groovy/linalg/SvdResultTest.groovy`
+  - `matrix-stats/src/test/groovy/linalg/LinalgTest.groovy`
+  - `matrix-stats/src/test/groovy/normality/CramerVonMisesTest.groovy`
+  - `matrix-stats/src/test/groovy/normality/ShapiroFranciaTest.groovy`
+  - `matrix-stats/src/test/groovy/util/NumericConversionTest.groovy`
+
 4.1 [ ] Clean up the higher-risk public API surfaces together so the migration pattern stays consistent across the numerically dense packages.
 - `regression`
 - `solver`
@@ -343,6 +378,11 @@ Depends on: PR 2 (shared utilities consolidation)
 - Run:
   - `./gradlew :matrix-stats:test --tests 'regression.*' --tests 'rootfinding.*' --tests 'timeseries.*' --tests 'normality.*' --tests 'distribution.*' --tests 'cluster.*'`
   - `./gradlew :matrix-stats:spotlessApply :matrix-stats:test :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
+
+4.8.1 [x] Verification for the current section 4 slice
+- Run:
+  - `./gradlew :matrix-stats:test --tests 'linalg.*' --tests 'normality.*' --tests 'util.NumericConversionTest'`
+  - `./gradlew :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
 
 ### 5. Final Consistency and Full Verification PR
 

--- a/matrix-stats/req/v2.4.0-idiomaticGroovy.md
+++ b/matrix-stats/req/v2.4.0-idiomaticGroovy.md
@@ -328,6 +328,18 @@ Current progress in this PR slice:
   - `ShapiroWilk`
   - `ShapiroFrancia`
 
+4.0.4 [x] Finish the remaining public normality facade/result cleanup for this package pass.
+- Updated:
+  - `AndersonDarling`
+  - `KSquared`
+  - `KolmogorovSmirnov`
+- Public scalar results in these classes now use `BigDecimal`.
+- Public significance-level parameters in the touched APIs now use `Number`.
+- Removed primitive public overloads from:
+  - `KSquared`
+  - `KolmogorovSmirnov.twoSampleTest(double[], double[])`
+- `KSquared` now accepts idiomatic list-based public sample input, while keeping Matrix-column entry points.
+
 4.0.3 [x] Add or update focused tests for the current section 4 slice.
 - Added:
   - `matrix-stats/src/test/groovy/normality/JarqueBeraTest.groovy`
@@ -335,6 +347,9 @@ Current progress in this PR slice:
   - `matrix-stats/src/test/groovy/linalg/SvdResultTest.groovy`
   - `matrix-stats/src/test/groovy/linalg/LinalgTest.groovy`
   - `matrix-stats/src/test/groovy/normality/CramerVonMisesTest.groovy`
+  - `matrix-stats/src/test/groovy/normality/AndersonDarlingTest.groovy`
+  - `matrix-stats/src/test/groovy/normality/KSquaredTest.groovy`
+  - `matrix-stats/src/test/groovy/normality/KolmogorovSmirnovTest.groovy`
   - `matrix-stats/src/test/groovy/normality/ShapiroFranciaTest.groovy`
   - `matrix-stats/src/test/groovy/util/NumericConversionTest.groovy`
 
@@ -382,6 +397,11 @@ Current progress in this PR slice:
 4.8.1 [x] Verification for the current section 4 slice
 - Run:
   - `./gradlew :matrix-stats:test --tests 'linalg.*' --tests 'normality.*' --tests 'util.NumericConversionTest'`
+  - `./gradlew :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
+
+4.8.2 [x] Verification for the remaining normality package pass
+- Run:
+  - `./gradlew :matrix-stats:test --tests 'normality.*'`
   - `./gradlew :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
 
 ### 5. Final Consistency and Full Verification PR

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Accuracy.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Accuracy.groovy
@@ -10,7 +10,6 @@ import java.math.MathContext
  * Statistical accuracy metrics for evaluating predictions against actual values.
  * All methods accept lists of actual and predicted values and return accuracy measures.
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'VariableName'])
 class Accuracy {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Accuracy.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Accuracy.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Stat
 
 import java.math.MathContext

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Anova.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Anova.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.ListConverter
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.distribution.FDistribution

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Anova.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Anova.groovy
@@ -15,7 +15,6 @@ import se.alipsa.matrix.stats.distribution.FDistribution
  * two or more population means are equal, and therefore generalizes the t-test beyond two means.
  * In other words, the ANOVA is used to test the difference between two or more means.
  */
-@CompileStatic
 class Anova {
 
   static AnovaResult aov(Matrix data, List<String> colNames) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Correlation.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Correlation.groovy
@@ -59,7 +59,6 @@ import groovy.transform.CompileStatic
  * @see <a href="https://en.wikipedia.org/wiki/Spearman%27s_rank_correlation_coefficient">Spearman's Rank Correlation</a>
  * @see <a href="https://en.wikipedia.org/wiki/Kendall_rank_correlation_coefficient">Kendall Tau Correlation</a>
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class Correlation {
 
@@ -362,7 +361,6 @@ class Correlation {
 
   }
 
-  @CompileStatic
   private static class MergeSelection {
     BigDecimalPair pair
     int nextI

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Correlation.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Correlation.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats
 
-import groovy.transform.CompileStatic
-
 /**
  * Statistical correlation measures that quantify the relationship between two variables.
  *

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Ellipse.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Ellipse.groovy
@@ -8,7 +8,6 @@ import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
  * Confidence ellipse calculations for bivariate normal data.
  */
 @SuppressWarnings('DuplicateNumberLiteral')
-@CompileStatic
 class Ellipse {
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Ellipse.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Ellipse.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
 
 /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
@@ -1,9 +1,5 @@
 package se.alipsa.matrix.stats
 
-import static se.alipsa.matrix.core.ValueConverter.convert
-
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Column
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Stat

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
@@ -22,7 +22,6 @@ import java.math.RoundingMode
  * </ol>
  *
  */
-@CompileStatic
 class Normalize {
 
   // ===== LOG NORMALIZATION =====

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Randomize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Randomize.groovy
@@ -106,7 +106,6 @@ import se.alipsa.matrix.core.Row
  * @see Sampler for train/test splitting after randomization
  * @see <a href="https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle">Fisher-Yates Shuffle Algorithm</a>
  */
-@CompileStatic
 class Randomize {
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Randomize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Randomize.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats
 
-
-import groovy.transform.CompileStatic
 import groovyjarjarantlr4.v4.runtime.misc.NotNull
 
 import se.alipsa.matrix.core.Matrix

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Sampler.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Sampler.groovy
@@ -12,7 +12,6 @@ import se.alipsa.matrix.core.Row
  * which is useful for machine learning workflows. This is distinct from
  * Matrix.split() and Matrix.splitInto() which provide deterministic chunking.</p>
  */
-@CompileStatic
 class Sampler {
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Sampler.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Sampler.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Row
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/StatUtils.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/StatUtils.groovy
@@ -1,11 +1,8 @@
 package se.alipsa.matrix.stats
 
-import groovy.transform.CompileStatic
-
 /**
  * Native statistical utility functions used by the stats module.
  */
-@CompileStatic
 final class StatUtils {
 
   private StatUtils() {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/ClusteredPoint.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/ClusteredPoint.groovy
@@ -121,7 +121,6 @@ import groovy.transform.CompileStatic
  * @see KMeansPlusPlus
  * @see KMeans
  */
-@CompileStatic
 class ClusteredPoint {
   final int clusterId
   final double[] point

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/ClusteredPoint.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/ClusteredPoint.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.cluster
 
-import groovy.transform.CompileStatic
-
 /**
  * ClusteredPoint is a simple data structure that represents a data point assigned to a cluster
  * in K-Means clustering. It pairs a cluster identifier with the point's feature vector.

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/GroupEstimator.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/GroupEstimator.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.cluster
 
-import groovy.transform.CompileStatic
-
 /**
  * GroupEstimator determines the optimal number of clusters (k) for K-Means clustering
  * using heuristic and analytical methods. Choosing the right k is critical for meaningful

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/GroupEstimator.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/GroupEstimator.groovy
@@ -130,7 +130,6 @@ import groovy.transform.CompileStatic
  */
 
 @SuppressWarnings('DuplicateNumberLiteral')
-@CompileStatic
 class GroupEstimator {
 
   private final CalculationMethod method

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeans.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeans.groovy
@@ -106,7 +106,6 @@ import se.alipsa.matrix.core.Matrix
  * @see GroupEstimator
  * @see ClusteredPoint
  */
-@CompileStatic
 class KMeans {
 
   private Matrix matrix

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeans.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeans.groovy
@@ -1,8 +1,5 @@
 package se.alipsa.matrix.stats.cluster
 
-
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.ListConverter
 import se.alipsa.matrix.core.Matrix
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeansPlusPlus.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeansPlusPlus.groovy
@@ -195,7 +195,6 @@ import se.alipsa.matrix.core.util.Logger
  * @see GroupEstimator
  * @see ClusteredPoint
  */
-@CompileStatic
 @SuppressWarnings('DuplicateStringLiteral')
 class KMeansPlusPlus {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeansPlusPlus.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeansPlusPlus.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.cluster
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.util.Logger
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Barnard.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Barnard.groovy
@@ -64,7 +64,6 @@ import groovy.transform.CompileStatic
  * enumerate all possible tables and optimize over the nuisance parameter π. For very large samples,
  * consider using the chi-squared test instead.</p>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
 class Barnard {
 
@@ -285,7 +284,6 @@ class Barnard {
   /**
    * Result class for Barnard's test.
    */
-  @CompileStatic
   static class BarnardResult {
     /** The Wald score statistic */
     double statistic

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Boschloo.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Boschloo.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.contingency
 
-import groovy.transform.CompileStatic
-
 /**
  * Boschloo's exact test is an unconditional exact test for 2×2 contingency tables that provides
  * uniformly greater statistical power than Fisher's exact test. It tests for association between

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Boschloo.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Boschloo.groovy
@@ -78,7 +78,6 @@ import groovy.transform.CompileStatic
  * at multiple values of the nuisance parameter. For very large samples, consider using the chi-squared
  * test or Barnard's test instead.</p>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral', 'VariableName'])
 class Boschloo {
 
@@ -301,7 +300,6 @@ class Boschloo {
   /**
    * Result class for Boschloo's test.
    */
-  @CompileStatic
   static class BoschlooResult {
     /** The p-value (two-sided) */
     double pValue

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/ChiSquared.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/ChiSquared.groovy
@@ -31,7 +31,6 @@ import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
  * println "p-value: ${result.pValue}"
  * </pre>
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class ChiSquared {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranArmitage.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranArmitage.groovy
@@ -86,7 +86,6 @@ import se.alipsa.matrix.stats.util.NumericConversion
  * If you suspect a non-linear dose-response relationship, consider using multiple indicator variables
  * or non-linear modeling approaches instead.</p>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
 class CochranArmitage {
 
@@ -236,7 +235,6 @@ class CochranArmitage {
   /**
    * Result class for the Cochran-Armitage test.
    */
-  @CompileStatic
   static class CochranArmitagResult {
     /** The test statistic (Z-score) */
     BigDecimal statistic

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranArmitage.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranArmitage.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.contingency
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.ListConverter
 import se.alipsa.matrix.stats.distribution.NormalDistribution
 import se.alipsa.matrix.stats.util.NumericConversion

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranMantelHaenszel.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranMantelHaenszel.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.contingency
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
 
 /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranMantelHaenszel.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranMantelHaenszel.groovy
@@ -106,7 +106,6 @@ import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
  * interpreting the CMH test results. When heterogeneity is present, consider analyzing strata
  * separately or using stratified logistic regression.</p>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
 class CochranMantelHaenszel {
 
@@ -240,7 +239,6 @@ class CochranMantelHaenszel {
   /**
    * Result class for the Cochran-Mantel-Haenszel test.
    */
-  @CompileStatic
   static class CochranMantelHaenszelResult {
     /** The CMH test statistic (chi-squared) */
     double statistic

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.contingency
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.distribution.HypergeometricDistribution
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
@@ -23,7 +23,6 @@ import se.alipsa.matrix.stats.distribution.HypergeometricDistribution
  * println "odds ratio: ${result.oddsRatio}"
  * </pre>
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class Fisher {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/ChiSquaredDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/ChiSquaredDistribution.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.distribution
 
-import groovy.transform.CompileStatic
-
 /**
  * Chi-squared distribution implementation backed by the regularized incomplete gamma function.
  */

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/ChiSquaredDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/ChiSquaredDistribution.groovy
@@ -5,7 +5,6 @@ import groovy.transform.CompileStatic
 /**
  * Chi-squared distribution implementation backed by the regularized incomplete gamma function.
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class ChiSquaredDistribution implements ContinuousDistribution {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/ContinuousDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/ContinuousDistribution.groovy
@@ -5,7 +5,6 @@ import groovy.transform.CompileStatic
 /**
  * Minimal interface for continuous distributions that expose a cumulative distribution function.
  */
-@CompileStatic
 interface ContinuousDistribution {
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/ContinuousDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/ContinuousDistribution.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.distribution
 
-import groovy.transform.CompileStatic
-
 /**
  * Minimal interface for continuous distributions that expose a cumulative distribution function.
  */

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/FDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/FDistribution.groovy
@@ -8,7 +8,6 @@ import groovy.transform.CompileStatic
  *
  * <p>Uses custom high-precision implementation with no external dependencies.</p>
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class FDistribution implements ContinuousDistribution {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/FDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/FDistribution.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.distribution
 
-import groovy.transform.CompileStatic
-
 /**
  * F-distribution (Fisher-Snedecor distribution) implementation.
  * Provides CDF and p-value calculations for ANOVA and variance ratio tests.

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/HypergeometricDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/HypergeometricDistribution.groovy
@@ -5,7 +5,6 @@ import groovy.transform.CompileStatic
 /**
  * Hypergeometric distribution implementation for exact contingency-table calculations.
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class HypergeometricDistribution {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/HypergeometricDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/HypergeometricDistribution.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.distribution
 
-import groovy.transform.CompileStatic
-
 /**
  * Hypergeometric distribution implementation for exact contingency-table calculations.
  */

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/NormalDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/NormalDistribution.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.distribution
 
-import groovy.transform.CompileStatic
-
 /**
  * Normal (Gaussian) distribution implementation with cumulative and inverse cumulative probability.
  */

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/NormalDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/NormalDistribution.groovy
@@ -5,7 +5,6 @@ import groovy.transform.CompileStatic
 /**
  * Normal (Gaussian) distribution implementation with cumulative and inverse cumulative probability.
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class NormalDistribution implements ContinuousDistribution {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/SpecialFunctions.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/SpecialFunctions.groovy
@@ -3,8 +3,6 @@ package se.alipsa.matrix.stats.distribution
 import static java.math.BigDecimal.*
 import static se.alipsa.matrix.ext.NumberExtension.*
 
-import groovy.transform.CompileStatic
-
 import java.math.MathContext
 import java.math.RoundingMode
 /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/SpecialFunctions.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/SpecialFunctions.groovy
@@ -14,7 +14,6 @@ import java.math.RoundingMode
  * <p>This implementation provides excellent numerical accuracy (1e-10 or better)
  * and is self-contained with no external dependencies.</p>
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class SpecialFunctions {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/TDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/TDistribution.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.distribution
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Stat
 
 /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/TDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/TDistribution.groovy
@@ -10,7 +10,6 @@ import se.alipsa.matrix.core.Stat
  *
  * <p>Uses custom high-precision implementation with no external dependencies.</p>
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class TDistribution {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/Formula.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/Formula.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.formula
 
-import groovy.transform.CompileStatic
-
 /**
  * Public entry point for formula parsing, normalization, and updates.
  *
@@ -21,7 +19,6 @@ import groovy.transform.CompileStatic
  * {@code *} and grouped powers into explicit interaction terms. Dot expansion is
  * resolved later by {@link ModelFrame} because it depends on the available data columns.
  */
-@CompileStatic
 final class Formula {
 
   private Formula() {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/FormulaExpression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/FormulaExpression.groovy
@@ -1,11 +1,8 @@
 package se.alipsa.matrix.stats.formula
 
-import groovy.transform.CompileStatic
-
 /**
  * Base type for parsed formula expressions.
  */
-@CompileStatic
 abstract class FormulaExpression {
 
   final int start
@@ -31,7 +28,6 @@ abstract class FormulaExpression {
   /**
    * Variable reference, including optional backtick-quoted names.
    */
-  @CompileStatic
   static final class Variable extends FormulaExpression {
     final String name
     final boolean quoted
@@ -54,7 +50,6 @@ abstract class FormulaExpression {
   /**
    * Dot placeholder used for later model-frame expansion.
    */
-  @CompileStatic
   static final class Dot extends FormulaExpression {
     Dot(int start, int end) {
       super(start, end)
@@ -69,7 +64,6 @@ abstract class FormulaExpression {
   /**
    * Numeric literal used inside formula expressions.
    */
-  @CompileStatic
   static final class NumberLiteral extends FormulaExpression {
     final BigDecimal value
     final String sourceText
@@ -89,7 +83,6 @@ abstract class FormulaExpression {
   /**
    * Function or transform call such as {@code log(x)} or {@code I(x + y)}.
    */
-  @CompileStatic
   static final class FunctionCall extends FormulaExpression {
     final String name
     final List<FormulaExpression> arguments
@@ -109,7 +102,6 @@ abstract class FormulaExpression {
   /**
    * Unary expression such as {@code -1} or {@code +x}.
    */
-  @CompileStatic
   static final class Unary extends FormulaExpression {
     final String operator
     final FormulaExpression expression
@@ -130,7 +122,6 @@ abstract class FormulaExpression {
   /**
    * Binary operator expression such as addition, interaction, or nesting.
    */
-  @CompileStatic
   static final class Binary extends FormulaExpression {
     final String operator
     final FormulaExpression left
@@ -166,7 +157,6 @@ abstract class FormulaExpression {
   /**
    * Parenthesized subexpression that preserves grouping during parsing.
    */
-  @CompileStatic
   static final class Grouping extends FormulaExpression {
     final FormulaExpression expression
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/FormulaParseException.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/FormulaParseException.groovy
@@ -1,11 +1,8 @@
 package se.alipsa.matrix.stats.formula
 
-import groovy.transform.CompileStatic
-
 /**
  * Exception raised when a formula cannot be tokenized or parsed.
  */
-@CompileStatic
 class FormulaParseException extends IllegalArgumentException {
 
   final int position

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/FormulaTerm.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/FormulaTerm.groovy
@@ -5,7 +5,6 @@ import groovy.transform.CompileStatic
 /**
  * A normalized predictor term made up of one or more factors.
  */
-@CompileStatic
 final class FormulaTerm {
 
   final List<FormulaExpression> factors

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/NaAction.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/NaAction.groovy
@@ -1,11 +1,8 @@
 package se.alipsa.matrix.stats.formula
 
-import groovy.transform.CompileStatic
-
 /**
  * Policy for handling NA (null) values during model frame evaluation.
  */
-@CompileStatic
 enum NaAction {
 
   /** Drop rows containing null values in any formula-referenced column. This is the default. */

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ParsedFormula.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ParsedFormula.groovy
@@ -1,11 +1,8 @@
 package se.alipsa.matrix.stats.formula
 
-import groovy.transform.CompileStatic
-
 /**
  * Parsed formula containing the raw expression AST for the response and predictors.
  */
-@CompileStatic
 final class ParsedFormula {
 
   final String source

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/BandwidthSelector.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/BandwidthSelector.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.kde
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.interpolation.Interpolation
 import se.alipsa.matrix.stats.util.NumericConversion
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/BandwidthSelector.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/BandwidthSelector.groovy
@@ -15,7 +15,6 @@ import se.alipsa.matrix.stats.util.NumericConversion
  * This class provides automatic bandwidth selection using common rules of thumb.
  */
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
-@CompileStatic
 class BandwidthSelector {
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/Kernel.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/Kernel.groovy
@@ -103,7 +103,6 @@ import se.alipsa.matrix.stats.util.NumericConversion
  * @see KernelDensity
  * @see BandwidthSelector
  */
-@CompileStatic
 enum Kernel {
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/Kernel.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/Kernel.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.kde
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.util.NumericConversion
 
 /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/KernelDensity.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/KernelDensity.groovy
@@ -175,7 +175,6 @@ import java.math.RoundingMode
  * @see BandwidthSelector
  */
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
-@CompileStatic
 class KernelDensity {
 
   /** The kernel function used for density estimation */

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/KernelDensity.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/KernelDensity.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.kde
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.util.NumericConversion
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linalg/Linalg.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linalg/Linalg.groovy
@@ -15,7 +15,8 @@ import se.alipsa.matrix.stats.util.NumericConversion
  * This API accepts idiomatic Groovy-facing numeric inputs such as {@link Matrix},
  * {@link Grid}, and numeric lists. Matrix-heavy computation still runs in floating-point
  * {@code double} precision internally through EJML, but public scalar and vector results
- * are exposed as {@code BigDecimal} and {@code List<BigDecimal>}.
+ * are exposed as {@code BigDecimal} and {@code List<BigDecimal>}. Decomposition results
+ * are exposed as {@link Matrix} components plus {@code List<BigDecimal>} singular values.
  * <p>
  * Matrix-shaped results returned as {@link Matrix} use synthetic column names (`c0`,
  * `c1`, ...) because decompositions and inverse matrices do not preserve the semantic
@@ -147,7 +148,11 @@ final class Linalg {
     for (int i = 0; i < singularValues.length; i++) {
       singularValues[i] = w.get(i, i)
     }
-    new SvdResult(LinalgAdapters.toDoubleArray(u), LinalgAdapters.toDoubleArray(vt), singularValues)
+    new SvdResult(
+      LinalgAdapters.toMatrix(LinalgAdapters.toDoubleArray(u)),
+      LinalgAdapters.toMatrix(LinalgAdapters.toDoubleArray(vt)),
+      LinalgAdapters.toBigDecimalVector(singularValues)
+    )
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linalg/SvdResult.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linalg/SvdResult.groovy
@@ -3,21 +3,29 @@ package se.alipsa.matrix.stats.linalg
 import org.ejml.simple.SimpleMatrix
 
 import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * Result carrier for singular value decomposition.
  * <p>
  * The decomposition uses the standard layout {@code A = U * Sigma * Vt}. Matrix-shaped
- * convenience accessors synthesize column names (`c0`, `c1`, ...) because the result
- * spaces no longer correspond directly to the original input column metadata.
+ * components use synthetic column names (`c0`, `c1`, ...) because the result spaces no
+ * longer correspond directly to the original input column metadata.
  */
 class SvdResult {
 
-  final double[][] u
-  final double[][] vt
-  final double[] singularValues
+  final Matrix u
+  final Matrix vt
+  final List<BigDecimal> singularValues
 
-  SvdResult(double[][] u, double[][] vt, double[] singularValues) {
+  /**
+   * Create a singular value decomposition result with idiomatic Groovy-facing components.
+   *
+   * @param u the left singular vectors
+   * @param vt the transposed right singular vectors
+   * @param singularValues the singular values on the Sigma diagonal
+   */
+  SvdResult(Matrix u, Matrix vt, List<? extends Number> singularValues) {
     this.u = copyMatrix(u, 'u')
     this.vt = copyMatrix(vt, 'vt')
     this.singularValues = copyVector(singularValues, 'singularValues')
@@ -28,65 +36,65 @@ class SvdResult {
    *
    * @return the Sigma matrix with singular values on the diagonal
    */
-  double[][] sigma() {
-    double[][] sigma = new double[u.length][vt[0].length]
-    int diagonalSize = Math.min(Math.min(u.length, vt[0].length), singularValues.length)
-    for (int i = 0; i < diagonalSize; i++) {
-      sigma[i][i] = singularValues[i]
+  Matrix sigma() {
+    int rows = u.rowCount()
+    int columns = vt.columnCount()
+    List<List<BigDecimal>> matrixRows = []
+    for (int row = 0; row < rows; row++) {
+      List<BigDecimal> currentRow = []
+      for (int col = 0; col < columns; col++) {
+        currentRow << (row == col && row < singularValues.size() ? singularValues[row] : 0.0)
+      }
+      matrixRows << currentRow
     }
-    sigma
+    Matrix.builder()
+      .columnNames(LinalgAdapters.syntheticColumnNames(columns))
+      .rows(matrixRows)
+      .types(([BigDecimal] * columns) as List<Class>)
+      .build()
   }
 
   /**
    * Reconstruct the original matrix using {@code U * Sigma * Vt}.
    *
-   * @return the reconstructed dense matrix
+   * @return the reconstructed matrix with synthetic column names
    */
-  double[][] reconstruct() {
-    LinalgAdapters.toDoubleArray(new SimpleMatrix(u).mult(new SimpleMatrix(sigma())).mult(new SimpleMatrix(vt)))
+  Matrix reconstruct() {
+    SimpleMatrix denseU = new SimpleMatrix(LinalgAdapters.toDoubleArray(u))
+    SimpleMatrix denseSigma = new SimpleMatrix(LinalgAdapters.toDoubleArray(sigma()))
+    SimpleMatrix denseVt = new SimpleMatrix(LinalgAdapters.toDoubleArray(vt))
+    LinalgAdapters.toMatrix(LinalgAdapters.toDoubleArray(denseU.mult(denseSigma).mult(denseVt)))
   }
 
   /**
    * @return {@code U} as a Matrix with synthetic column names
    */
   Matrix uMatrix() {
-    LinalgAdapters.toMatrix(u)
+    u
   }
 
   /**
    * @return {@code Vt} as a Matrix with synthetic column names
    */
   Matrix vtMatrix() {
-    LinalgAdapters.toMatrix(vt)
+    vt
   }
 
   /**
    * @return {@code Sigma} as a Matrix with synthetic column names
    */
   Matrix sigmaMatrix() {
-    LinalgAdapters.toMatrix(sigma())
+    sigma()
   }
 
-  private static double[][] copyMatrix(double[][] matrix, String label) {
-    int[] shape = LinalgAdapters.validateRectangular(matrix, label)
-    double[][] copy = new double[shape[0]][shape[1]]
-    for (int row = 0; row < shape[0]; row++) {
-      System.arraycopy(matrix[row], 0, copy[row], 0, shape[1])
+  private static Matrix copyMatrix(Matrix matrix, String label) {
+    if (matrix == null) {
+      throw new IllegalArgumentException("${label.capitalize()} cannot be null")
     }
-    copy
+    LinalgAdapters.toMatrix(LinalgAdapters.toDoubleArray(matrix))
   }
 
-  private static double[] copyVector(double[] values, String label) {
-    if (values == null || values.length == 0) {
-      throw new IllegalArgumentException("${label.capitalize()} must contain at least one value")
-    }
-    double[] copy = new double[values.length]
-    for (int i = 0; i < values.length; i++) {
-      if (!Double.isFinite(values[i])) {
-        throw new IllegalArgumentException("${label.capitalize()} must contain only finite values")
-      }
-      copy[i] = values[i]
-    }
-    copy
+  private static List<BigDecimal> copyVector(List<? extends Number> values, String label) {
+    LinalgAdapters.toBigDecimalVector(NumericConversion.toDoubleArray(values, label)).asImmutable() as List<BigDecimal>
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linear/MatrixAlgebra.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linear/MatrixAlgebra.groovy
@@ -1,14 +1,11 @@
 package se.alipsa.matrix.stats.linear
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.util.Logger
 
 /**
  * Native matrix operations used by the statistics implementations to avoid runtime
  * dependence on commons-math3 linear algebra classes.
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 final class MatrixAlgebra {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/AndersonDarling.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/AndersonDarling.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.normality
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.distribution.NormalDistribution
 import se.alipsa.matrix.stats.util.NumericConversion
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/AndersonDarling.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/AndersonDarling.groovy
@@ -3,6 +3,7 @@ package se.alipsa.matrix.stats.normality
 import groovy.transform.CompileStatic
 
 import se.alipsa.matrix.stats.distribution.NormalDistribution
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * The Anderson–Darling test is a statistical test of whether a given sample of data is drawn from a
@@ -33,8 +34,9 @@ class AndersonDarling {
    * @return AndersonDarlingResult containing test statistic, adjusted statistic, and p-value
    * @throws IllegalArgumentException if data is null, empty, or has fewer than 3 observations
    */
-  static AndersonDarlingResult testNormality(List<? extends Number> data, double alpha = 0.05) {
+  static AndersonDarlingResult testNormality(List<? extends Number> data, Number alpha = 0.05) {
     validateInput(data)
+    BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
 
     int n = data.size()
 
@@ -66,13 +68,13 @@ class AndersonDarling {
     double pValue = calculatePValue(adjustedASquared)
 
     return new AndersonDarlingResult(
-      statistic: aSquared,
-      adjustedStatistic: adjustedASquared,
-      pValue: pValue,
-      alpha: alpha,
+      statistic: BigDecimal.valueOf(aSquared),
+      adjustedStatistic: BigDecimal.valueOf(adjustedASquared),
+      pValue: BigDecimal.valueOf(pValue),
+      alpha: alphaValue,
       sampleSize: n,
-      mean: mean,
-      stdDev: stdDev
+      mean: BigDecimal.valueOf(mean),
+      stdDev: BigDecimal.valueOf(stdDev)
     )
   }
 
@@ -144,25 +146,25 @@ class AndersonDarling {
   @CompileStatic
   static class AndersonDarlingResult {
     /** The raw Anderson-Darling test statistic */
-    double statistic
+    BigDecimal statistic
 
     /** The adjusted test statistic (accounting for estimated parameters) */
-    double adjustedStatistic
+    BigDecimal adjustedStatistic
 
     /** The p-value for the test */
-    double pValue
+    BigDecimal pValue
 
     /** The significance level used for evaluation */
-    double alpha
+    BigDecimal alpha
 
     /** The sample size */
     int sampleSize
 
     /** The sample mean */
-    double mean
+    BigDecimal mean
 
     /** The sample standard deviation */
-    double stdDev
+    BigDecimal stdDev
 
     /**
      * Evaluates the test result at the specified significance level.

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/AndersonDarling.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/AndersonDarling.groovy
@@ -19,7 +19,6 @@ import se.alipsa.matrix.stats.util.NumericConversion
  *
  * Reference: R's nortest::ad.test()
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral', 'VariableName'])
 class AndersonDarling {
 
@@ -143,7 +142,6 @@ class AndersonDarling {
   /**
    * Result class for the Anderson-Darling normality test.
    */
-  @CompileStatic
   static class AndersonDarlingResult {
     /** The raw Anderson-Darling test statistic */
     BigDecimal statistic

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/CramerVonMises.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/CramerVonMises.groovy
@@ -3,6 +3,7 @@ package se.alipsa.matrix.stats.normality
 import groovy.transform.CompileStatic
 
 import se.alipsa.matrix.stats.distribution.NormalDistribution
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * Cramér-von Mises test for normality.
@@ -35,8 +36,9 @@ class CramerVonMises {
    * @param alpha The significance level (default: 0.05)
    * @return CramerVonMisesResult containing test statistic, p-value, and conclusion
    */
-  static CramerVonMisesResult testNormality(List<? extends Number> data, double alpha = 0.05) {
-    validateInput(data, alpha)
+  static CramerVonMisesResult testNormality(List<? extends Number> data, Number alpha = 0.05) {
+    BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
+    validateInput(data, alphaValue)
 
     int n = data.size()
 
@@ -91,17 +93,17 @@ class CramerVonMises {
 
     // Calculate p-value and critical value
     double pValue = calculatePValue(modifiedWSquared)
-    double criticalValue = getCriticalValue(alpha)
+    double criticalValue = getCriticalValue(alphaValue as double)
 
     return new CramerVonMisesResult(
-      statistic: modifiedWSquared,
-      rawStatistic: wSquared,
+      statistic: BigDecimal.valueOf(modifiedWSquared),
+      rawStatistic: BigDecimal.valueOf(wSquared),
       sampleSize: n,
-      mean: mean,
-      stdDev: stdDev,
-      alpha: alpha,
-      pValue: pValue,
-      criticalValue: criticalValue
+      mean: BigDecimal.valueOf(mean),
+      stdDev: BigDecimal.valueOf(stdDev),
+      alpha: alphaValue,
+      pValue: BigDecimal.valueOf(pValue),
+      criticalValue: BigDecimal.valueOf(criticalValue)
     )
   }
 
@@ -157,7 +159,7 @@ class CramerVonMises {
     }
   }
 
-  private static void validateInput(List<? extends Number> data, double alpha) {
+  private static void validateInput(List<? extends Number> data, BigDecimal alpha) {
     if (data == null) {
       throw new IllegalArgumentException("Data cannot be null")
     }
@@ -166,9 +168,6 @@ class CramerVonMises {
     }
     if (data.size() < 3) {
       throw new IllegalArgumentException("Cramér-von Mises test requires at least 3 observations, got ${data.size()}")
-    }
-    if (alpha <= 0 || alpha >= 1) {
-      throw new IllegalArgumentException("Alpha must be between 0 and 1, got ${alpha}")
     }
     // Check for non-null values
     for (Number value : data) {
@@ -184,28 +183,28 @@ class CramerVonMises {
   @CompileStatic
   static class CramerVonMisesResult {
     /** The modified Cramér-von Mises test statistic W²* */
-    double statistic
+    BigDecimal statistic
 
     /** The raw W² statistic before modification */
-    double rawStatistic
+    BigDecimal rawStatistic
 
     /** The sample size */
     int sampleSize
 
     /** The sample mean */
-    double mean
+    BigDecimal mean
 
     /** The sample standard deviation */
-    double stdDev
+    BigDecimal stdDev
 
     /** The significance level */
-    double alpha
+    BigDecimal alpha
 
     /** The approximate p-value */
-    double pValue
+    BigDecimal pValue
 
     /** The critical value at the specified alpha level */
-    double criticalValue
+    BigDecimal criticalValue
 
     /**
      * Interprets the Cramér-von Mises test result.

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/CramerVonMises.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/CramerVonMises.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.normality
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.distribution.NormalDistribution
 import se.alipsa.matrix.stats.util.NumericConversion
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/CramerVonMises.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/CramerVonMises.groovy
@@ -25,7 +25,6 @@ import se.alipsa.matrix.stats.util.NumericConversion
  * - von Mises, R. (1928). "Wahrscheinlichkeit, Statistik und Wahrheit"
  * - Anderson, T.W. (1962). "On the Distribution of the Two-Sample Cramer-von Mises Criterion"
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
 class CramerVonMises {
 
@@ -180,7 +179,6 @@ class CramerVonMises {
   /**
    * Result class for the Cramér-von Mises test.
    */
-  @CompileStatic
   static class CramerVonMisesResult {
     /** The modified Cramér-von Mises test statistic W²* */
     BigDecimal statistic

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/JarqueBera.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/JarqueBera.groovy
@@ -3,6 +3,7 @@ package se.alipsa.matrix.stats.normality
 import groovy.transform.CompileStatic
 
 import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * The Jarque-Bera test is a goodness-of-fit test that determines whether sample data have skewness
@@ -147,23 +148,13 @@ class JarqueBera {
     double pValue = 1.0 - chiSq.cumulativeProbability(jbStatistic)
 
     return new JarqueBeraResult(
-      jbStatistic: jbStatistic,
-      skewness: skewness,
-      kurtosis: kurtosis,
-      excessKurtosis: kurtosis - 3,
-      pValue: pValue,
+      jbStatistic: BigDecimal.valueOf(jbStatistic),
+      skewness: BigDecimal.valueOf(skewness),
+      kurtosis: BigDecimal.valueOf(kurtosis),
+      excessKurtosis: BigDecimal.valueOf(kurtosis - 3),
+      pValue: BigDecimal.valueOf(pValue),
       sampleSize: n
     )
-  }
-
-  /**
-   * Performs the Jarque-Bera test on a double array.
-   *
-   * @param data The sample data array
-   * @return JarqueBeraResult containing the test statistic and p-value
-   */
-  static JarqueBeraResult test(double[] data) {
-    return test(data.toList())
   }
 
   private static void validateData(List<? extends Number> data) {
@@ -187,19 +178,19 @@ class JarqueBera {
    */
   static class JarqueBeraResult {
     /** The Jarque-Bera test statistic */
-    Double jbStatistic
+    BigDecimal jbStatistic
 
     /** The sample skewness */
-    Double skewness
+    BigDecimal skewness
 
     /** The sample kurtosis */
-    Double kurtosis
+    BigDecimal kurtosis
 
     /** The excess kurtosis (kurtosis - 3) */
-    Double excessKurtosis
+    BigDecimal excessKurtosis
 
     /** The p-value of the test */
-    Double pValue
+    BigDecimal pValue
 
     /** The sample size */
     Integer sampleSize
@@ -210,15 +201,15 @@ class JarqueBera {
      * @param alpha Significance level (default 0.05)
      * @return true if null hypothesis should be rejected (p-value < alpha), indicating non-normality
      */
-    boolean evaluate(double alpha = 0.05) {
-      return pValue < alpha
+    boolean evaluate(Number alpha = 0.05) {
+      pValue < NumericConversion.toAlpha(alpha)
     }
 
     /**
      * Returns true if the data appears to be normally distributed at the given significance level.
      */
-    boolean isNormal(double alpha = 0.05) {
-      return pValue >= alpha
+    boolean isNormal(Number alpha = 0.05) {
+      pValue >= NumericConversion.toAlpha(alpha)
     }
 
     @Override

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/JarqueBera.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/JarqueBera.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.normality
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
 import se.alipsa.matrix.stats.util.NumericConversion
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/JarqueBera.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/JarqueBera.groovy
@@ -92,7 +92,6 @@ import se.alipsa.matrix.stats.util.NumericConversion
  * consider using the Shapiro-Wilk test. For medium samples (50 ≤ n < 2000), consider Anderson-Darling
  * or Shapiro-Francia tests.</p>
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class JarqueBera {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KSquared.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KSquared.groovy
@@ -95,7 +95,6 @@ import se.alipsa.matrix.stats.util.NumericConversion
  * For very large samples (n > 2000), the Jarque-Bera test is also appropriate and computationally
  * simpler, though K² generally has better finite-sample properties.</p>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral', 'VariableName'])
 class KSquared {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KSquared.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KSquared.groovy
@@ -4,6 +4,7 @@ import groovy.transform.CompileStatic
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * D'Agostino's K² test (K-squared test) is a powerful omnibus test for normality that combines
@@ -53,7 +54,7 @@ import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
  * <p><b>Example usage:</b></p>
  * <pre>
  * // Test normality of a dataset
- * def data = [2.3, 3.1, 2.8, 3.5, 2.9, 3.2, 2.7, 3.0, 3.3, 2.6] as double[]
+ * def data = [2.3, 3.1, 2.8, 3.5, 2.9, 3.2, 2.7, 3.0, 3.3, 2.6]
  * def result = KSquared.test(data)
  * println "K² statistic: ${result.statistic}"
  * println "p-value: ${result.pValue}"
@@ -101,22 +102,23 @@ class KSquared {
   /**
    * Performs D'Agostino's K² test for normality.
    *
-   * @param data The sample data as double array
+   * @param data The sample data
    * @return KSquaredResult containing test statistic, p-value, and component Z-scores
    */
-  static KSquaredResult test(double[] data) {
+  static KSquaredResult test(List<? extends Number> data) {
     if (data == null) {
       throw new IllegalArgumentException("Data cannot be null")
     }
-    if (data.length < 8) {
-      throw new IllegalArgumentException("Sample size must be at least 8 (got ${data.length})")
+    if (data.size() < 8) {
+      throw new IllegalArgumentException("Sample size must be at least 8 (got ${data.size()})")
     }
 
-    int n = data.length
+    double[] numericData = NumericConversion.toDoubleArray(data, 'data')
+    int n = numericData.length
 
     // Calculate mean
     double mean = 0.0
-    for (double x : data) {
+    for (double x : numericData) {
       mean += x
     }
     mean /= n
@@ -126,7 +128,7 @@ class KSquared {
     double m3 = 0.0  // Third moment (for skewness)
     double m4 = 0.0  // Fourth moment (for kurtosis)
 
-    for (double x : data) {
+    for (double x : numericData) {
       double diff = x - mean
       double diff2 = diff * diff
       m2 += diff2
@@ -177,12 +179,12 @@ class KSquared {
     double pValue = 1.0 - chiSq.cumulativeProbability(kSquared)
 
     return new KSquaredResult(
-      statistic: kSquared,
-      pValue: pValue,
-      skewness: b1,
-      kurtosis: b2,
-      zSkewness: zSkewness,
-      zKurtosis: zKurtosis,
+      statistic: BigDecimal.valueOf(kSquared),
+      pValue: BigDecimal.valueOf(pValue),
+      skewness: BigDecimal.valueOf(b1),
+      kurtosis: BigDecimal.valueOf(b2),
+      zSkewness: BigDecimal.valueOf(zSkewness),
+      zKurtosis: BigDecimal.valueOf(zKurtosis),
       sampleSize: n
     )
   }
@@ -199,10 +201,8 @@ class KSquared {
       throw new IllegalArgumentException("Matrix cannot be null")
     }
 
-    List<Object> column = matrix.column(columnName)
-    double[] data = column.collect { it as double } as double[]
-
-    return test(data)
+    List<?> column = matrix.column(columnName)
+    test(toNumericList(column, "Matrix column '${columnName}'"))
   }
 
   /**
@@ -217,10 +217,8 @@ class KSquared {
       throw new IllegalArgumentException("Matrix cannot be null")
     }
 
-    List<Object> column = matrix.column(columnIndex)
-    double[] data = column.collect { it as double } as double[]
-
-    return test(data)
+    List<?> column = matrix.column(columnIndex)
+    test(toNumericList(column, "Matrix column ${columnIndex}"))
   }
 
   /**
@@ -229,22 +227,22 @@ class KSquared {
   @CompileStatic
   static class KSquaredResult {
     /** The K² test statistic */
-    double statistic
+    BigDecimal statistic
 
     /** The p-value */
-    double pValue
+    BigDecimal pValue
 
     /** Sample skewness */
-    double skewness
+    BigDecimal skewness
 
     /** Sample kurtosis (excess kurtosis relative to normal distribution) */
-    double kurtosis
+    BigDecimal kurtosis
 
     /** Z-score for skewness */
-    double zSkewness
+    BigDecimal zSkewness
 
     /** Z-score for kurtosis */
-    double zKurtosis
+    BigDecimal zKurtosis
 
     /** Sample size */
     int sampleSize
@@ -255,8 +253,9 @@ class KSquared {
      * @param alpha The significance level (default: 0.05)
      * @return A string describing whether the data appears normal
      */
-    String interpret(double alpha = 0.05) {
-      if (pValue < alpha) {
+    String interpret(Number alpha = 0.05) {
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
+      if (pValue < alphaValue) {
         String reason = determineReason()
         return "Reject H0: Data significantly departs from normality (K² = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)}) - ${reason}"
       } else {
@@ -268,8 +267,8 @@ class KSquared {
      * Determines the primary reason for departure from normality.
      */
     private String determineReason() {
-      double absZSkew = Math.abs(zSkewness)
-      double absZKurt = Math.abs(zKurtosis)
+      BigDecimal absZSkew = zSkewness.abs()
+      BigDecimal absZKurt = zKurtosis.abs()
 
       if (absZSkew > 1.96 && absZKurt > 1.96) {
         return "both skewness and kurtosis"
@@ -286,8 +285,9 @@ class KSquared {
      * @param alpha The significance level (default: 0.05)
      * @return A detailed description of the test result
      */
-    String evaluate(double alpha = 0.05) {
-      String conclusion = pValue < alpha ? "significant departure from normality" : "consistent with normality"
+    String evaluate(Number alpha = 0.05) {
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
+      String conclusion = pValue < alphaValue ? "significant departure from normality" : "consistent with normality"
 
       return String.format(
         "D'Agostino's K² test:\\n" +
@@ -298,7 +298,7 @@ class KSquared {
         "Kurtosis: %.4f (Z = %.4f)\\n" +
         "Conclusion: Data shows %s at %.0f%% significance level",
         statistic, pValue, sampleSize, skewness, zSkewness, kurtosis, zKurtosis,
-        conclusion, alpha * 100
+        conclusion, alphaValue * 100
       )
     }
 
@@ -311,7 +311,19 @@ class KSquared {
   Skewness: ${String.format('%.4f', skewness)} (Z = ${String.format('%.4f', zSkewness)})
   Kurtosis: ${String.format('%.4f', kurtosis)} (Z = ${String.format('%.4f', zKurtosis)})
 
-  ${interpret()}"""
+      ${interpret()}"""
     }
+  }
+
+  private static List<Number> toNumericList(List<?> values, String label) {
+    List<Number> numericValues = []
+    for (int i = 0; i < values.size(); i++) {
+      Object value = values[i]
+      if (!(value instanceof Number)) {
+        throw new IllegalArgumentException("${label} must be numeric")
+      }
+      numericValues << (value as Number)
+    }
+    numericValues
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KSquared.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KSquared.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.normality
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
 import se.alipsa.matrix.stats.util.NumericConversion
@@ -223,7 +221,6 @@ class KSquared {
   /**
    * Result class for D'Agostino's K² test.
    */
-  @CompileStatic
   static class KSquaredResult {
     /** The K² test statistic */
     BigDecimal statistic

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KolmogorovSmirnov.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KolmogorovSmirnov.groovy
@@ -105,7 +105,6 @@ import se.alipsa.matrix.stats.util.NumericConversion
  * Lilliefors test instead, which provides a corrected version of the K-S test specifically for normality
  * testing with estimated parameters.</p>
  */
-@CompileStatic
 class KolmogorovSmirnov {
 
   private static final int EXACT_TWO_SAMPLE_MAX_PRODUCT = 10_000

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KolmogorovSmirnov.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KolmogorovSmirnov.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.normality
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.distribution.ContinuousDistribution
 import se.alipsa.matrix.stats.distribution.NormalDistribution
 import se.alipsa.matrix.stats.util.NumericConversion

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KolmogorovSmirnov.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KolmogorovSmirnov.groovy
@@ -4,6 +4,7 @@ import groovy.transform.CompileStatic
 
 import se.alipsa.matrix.stats.distribution.ContinuousDistribution
 import se.alipsa.matrix.stats.distribution.NormalDistribution
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * The Kolmogorov-Smirnov (K-S) test is a nonparametric goodness-of-fit test that compares a sample
@@ -166,8 +167,8 @@ class KolmogorovSmirnov {
     double pValue = calculateOneSamplePValue(dStatistic, values.length)
 
     return new KSResult(
-      dStatistic: dStatistic,
-      pValue: pValue,
+      dStatistic: BigDecimal.valueOf(dStatistic),
+      pValue: BigDecimal.valueOf(pValue),
       sampleSize: values.length,
       testType: testName
     )
@@ -195,22 +196,11 @@ class KolmogorovSmirnov {
     double pValue = calculateTwoSamplePValue(dStatistic, values1.length, values2.length)
 
     return new KSResult(
-      dStatistic: dStatistic,
-      pValue: pValue,
+      dStatistic: BigDecimal.valueOf(dStatistic),
+      pValue: BigDecimal.valueOf(pValue),
       sampleSize: values1.length + values2.length,
       testType: "Two-Sample K-S"
     )
-  }
-
-  /**
-   * Performs a two-sample Kolmogorov-Smirnov test on double arrays.
-   *
-   * @param sample1 The first sample
-   * @param sample2 The second sample
-   * @return KSResult containing the D statistic and p-value
-   */
-  static KSResult twoSampleTest(double[] sample1, double[] sample2) {
-    return twoSampleTest(sample1.toList(), sample2.toList())
   }
 
   private static double calculateOneSampleStatistic(double[] sortedValues, ContinuousDistribution distribution) {
@@ -367,10 +357,10 @@ class KolmogorovSmirnov {
    */
   static class KSResult {
     /** The D test statistic (maximum distance between ECDFs) */
-    Double dStatistic
+    BigDecimal dStatistic
 
     /** The p-value of the test */
-    Double pValue
+    BigDecimal pValue
 
     /** The total sample size */
     Integer sampleSize
@@ -384,15 +374,15 @@ class KolmogorovSmirnov {
      * @param alpha Significance level (default 0.05)
      * @return true if null hypothesis should be rejected (p-value < alpha)
      */
-    boolean evaluate(double alpha = 0.05) {
-      return pValue < alpha
+    boolean evaluate(Number alpha = 0.05) {
+      pValue < NumericConversion.toAlpha(alpha)
     }
 
     /**
      * For normality tests, returns true if data appears normally distributed.
      */
-    boolean isNormal(double alpha = 0.05) {
-      return pValue >= alpha
+    boolean isNormal(Number alpha = 0.05) {
+      pValue >= NumericConversion.toAlpha(alpha)
     }
 
     @Override

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/Lilliefors.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/Lilliefors.groovy
@@ -3,6 +3,7 @@ package se.alipsa.matrix.stats.normality
 import groovy.transform.CompileStatic
 
 import se.alipsa.matrix.stats.distribution.NormalDistribution
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * The Lilliefors test is a normality test based on the Kolmogorov–Smirnov test.
@@ -31,8 +32,9 @@ class Lilliefors {
    * @return LillieforsResult containing test statistic and p-value
    * @throws IllegalArgumentException if data is null, empty, or has fewer than 4 observations
    */
-  static LillieforsResult testNormality(List<? extends Number> data, double alpha = 0.05) {
+  static LillieforsResult testNormality(List<? extends Number> data, Number alpha = 0.05) {
     validateInput(data)
+    BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
 
     int n = data.size()
 
@@ -53,12 +55,12 @@ class Lilliefors {
     double pValue = calculatePValue(dStatistic, n)
 
     return new LillieforsResult(
-      statistic: dStatistic,
-      pValue: pValue,
-      alpha: alpha,
+      statistic: BigDecimal.valueOf(dStatistic),
+      pValue: BigDecimal.valueOf(pValue),
+      alpha: alphaValue,
       sampleSize: n,
-      mean: mean,
-      stdDev: stdDev
+      mean: BigDecimal.valueOf(mean),
+      stdDev: BigDecimal.valueOf(stdDev)
     )
   }
 
@@ -165,22 +167,22 @@ class Lilliefors {
   @CompileStatic
   static class LillieforsResult {
     /** The Kolmogorov-Smirnov test statistic D */
-    double statistic
+    BigDecimal statistic
 
     /** The p-value for the test */
-    double pValue
+    BigDecimal pValue
 
     /** The significance level used for evaluation */
-    double alpha
+    BigDecimal alpha
 
     /** The sample size */
     int sampleSize
 
     /** The sample mean */
-    double mean
+    BigDecimal mean
 
     /** The sample standard deviation */
-    double stdDev
+    BigDecimal stdDev
 
     /**
      * Evaluates the test result at the specified significance level.

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/Lilliefors.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/Lilliefors.groovy
@@ -17,7 +17,6 @@ import se.alipsa.matrix.stats.util.NumericConversion
  *
  * Reference: R's nortest::lillie.test()
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
 class Lilliefors {
 
@@ -164,7 +163,6 @@ class Lilliefors {
   /**
    * Result class for the Lilliefors normality test.
    */
-  @CompileStatic
   static class LillieforsResult {
     /** The Kolmogorov-Smirnov test statistic D */
     BigDecimal statistic

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/Lilliefors.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/Lilliefors.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.normality
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.distribution.NormalDistribution
 import se.alipsa.matrix.stats.util.NumericConversion
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroFrancia.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroFrancia.groovy
@@ -4,6 +4,7 @@ import groovy.transform.CompileStatic
 
 import se.alipsa.matrix.stats.StatUtils
 import se.alipsa.matrix.stats.distribution.NormalDistribution
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * The Shapiro-Francia test is a simplified and computationally efficient approximation to the
@@ -135,22 +136,12 @@ class ShapiroFrancia {
     double pValue = calculatePValue(wPrime, n)
 
     return new ShapiroFranciaResult(
-      W: wPrime,
-      pValue: pValue,
+      W: BigDecimal.valueOf(wPrime),
+      pValue: BigDecimal.valueOf(pValue),
       sampleSize: n,
-      mean: mean,
-      stdDev: Math.sqrt(variance)
+      mean: BigDecimal.valueOf(mean),
+      stdDev: BigDecimal.valueOf(Math.sqrt(variance))
     )
-  }
-
-  /**
-   * Performs the Shapiro-Francia test for normality on an array of doubles.
-   *
-   * @param data The sample data array
-   * @return ShapiroFranciaResult containing W' statistic and p-value
-   */
-  static ShapiroFranciaResult test(double[] data) {
-    return test(data.toList())
   }
 
   private static void validateData(List<? extends Number> data) {
@@ -278,19 +269,19 @@ class ShapiroFrancia {
   @SuppressWarnings('PropertyName')
   static class ShapiroFranciaResult {
     /** The Shapiro-Francia W' test statistic (0 to 1, higher values indicate more normality) */
-    double W
+    BigDecimal W
 
     /** The p-value for the test */
-    double pValue
+    BigDecimal pValue
 
     /** The sample size */
     int sampleSize
 
     /** The sample mean */
-    double mean
+    BigDecimal mean
 
     /** The sample standard deviation */
-    double stdDev
+    BigDecimal stdDev
 
     /**
      * Interprets the test result at the 5% significance level.
@@ -298,8 +289,9 @@ class ShapiroFrancia {
      * @param alpha The significance level (default: 0.05)
      * @return A string describing whether the data appears normally distributed
      */
-    String interpret(double alpha = 0.05) {
-      if (pValue < alpha) {
+    String interpret(Number alpha = 0.05) {
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
+      if (pValue < alphaValue) {
         return "Reject H0: Data does not appear to be normally distributed (W' = ${String.format('%.4f', W)}, p = ${String.format('%.4f', pValue)})"
       } else {
         return "Fail to reject H0: Data appears to be consistent with a normal distribution (W' = ${String.format('%.4f', W)}, p = ${String.format('%.4f', pValue)})"
@@ -311,8 +303,9 @@ class ShapiroFrancia {
      *
      * @return A detailed description of the test result
      */
-    String evaluate(double alpha = 0.05) {
-      String conclusion = pValue < alpha ?
+    String evaluate(Number alpha = 0.05) {
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
+      String conclusion = pValue < alphaValue ?
         "not normally distributed" :
         "consistent with a normal distribution"
 
@@ -321,7 +314,7 @@ class ShapiroFrancia {
         "p-value: %.4f\n" +
         "Sample: n=%d, mean=%.4f, sd=%.4f\n" +
         "Conclusion at %.0f%% level: Data appears %s",
-        W, pValue, sampleSize, mean, stdDev, alpha * 100, conclusion
+        W, pValue, sampleSize, mean, stdDev, alphaValue * 100, conclusion
       )
     }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroFrancia.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroFrancia.groovy
@@ -101,7 +101,6 @@ import se.alipsa.matrix.stats.util.NumericConversion
  * or asymptotic tests like Jarque-Bera. The Shapiro-Francia test is optimal for the intermediate range
  * of 50 to 5000 observations where it provides an excellent balance of power and computational efficiency.</p>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
 class ShapiroFrancia {
 
@@ -265,7 +264,6 @@ class ShapiroFrancia {
   /**
    * Result class for the Shapiro-Francia test.
    */
-  @CompileStatic
   @SuppressWarnings('PropertyName')
   static class ShapiroFranciaResult {
     /** The Shapiro-Francia W' test statistic (0 to 1, higher values indicate more normality) */

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroFrancia.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroFrancia.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.normality
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.StatUtils
 import se.alipsa.matrix.stats.distribution.NormalDistribution
 import se.alipsa.matrix.stats.util.NumericConversion

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroWilk.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroWilk.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.normality
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.StatUtils
 import se.alipsa.matrix.stats.distribution.NormalDistribution
 import se.alipsa.matrix.stats.util.NumericConversion

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroWilk.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroWilk.groovy
@@ -103,7 +103,6 @@ import se.alipsa.matrix.stats.util.NumericConversion
  * which provides good accuracy for sample sizes 3 ≤ n ≤ 5000. For very large samples (n > 5000),
  * consider using Anderson-Darling or other tests designed for large samples.</p>
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class ShapiroWilk {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroWilk.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroWilk.groovy
@@ -4,6 +4,7 @@ import groovy.transform.CompileStatic
 
 import se.alipsa.matrix.stats.StatUtils
 import se.alipsa.matrix.stats.distribution.NormalDistribution
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * The Shapiro-Wilk test is widely considered the most powerful statistical test for assessing
@@ -134,20 +135,10 @@ class ShapiroWilk {
     double pValue = calculatePValue(w, n)
 
     return new ShapiroWilkResult(
-      W: w,
-      pValue: pValue,
+      W: BigDecimal.valueOf(w),
+      pValue: BigDecimal.valueOf(pValue),
       sampleSize: n
     )
-  }
-
-  /**
-   * Performs the Shapiro-Wilk test for normality on an array of doubles.
-   *
-   * @param data The sample data array
-   * @return ShapiroWilkResult containing W statistic and p-value
-   */
-  static ShapiroWilkResult test(double[] data) {
-    return test(data.toList())
   }
 
   private static void validateData(List<? extends Number> data) {
@@ -284,10 +275,10 @@ class ShapiroWilk {
   @SuppressWarnings('PropertyName')
   static class ShapiroWilkResult {
     /** The W test statistic (0 < W ≤ 1, closer to 1 indicates normality) */
-    Double W
+    BigDecimal W
 
     /** The p-value of the test */
-    Double pValue
+    BigDecimal pValue
 
     /** The sample size */
     Integer sampleSize
@@ -298,15 +289,15 @@ class ShapiroWilk {
      * @param alpha Significance level (default 0.05)
      * @return true if null hypothesis should be rejected (p-value < alpha), indicating non-normality
      */
-    boolean evaluate(double alpha = 0.05) {
-      return pValue < alpha
+    boolean evaluate(Number alpha = 0.05) {
+      pValue < NumericConversion.toAlpha(alpha)
     }
 
     /**
      * Returns true if the data appears to be normally distributed at the 5% significance level.
      */
-    boolean isNormal(double alpha = 0.05) {
-      return pValue >= alpha
+    boolean isNormal(Number alpha = 0.05) {
+      pValue >= NumericConversion.toAlpha(alpha)
     }
 
     @Override

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/DecisionTree.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/DecisionTree.groovy
@@ -136,14 +136,12 @@ import java.math.RoundingMode
  * <p><b>Note:</b> This implementation supports single-feature (univariate) regression only. For multivariate
  * regression trees, consider using ensemble methods or dedicated machine learning libraries.</p>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
 class DecisionTree {
 
   /**
    * Internal node class representing a binary tree node
    */
-  @CompileStatic
   static class Node {
     /** Split threshold (null for leaf nodes) */
     BigDecimal threshold

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/DecisionTree.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/DecisionTree.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Stat
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
@@ -26,7 +26,6 @@ import java.math.RoundingMode
  *   <li>X is the independent variable.</li>
  * </ul>
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class LinearRegression {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Stat
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LogisticRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LogisticRegression.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.solver.MultivariateObjective
 import se.alipsa.matrix.stats.solver.NelderMeadOptimizer

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LogisticRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LogisticRegression.groovy
@@ -149,7 +149,6 @@ import java.math.RoundingMode
  * For multivariate logistic regression with multiple predictors, consider using dedicated statistical
  * or machine learning libraries. The dependent variable must be binary (coded as 0 or 1).</p>
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class LogisticRegression {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/MultipleLinearRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/MultipleLinearRegression.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.linear.MatrixAlgebra
 
 /**
@@ -12,7 +10,6 @@ import se.alipsa.matrix.stats.linear.MatrixAlgebra
  * regression utility for higher-dimensional or more ill-conditioned problems, it should move to a
  * QR- or SVD-based solver rather than relying on the normal equations.
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class MultipleLinearRegression {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/PolynomialRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/PolynomialRegression.groovy
@@ -22,7 +22,6 @@ import java.math.RoundingMode
  * println poly.predict(6)  // ~36
  * </pre>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
 class PolynomialRegression {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/PolynomialRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/PolynomialRegression.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Stat
 import se.alipsa.matrix.stats.linear.MatrixAlgebra

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/QuantileRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/QuantileRegression.groovy
@@ -156,7 +156,6 @@ import java.math.RoundingMode
  * For multivariate quantile regression, consider using R's quantreg package or Python's statsmodels.
  * The quantile parameter τ must be in the open interval (0, 1).</p>
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class QuantileRegression {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/QuantileRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/QuantileRegression.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.solver.LinearProgramSolver
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/RegressionUtils.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/RegressionUtils.groovy
@@ -8,7 +8,6 @@ import se.alipsa.matrix.stats.linear.SingularMatrixException
 /**
  * Internal helpers for regression diagnostics and standard error calculations.
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class RegressionUtils {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/RegressionUtils.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/RegressionUtils.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.linear.MatrixAlgebra
 import se.alipsa.matrix.stats.linear.SingularMatrixException
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/BrentSolver.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/BrentSolver.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.solver
 
-import groovy.transform.CompileStatic
-
 /**
  * Bracketing Brent-Dekker root solver for one-dimensional continuous functions.
  *
@@ -149,7 +147,6 @@ final class BrentSolver {
     throw new IllegalStateException("Brent solver failed to converge after $maxIterations iterations")
   }
 
-  @CompileStatic
   static class SolverResult {
     /** Root value returned by the solver. */
     double root

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/BrentSolver.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/BrentSolver.groovy
@@ -9,7 +9,6 @@ import groovy.transform.CompileStatic
  * rather than BigDecimal to preserve the algorithm's expected floating-point behavior
  * and avoid allocation inside the iteration loop.</p>
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 final class BrentSolver {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/GoalSeek.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/GoalSeek.groovy
@@ -1,8 +1,5 @@
 package se.alipsa.matrix.stats.solver
 
-
-import groovy.transform.CompileStatic
-
 /**
  * Root-finding utility that mirrors spreadsheet "goal seek" behavior for one-dimensional functions.
  */

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/GoalSeek.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/GoalSeek.groovy
@@ -6,7 +6,6 @@ import groovy.transform.CompileStatic
 /**
  * Root-finding utility that mirrors spreadsheet "goal seek" behavior for one-dimensional functions.
  */
-@CompileStatic
 class GoalSeek {
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/LinearProgramSolver.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/LinearProgramSolver.groovy
@@ -218,7 +218,6 @@ final class LinearProgramSolver {
     negated
   }
 
-  @CompileStatic
   static class Solution {
     /** Optimal point for the original variables. */
     double[] point
@@ -228,7 +227,6 @@ final class LinearProgramSolver {
     int iterations
   }
 
-  @CompileStatic
   private static class PhaseState {
     double[][] tableau
     int[] basis

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/LinearProgramSolver.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/LinearProgramSolver.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.solver
 
-import groovy.transform.CompileStatic
-
 /**
  * Two-phase simplex solver for linear programs in equality form with non-negative variables.
  *
@@ -9,7 +7,6 @@ import groovy.transform.CompileStatic
  * pivots are numerically low-level operations where primitive arrays keep the code fast
  * and predictable while the public stats APIs still expose Groovy-friendly types.</p>
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 final class LinearProgramSolver {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/MultivariateObjective.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/MultivariateObjective.groovy
@@ -8,7 +8,6 @@ import groovy.transform.CompileStatic
  * <p>This low-level solver boundary intentionally uses primitive double arrays to avoid
  * boxing and to preserve parity with the native optimization kernels.</p>
  */
-@CompileStatic
 interface MultivariateObjective {
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/MultivariateObjective.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/MultivariateObjective.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.solver
 
-import groovy.transform.CompileStatic
-
 /**
  * Objective function for multivariate derivative-free optimization.
  *

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/NelderMeadOptimizer.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/NelderMeadOptimizer.groovy
@@ -9,7 +9,6 @@ import groovy.transform.CompileStatic
  * That keeps the implementation close to the standard algorithm and avoids boxing or
  * BigDecimal overhead inside hot optimization loops.</p>
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 final class NelderMeadOptimizer {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/UnivariateObjective.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/UnivariateObjective.groovy
@@ -8,7 +8,6 @@ import groovy.transform.CompileStatic
  * <p>This low-level solver boundary intentionally uses primitive doubles to avoid
  * boxing and to match the native numeric kernels used by the concrete solvers.</p>
  */
-@CompileStatic
 interface UnivariateObjective {
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/UnivariateObjective.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/UnivariateObjective.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.solver
 
-import groovy.transform.CompileStatic
-
 /**
  * Objective function for one-dimensional root-finding.
  *

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Adf.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Adf.groovy
@@ -18,7 +18,6 @@ import se.alipsa.matrix.stats.regression.MultipleLinearRegression
  *
  * Reference: R's tseries::adf.test() and urca::ur.df()
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral', 'VariableName'])
 class Adf {
 
@@ -247,7 +246,6 @@ class Adf {
   /**
    * Result class for the Augmented Dickey-Fuller test.
    */
-  @CompileStatic
   static class AdfResult {
     /** The ADF test statistic (t-statistic for γ coefficient) */
     double statistic

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Adf.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Adf.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.timeseries
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.regression.MultipleLinearRegression
 
 /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/AdfGls.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/AdfGls.groovy
@@ -54,7 +54,6 @@ import se.alipsa.matrix.core.util.Logger
  * <li>Stata's dfuller command with -gls option</li>
  * </ul>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral', 'ParameterName', 'VariableName'])
 class AdfGls {
   private static final Logger log = Logger.getLogger(AdfGls)
@@ -343,7 +342,6 @@ class AdfGls {
   /**
    * Result class for ADF-GLS test.
    */
-  @CompileStatic
   static class AdfGlsResult {
     /** The ADF-GLS test statistic (t-statistic for γ) */
     double statistic

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/AdfGls.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/AdfGls.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.timeseries
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.util.Logger
 
 /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
@@ -61,7 +61,6 @@ import groovy.transform.CompileStatic
  * Scientific Reports, 5, 14750.</li>
  * </ul>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral', 'ParameterName', 'VariableName'])
 class Ccm {
 
@@ -327,7 +326,6 @@ class Ccm {
   /**
    * Helper class for nearest neighbor with distance.
    */
-  @CompileStatic
   private static class NeighborDistance {
     int index
     double distance
@@ -336,7 +334,6 @@ class Ccm {
   /**
    * Result class for CCM test.
    */
-  @CompileStatic
   static class CcmResult {
     /** Cross-map skill: X cross-mapped from Y (if positive and increasing, Y causes X) */
     double[] xmapY

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.timeseries
 
-import groovy.transform.CompileStatic
-
 /**
  * Convergent Cross Mapping (CCM) is a statistical test for detecting causal relationships between variables
  * in dynamical systems. Unlike Granger causality which assumes separable influences, CCM is designed for

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Chow.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Chow.groovy
@@ -57,7 +57,6 @@ import se.alipsa.matrix.stats.distribution.FDistribution
  * <li>Stata's chow command</li>
  * </ul>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral', 'ParameterName', 'VariableName'])
 class Chow {
 
@@ -155,7 +154,6 @@ class Chow {
   /**
    * Result class for Chow test.
    */
-  @CompileStatic
   static class ChowResult {
     /** The Chow F-statistic */
     double statistic

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Chow.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Chow.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.timeseries
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.distribution.FDistribution
 
 /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Df.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Df.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.timeseries
 
-import groovy.transform.CompileStatic
-
 /**
  * The Dickey-Fuller (DF) test is the foundational statistical test for detecting unit roots in time series.
  * A unit root indicates non-stationarity, meaning the series has no tendency to return to a long-run mean

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Df.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Df.groovy
@@ -56,7 +56,6 @@ import groovy.transform.CompileStatic
  * <li>R's tseries package: adf.test() and urca package: ur.df()</li>
  * </ul>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral', 'ParameterName', 'VariableName'])
 class Df {
 
@@ -262,7 +261,6 @@ class Df {
   /**
    * Result class for Dickey-Fuller test.
    */
-  @CompileStatic
   static class DfResult {
     /** The Dickey-Fuller test statistic (t-statistic for γ) */
     double statistic

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/DurbinWatson.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/DurbinWatson.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.timeseries
 
-import groovy.transform.CompileStatic
-
 /**
  * The Durbin–Watson statistic is a test statistic used to detect the presence of autocorrelation at lag 1 in
  * the residuals (prediction errors) from a regression analysis. It is named after James Durbin and Geoffrey Watson.

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/DurbinWatson.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/DurbinWatson.groovy
@@ -22,7 +22,6 @@ import groovy.transform.CompileStatic
  *
  * Reference: R's lmtest::dwtest()
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
 class DurbinWatson {
 
@@ -108,7 +107,6 @@ class DurbinWatson {
   /**
    * Result class for the Durbin-Watson test.
    */
-  @CompileStatic
   static class DurbinWatsonResult {
     /** The Durbin-Watson test statistic */
     double statistic

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Granger.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Granger.groovy
@@ -70,7 +70,6 @@ import se.alipsa.matrix.stats.distribution.FDistribution
  * <li>Stata's vargranger command</li>
  * </ul>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral', 'ParameterName', 'VariableName'])
 class Granger {
   private static final Logger log = Logger.getLogger(Granger)
@@ -229,7 +228,6 @@ class Granger {
   /**
    * Result class for Granger causality test.
    */
-  @CompileStatic
   static class GrangerResult {
     /** The F-statistic */
     double statistic

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Granger.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Granger.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.timeseries
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.util.Logger
 import se.alipsa.matrix.stats.distribution.FDistribution
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
@@ -74,7 +74,6 @@ import se.alipsa.matrix.stats.linear.SingularMatrixException
  * <li>Stata's vecrank command</li>
  * </ul>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral', 'VariableName'])
 class Johansen {
 
@@ -298,7 +297,6 @@ class Johansen {
   /**
    * Result class for Johansen cointegration test.
    */
-  @CompileStatic
   static class JohansenResult {
     /** Eigenvalues (sorted in descending order) */
     double[] eigenvalues
@@ -362,20 +360,17 @@ class Johansen {
     }
   }
 
-  @CompileStatic
   private static class DifferencedData {
     double[][] deltaY
     double[][] laggedY
     int effectiveN
   }
 
-  @CompileStatic
   private static class ResidualMatrices {
     double[][] r0
     double[][] r1
   }
 
-  @CompileStatic
   private static class MomentMatrices {
     double[][] s00
     double[][] s11

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.timeseries
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.linear.MatrixAlgebra
 import se.alipsa.matrix.stats.linear.SingularMatrixException
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Kpss.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Kpss.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.timeseries
 
-import groovy.transform.CompileStatic
-
 /**
  * Kwiatkowski–Phillips–Schmidt–Shin (KPSS) tests are used for testing a null hypothesis that an observable
  * time series is stationary around a deterministic trend (i.e. trend-stationary) against the alternative

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Kpss.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Kpss.groovy
@@ -18,7 +18,6 @@ import groovy.transform.CompileStatic
  *
  * Reference: R's tseries::kpss.test()
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
 class Kpss {
 
@@ -185,7 +184,6 @@ class Kpss {
   /**
    * Result class for the KPSS test.
    */
-  @CompileStatic
   static class KpssResult {
     /** The KPSS test statistic */
     double statistic

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Portmanteau.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Portmanteau.groovy
@@ -17,7 +17,6 @@ import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
  *
  * Reference: Ljung, G. M. and Box, G. E. P. (1978). "On a Measure of Lack of Fit in Time Series Models"
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
 class Portmanteau {
 
@@ -148,7 +147,6 @@ class Portmanteau {
   /**
    * Result class for the Ljung-Box test.
    */
-  @CompileStatic
   static class LjungBoxResult {
     /** The Ljung-Box Q test statistic */
     double statistic

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Portmanteau.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Portmanteau.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.timeseries
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
 
 /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtils.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtils.groovy
@@ -1,6 +1,5 @@
 package se.alipsa.matrix.stats.timeseries
 
-import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 
 import se.alipsa.matrix.core.util.Logger

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtils.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtils.groovy
@@ -10,7 +10,6 @@ import se.alipsa.matrix.core.util.Logger
  * The solving routines support the current time-series callers while adding
  * consistent validation, singularity checks, and diagnostic logging for numerical edge cases.
  */
-@CompileStatic
 @PackageScope
 @SuppressWarnings(['ParameterName'])
 final class TimeSeriesUtils {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TurningPoint.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TurningPoint.groovy
@@ -72,7 +72,6 @@ import se.alipsa.matrix.stats.distribution.NormalDistribution
  * <li>Mood, A. M. (1940). "The Distribution Theory of Runs", Annals of Mathematical Statistics, 11(4), 367-392.</li>
  * </ul>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
 class TurningPoint {
 
@@ -147,7 +146,6 @@ class TurningPoint {
   /**
    * Result class for Turning Point test.
    */
-  @CompileStatic
   static class TurningPointResult {
     /** The Z-statistic (standardized test statistic) */
     double statistic

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TurningPoint.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TurningPoint.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.timeseries
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.distribution.NormalDistribution
 
 /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/UnitRoot.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/UnitRoot.groovy
@@ -88,7 +88,6 @@ import groovy.transform.CompileStatic
  * <li>Enders, W. (2014). Applied Econometric Time Series, 4th Edition, Chapter 4.</li>
  * </ul>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
 class UnitRoot {
 
@@ -152,7 +151,6 @@ class UnitRoot {
   /**
    * Result class containing results from multiple unit root tests.
    */
-  @CompileStatic
   static class UnitRootResult {
     /** Dickey-Fuller test result */
     Df.DfResult dfResult

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/UnitRoot.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/UnitRoot.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.timeseries
 
-import groovy.transform.CompileStatic
-
 /**
  * Comprehensive unit root testing framework that runs multiple complementary tests and synthesizes
  * their results into a unified assessment. Unit roots indicate non-stationarity where shocks have

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Student.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Student.groovy
@@ -37,7 +37,6 @@ import java.math.RoundingMode
  * which does not assume equal variances. For a cleaner API that always uses Welch's t-test,
  * see the {@link Welch} class.</p>
  */
-@CompileStatic
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
 class Student {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Student.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Student.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.ttest
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Stat
 import se.alipsa.matrix.stats.distribution.TDistribution
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/TtestResult.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/TtestResult.groovy
@@ -8,7 +8,6 @@ import java.math.RoundingMode
  * Result object for two-sample t-tests (Student's and Welch's).
  * Contains all relevant statistics from a t-test comparison of two independent samples.
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class TtestResult {
   Integer n1

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/TtestResult.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/TtestResult.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.ttest
 
-import groovy.transform.CompileStatic
-
 import java.math.RoundingMode
 
 /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Welch.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Welch.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.ttest
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Stat
 import se.alipsa.matrix.stats.distribution.TDistribution
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Welch.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Welch.groovy
@@ -18,7 +18,6 @@ import java.math.RoundingMode
  * <p>The test uses the Welch-Satterthwaite equation to compute the degrees of freedom,
  * which may result in non-integer degrees of freedom.</p>
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class Welch {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/util/NumericConversion.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/util/NumericConversion.groovy
@@ -127,6 +127,22 @@ final class NumericConversion {
   }
 
   /**
+   * Convert a significance level to {@code BigDecimal} and validate that it lies in {@code (0, 1)}.
+   *
+   * @param value the source significance level
+   * @param label the label used in validation messages
+   * @return the validated significance level
+   * @since 2.4.0
+   */
+  static BigDecimal toAlpha(Object value, String label = 'alpha') {
+    BigDecimal alpha = toBigDecimal(value, label)
+    if (alpha <= 0 || alpha >= 1) {
+      throw new IllegalArgumentException("${label.capitalize()} must be between 0 and 1, got ${alpha}")
+    }
+    alpha
+  }
+
+  /**
    * Extract a numeric Matrix column as {@code BigDecimal} values.
    *
    * @param matrix the source matrix

--- a/matrix-stats/src/test/groovy/distribution/NormalDistributionTest.groovy
+++ b/matrix-stats/src/test/groovy/distribution/NormalDistributionTest.groovy
@@ -3,8 +3,6 @@ package distribution
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertThrows
 
-import groovy.transform.CompileStatic
-
 import org.apache.commons.math3.distribution.NormalDistribution as ApacheNormalDistribution
 import org.junit.jupiter.api.Test
 
@@ -13,7 +11,6 @@ import se.alipsa.matrix.stats.distribution.NormalDistribution
 /**
  * Reference tests for the native normal distribution implementation.
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class NormalDistributionTest {
 

--- a/matrix-stats/src/test/groovy/linalg/LinalgTest.groovy
+++ b/matrix-stats/src/test/groovy/linalg/LinalgTest.groovy
@@ -1,6 +1,5 @@
 package linalg
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.junit.jupiter.api.Assertions.assertTrue
@@ -122,7 +121,7 @@ class LinalgTest {
 
     def result = Linalg.svd(matrix)
 
-    assertArrayEquals([4.242640687119285d, 2.0d] as double[], result.singularValues, 1e-8)
+    assertVectorEquals([4.242640687119285d, 2.0d] as double[], result.singularValues, 1e-8)
     assertMatrixEquals([
       [3.0d, 1.0d],
       [1.0d, 3.0d],
@@ -245,14 +244,6 @@ class LinalgTest {
       for (int col = 0; col < expected[row].length; col++) {
         assertEquals(expected[row][col], actual[row, col] as double, tolerance, "Mismatch at [${row},${col}]")
       }
-    }
-  }
-
-  private static void assertMatrixEquals(double[][] expected, double[][] actual, double tolerance = TOLERANCE) {
-    assertEquals(expected.length, actual.length)
-    assertEquals(expected[0].length, actual[0].length)
-    for (int row = 0; row < expected.length; row++) {
-      assertArrayEquals(expected[row], actual[row], tolerance, "Mismatch at row ${row}")
     }
   }
 

--- a/matrix-stats/src/test/groovy/linalg/SvdResultTest.groovy
+++ b/matrix-stats/src/test/groovy/linalg/SvdResultTest.groovy
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.stats.linalg.Linalg
 import se.alipsa.matrix.stats.linalg.SvdResult
 
 class SvdResultTest {
@@ -43,6 +44,28 @@ class SvdResultTest {
         []
       )
     }
+  }
+
+  @Test
+  void testReconstructReturnsOriginalMatrix() {
+    Matrix original = Matrix.builder()
+      .columnNames(['c0', 'c1'])
+      .rows([
+        [3.0d, 1.0d],
+        [1.0d, 3.0d],
+      ])
+      .types([Double, Double])
+      .build()
+
+    def svd = Linalg.svd(original)
+    Matrix reconstructed = svd.reconstruct()
+
+    assertEquals(2, reconstructed.rowCount())
+    assertEquals(2, reconstructed.columnCount())
+    assertEquals(3.0d, reconstructed[0, 0] as double, 1e-10)
+    assertEquals(1.0d, reconstructed[0, 1] as double, 1e-10)
+    assertEquals(1.0d, reconstructed[1, 0] as double, 1e-10)
+    assertEquals(3.0d, reconstructed[1, 1] as double, 1e-10)
   }
 
   private static Matrix matrix(List<List<Double>> rows) {

--- a/matrix-stats/src/test/groovy/linalg/SvdResultTest.groovy
+++ b/matrix-stats/src/test/groovy/linalg/SvdResultTest.groovy
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows
 
 import org.junit.jupiter.api.Test
 
+import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.linalg.SvdResult
 
 class SvdResultTest {
@@ -12,35 +13,43 @@ class SvdResultTest {
   @Test
   void testSigmaMatrixShapeAndDiagonal() {
     SvdResult result = new SvdResult(
-      [
+      matrix([
         [1.0d, 0.0d],
         [0.0d, 1.0d],
         [0.0d, 0.0d],
-      ] as double[][],
-      [
+      ]),
+      matrix([
         [1.0d, 0.0d],
         [0.0d, 1.0d],
-      ] as double[][],
-      [5.0d, 2.0d] as double[]
+      ]),
+      [5.0d, 2.0d]
     )
 
-    double[][] sigma = result.sigma()
+    Matrix sigma = result.sigma()
 
-    assertEquals(3, sigma.length)
-    assertEquals(2, sigma[0].length)
-    assertEquals(5.0d, sigma[0][0], 1e-12)
-    assertEquals(2.0d, sigma[1][1], 1e-12)
-    assertEquals(0.0d, sigma[2][0], 1e-12)
+    assertEquals(3, sigma.rowCount())
+    assertEquals(2, sigma.columnCount())
+    assertEquals(5.0d, sigma[0, 0] as double, 1e-12)
+    assertEquals(2.0d, sigma[1, 1] as double, 1e-12)
+    assertEquals(0.0d, sigma[2, 0] as double, 1e-12)
   }
 
   @Test
   void testRejectsEmptySingularValueVector() {
     assertThrows(IllegalArgumentException) {
       new SvdResult(
-        [[1.0d]] as double[][],
-        [[1.0d]] as double[][],
-        [] as double[]
+        matrix([[1.0d]]),
+        matrix([[1.0d]]),
+        []
       )
     }
+  }
+
+  private static Matrix matrix(List<List<Double>> rows) {
+    Matrix.builder()
+      .columnNames((0..<rows[0].size()).collect { "x${it}" })
+      .rows(rows)
+      .types(([Double] * rows[0].size()) as List<Class>)
+      .build()
   }
 }

--- a/matrix-stats/src/test/groovy/normality/AndersonDarlingTest.groovy
+++ b/matrix-stats/src/test/groovy/normality/AndersonDarlingTest.groovy
@@ -50,8 +50,8 @@ class AndersonDarlingTest {
 
     def result = AndersonDarling.testNormality(data)
 
-    assertEquals(0.1558, result.adjustedStatistic, 0.01, 'Adjusted A² statistic')
-    assertEquals(0.9427, result.pValue, 0.05, 'P-value')
+    assertEquals(0.1558, result.adjustedStatistic as double, 0.01, 'Adjusted A² statistic')
+    assertEquals(0.9427, result.pValue as double, 0.05, 'P-value')
   }
 
   @Test
@@ -143,8 +143,8 @@ class AndersonDarlingTest {
 
     def result = AndersonDarling.testNormality(data)
 
-    assertEquals(0.2697, result.adjustedStatistic, 0.01, 'Adjusted A² for standard normal')
-    assertEquals(0.6414, result.pValue, 0.05, 'P-value for standard normal')
+    assertEquals(0.2697, result.adjustedStatistic as double, 0.01, 'Adjusted A² for standard normal')
+    assertEquals(0.6414, result.pValue as double, 0.05, 'P-value for standard normal')
     assertTrue(result.pValue > 0.05, 'Should not reject H0 for standard normal data')
   }
 }

--- a/matrix-stats/src/test/groovy/normality/CramerVonMisesTest.groovy
+++ b/matrix-stats/src/test/groovy/normality/CramerVonMisesTest.groovy
@@ -132,8 +132,8 @@ class CramerVonMisesTest {
     def result05 = CramerVonMises.testNormality(data, 0.05)
     def result01 = CramerVonMises.testNormality(data, 0.01)
 
-    assertEquals(0.05, result05.alpha, TOLERANCE, 'Alpha should be 0.05')
-    assertEquals(0.01, result01.alpha, TOLERANCE, 'Alpha should be 0.01')
+    assertEquals(0.05, result05.alpha as double, TOLERANCE, 'Alpha should be 0.05')
+    assertEquals(0.01, result01.alpha as double, TOLERANCE, 'Alpha should be 0.01')
 
     // Critical values should be different
     assertTrue(result01.criticalValue > result05.criticalValue,
@@ -214,9 +214,9 @@ class CramerVonMisesTest {
 
     def result = CramerVonMises.testNormality(data)
 
-    assertEquals(3.0, result.mean, TOLERANCE, 'Mean should be 3.0')
+    assertEquals(3.0, result.mean as double, TOLERANCE, 'Mean should be 3.0')
     // Sample std dev = sqrt(2.5) ≈ 1.581
-    assertEquals(1.581, result.stdDev, 0.01, 'Std dev should be approximately 1.581')
+    assertEquals(1.581, result.stdDev as double, 0.01, 'Std dev should be approximately 1.581')
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/normality/JarqueBeraTest.groovy
+++ b/matrix-stats/src/test/groovy/normality/JarqueBeraTest.groovy
@@ -1,0 +1,56 @@
+package normality
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+import org.junit.jupiter.api.Test
+
+import se.alipsa.matrix.stats.normality.JarqueBera
+
+class JarqueBeraTest {
+
+  @Test
+  void testNormalLikeSampleProducesBigDecimalScalars() {
+    List<Double> data = [2.3, 3.1, 2.8, 3.5, 2.9, 3.2, 3.0, 2.7, 3.4, 2.6]
+
+    def result = JarqueBera.test(data)
+
+    assertNotNull(result)
+    assertTrue(result.jbStatistic instanceof BigDecimal)
+    assertTrue(result.skewness instanceof BigDecimal)
+    assertTrue(result.kurtosis instanceof BigDecimal)
+    assertTrue(result.excessKurtosis instanceof BigDecimal)
+    assertTrue(result.pValue instanceof BigDecimal)
+    assertEquals(10, result.sampleSize)
+    assertTrue(result.jbStatistic >= 0)
+    assertTrue(result.pValue >= 0 && result.pValue <= 1)
+  }
+
+  @Test
+  void testValidationRejectsInvalidSamples() {
+    assertThrows(IllegalArgumentException) {
+      JarqueBera.test(null)
+    }
+    assertThrows(IllegalArgumentException) {
+      JarqueBera.test([])
+    }
+    assertThrows(IllegalArgumentException) {
+      JarqueBera.test([1.0, 2.0, 3.0])
+    }
+    assertThrows(IllegalArgumentException) {
+      JarqueBera.test([5.0, 5.0, 5.0, 5.0])
+    }
+  }
+
+  @Test
+  void testEvaluateUsesNumericAlphaInput() {
+    List<Double> data = [1.0, 1.1, 1.2, 1.3, 1.4, 2.0, 3.0, 5.0, 10.0, 20.0]
+
+    def result = JarqueBera.test(data)
+
+    assertTrue(result.evaluate(0.05) == (result.pValue < 0.05))
+    assertTrue(result.isNormal(0.05) == (result.pValue >= 0.05))
+  }
+}

--- a/matrix-stats/src/test/groovy/normality/KSquaredTest.groovy
+++ b/matrix-stats/src/test/groovy/normality/KSquaredTest.groovy
@@ -21,7 +21,7 @@ class KSquaredTest {
       2.2, 2.6, 2.85, 3.05, 3.25, 3.55, 3.85, 4.05
     ] as double[]
 
-    def result = KSquared.test(data)
+    def result = KSquared.test(data.toList())
 
     assertNotNull(result, 'Result should not be null')
     assertEquals(24, result.sampleSize, 'Sample size should be 24')
@@ -38,7 +38,7 @@ class KSquaredTest {
       9, 10, 12, 15, 20, 25, 30, 40
     ] as double[]
 
-    def result = KSquared.test(data)
+    def result = KSquared.test(data.toList())
 
     assertNotNull(result, 'Result should not be null')
     assertTrue(result.skewness > 0, 'Should detect positive skewness')
@@ -53,7 +53,7 @@ class KSquaredTest {
       9, 8, 8, 7, 6, 5, 3, 1
     ] as double[]
 
-    def result = KSquared.test(data)
+    def result = KSquared.test(data.toList())
 
     assertNotNull(result, 'Result should not be null')
     assertTrue(result.skewness < 0, 'Should detect negative skewness')
@@ -68,7 +68,7 @@ class KSquaredTest {
       0, 0, 0, 0, 0, 0, 15, 20
     ] as double[]
 
-    def result = KSquared.test(data)
+    def result = KSquared.test(data.toList())
 
     assertNotNull(result, 'Result should not be null')
     assertTrue(result.kurtosis > 3, 'Should detect heavy tails')
@@ -85,7 +85,7 @@ class KSquaredTest {
       17, 18, 19, 20, 21, 22, 23, 24
     ] as double[]
 
-    def result = KSquared.test(data)
+    def result = KSquared.test(data.toList())
 
     assertNotNull(result, 'Result should not be null')
     assertTrue(result.kurtosis < 3, 'Should detect light tails')
@@ -99,14 +99,14 @@ class KSquaredTest {
       2.3, 2.7, 2.9, 3.1, 3.3, 3.6, 3.9, 4.1
     ] as double[]
 
-    def result = KSquared.test(data)
+    def result = KSquared.test(data.toList())
 
     assertNotNull(result.zSkewness, 'Z-score for skewness should be calculated')
     assertNotNull(result.zKurtosis, 'Z-score for kurtosis should be calculated')
 
     // K² should equal sum of squared Z-scores
-    double expected = result.zSkewness * result.zSkewness + result.zKurtosis * result.zKurtosis
-    assertEquals(expected, result.statistic, 0.0001, 'K² should equal sum of Z²')
+    double expected = (result.zSkewness * result.zSkewness + result.zKurtosis * result.zKurtosis) as double
+    assertEquals(expected, result.statistic as double, 0.0001, 'K² should equal sum of Z²')
   }
 
   @Test
@@ -146,19 +146,19 @@ class KSquaredTest {
   void testValidation() {
     // Null data
     assertThrows(IllegalArgumentException) {
-      KSquared.test(null as double[])
+      KSquared.test(null as List<Double>)
     }
 
     // Too small sample
     double[] tooSmall = [1, 2, 3, 4, 5, 6, 7] as double[]
     assertThrows(IllegalArgumentException) {
-      KSquared.test(tooSmall)
+      KSquared.test(tooSmall.toList())
     }
 
     // Zero variance
     double[] constant = [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0] as double[]
     assertThrows(IllegalArgumentException) {
-      KSquared.test(constant)
+      KSquared.test(constant.toList())
     }
 
     // Null matrix
@@ -175,7 +175,7 @@ class KSquaredTest {
       2.3, 2.7, 2.9, 3.1, 3.3, 3.6, 3.9, 4.1
     ] as double[]
 
-    def normalResult = KSquared.test(normalData)
+    def normalResult = KSquared.test(normalData.toList())
     String normalInterp = normalResult.interpret()
 
     assertTrue(normalInterp.contains('Fail to reject H0'), 'Should not reject H0 for normal data')
@@ -187,7 +187,7 @@ class KSquaredTest {
       3, 4, 5, 7, 10, 15, 25, 50
     ] as double[]
 
-    def skewedResult = KSquared.test(skewedData)
+    def skewedResult = KSquared.test(skewedData.toList())
 
     // Skewed data should show departure from normality (check p-value is low)
     if (skewedResult.pValue < 0.05) {
@@ -208,7 +208,7 @@ class KSquaredTest {
       2.3, 2.7, 2.9, 3.1, 3.3, 3.6, 3.9, 4.1
     ] as double[]
 
-    def result = KSquared.test(data)
+    def result = KSquared.test(data.toList())
     String evaluation = result.evaluate()
 
     assertNotNull(evaluation, 'Evaluation should not be null')
@@ -226,7 +226,7 @@ class KSquaredTest {
       2.3, 2.7, 2.9, 3.1, 3.3, 3.6, 3.9, 4.1
     ] as double[]
 
-    def result = KSquared.test(data)
+    def result = KSquared.test(data.toList())
     String str = result
 
     assertTrue(str.contains('D\'Agostino'), 'Should contain test name')
@@ -247,7 +247,7 @@ class KSquaredTest {
     ]
 
     for (double[] data : testData) {
-      def result = KSquared.test(data)
+      def result = KSquared.test(data.toList())
 
       assertTrue(result.pValue >= 0, "p-value should be >= 0, got ${result.pValue}")
       assertTrue(result.pValue <= 1, "p-value should be <= 1, got ${result.pValue}")
@@ -262,7 +262,7 @@ class KSquaredTest {
       10, 15, 20, 25, 30, 40, 50, 60
     ] as double[]
 
-    def result = KSquared.test(data)
+    def result = KSquared.test(data.toList())
 
     String interp01 = result.interpret(0.01)
     String interp05 = result.interpret(0.05)
@@ -278,7 +278,7 @@ class KSquaredTest {
     // Test with minimum allowed sample size (8)
     double[] data = [1, 2, 3, 4, 5, 6, 7, 8] as double[]
 
-    def result = KSquared.test(data)
+    def result = KSquared.test(data.toList())
 
     assertNotNull(result, 'Should handle minimum sample size')
     assertEquals(8, result.sampleSize, 'Sample size should be 8')
@@ -293,7 +293,7 @@ class KSquaredTest {
       data[i] = rnd.nextGaussian() * 2 + 5
     }
 
-    def result = KSquared.test(data)
+    def result = KSquared.test(data.toList())
 
     assertNotNull(result, 'Should handle large samples')
     assertEquals(100, result.sampleSize, 'Sample size should be 100')
@@ -308,10 +308,10 @@ class KSquaredTest {
       4, -3.5, -2.5, -1.5, -0.5, 0.5, 1.5, 2.5, 3.5
     ] as double[]
 
-    def result = KSquared.test(data)
+    def result = KSquared.test(data.toList())
 
     assertNotNull(result, 'Result should not be null')
-    assertTrue(Math.abs(result.skewness) < 0.5, 'Skewness should be near 0 for symmetric data')
+    assertTrue((result.skewness as BigDecimal).abs() < 0.5, 'Skewness should be near 0 for symmetric data')
   }
 
   @Test
@@ -322,7 +322,7 @@ class KSquaredTest {
       15, 20, 30, 40, 50, 60, 70, 80
     ] as double[]
 
-    def skewedResult = KSquared.test(skewed)
+    def skewedResult = KSquared.test(skewed.toList())
     if (skewedResult.pValue < 0.05) {
       String interp = skewedResult.interpret()
       assertTrue(interp.contains('skewness') || interp.contains('tail'),
@@ -339,7 +339,7 @@ class KSquaredTest {
       2.3, 2.7, 2.9, 3.1, 3.3, 3.6, 3.9, 4.1
     ] as double[]
 
-    def result = KSquared.test(data)
+    def result = KSquared.test(data.toList())
 
     assertTrue(result.kurtosis > 0, 'Kurtosis should be calculated')
     // For roughly normal data, kurtosis should be near 3

--- a/matrix-stats/src/test/groovy/normality/KolmogorovSmirnovTest.groovy
+++ b/matrix-stats/src/test/groovy/normality/KolmogorovSmirnovTest.groovy
@@ -34,8 +34,8 @@ class KolmogorovSmirnovTest {
     ApacheNormalDistribution apacheDistribution = new ApacheNormalDistribution(0.0d, 1.0d)
     double[] sample = data as double[]
 
-    assertEquals(apacheTest.kolmogorovSmirnovStatistic(apacheDistribution, sample), result.dStatistic, D_TOLERANCE)
-    assertEquals(apacheTest.kolmogorovSmirnovTest(apacheDistribution, sample), result.pValue, ONE_SAMPLE_P_TOLERANCE)
+    assertEquals(apacheTest.kolmogorovSmirnovStatistic(apacheDistribution, sample), result.dStatistic as double, D_TOLERANCE)
+    assertEquals(apacheTest.kolmogorovSmirnovTest(apacheDistribution, sample), result.pValue as double, ONE_SAMPLE_P_TOLERANCE)
   }
 
   @Test
@@ -48,8 +48,8 @@ class KolmogorovSmirnovTest {
     double[] first = sample1 as double[]
     double[] second = sample2 as double[]
 
-    assertEquals(apacheTest.kolmogorovSmirnovStatistic(first, second), result.dStatistic, D_TOLERANCE)
-    assertEquals(apacheTest.kolmogorovSmirnovTest(first, second), result.pValue, TWO_SAMPLE_P_TOLERANCE)
+    assertEquals(apacheTest.kolmogorovSmirnovStatistic(first, second), result.dStatistic as double, D_TOLERANCE)
+    assertEquals(apacheTest.kolmogorovSmirnovTest(first, second), result.pValue as double, TWO_SAMPLE_P_TOLERANCE)
   }
 
   @Test
@@ -62,8 +62,8 @@ class KolmogorovSmirnovTest {
     double[] first = sample1 as double[]
     double[] second = sample2 as double[]
 
-    assertEquals(apacheTest.kolmogorovSmirnovStatistic(first, second), result.dStatistic, D_TOLERANCE)
-    assertEquals(apacheTest.kolmogorovSmirnovTest(first, second), result.pValue, TWO_SAMPLE_P_TOLERANCE)
+    assertEquals(apacheTest.kolmogorovSmirnovStatistic(first, second), result.dStatistic as double, D_TOLERANCE)
+    assertEquals(apacheTest.kolmogorovSmirnovTest(first, second), result.pValue as double, TWO_SAMPLE_P_TOLERANCE)
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/normality/ShapiroFranciaTest.groovy
+++ b/matrix-stats/src/test/groovy/normality/ShapiroFranciaTest.groovy
@@ -123,12 +123,11 @@ class ShapiroFranciaTest {
   }
 
   @Test
-  void testArrayInput() {
-    // Test with array input
-    double[] data = new double[50]
+  void testListInputFromArraySource() {
+    List<Double> data = []
     Random rnd = new Random(789)
     for (int i = 0; i < 50; i++) {
-      data[i] = rnd.nextGaussian()
+      data << rnd.nextGaussian()
     }
 
     def result = ShapiroFrancia.test(data)

--- a/matrix-stats/src/test/groovy/util/NumericConversionTest.groovy
+++ b/matrix-stats/src/test/groovy/util/NumericConversionTest.groovy
@@ -31,6 +31,21 @@ class NumericConversionTest {
   }
 
   @Test
+  void testToAlphaValidation() {
+    assertEquals(0.05, NumericConversion.toAlpha(0.05))
+
+    IllegalArgumentException low = assertThrows(IllegalArgumentException) {
+      NumericConversion.toAlpha(0.0)
+    }
+    IllegalArgumentException high = assertThrows(IllegalArgumentException) {
+      NumericConversion.toAlpha(1.0)
+    }
+
+    assertTrue(low.message.contains('between 0 and 1'))
+    assertTrue(high.message.contains('between 0 and 1'))
+  }
+
+  @Test
   void testToDoubleArrayForMatrixAndGridColumns() {
     Matrix matrix = Matrix.builder()
       .columnNames(['x', 'y'])


### PR DESCRIPTION
## Summary
- reshape `SvdResult` to expose idiomatic `Matrix` and `List<BigDecimal>` results
- clean up the normality public APIs to use `Number` inputs and `BigDecimal` scalar outputs
- update the section 4 plan record and the focused normality/linalg tests

## Tests
- `./gradlew :matrix-stats:test --tests 'linalg.*' --tests 'normality.*' --tests 'util.NumericConversionTest'`
- `./gradlew :matrix-stats:test --tests 'normality.*'`
- `./gradlew :matrix-stats:codenarcMain :matrix-stats:codenarcTest`