### PR TITLE
Stats idiomatic groovy 4.x

### DIFF
--- a/matrix-stats/build.gradle
+++ b/matrix-stats/build.gradle
@@ -39,6 +39,11 @@ compileGroovy {
   groovyOptions.configurationScript = rootProject.file('config/groovy/compileStatic.groovy')
 }
 
+codenarc {
+  configFile = file('config/codenarc/ruleset.groovy')
+  ignoreFailures = false
+}
+
 dependencies {
   compileOnly libs.groovy
 

--- a/matrix-stats/config/codenarc/ruleset.groovy
+++ b/matrix-stats/config/codenarc/ruleset.groovy
@@ -1,0 +1,116 @@
+ruleset {
+    description 'CodeNarc ruleset for Matrix Stats'
+
+    ruleset('rulesets/basic.xml') {
+        exclude 'EmptyCatchBlock'
+        exclude 'EmptyIfStatement'
+        exclude 'EmptyElseBlock'
+    }
+
+    ruleset('rulesets/braces.xml')
+
+    ruleset('rulesets/design.xml') {
+        exclude 'AbstractClassWithoutAbstractMethod'
+        exclude 'BuilderMethodWithSideEffects'
+        exclude 'Instanceof'
+        exclude 'NestedForLoop'
+        exclude 'PrivateFieldCouldBeFinal'
+    }
+
+    ruleset('rulesets/dry.xml') {
+        exclude 'DuplicateListLiteral'
+        exclude 'DuplicateNumberLiteral'
+        exclude 'DuplicateStringLiteral'
+    }
+
+    ruleset('rulesets/exceptions.xml') {
+        exclude 'CatchException'
+        exclude 'CatchThrowable'
+    }
+
+    ruleset('rulesets/imports.xml') {
+        exclude 'NoWildcardImports'
+    }
+
+    ruleset('rulesets/naming.xml') {
+        'MethodName' {
+            regex = /[a-z][\w]*/
+        }
+        'ClassName' {
+            regex = /[A-Z][\w$]*/
+        }
+        'FieldName' {
+            finalRegex = /[a-z][a-zA-Z0-9]*/
+            staticRegex = /([a-z][a-zA-Z0-9]*|[A-Z][A-Z_0-9]*)/
+            staticFinalRegex = /(log|[A-Z][A-Z_0-9]*)/
+            regex = /[a-z][a-zA-Z0-9]*/
+        }
+        exclude 'FactoryMethodName'
+        exclude 'ConfusingMethodName'
+    }
+
+    ruleset('rulesets/size.xml') {
+        exclude 'CrapMetric'
+        'AbcMetric' {
+            maxMethodAbcScore = 70
+            doNotApplyToFilesMatching = /.*Test\.groovy/
+        }
+        'CyclomaticComplexity' {
+            maxMethodComplexity = 35
+            doNotApplyToFilesMatching = /.*Test\.groovy/
+        }
+        'MethodCount' {
+            maxMethods = 250
+        }
+        'MethodSize' {
+            maxLines = 100
+        }
+        'ClassSize' {
+            maxLines = 1000
+        }
+        'ParameterCount' {
+            maxParameters = 7
+        }
+    }
+
+    ruleset('rulesets/unnecessary.xml') {
+        exclude 'UnnecessaryCollectCall'
+        exclude 'UnnecessaryElseStatement'
+        exclude 'UnnecessaryGString'
+        exclude 'UnnecessaryGetter'
+        exclude 'UnnecessaryObjectReferences'
+        exclude 'UnnecessaryPublicModifier'
+        exclude 'UnnecessaryReturnKeyword'
+        exclude 'UnnecessarySetter'
+    }
+
+    ruleset('rulesets/unused.xml') {
+        exclude 'UnusedVariable'
+    }
+
+    ruleset('rulesets/formatting.xml') {
+        exclude 'BlockEndsWithBlankLine'
+        exclude 'BlockStartsWithBlankLine'
+        exclude 'ClassEndsWithBlankLine'
+        exclude 'ClassStartsWithBlankLine'
+        exclude 'ConsecutiveBlankLines'
+        exclude 'Indentation'
+        exclude 'LineLength'
+        exclude 'SpaceAfterComma'
+        exclude 'SpaceAfterMethodCallName'
+        exclude 'SpaceAfterOpeningBrace'
+        exclude 'SpaceAroundMapEntryColon'
+        exclude 'SpaceAroundOperator'
+        exclude 'SpaceBeforeClosingBrace'
+        exclude 'SpaceInsideParentheses'
+    }
+
+    ruleset('rulesets/comments.xml') {
+        'ClassJavadoc' {
+            doNotApplyToFilesMatching = /.*Test\.groovy/
+        }
+        exclude 'SpaceAfterCommentDelimiter'
+    }
+
+    ruleset('rulesets/groovyism.xml')
+}

--- a/matrix-stats/config/codenarc/ruleset.groovy
+++ b/matrix-stats/config/codenarc/ruleset.groovy
@@ -2,9 +2,6 @@ ruleset {
     description 'CodeNarc ruleset for Matrix Stats'
 
     ruleset('rulesets/basic.xml') {
-        exclude 'EmptyCatchBlock'
-        exclude 'EmptyIfStatement'
-        exclude 'EmptyElseBlock'
     }
 
     ruleset('rulesets/braces.xml')
@@ -80,13 +77,10 @@ ruleset {
         exclude 'UnnecessaryGetter'
         exclude 'UnnecessaryObjectReferences'
         exclude 'UnnecessaryPublicModifier'
-        exclude 'UnnecessaryReturnKeyword'
         exclude 'UnnecessarySetter'
     }
 
-    ruleset('rulesets/unused.xml') {
-        exclude 'UnusedVariable'
-    }
+    ruleset('rulesets/unused.xml')
 
     ruleset('rulesets/formatting.xml') {
         exclude 'BlockEndsWithBlankLine'

--- a/matrix-stats/req/v2.4.0-idiomaticGroovy.md
+++ b/matrix-stats/req/v2.4.0-idiomaticGroovy.md
@@ -419,9 +419,42 @@ Implemented in this slice:
 - Primitive-oriented overloads remain where they are still compatibility bridges or low-level numeric kernels, but user-facing Groovy callers no longer have to provide primitive parameters for these section-4.2 surfaces.
 - Public scalar result fields such as `AnovaResult` and the timeseries result statistics remain intentionally deferred to `4.3`, where the return-value migration to `BigDecimal` is tracked explicitly.
 
-4.3 [ ] Replace public scalar return values with `BigDecimal`.
+4.3 [x] Replace public scalar return values with `BigDecimal`.
 
-4.4 [ ] Replace public primitive vector/matrix outputs with idiomatic Groovy-facing containers.
+Implemented in this slice:
+- Public result scalars now use `BigDecimal` across:
+  - `Anova.AnovaResult`
+  - `contingency.Fisher.FisherResult`
+  - `contingency.ChiSquared.ChiSquaredResult`
+  - `contingency.Boschloo.BoschlooResult`
+  - `contingency.Barnard.BarnardResult`
+  - `contingency.CochranMantelHaenszel.CochranMantelHaenszelResult`
+  - `timeseries.Adf.AdfResult`
+  - `timeseries.AdfGls.AdfGlsResult`
+  - `timeseries.Chow.ChowResult`
+  - `timeseries.Df.DfResult`
+  - `timeseries.DurbinWatson.DurbinWatsonResult`
+  - `timeseries.Granger.GrangerResult`
+  - `timeseries.Kpss.KpssResult`
+  - `timeseries.Portmanteau.LjungBoxResult`
+  - `timeseries.TurningPoint.TurningPointResult`
+- Result-construction sites now convert primitive numeric kernels to `BigDecimal` exactly once at the public result boundary.
+- For degenerate numerical edge cases where the previous primitive API could surface `NaN`, the Groovy-facing result now keeps the public field nullable and formats that state explicitly instead of failing during result construction.
+
+4.4 [x] Replace public primitive vector/matrix outputs with idiomatic Groovy-facing containers.
+
+Implemented in this slice:
+- Public vector and matrix outputs now use immutable Groovy-facing containers across:
+  - `contingency.Fisher.FisherResult.confidenceInterval`
+  - `timeseries.Ccm.CcmResult.xmapY`
+  - `timeseries.Ccm.CcmResult.ymapX`
+  - `timeseries.Ccm.CcmResult.librarySizes`
+  - `timeseries.Johansen.JohansenResult.eigenvalues`
+  - `timeseries.Johansen.JohansenResult.traceStatistics`
+  - `timeseries.Johansen.JohansenResult.criticalValues5pct`
+  - `timeseries.Portmanteau.LjungBoxResult.autocorrelations`
+- Result methods and tests were updated to use Groovy collection semantics (`size()`, list indexing, `collect`) instead of primitive array assumptions.
+- `Ccm` correlation outputs intentionally preserve `NaN` entries as `Double.NaN` within a `List<Number>` when the underlying primitive kernel yields non-finite cross-map skill values.
 
 4.5 [ ] For each hotspot identified in PR 1, benchmark the idiomatic Groovy-facing path against a Java primitive utility.
 - Candidate hotspots:
@@ -466,6 +499,10 @@ Implemented in this slice:
 4.8.4 [x] Verification for the section 4.2 public-parameter cleanup slice
 - Run:
   - `./gradlew :matrix-stats:spotlessApply :matrix-stats:test --tests 'AnovaTest' --tests 'contingency.*' --tests 'formula.SplineBasisTest' --tests 'regression.*' --tests 'solver.*' --tests 'StatUtilsTest' --tests 'KMeansPlusPlusTest' :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
+
+4.8.5 [x] Verification for the section 4.3 and 4.4 result-surface migration slice
+- Run:
+  - `./gradlew :matrix-stats:test --tests 'AnovaTest' --tests 'contingency.*' --tests 'timeseries.*' :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
 
 ### 5. Final Consistency and Full Verification PR
 

--- a/matrix-stats/req/v2.4.0-idiomaticGroovy.md
+++ b/matrix-stats/req/v2.4.0-idiomaticGroovy.md
@@ -471,10 +471,37 @@ Implemented in this slice:
   - `NelderMeadOptimizer.minimize(List, List)` avg `24.68ms` vs primitive `17.32ms`
   - `timeseries list normalization + fitOLS` avg `88.04ms` vs primitive `9.09ms`
 
-4.6 [ ] For each area benchmarked, decide explicitly whether to:
+4.6 [x] For each area benchmarked, decide explicitly whether to:
 - use only the idiomatic Groovy implementation
 - keep an idiomatic Groovy public wrapper over a Java primitive utility
 - defer deeper internal cleanup if the algorithmic risk is too high for the current PR
+
+Decision record for the section-4.5 hotspots:
+
+- `linalg`
+  - Decision: defer deeper internal cleanup for `Linalg.svd(Matrix)` in this PR.
+  - Reason: the benchmark compared the full public `SvdResult` construction path against direct primitive singular-value extraction from EJML, so it materially overstates Groovy overhead for a like-for-like internal-kernel decision. `Linalg` already delegates its numeric decomposition work to EJML (Java), and a deeper result-shaping optimization would be a separate design change rather than a small primitive-kernel extraction.
+- `regression`
+  - Decision: keep the idiomatic Groovy public API and move the retained dense least-squares kernel into a shared Java utility.
+  - Implemented:
+    - `MultipleLinearRegression` now routes its normal-equation solve and residual/standard-error computation through `se.alipsa.matrix.stats.util.LeastSquaresKernel`.
+  - Reason: the benchmark gap for `MultipleLinearRegression(List, List)` versus the primitive constructor was large enough to justify extracting the hot floating-point loops out of Groovy while preserving the list-based public constructor and `BigDecimal`-friendly accessors.
+- `solver/BrentSolver`
+  - Decision: use only the current idiomatic Groovy-facing implementation.
+  - Reason: the measured gap between the `Number` overload and the primitive overload was small relative to the absolute runtime, and the current implementation is already a compact, low-risk primitive kernel with a thin Groovy-facing wrapper.
+- `solver/LinearProgramSolver`
+  - Decision: defer deeper internal cleanup for this PR.
+  - Reason: the benchmark shows a real gap, but the current simplex implementation is algorithmically denser and riskier to migrate than the regression/timeseries kernels. The public Groovy-facing API is already in place, so the deeper Java-kernel extraction is deferred to a dedicated follow-up.
+- `solver/NelderMeadOptimizer`
+  - Decision: use only the current idiomatic Groovy-facing implementation.
+  - Reason: the measured gap between list and primitive overloads was modest, and moving the simplex state machine into Java would add maintenance complexity without enough demonstrated benefit in this PR.
+- `timeseries`
+  - Decision: keep the idiomatic Groovy package API and move the retained dense least-squares kernel into a shared Java utility.
+  - Implemented:
+    - `TimeSeriesUtils.fitOLS(...)`
+    - `TimeSeriesUtils.calculateRSS(...)`
+    - both now delegate to `se.alipsa.matrix.stats.util.LeastSquaresKernel`.
+  - Reason: the benchmark gap for list normalization plus OLS was large enough to justify moving the hot least-squares loops into Java, while leaving the package-level Groovy helpers and caller-facing result surfaces unchanged.
 
 4.7 [ ] Add output-equivalence tests for every retained Java utility path.
 
@@ -514,6 +541,10 @@ Implemented in this slice:
 - Run:
   - `./gradlew :matrix-stats:test --tests 'se.alipsa.matrix.stats.timeseries.Section45BenchmarkTest' :matrix-stats:codenarcTest`
   - `./gradlew :matrix-stats:codenarcMain`
+
+4.8.7 [x] Verification for the section 4.6 hotspot-decision slice
+- Run:
+  - `./gradlew :matrix-stats:spotlessApply :matrix-stats:test --tests 'regression.MultipleLinearRegressionTest' --tests 'se.alipsa.matrix.stats.timeseries.TimeSeriesUtilsTest' --tests 'util.LeastSquaresKernelTest' --tests 'se.alipsa.matrix.stats.timeseries.Section45BenchmarkTest' :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
 
 ### 5. Final Consistency and Full Verification PR
 

--- a/matrix-stats/req/v2.4.0-idiomaticGroovy.md
+++ b/matrix-stats/req/v2.4.0-idiomaticGroovy.md
@@ -370,7 +370,7 @@ Current progress in this PR slice:
   - `matrix-stats/src/test/groovy/distribution/HypergeometricDistributionTest.groovy`
   - `matrix-stats/src/test/groovy/distribution/TDistributionTest.groovy`
 
-4.1 [ ] Clean up the higher-risk public API surfaces together so the migration pattern stays consistent across the numerically dense packages.
+4.1 [x] Clean up the higher-risk public API surfaces together so the migration pattern stays consistent across the numerically dense packages.
 - `regression`
 - `solver`
 - `timeseries`
@@ -378,6 +378,22 @@ Current progress in this PR slice:
 - `distribution`
 - `cluster`
 - any remaining high-risk `linalg` scalar or decomposition APIs
+
+Implemented in this slice:
+- `regression`
+  - `MultipleLinearRegression` now accepts Groovy-facing list inputs and exposes `BigDecimal`-friendly scalar/vector accessors.
+- `solver`
+  - `BrentSolver`, `LinearProgramSolver`, and `NelderMeadOptimizer` now expose `Number`/list-based entry points plus `BigDecimal`-friendly result accessors.
+- `timeseries`
+  - `Ccm` now accepts list inputs and exposes Groovy-friendly result vectors.
+  - `Johansen` now accepts `List<Number>` series alongside primitive arrays and exposes BigDecimal-backed result accessors.
+  - `AdfGls`, `Df`, `Chow`, `Granger`, `TurningPoint`, `Portmanteau`, and `UnitRoot` now use `Number` for public significance-level parameters.
+- `distribution`
+  - `ContinuousDistribution` exposes a `Number`/`BigDecimal`-friendly cumulative-probability contract, with a temporary primitive bridge retained for compatibility.
+  - `SpecialFunctions` exposes `Number`-based overloads for the public incomplete beta/gamma entry points.
+- `cluster`
+  - `ClusteredPoint`, `GroupEstimator`, and `KMeansPlusPlus` now expose Groovy-facing list-based inputs and BigDecimal-friendly outputs.
+- `normality` and the remaining high-risk `linalg` decomposition surface were completed in earlier section 4 sub-slices (`4.0.1` to `4.0.5`) and are part of the now-consistent section-4 migration pattern.
 
 4.2 [ ] Replace public primitive parameters with idiomatic Groovy-facing inputs.
 
@@ -420,6 +436,10 @@ Current progress in this PR slice:
 - Run:
   - `./gradlew :matrix-stats:test --tests 'normality.*'`
   - `./gradlew :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
+
+4.8.3 [x] Verification for the section 4.1 high-risk public API cleanup slice
+- Run:
+  - `./gradlew :matrix-stats:spotlessApply :matrix-stats:test --tests 'regression.*' --tests 'solver.*' --tests 'timeseries.*' --tests 'normality.*' --tests 'distribution.*' --tests 'KMeansPlusPlusTest' :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
 
 ### 5. Final Consistency and Full Verification PR
 

--- a/matrix-stats/req/v2.4.0-idiomaticGroovy.md
+++ b/matrix-stats/req/v2.4.0-idiomaticGroovy.md
@@ -353,6 +353,23 @@ Current progress in this PR slice:
   - `matrix-stats/src/test/groovy/normality/ShapiroFranciaTest.groovy`
   - `matrix-stats/src/test/groovy/util/NumericConversionTest.groovy`
 
+4.0.5 [x] Expand the public distribution facade toward idiomatic Groovy-facing overloads without forcing the whole remaining section 4 surface closed prematurely.
+- Updated:
+  - `FDistribution`
+  - `NormalDistribution`
+  - `ChiSquaredDistribution`
+  - `HypergeometricDistribution`
+  - `TDistribution`
+- Added public `Number`/`BigDecimal`-friendly overloads for user-facing probability and quantile entry points.
+- Added idiomatic list-based ANOVA and t-test entry points where the old surface still leaned on primitive arrays.
+- Kept the older primitive-oriented entry points available during the transition so the remaining section 4 packages can migrate incrementally.
+- Updated focused tests:
+  - `matrix-stats/src/test/groovy/distribution/FDistributionTest.groovy`
+  - `matrix-stats/src/test/groovy/distribution/NormalDistributionTest.groovy`
+  - `matrix-stats/src/test/groovy/distribution/ChiSquaredDistributionTest.groovy`
+  - `matrix-stats/src/test/groovy/distribution/HypergeometricDistributionTest.groovy`
+  - `matrix-stats/src/test/groovy/distribution/TDistributionTest.groovy`
+
 4.1 [ ] Clean up the higher-risk public API surfaces together so the migration pattern stays consistent across the numerically dense packages.
 - `regression`
 - `solver`

--- a/matrix-stats/req/v2.4.0-idiomaticGroovy.md
+++ b/matrix-stats/req/v2.4.0-idiomaticGroovy.md
@@ -528,7 +528,7 @@ Implemented:
   - dense-array to `Matrix` / `Grid<BigDecimal>` result shaping
   - dense-vector to `List<BigDecimal>` conversion
 
-4.8 [ ] Verification
+4.8 [x] Verification
 - Run:
   - `./gradlew :matrix-stats:test --tests 'regression.*' --tests 'rootfinding.*' --tests 'timeseries.*' --tests 'normality.*' --tests 'distribution.*' --tests 'cluster.*'`
   - `./gradlew :matrix-stats:spotlessApply :matrix-stats:test :matrix-stats:codenarcMain :matrix-stats:codenarcTest`

--- a/matrix-stats/req/v2.4.0-idiomaticGroovy.md
+++ b/matrix-stats/req/v2.4.0-idiomaticGroovy.md
@@ -395,7 +395,28 @@ Implemented in this slice:
   - `ClusteredPoint`, `GroupEstimator`, and `KMeansPlusPlus` now expose Groovy-facing list-based inputs and BigDecimal-friendly outputs.
 - `normality` and the remaining high-risk `linalg` decomposition surface were completed in earlier section 4 sub-slices (`4.0.1` to `4.0.5`) and are part of the now-consistent section-4 migration pattern.
 
-4.2 [ ] Replace public primitive parameters with idiomatic Groovy-facing inputs.
+4.2 [x] Replace public primitive parameters with idiomatic Groovy-facing inputs.
+
+Implemented in this slice:
+- Result/evaluation APIs now accept Groovy-facing `Number` alpha inputs across:
+  - `Anova.AnovaResult`
+  - `contingency.Fisher.FisherResult`
+  - `contingency.ChiSquared.ChiSquaredResult`
+  - `contingency.Boschloo.BoschlooResult`
+  - `contingency.Barnard.BarnardResult`
+  - `contingency.CochranMantelHaenszel.CochranMantelHaenszelResult`
+- Regression and clustering option surfaces now accept `Number` inputs for:
+  - `LoessOptions(span)`
+  - `GamOptions(lambda)`
+  - `KMeansPlusPlus.Builder.epsilon(...)`
+- Utility and formula helpers now expose Groovy-facing collection inputs for:
+  - `StatUtils.mean(...)`
+  - `StatUtils.variance(...)`
+  - `SplineBasisExpander.naturalCubicSplineBasis(...)`
+- Low-level solver functional interfaces now include Groovy-facing bridges while retaining primitive kernels:
+  - `UnivariateObjective.value(Number)`
+  - `MultivariateObjective.value(List<Number>)`
+- Primitive-oriented overloads remain where they are still compatibility bridges or low-level numeric kernels, but user-facing Groovy callers no longer have to provide primitive parameters for these section-4.2 surfaces.
 
 4.3 [ ] Replace public scalar return values with `BigDecimal`.
 
@@ -440,6 +461,10 @@ Implemented in this slice:
 4.8.3 [x] Verification for the section 4.1 high-risk public API cleanup slice
 - Run:
   - `./gradlew :matrix-stats:spotlessApply :matrix-stats:test --tests 'regression.*' --tests 'solver.*' --tests 'timeseries.*' --tests 'normality.*' --tests 'distribution.*' --tests 'KMeansPlusPlusTest' :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
+
+4.8.4 [x] Verification for the section 4.2 public-parameter cleanup slice
+- Run:
+  - `./gradlew :matrix-stats:spotlessApply :matrix-stats:test --tests 'AnovaTest' --tests 'contingency.*' --tests 'formula.SplineBasisTest' --tests 'regression.*' --tests 'solver.*' --tests 'StatUtilsTest' --tests 'KMeansPlusPlusTest' :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
 
 ### 5. Final Consistency and Full Verification PR
 

--- a/matrix-stats/req/v2.4.0-idiomaticGroovy.md
+++ b/matrix-stats/req/v2.4.0-idiomaticGroovy.md
@@ -456,14 +456,20 @@ Implemented in this slice:
 - Result methods and tests were updated to use Groovy collection semantics (`size()`, list indexing, `collect`) instead of primitive array assumptions.
 - `Ccm` correlation outputs intentionally preserve `NaN` entries as `Double.NaN` within a `List<Number>` when the underlying primitive kernel yields non-finite cross-map skill values.
 
-4.5 [ ] For each hotspot identified in PR 1, benchmark the idiomatic Groovy-facing path against a Java primitive utility.
-- Candidate hotspots:
-  - matrix decompositions
-  - regression fitting
-  - quantile regression / LP solving
-  - time-series matrix helpers
-  - distribution/normality approximation kernels
-  - clustering distance/update loops
+4.5 [x] For each hotspot identified in PR 1, benchmark the idiomatic Groovy-facing path against a Java primitive utility.
+- Added `se.alipsa.matrix.stats.timeseries.Section45BenchmarkTest` to benchmark the initial hotspot areas identified in `1.5`:
+  - `linalg`: `Linalg.svd(Matrix)` against direct primitive EJML SVD
+  - `regression`: `MultipleLinearRegression(List, List)` against `MultipleLinearRegression(double[], double[][])`
+  - `solver`: `BrentSolver.solve(Number...)`, `LinearProgramSolver.minimize(List, List, List)`, and `NelderMeadOptimizer.minimize(List, List)` against their primitive overloads
+  - `timeseries`: list normalization plus `TimeSeriesUtils.fitOLS(...)` against direct primitive `TimeSeriesUtils.fitOLS(...)`
+- The benchmark tests are informational only: they warm up, assert output equivalence, and log average/min/max timings without brittle pass/fail thresholds.
+- Local snapshot from `4.8.6` on the development machine:
+  - `linalg.svd(Matrix)` avg `150.93ms` vs primitive `6.12ms`
+  - `MultipleLinearRegression(List, List)` avg `126.82ms` vs primitive `13.31ms`
+  - `BrentSolver.solve(Number...)` avg `7.79ms` vs primitive `4.02ms`
+  - `LinearProgramSolver.minimize(List, List, List)` avg `32.36ms` vs primitive `13.02ms`
+  - `NelderMeadOptimizer.minimize(List, List)` avg `24.68ms` vs primitive `17.32ms`
+  - `timeseries list normalization + fitOLS` avg `88.04ms` vs primitive `9.09ms`
 
 4.6 [ ] For each area benchmarked, decide explicitly whether to:
 - use only the idiomatic Groovy implementation
@@ -503,6 +509,11 @@ Implemented in this slice:
 4.8.5 [x] Verification for the section 4.3 and 4.4 result-surface migration slice
 - Run:
   - `./gradlew :matrix-stats:test --tests 'AnovaTest' --tests 'contingency.*' --tests 'timeseries.*' :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
+
+4.8.6 [x] Verification for the section 4.5 benchmark slice
+- Run:
+  - `./gradlew :matrix-stats:test --tests 'se.alipsa.matrix.stats.timeseries.Section45BenchmarkTest' :matrix-stats:codenarcTest`
+  - `./gradlew :matrix-stats:codenarcMain`
 
 ### 5. Final Consistency and Full Verification PR
 

--- a/matrix-stats/req/v2.4.0-idiomaticGroovy.md
+++ b/matrix-stats/req/v2.4.0-idiomaticGroovy.md
@@ -503,12 +503,30 @@ Decision record for the section-4.5 hotspots:
     - both now delegate to `se.alipsa.matrix.stats.util.LeastSquaresKernel`.
   - Reason: the benchmark gap for list normalization plus OLS was large enough to justify moving the hot least-squares loops into Java, while leaving the package-level Groovy helpers and caller-facing result surfaces unchanged.
 
-4.7 [ ] Add output-equivalence tests for every retained Java utility path.
+4.7 [x] Add output-equivalence tests for every retained Java utility path.
 
-4.7.1 [ ] Remove or simplify any remaining adapter classes whose primitive bridge methods have become pure delegation only.
+Implemented:
+- Added explicit output-equivalence coverage for the retained section-4.6 Java utility path in:
+  - `matrix-stats/src/test/groovy/regression/MultipleLinearRegressionTest.groovy`
+  - `matrix-stats/src/test/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtilsTest.groovy`
+- Coverage now verifies:
+  - `MultipleLinearRegression(List, List)` matches `LeastSquaresKernel.fitMultipleLinearRegression(...)`
+  - `TimeSeriesUtils.fitOLS(...)` matches `LeastSquaresKernel.fitOls(...)`
+  - `TimeSeriesUtils.calculateRSS(...)` matches `LeastSquaresKernel.calculateResidualSumOfSquares(...)`
+
+4.7.1 [x] Remove or simplify any remaining adapter classes whose primitive bridge methods have become pure delegation only.
 - The target state after PRs 3-4 is:
   - no permanent adapter layer whose only job is to forward `toDoubleArray(...)` calls
   - adapter classes kept only where they still own real responsibilities
+
+Implemented:
+- Removed the pure `Matrix`/`Grid` `toDoubleArray(...)` pass-through methods from `LinalgAdapters`.
+- Updated `Linalg` and `SvdResult` to call `NumericConversion.toDoubleArray(...)` directly for `Matrix`-based and `Grid`-based dense extraction.
+- `LinalgAdapters` now remains responsible only for linalg-specific concerns that still add behavior:
+  - EJML `SimpleMatrix` conversion
+  - synthetic column naming
+  - dense-array to `Matrix` / `Grid<BigDecimal>` result shaping
+  - dense-vector to `List<BigDecimal>` conversion
 
 4.8 [ ] Verification
 - Run:
@@ -545,6 +563,10 @@ Decision record for the section-4.5 hotspots:
 4.8.7 [x] Verification for the section 4.6 hotspot-decision slice
 - Run:
   - `./gradlew :matrix-stats:spotlessApply :matrix-stats:test --tests 'regression.MultipleLinearRegressionTest' --tests 'se.alipsa.matrix.stats.timeseries.TimeSeriesUtilsTest' --tests 'util.LeastSquaresKernelTest' --tests 'se.alipsa.matrix.stats.timeseries.Section45BenchmarkTest' :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
+
+4.8.8 [x] Verification for the section 4.7 equivalence and adapter-cleanup slice
+- Run:
+  - `./gradlew :matrix-stats:spotlessApply :matrix-stats:test --tests 'regression.MultipleLinearRegressionTest' --tests 'util.LeastSquaresKernelTest' --tests 'se.alipsa.matrix.stats.timeseries.TimeSeriesUtilsTest' --tests 'linalg.*' :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
 
 ### 5. Final Consistency and Full Verification PR
 

--- a/matrix-stats/req/v2.4.0-idiomaticGroovy.md
+++ b/matrix-stats/req/v2.4.0-idiomaticGroovy.md
@@ -417,6 +417,7 @@ Implemented in this slice:
   - `UnivariateObjective.value(Number)`
   - `MultivariateObjective.value(List<Number>)`
 - Primitive-oriented overloads remain where they are still compatibility bridges or low-level numeric kernels, but user-facing Groovy callers no longer have to provide primitive parameters for these section-4.2 surfaces.
+- Public scalar result fields such as `AnovaResult` and the timeseries result statistics remain intentionally deferred to `4.3`, where the return-value migration to `BigDecimal` is tracked explicitly.
 
 4.3 [ ] Replace public scalar return values with `BigDecimal`.
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Accuracy.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Accuracy.groovy
@@ -58,7 +58,7 @@ class Accuracy {
       def pred = predictions[i] as BigDecimal
       sae += (act - pred).abs()
     }
-    return sae / N
+    sae / N
   }
 
   /**
@@ -80,7 +80,7 @@ class Accuracy {
       def pred = predictions[i] as BigDecimal
       sse += (act - pred)**2
     }
-    return sse / N
+    sse / N
   }
 
   /**
@@ -94,7 +94,7 @@ class Accuracy {
    * @return Root mean squared error
    */
   static BigDecimal rmse(List actuals, List predictions) {
-    return mse(actuals, predictions).sqrt(PRECISION)
+    mse(actuals, predictions).sqrt(PRECISION)
   }
 
   /**
@@ -119,7 +119,7 @@ class Accuracy {
       def pred = predictions[i] as BigDecimal
       m += ((act - pred) / act).abs() / N
     }
-    return m
+    m
   }
 
   /**
@@ -145,7 +145,7 @@ class Accuracy {
         s += numerator / denominator
       }
     }
-    return s / N
+    s / N
   }
 
   /**
@@ -168,7 +168,7 @@ class Accuracy {
       def pred = predictions[i] as BigDecimal
       sumError += (pred - act)
     }
-    return sumError / N
+    sumError / N
   }
 
   /**
@@ -193,7 +193,7 @@ class Accuracy {
         maxErr = err
       }
     }
-    return maxErr
+    maxErr
   }
 
   /**
@@ -215,7 +215,7 @@ class Accuracy {
       def pred = predictions[i] as BigDecimal
       errors << (act - pred).abs()
     }
-    return Stat.median(errors)
+    Stat.median(errors)
   }
 
   /**
@@ -248,7 +248,7 @@ class Accuracy {
       return 1.0G  // Perfect fit if all actuals are the same
     }
 
-    return 1 - (ssRes / ssTot)
+    1 - (ssRes / ssTot)
   }
 
   private static void validatePredictionInputs(List actuals, List predictions) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Anova.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Anova.groovy
@@ -2,6 +2,7 @@ package se.alipsa.matrix.stats
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.distribution.FDistribution
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * Analysis of variance (ANOVA) is a collection of statistical models and their associated estimation
@@ -50,8 +51,8 @@ class Anova {
       return "pValue: ${pValue}, fValue: ${fValue}"
     }
 
-    boolean evaluate(double alpha = 0.05) {
-      return pValue < alpha
+    boolean evaluate(Number alpha = 0.05) {
+      pValue < NumericConversion.toAlpha(alpha)
     }
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Anova.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Anova.groovy
@@ -38,14 +38,14 @@ class Anova {
       categoryData << values
     }
 
-    result.fValue = FDistribution.oneWayAnovaFValue(categoryData) as Double
-    result.pValue = FDistribution.oneWayAnovaPValue(categoryData) as Double
+    result.fValue = FDistribution.oneWayAnovaFValue(categoryData)
+    result.pValue = FDistribution.oneWayAnovaPValue(categoryData)
     return result
   }
 
   static class AnovaResult {
-    Double pValue
-    Double fValue
+    BigDecimal pValue
+    BigDecimal fValue
 
     String toString() {
       return "pValue: ${pValue}, fValue: ${fValue}"

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Anova.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Anova.groovy
@@ -1,6 +1,5 @@
 package se.alipsa.matrix.stats
 
-import se.alipsa.matrix.core.ListConverter
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.distribution.FDistribution
 
@@ -26,7 +25,6 @@ class Anova {
 
   /**
    * Implements one-way ANOVA (analysis of variance) statistics.
-   *
    */
   static AnovaResult aov(Map<String, List<? extends Number>> data) {
     if (data.size() < 2) {
@@ -34,13 +32,13 @@ class Anova {
     }
     def result = new AnovaResult()
     // Use native FDistribution for ANOVA calculations
-    List<double[]> categoryData = []
+    List<List<? extends Number>> categoryData = []
     data.each { String key, List<? extends Number> values ->
-      categoryData.add(ListConverter.toDoubleArray(values))
+      categoryData << values
     }
 
-    result.fValue = FDistribution.oneWayAnovaFValue(categoryData)
-    result.pValue = FDistribution.oneWayAnovaPValue(categoryData)
+    result.fValue = FDistribution.oneWayAnovaFValue(categoryData) as Double
+    result.pValue = FDistribution.oneWayAnovaPValue(categoryData) as Double
     return result
   }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Anova.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Anova.groovy
@@ -38,8 +38,8 @@ class Anova {
       categoryData << values
     }
 
-    result.fValue = FDistribution.oneWayAnovaFValue(categoryData)
-    result.pValue = FDistribution.oneWayAnovaPValue(categoryData)
+    result.fValue = FDistribution.oneWayAnovaFValueFromLists(categoryData)
+    result.pValue = FDistribution.oneWayAnovaPValueFromLists(categoryData)
     result
   }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Anova.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Anova.groovy
@@ -21,7 +21,7 @@ class Anova {
       String colName = it
       d.put(colName, data[colName] as List<? extends Number>)
     }
-    return aov(d)
+    aov(d)
   }
 
   /**
@@ -40,7 +40,7 @@ class Anova {
 
     result.fValue = FDistribution.oneWayAnovaFValue(categoryData)
     result.pValue = FDistribution.oneWayAnovaPValue(categoryData)
-    return result
+    result
   }
 
   static class AnovaResult {
@@ -48,7 +48,7 @@ class Anova {
     BigDecimal fValue
 
     String toString() {
-      return "pValue: ${pValue}, fValue: ${fValue}"
+      "pValue: ${pValue}, fValue: ${fValue}"
     }
 
     boolean evaluate(Number alpha = 0.05) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Correlation.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Correlation.groovy
@@ -96,8 +96,8 @@ class Correlation {
     BigDecimal sumY2 = 0
     int size = numbersX.size()
 
-    def final itX = numbersX.iterator()
-    def final itY = numbersY.iterator()
+    final Iterator<? extends Number> itX = numbersX.iterator()
+    final Iterator<? extends Number> itY = numbersY.iterator()
     for (int i = 0; i < size; i++) {
       BigDecimal x = itX.next() as BigDecimal
       BigDecimal y = itY.next() as BigDecimal

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Correlation.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Correlation.groovy
@@ -115,7 +115,7 @@ class Correlation {
     }
     BigDecimal bottom = bottomSquared.sqrt()
     BigDecimal top = size * sumXY - sumX * sumY
-    return top / bottom
+    top / bottom
   }
 
   /**
@@ -132,7 +132,7 @@ class Correlation {
 
     List<BigDecimal> ranksX = rank(numbersX)
     List<BigDecimal> ranksY = rank(numbersY)
-    return corPearson(ranksX, ranksY)
+    corPearson(ranksX, ranksY)
   }
 
   /**
@@ -155,7 +155,7 @@ class Correlation {
 
     Arrays.sort(pairs, (p1, p2) -> {
       int compareKey = compare(p1.getFirst(), p2.getFirst())
-      return compareKey != 0 ? compareKey : compare(p1.getSecond(), p2.getSecond())
+      compareKey != 0 ? compareKey : compare(p1.getSecond(), p2.getSecond())
     })
 
     long tiedXPairs = 0
@@ -212,7 +212,7 @@ class Correlation {
 
     final long concordantMinusDiscordant = numPairs - tiedXPairs - tiedYPairs + tiedXYPairs - 2 * swaps
     final BigDecimal nonTiedPairsMultiplied = (numPairs - tiedXPairs) * (numPairs - tiedYPairs)
-    return concordantMinusDiscordant / nonTiedPairsMultiplied.sqrt()
+    concordantMinusDiscordant / nonTiedPairsMultiplied.sqrt()
   }
 
   /**
@@ -252,7 +252,7 @@ class Correlation {
       i = j + 1
     }
 
-    return ranks.toList()
+    ranks.toList()
   }
 
   private static int compare(Number x, Number y) {
@@ -262,7 +262,7 @@ class Correlation {
     if (x < y) {
       return -1
     }
-    return 1
+    1
   }
 
   /**
@@ -273,7 +273,7 @@ class Correlation {
    * @return the sum of the number from 1 to n
    */
   private static long sumN(long n) {
-    return (long)(n * (n + 1) / 2)
+    (long)(n * (n + 1) / 2)
   }
 
   private static long mergeSegment(BigDecimalPair[] pairs, BigDecimalPair[] pairsDestination, int offset, int segmentSize, int n) {
@@ -291,7 +291,7 @@ class Correlation {
       j = selection.nextJ
       swaps += selection.swaps
     }
-    return swaps
+    swaps
   }
 
   private static MergeSelection selectNextPair(BigDecimalPair[] pairs, int i, int iEnd, int j, int jEnd) {
@@ -304,7 +304,7 @@ class Correlation {
     if (compare(pairs[i].getSecond(), pairs[j].getSecond()) <= 0) {
       return new MergeSelection(pair: pairs[i], nextI: i + 1, nextJ: j, swaps: 0)
     }
-    return new MergeSelection(pair: pairs[j], nextI: i, nextJ: j + 1, swaps: iEnd - i)
+    new MergeSelection(pair: pairs[j], nextI: i, nextJ: j + 1, swaps: iEnd - i)
   }
 
   /**
@@ -349,12 +349,12 @@ class Correlation {
 
     /** @return the first value.  */
     BigDecimal getFirst() {
-      return first
+      first
     }
 
     /** @return the second value.  */
     BigDecimal getSecond() {
-      return second
+      second
     }
 
   }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Ellipse.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Ellipse.groovy
@@ -129,6 +129,6 @@ class Ellipse {
       ellipseY << ((ry + meanY) as BigDecimal)
     }
 
-    return new EllipseData(ellipseX, ellipseY)
+    new EllipseData(ellipseX, ellipseY)
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
@@ -16,7 +16,6 @@ import java.math.RoundingMode
  *   <li>Mean normalization, X´ = ( X - μ ) / ( max(X) - min(X) )</li>
  *   <li>Standard deviation normalization (Z score), Z = ( X<sub>i</sub> - μ ) / σ</li>
  * </ol>
- *
  */
 class Normalize {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
@@ -42,14 +42,14 @@ class Normalize {
       return convertToType(bd, x)
     }
 
-    return convertToType(logResult, x)
+    convertToType(logResult, x)
   }
 
   /**
    * Apply logarithmic normalization to an array of values.
    */
   static <T extends Number> List<T> logNorm(T[] values, int... decimals) {
-    return values.collect { logNorm(it, decimals) }
+    values.collect { logNorm(it, decimals) }
   }
 
   /**
@@ -60,7 +60,7 @@ class Normalize {
       if (val instanceof String) {
         return val
       }
-      return logNorm(val as Number, decimals)
+      logNorm(val as Number, decimals)
     }
     // Force BigDecimal preservation - if any input was BigDecimal, ensure outputs stay BigDecimal
     if (values.any { it instanceof BigDecimal }) {
@@ -79,17 +79,17 @@ class Normalize {
           // Safety: convert any other numeric type to BigDecimal
           return new BigDecimal(val.toString()).setScale(decimals.length > 0 ? decimals[0] : 6, RoundingMode.HALF_EVEN)
         }
-        return val
+        val
       }
     }
-    return result
+    result
   }
 
   /**
    * Apply logarithmic normalization to a specific column in a Matrix.
    */
   static List<? extends Number> logNorm(Matrix table, String columnName, int... decimals) {
-    return logNorm(table.column(columnName) as List, decimals)
+    logNorm(table.column(columnName) as List, decimals)
   }
 
   /**
@@ -100,7 +100,7 @@ class Normalize {
     for (Column col in table.columns()) {
       columns << logNorm(col as List, decimals)
     }
-    return Matrix.builder(table.matrixName)
+    Matrix.builder(table.matrixName)
         .columnNames(table.columnNames())
         .columns(columns)
         .types(table.types())
@@ -140,7 +140,7 @@ class Normalize {
       return convertToType(bd, x)
     }
 
-    return convertToType(result, x)
+    convertToType(result, x)
   }
 
   /**
@@ -154,7 +154,7 @@ class Normalize {
     T min = values.min()
     T max = values.max()
 
-    return values.collect { minMaxNorm(it, min, max, decimals) }
+    values.collect { minMaxNorm(it, min, max, decimals) }
   }
 
   /**
@@ -171,14 +171,14 @@ class Normalize {
     Number min = values.min() as Number
     Number max = values.max() as Number
 
-    return values.collect { minMaxNorm(it as Number, min, max, decimals) }
+    values.collect { minMaxNorm(it as Number, min, max, decimals) }
   }
 
   /**
    * Apply min-max normalization to a specific column in a Matrix.
    */
   static List<? extends Number> minMaxNorm(Matrix table, String columnName, int... decimals) {
-    return minMaxNorm(table.column(columnName) as List, decimals)
+    minMaxNorm(table.column(columnName) as List, decimals)
   }
 
   /**
@@ -189,7 +189,7 @@ class Normalize {
     for (Column col in table.columns()) {
       columns << minMaxNorm(col as List, decimals)
     }
-    return Matrix.builder(table.matrixName)
+    Matrix.builder(table.matrixName)
         .columnNames(table.columnNames())
         .columns(columns)
         .types(table.types())
@@ -231,7 +231,7 @@ class Normalize {
       return convertToType(bd, x)
     }
 
-    return convertToType(result, x)
+    convertToType(result, x)
   }
 
   /**
@@ -247,7 +247,7 @@ class Normalize {
     T min = list.min()
     T max = list.max()
 
-    return values.collect { meanNorm(it, mean, min, max, decimals) }
+    values.collect { meanNorm(it, mean, min, max, decimals) }
   }
 
   /**
@@ -265,14 +265,14 @@ class Normalize {
     Number min = values.min() as Number
     Number max = values.max() as Number
 
-    return values.collect { meanNorm(it as Number, mean, min, max, decimals) }
+    values.collect { meanNorm(it as Number, mean, min, max, decimals) }
   }
 
   /**
    * Apply mean normalization to a specific column in a Matrix.
    */
   static List<? extends Number> meanNorm(Matrix table, String columnName, int... decimals) {
-    return meanNorm(table.column(columnName) as List, decimals)
+    meanNorm(table.column(columnName) as List, decimals)
   }
 
   /**
@@ -280,7 +280,7 @@ class Normalize {
    */
   static Matrix meanNorm(Matrix table, int... decimals) {
     List<List> columns = table.columns().collect { Column col -> meanNorm(col as List, decimals) }
-    return Matrix.builder(table.matrixName)
+    Matrix.builder(table.matrixName)
         .columnNames(table.columnNames())
         .columns(columns)
         .types(table.types())
@@ -319,7 +319,7 @@ class Normalize {
       return convertToType(bd, x)
     }
 
-    return convertToType(result, x)
+    convertToType(result, x)
   }
 
   /**
@@ -334,7 +334,7 @@ class Normalize {
     BigDecimal mean = Stat.mean(list)
     BigDecimal stdDev = Stat.sd(list)
 
-    return values.collect { stdScaleNorm(it, mean, stdDev, decimals) }
+    values.collect { stdScaleNorm(it, mean, stdDev, decimals) }
   }
 
   /**
@@ -351,14 +351,14 @@ class Normalize {
     BigDecimal mean = Stat.mean(values)
     BigDecimal stdDev = Stat.sd(values)
 
-    return values.collect { stdScaleNorm(it as Number, mean, stdDev, decimals) }
+    values.collect { stdScaleNorm(it as Number, mean, stdDev, decimals) }
   }
 
   /**
    * Apply standard deviation normalization to a specific column in a Matrix.
    */
   static List<? extends Number> stdScaleNorm(Matrix table, String columnName, int... decimals) {
-    return stdScaleNorm(table.column(columnName) as List, decimals)
+    stdScaleNorm(table.column(columnName) as List, decimals)
   }
 
   /**
@@ -369,7 +369,7 @@ class Normalize {
     for (Column col in table.columns()) {
       columns << stdScaleNorm(col as List, decimals)
     }
-    return Matrix.builder(table.matrixName)
+    Matrix.builder(table.matrixName)
         .columnNames(table.columnNames())
         .columns(columns)
         .types(table.types())
@@ -389,7 +389,7 @@ class Normalize {
       return Double.NaN as T
     }
     // Byte, Short, Float
-    return Float.NaN as T
+    Float.NaN as T
   }
 
   /**
@@ -403,7 +403,7 @@ class Normalize {
       return Double.NaN as T
     }
     // Byte, Short, Integer, Long, Float
-    return Float.NaN as T
+    Float.NaN as T
   }
 
   /**
@@ -445,6 +445,6 @@ class Normalize {
       return value.floatValue() as T
     }
     // Default to the value's natural type
-    return value as T
+    value as T
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Randomize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Randomize.groovy
@@ -116,7 +116,7 @@ class Randomize {
     Matrix copy = data.clone()
     List<Row> rows = copy.rows()
     rows.shuffle()
-    return Matrix.builder()
+    Matrix.builder()
         .matrixName(copy.matrixName)
         .columnNames(copy.columnNames())
         .rowList(rows)
@@ -135,7 +135,7 @@ class Randomize {
     Matrix copy = data.clone()
     List<Row> rows = copy.rows()
     rows.shuffle(random)
-    return Matrix.builder()
+    Matrix.builder()
         .matrixName(copy.matrixName)
         .columnNames(copy.columnNames())
         .rowList(rows)
@@ -152,6 +152,6 @@ class Randomize {
    */
   static Matrix randomOrder(Matrix data, long seed) {
     Random random = new Random(seed)
-    return randomOrder(data, random)
+    randomOrder(data, random)
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Sampler.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Sampler.groovy
@@ -50,6 +50,6 @@ class Sampler {
         .rowList(testRows)
         .types(data.types())
         .build()
-    return [trainMatrix, testMatrix]
+    [trainMatrix, testMatrix]
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/StatUtils.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/StatUtils.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Native statistical utility functions used by the stats module.
  */
@@ -31,6 +33,17 @@ final class StatUtils {
   }
 
   /**
+   * Computes the arithmetic mean for the supplied values.
+   *
+   * @param values the sample values
+   * @return the arithmetic mean
+   * @throws IllegalArgumentException if the list is null or empty
+   */
+  static double mean(List<? extends Number> values) {
+    mean(NumericConversion.toDoubleArray(values, 'values'))
+  }
+
+  /**
    * Computes the sample variance using Bessel's correction.
    *
    * @param values the sample values
@@ -39,6 +52,17 @@ final class StatUtils {
    */
   static double variance(double[] values) {
     variance(values, mean(values))
+  }
+
+  /**
+   * Computes the sample variance using Bessel's correction.
+   *
+   * @param values the sample values
+   * @return the sample variance
+   * @throws IllegalArgumentException if the list is null or has fewer than two observations
+   */
+  static double variance(List<? extends Number> values) {
+    variance(NumericConversion.toDoubleArray(values, 'values'))
   }
 
   /**
@@ -58,6 +82,21 @@ final class StatUtils {
       sumSquaredDeviation += deviation * deviation
     }
     sumSquaredDeviation / (values.length - 1)
+  }
+
+  /**
+   * Computes the sample variance using a precomputed mean and Bessel's correction.
+   *
+   * @param values the sample values
+   * @param mean the precomputed arithmetic mean
+   * @return the sample variance
+   * @throws IllegalArgumentException if the list is null or has fewer than two observations
+   */
+  static double variance(List<? extends Number> values, Number mean) {
+    variance(
+      NumericConversion.toDoubleArray(values, 'values'),
+      NumericConversion.toFiniteDouble(mean, 'mean')
+    )
   }
 
   private static void validateNotEmpty(double[] values, String operation) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/StatUtils.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/StatUtils.groovy
@@ -1,9 +1,11 @@
 package se.alipsa.matrix.stats
 
-import se.alipsa.matrix.stats.util.NumericConversion
-
 /**
- * Native statistical utility functions used by the stats module.
+ * Primitive double-precision statistical utilities for internal use by the stats module.
+ *
+ * <p>These methods operate on {@code double[]} and use compensated (Kahan) summation
+ * for numerical stability. For BigDecimal / List-based mean and variance, use
+ * {@link se.alipsa.matrix.core.Stat} instead.</p>
  */
 final class StatUtils {
 
@@ -11,7 +13,7 @@ final class StatUtils {
   }
 
   /**
-   * Computes the arithmetic mean for the supplied values.
+   * Computes the arithmetic mean for the supplied values using compensated summation.
    *
    * @param values the sample values
    * @return the arithmetic mean
@@ -20,7 +22,6 @@ final class StatUtils {
   static double mean(double[] values) {
     validateNotEmpty(values, 'Mean')
 
-    // Use compensated summation to reduce drift when these helpers are reused for larger samples.
     double sum = 0.0d
     double compensation = 0.0d
     for (double value : values) {
@@ -33,17 +34,6 @@ final class StatUtils {
   }
 
   /**
-   * Computes the arithmetic mean for the supplied values.
-   *
-   * @param values the sample values
-   * @return the arithmetic mean
-   * @throws IllegalArgumentException if the list is null or empty
-   */
-  static double mean(List<? extends Number> values) {
-    mean(NumericConversion.toDoubleArray(values, 'values'))
-  }
-
-  /**
    * Computes the sample variance using Bessel's correction.
    *
    * @param values the sample values
@@ -52,17 +42,6 @@ final class StatUtils {
    */
   static double variance(double[] values) {
     variance(values, mean(values))
-  }
-
-  /**
-   * Computes the sample variance using Bessel's correction.
-   *
-   * @param values the sample values
-   * @return the sample variance
-   * @throws IllegalArgumentException if the list is null or has fewer than two observations
-   */
-  static double variance(List<? extends Number> values) {
-    variance(NumericConversion.toDoubleArray(values, 'values'))
   }
 
   /**
@@ -82,21 +61,6 @@ final class StatUtils {
       sumSquaredDeviation += deviation * deviation
     }
     sumSquaredDeviation / (values.length - 1)
-  }
-
-  /**
-   * Computes the sample variance using a precomputed mean and Bessel's correction.
-   *
-   * @param values the sample values
-   * @param mean the precomputed arithmetic mean
-   * @return the sample variance
-   * @throws IllegalArgumentException if the list is null or has fewer than two observations
-   */
-  static double variance(List<? extends Number> values, Number mean) {
-    variance(
-      NumericConversion.toDoubleArray(values, 'values'),
-      NumericConversion.toFiniteDouble(mean, 'mean')
-    )
   }
 
   private static void validateNotEmpty(double[] values, String operation) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/ClusteredPoint.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/ClusteredPoint.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.cluster
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * ClusteredPoint is a simple data structure that represents a data point assigned to a cluster
  * in K-Means clustering. It pairs a cluster identifier with the point's feature vector.
@@ -128,6 +130,14 @@ class ClusteredPoint {
     this.point = point
   }
 
+  ClusteredPoint(int clusterId, List<? extends Number> point) {
+    this(clusterId, NumericConversion.toDoubleArray(point as List<? extends Number>, 'point'))
+  }
+
   int getClusterId() { clusterId }
   double[] getPoint() { point }
+
+  List<BigDecimal> getPointValues() {
+    NumericConversion.toBigDecimalList(point, 'point')
+  }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/ClusteredPoint.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/ClusteredPoint.groovy
@@ -131,7 +131,7 @@ class ClusteredPoint {
   }
 
   ClusteredPoint(int clusterId, List<? extends Number> point) {
-    this(clusterId, NumericConversion.toDoubleArray(point as List<? extends Number>, 'point'))
+    this(clusterId, NumericConversion.toDoubleArray(point, 'point'))
   }
 
   int getClusterId() { clusterId }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/GroupEstimator.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/GroupEstimator.groovy
@@ -187,7 +187,7 @@ class GroupEstimator {
       wcssList << clustering.getWCSS()
     }
 
-    return findElbow(ks, wcssList)
+    findElbow(ks, wcssList)
   }
 
   /**
@@ -209,7 +209,7 @@ class GroupEstimator {
     int estimatedSqrt = (int) Math.round(Math.sqrt(n / 2.0d))
     // More conservative heuristic: cbrt(n), tends to underestimate
     int estimatedQbrt = Math.max(2, (int) Math.round(Math.cbrt(points.length)))
-    return ((estimatedSqrt + estimatedQbrt) / 2) as int
+    ((estimatedSqrt + estimatedQbrt) / 2) as int
   }
 
   /**
@@ -240,6 +240,6 @@ class GroupEstimator {
       }
     }
 
-    return bestK
+    bestK
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/GroupEstimator.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/GroupEstimator.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.cluster
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * GroupEstimator determines the optimal number of clusters (k) for K-Means clustering
  * using heuristic and analytical methods. Choosing the right k is critical for meaningful
@@ -155,6 +157,16 @@ class GroupEstimator {
     }
   }
 
+  /**
+   * Estimates the number of groups from Groovy-facing point rows.
+   *
+   * @param points the numeric point rows
+   * @return the estimated number of groups
+   */
+  int estimateNumberOfGroups(List<? extends List<? extends Number>> points) {
+    estimateNumberOfGroups(NumericConversion.toDoubleMatrix(points, 'points'))
+  }
+
   static int estimateKByElbow(double[][] points, int maxK = 10, int iterations = 10) {
     Set<String> uniquePoints = points.collect { it.toList().toString() }.toSet()
     int maxClusters = Math.min(maxK, uniquePoints.size())
@@ -176,6 +188,18 @@ class GroupEstimator {
     }
 
     return findElbow(ks, wcssList)
+  }
+
+  /**
+   * Estimates {@code k} from Groovy-facing point rows using the elbow method.
+   *
+   * @param points the numeric point rows
+   * @param maxK maximum number of clusters to test
+   * @param iterations number of KMeans runs per candidate {@code k}
+   * @return the estimated number of groups
+   */
+  static int estimateKByElbow(List<? extends List<? extends Number>> points, int maxK = 10, int iterations = 10) {
+    estimateKByElbow(NumericConversion.toDoubleMatrix(points, 'points'), maxK, iterations)
   }
 
   private static int ruleOfThumb(double[][] points) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeans.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeans.groovy
@@ -127,7 +127,7 @@ class KMeans {
     m.eachWithIndex { row, i ->
       points[i] = ListConverter.toDoubleArray(row as List<? extends Number>)
     }
-    return points
+    points
   }
 
   Matrix fit(List<String> columnNames, int k, int iterations, String columnName = "Group", boolean mutate = true) {
@@ -137,7 +137,7 @@ class KMeans {
         .pp(true)
         .useEpsilon(true)
         .build()
-    return addClusterColumn(clustering, columnName, mutate)
+    addClusterColumn(clustering, columnName, mutate)
   }
 
   Matrix fit(List<String> columnNames, int iterations = 30, GroupEstimator.CalculationMethod method = GroupEstimator.CalculationMethod.ELBOW, String columnName = "Group", boolean mutate = true) {
@@ -147,7 +147,7 @@ class KMeans {
         .pp(true)
         .useEpsilon(true)
         .build()
-    return addClusterColumn(clustering, columnName, mutate)
+    addClusterColumn(clustering, columnName, mutate)
   }
 
   private Matrix addClusterColumn(KMeansPlusPlus clustering, String columnName, boolean mutate) {
@@ -160,14 +160,14 @@ class KMeans {
   }
 
   String reportTime() {
-    return clustering?.timing ?: "No clustering performed yet, call fit() first."
+    clustering?.timing ?: "No clustering performed yet, call fit() first."
   }
 
   int getExecutionTimeMillis() {
     if (clustering == null) {
       return -1
     }
-    return clustering.executionTimeMillis as int
+    clustering.executionTimeMillis as int
   }
 
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeansPlusPlus.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeansPlusPlus.groovy
@@ -398,12 +398,13 @@ class KMeansPlusPlus {
      * @param epsilon a small non-negative number (e.g., 0.001)
      * @return the updated builder instance
      */
-    Builder epsilon(double epsilon) {
-      if (epsilon < 0.0) {
+    Builder epsilon(Number epsilon) {
+      double normalizedEpsilon = NumericConversion.toFiniteDouble(epsilon, 'epsilon')
+      if (normalizedEpsilon < 0.0d) {
         throw new IllegalArgumentException("Required: non-negative value of epsilon. Ex: .001")
       }
 
-      this.epsilon = epsilon
+      this.epsilon = normalizedEpsilon
       return this
     }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeansPlusPlus.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeansPlusPlus.groovy
@@ -2,6 +2,7 @@ package se.alipsa.matrix.stats.cluster
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.util.Logger
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * KMeans++ is an enhanced K-Means clustering algorithm that uses an improved initialization
@@ -302,6 +303,16 @@ class KMeansPlusPlus {
     }
 
     /**
+     * Create a Builder that estimates the number of clusters automatically using Groovy-facing point rows.
+     *
+     * @param points the data points to cluster
+     * @param method the cluster estimation strategy to use
+     */
+    Builder(List<? extends List<? extends Number>> points, GroupEstimator.CalculationMethod method = GroupEstimator.CalculationMethod.ELBOW) {
+      this(NumericConversion.toDoubleMatrix(points, 'points'), method)
+    }
+
+    /**
      * Create a Builder with a fixed number of clusters.
      *
      * @param k the number of clusters to find
@@ -332,6 +343,16 @@ class KMeansPlusPlus {
 
       this.k = k
       this.points = points
+    }
+
+    /**
+     * Create a Builder with a fixed number of clusters from Groovy-facing point rows.
+     *
+     * @param k the number of clusters to find
+     * @param points the data points to cluster
+     */
+    Builder(int k, List<? extends List<? extends Number>> points) {
+      this(k, NumericConversion.toDoubleMatrix(points, 'points'))
     }
 
     /**
@@ -771,6 +792,15 @@ class KMeansPlusPlus {
   }
 
   /**
+   * Returns cluster assignments as an immutable list.
+   *
+   * @return the clustered points
+   */
+  List<ClusteredPoint> getAssignments() {
+    assignment.toList().asImmutable() as List<ClusteredPoint>
+  }
+
+  /**
    * Returns a map of cluster ID to a Matrix containing the points assigned to that cluster.
    *
    * @return a map where keys are cluster IDs (0 to k-1) and values are a {@link Matrix} containing cluster points
@@ -809,6 +839,15 @@ class KMeansPlusPlus {
   }
 
   /**
+   * Returns the centroids as immutable BigDecimal rows.
+   *
+   * @return the centroid rows
+   */
+  List<List<BigDecimal>> getCentroidValues() {
+    NumericConversion.toBigDecimalRows(centroids, 'centroids')
+  }
+
+  /**
    * Returns the wcss (Within-Cluster-Sum-of-Squares, also known as inertia) of the clustering.
    * wcss is a metric used to measure the compactness or cohesion of clusters.
    * It represents the sum of squared distances between each data point and the centroid of its assigned cluster.
@@ -819,6 +858,15 @@ class KMeansPlusPlus {
    */
   double getWCSS() {
     return wcss
+  }
+
+  /**
+   * Returns the within-cluster sum of squares as {@code BigDecimal}.
+   *
+   * @return the clustering error
+   */
+  BigDecimal getWcssValue() {
+    BigDecimal.valueOf(wcss)
   }
 
   /**
@@ -839,6 +887,15 @@ class KMeansPlusPlus {
    */
   double getExecutionTimeMillis() {
     return end - start
+  }
+
+  /**
+   * Returns the execution time in milliseconds as {@code BigDecimal}.
+   *
+   * @return the execution time
+   */
+  BigDecimal getExecutionTimeValue() {
+    BigDecimal.valueOf(getExecutionTimeMillis())
   }
 
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeansPlusPlus.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeansPlusPlus.groovy
@@ -367,7 +367,7 @@ class KMeansPlusPlus {
         throw new IllegalArgumentException("Required: non-negative number of iterations. Ex: 50")
       }
       this.iterations = iterations
-      return this
+      this
     }
 
     /**
@@ -378,7 +378,7 @@ class KMeansPlusPlus {
      */
     Builder pp(boolean pp) {
       this.pp = pp
-      return this
+      this
     }
 
     /**
@@ -405,7 +405,7 @@ class KMeansPlusPlus {
       }
 
       this.epsilon = normalizedEpsilon
-      return this
+      this
     }
 
     /**
@@ -421,7 +421,7 @@ class KMeansPlusPlus {
      */
     Builder useEpsilon(boolean useEpsilon) {
       this.useEpsilon = useEpsilon
-      return this
+      this
     }
 
     /**
@@ -436,7 +436,7 @@ class KMeansPlusPlus {
      */
     Builder useL1norm(boolean l1Norm) {
       this.l1Norm = l1Norm
-      return this
+      this
     }
 
     /**
@@ -459,7 +459,7 @@ class KMeansPlusPlus {
       //println "Running KMeansPlusPlus clustering..."
       //println "Input points: ${points.length}"
       //println "k = $k, iterations = $iterations"
-      return new KMeansPlusPlus(this)
+      new KMeansPlusPlus(this)
     }
   }
 
@@ -708,7 +708,7 @@ class KMeansPlusPlus {
    * @return true when the epsilon threshold indicates convergence
    */
   private boolean epsilonTest(double prevWCSS) {
-    return epsilon > 1 - (wcss / prevWCSS)
+    epsilon > 1 - (wcss / prevWCSS)
   }
 
   /***********************************************************************
@@ -721,7 +721,7 @@ class KMeansPlusPlus {
    * @return the configured distance between the two points
    */
   private double distance(double[] x, double[] y) {
-    return l1Norm ? Distance.manhattanDistance(x, y) : Distance.euclideanDistance(x, y)
+    l1Norm ? Distance.manhattanDistance(x, y) : Distance.euclideanDistance(x, y)
   }
 
   private Random randomForIteration(int iteration) {
@@ -745,7 +745,7 @@ class KMeansPlusPlus {
       for (int i = 0; i < x.length; i++) {
         dist += Math.abs(x[i] - y[i])
       }
-      return dist
+      dist
     }
 
     /**
@@ -764,7 +764,7 @@ class KMeansPlusPlus {
         double diff = x[i] - y[i]
         dist += diff * diff
       }
-      return dist
+      dist
     }
   }
 
@@ -789,7 +789,7 @@ class KMeansPlusPlus {
    * @return an array where each entry corresponds to a {@link ClusteredPoint} and its assigned cluster
    */
   ClusteredPoint[] getAssignment() {
-    return assignment
+    assignment
   }
 
   /**
@@ -836,7 +836,7 @@ class KMeansPlusPlus {
    * where each centroid is represented as an array of doubles.
    */
   double[][] getCentroids() {
-    return centroids
+    centroids
   }
 
   /**
@@ -858,7 +858,7 @@ class KMeansPlusPlus {
    * @return wcss the Within-Cluster-Sum-of-Squares
    */
   double getWCSS() {
-    return wcss
+    wcss
   }
 
   /**
@@ -877,7 +877,7 @@ class KMeansPlusPlus {
    * @return a string indicating the time taken for KMeans++ clustering
    */
   String getTiming() {
-    return "KMeans++ took: " + getExecutionTimeMillis() / 1000.0 + " seconds"
+    "KMeans++ took: " + getExecutionTimeMillis() / 1000.0 + " seconds"
   }
 
   /**
@@ -887,7 +887,7 @@ class KMeansPlusPlus {
    * @return the execution time in milliseconds
    */
   double getExecutionTimeMillis() {
-    return end - start
+    end - start
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeansPlusPlus.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeansPlusPlus.groovy
@@ -208,7 +208,7 @@ class KMeansPlusPlus {
   private int iterations       // number of times to repeat the clustering. Choose run with lowest wcss
   private boolean pp           // true --> KMeans++. false --> basic random sampling
   private double epsilon       // stops running when improvement in error < epsilon
-  private boolean useEpsilon;  // true  --> stop running when marginal improvement in wcss < epsilon
+  private boolean useEpsilon   // true  --> stop running when marginal improvement in wcss < epsilon
   // false --> stop running when 0 improvement
   private boolean l1Norm       // true --> L1 norm to calculate distance; false --> L2 norm
 
@@ -343,7 +343,7 @@ class KMeansPlusPlus {
      */
     Builder iterations(int iterations) {
       if (iterations < 1) {
-        throw new IllegalArgumentException("Required: non-negative number of iterations. Ex: 50");
+        throw new IllegalArgumentException("Required: non-negative number of iterations. Ex: 50")
       }
       this.iterations = iterations
       return this
@@ -586,7 +586,7 @@ class KMeansPlusPlus {
     centroids = new double[k][n]
     double[][] copy = points
 
-    int rand;
+    int rand
     for (int i = 0; i < k; i++) {
       rand = random.nextInt(m - i)
       for (int j = 0; j < n; j++) {
@@ -619,7 +619,7 @@ class KMeansPlusPlus {
         // check if the most recently added centroid is closer to any of the points than previously added ones
         for (int p = 0; p < m; p++) {
           // gives chosen points 0 probability of being chosen again -> sampling without replacement
-          double tempDistance = Distance.euclideanDistance(points[p], centroids[c - 1]); // need L2 norm here, not L1
+          double tempDistance = Distance.euclideanDistance(points[p], centroids[c - 1]) // need L2 norm here, not L1
 
           // base case: if we have only chosen one centroid so far, nothing to compare to
           if (c == 1) {
@@ -669,7 +669,7 @@ class KMeansPlusPlus {
   /**
    * Calculates whether to stop the run
    * @param prevWCSS error from previous step in the run
-   * @return
+   * @return true when the algorithm should stop iterating
    */
   private boolean stop(double prevWCSS) {
     if (useEpsilon) {
@@ -683,7 +683,7 @@ class KMeansPlusPlus {
    * Signals to stop running KMeans when the marginal improvement in wcss
    * from the last step is small.
    * @param prevWCSS error from previous step in the run
-   * @return
+   * @return true when the epsilon threshold indicates convergence
    */
   private boolean epsilonTest(double prevWCSS) {
     return epsilon > 1 - (wcss / prevWCSS)
@@ -694,9 +694,9 @@ class KMeansPlusPlus {
    **********************************************************************/
   /**
    * Calculates distance between two n-dimensional points.
-   * @param x
-   * @param y
-   * @return
+   * @param x the first point
+   * @param y the second point
+   * @return the configured distance between the two points
    */
   private double distance(double[] x, double[] y) {
     return l1Norm ? Distance.manhattanDistance(x, y) : Distance.euclideanDistance(x, y)
@@ -711,9 +711,9 @@ class KMeansPlusPlus {
     /**
      * L1 norm: distance(X,Y) = sum_i=1:n[|x_i - y_i|]
      * <P> Minkowski distance of order 1.
-     * @param x
-    * @param y
-    * @return
+     * @param x the first point
+     * @param y the second point
+     * @return the Manhattan distance between the two points
      */
     static double manhattanDistance(double[] x, double[] y) {
       if (x.length != y.length) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Barnard.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Barnard.groovy
@@ -114,9 +114,9 @@ class Barnard {
     maxPValue = Math.max(0.0, Math.min(1.0, maxPValue))
 
     return new BarnardResult(
-      statistic: observedT,
-      pValue: maxPValue,
-      nuisanceParameter: optimalPi,
+      statistic: BigDecimal.valueOf(observedT),
+      pValue: BigDecimal.valueOf(maxPValue),
+      nuisanceParameter: BigDecimal.valueOf(optimalPi),
       sampleSize: n
     )
   }
@@ -286,13 +286,13 @@ class Barnard {
    */
   static class BarnardResult {
     /** The Wald score statistic */
-    double statistic
+    BigDecimal statistic
 
     /** The p-value (two-sided) */
-    double pValue
+    BigDecimal pValue
 
     /** The nuisance parameter that maximizes p-value */
-    double nuisanceParameter
+    BigDecimal nuisanceParameter
 
     /** The total sample size */
     int sampleSize

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Barnard.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Barnard.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.contingency
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Barnard's exact test is an unconditional exact test for 2×2 contingency tables that is uniformly
  * more powerful than Fisher's exact test. It tests for association between two binary variables
@@ -301,8 +303,9 @@ class Barnard {
      * @param alpha The significance level (default: 0.05)
      * @return A string describing whether there is a significant association
      */
-    String interpret(double alpha = 0.05) {
-      if (pValue < alpha) {
+    String interpret(Number alpha = 0.05) {
+      BigDecimal normalizedAlpha = NumericConversion.toAlpha(alpha)
+      if (pValue < normalizedAlpha) {
         return "Reject H0: Significant association detected (T = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
       } else {
         return "Fail to reject H0: No significant association detected (T = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
@@ -314,8 +317,9 @@ class Barnard {
      *
      * @return A detailed description of the test result
      */
-    String evaluate(double alpha = 0.05) {
-      String significance = pValue < alpha ? "significant" : "not significant"
+    String evaluate(Number alpha = 0.05) {
+      BigDecimal normalizedAlpha = NumericConversion.toAlpha(alpha)
+      String significance = pValue < normalizedAlpha ? "significant" : "not significant"
 
       return String.format(
         "Barnard's exact test:\\n" +
@@ -324,7 +328,7 @@ class Barnard {
         "Nuisance parameter (π): %.4f\\n" +
         "Sample size: %d\\n" +
         "Conclusion: Association is %s at %.0f%% significance level",
-        statistic, pValue, nuisanceParameter, sampleSize, significance, alpha * 100
+        statistic, pValue, nuisanceParameter, sampleSize, significance, normalizedAlpha * 100
       )
     }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Barnard.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Barnard.groovy
@@ -113,7 +113,7 @@ class Barnard {
     // Clamp p-value to [0, 1] to handle numerical precision issues
     maxPValue = Math.max(0.0, Math.min(1.0, maxPValue))
 
-    return new BarnardResult(
+    new BarnardResult(
       statistic: BigDecimal.valueOf(observedT),
       pValue: BigDecimal.valueOf(maxPValue),
       nuisanceParameter: BigDecimal.valueOf(optimalPi),
@@ -150,7 +150,7 @@ class Barnard {
       return (Math.abs(p1 - p2) > 1e-10) ? (Double.POSITIVE_INFINITY as double) : (0.0 as double)
     }
 
-    return (p1 - p2) / Math.sqrt(variance)
+    (p1 - p2) / Math.sqrt(variance)
   }
 
   /**
@@ -179,7 +179,7 @@ class Barnard {
       }
     }
 
-    return pValue
+    pValue
   }
 
   /**
@@ -206,7 +206,7 @@ class Barnard {
       return Math.abs(p1 - p2) > 1e-10 ? 1000.0 : 0.0
     }
 
-    return (p1 - p2) / Math.sqrt(variance)
+    (p1 - p2) / Math.sqrt(variance)
   }
 
   /**
@@ -228,7 +228,7 @@ class Barnard {
     // Use log probabilities for numerical stability
     double logProb = logBinomialCoefficient(n, k) + k * Math.log(p) + (n - k) * Math.log(1 - p)
 
-    return Math.exp(logProb)
+    Math.exp(logProb)
   }
 
   /**
@@ -253,7 +253,7 @@ class Barnard {
       result += Math.log(n - k + i) - Math.log(i)
     }
 
-    return result
+    result
   }
 
   private static void validateTable(int[][] table) {
@@ -321,7 +321,7 @@ class Barnard {
       BigDecimal normalizedAlpha = NumericConversion.toAlpha(alpha)
       String significance = pValue < normalizedAlpha ? "significant" : "not significant"
 
-      return String.format(
+      String.format(
         "Barnard's exact test:\\n" +
         "Wald score statistic: %.4f\\n" +
         "p-value: %.4f\\n" +
@@ -334,7 +334,7 @@ class Barnard {
 
     @Override
     String toString() {
-      return """Barnard's Exact Test
+      """Barnard's Exact Test
   Sample size: ${sampleSize}
   Wald score statistic: ${String.format('%.4f', statistic)}
   p-value: ${String.format('%.4f', pValue)}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Barnard.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Barnard.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.contingency
 
-import groovy.transform.CompileStatic
-
 /**
  * Barnard's exact test is an unconditional exact test for 2×2 contingency tables that is uniformly
  * more powerful than Fisher's exact test. It tests for association between two binary variables

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Boschloo.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Boschloo.groovy
@@ -126,7 +126,7 @@ class Boschloo {
     // Clamp p-value to [0, 1] to handle numerical precision issues
     maxPValue = Math.max(0.0, Math.min(1.0, maxPValue))
 
-    return new BoschlooResult(
+    new BoschlooResult(
       pValue: BigDecimal.valueOf(maxPValue),
       fisherPValue: BigDecimal.valueOf(observedFisherP),
       nuisanceParameter: BigDecimal.valueOf(optimalPi),
@@ -159,7 +159,7 @@ class Boschloo {
       }
     }
 
-    return pValue
+    pValue
   }
 
   /**
@@ -184,7 +184,6 @@ class Boschloo {
     double pValue = 0.0
 
     for (int x = 0; x <= Math.min(n1, k1); x++) {
-      int y = n1 - x
       int z = k1 - x
       int w = n2 - z
 
@@ -200,7 +199,7 @@ class Boschloo {
     }
 
     // Clamp p-value to [0, 1] to handle numerical precision issues
-    return Math.max(0.0, Math.min(1.0, pValue))
+    Math.max(0.0, Math.min(1.0, pValue))
   }
 
   /**
@@ -222,7 +221,7 @@ class Boschloo {
                      logBinomialCoefficient(N - t, n - k) -
                      logBinomialCoefficient(N, n)
 
-    return Math.exp(logProb)
+    Math.exp(logProb)
   }
 
   /**
@@ -244,7 +243,7 @@ class Boschloo {
     // Use log probabilities for numerical stability
     double logProb = logBinomialCoefficient(n, k) + k * Math.log(p) + (n - k) * Math.log(1 - p)
 
-    return Math.exp(logProb)
+    Math.exp(logProb)
   }
 
   /**
@@ -269,7 +268,7 @@ class Boschloo {
       result += Math.log(n - k + i) - Math.log(i)
     }
 
-    return result
+    result
   }
 
   private static void validateTable(int[][] table) {
@@ -337,7 +336,7 @@ class Boschloo {
       BigDecimal normalizedAlpha = NumericConversion.toAlpha(alpha)
       String significance = pValue < normalizedAlpha ? "significant" : "not significant"
 
-      return String.format(
+      String.format(
         "Boschloo's exact test:\\n" +
         "p-value: %.4f\\n" +
         "Fisher's p-value: %.4f\\n" +
@@ -350,7 +349,7 @@ class Boschloo {
 
     @Override
     String toString() {
-      return """Boschloo's Exact Test
+      """Boschloo's Exact Test
   Sample size: ${sampleSize}
   p-value: ${String.format('%.4f', pValue)}
   Fisher's p-value: ${String.format('%.4f', fisherPValue)}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Boschloo.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Boschloo.groovy
@@ -127,9 +127,9 @@ class Boschloo {
     maxPValue = Math.max(0.0, Math.min(1.0, maxPValue))
 
     return new BoschlooResult(
-      pValue: maxPValue,
-      fisherPValue: observedFisherP,
-      nuisanceParameter: optimalPi,
+      pValue: BigDecimal.valueOf(maxPValue),
+      fisherPValue: BigDecimal.valueOf(observedFisherP),
+      nuisanceParameter: BigDecimal.valueOf(optimalPi),
       sampleSize: n
     )
   }
@@ -302,13 +302,13 @@ class Boschloo {
    */
   static class BoschlooResult {
     /** The p-value (two-sided) */
-    double pValue
+    BigDecimal pValue
 
     /** Fisher's exact p-value for the observed table */
-    double fisherPValue
+    BigDecimal fisherPValue
 
     /** The nuisance parameter that maximizes p-value */
-    double nuisanceParameter
+    BigDecimal nuisanceParameter
 
     /** The total sample size */
     int sampleSize

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Boschloo.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Boschloo.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.contingency
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Boschloo's exact test is an unconditional exact test for 2×2 contingency tables that provides
  * uniformly greater statistical power than Fisher's exact test. It tests for association between
@@ -317,8 +319,9 @@ class Boschloo {
      * @param alpha The significance level (default: 0.05)
      * @return A string describing whether there is a significant association
      */
-    String interpret(double alpha = 0.05) {
-      if (pValue < alpha) {
+    String interpret(Number alpha = 0.05) {
+      BigDecimal normalizedAlpha = NumericConversion.toAlpha(alpha)
+      if (pValue < normalizedAlpha) {
         return "Reject H0: Significant association detected (p = ${String.format('%.4f', pValue)})"
       } else {
         return "Fail to reject H0: No significant association detected (p = ${String.format('%.4f', pValue)})"
@@ -330,8 +333,9 @@ class Boschloo {
      *
      * @return A detailed description of the test result
      */
-    String evaluate(double alpha = 0.05) {
-      String significance = pValue < alpha ? "significant" : "not significant"
+    String evaluate(Number alpha = 0.05) {
+      BigDecimal normalizedAlpha = NumericConversion.toAlpha(alpha)
+      String significance = pValue < normalizedAlpha ? "significant" : "not significant"
 
       return String.format(
         "Boschloo's exact test:\\n" +
@@ -340,7 +344,7 @@ class Boschloo {
         "Nuisance parameter (π): %.4f\\n" +
         "Sample size: %d\\n" +
         "Conclusion: Association is %s at %.0f%% significance level",
-        pValue, fisherPValue, nuisanceParameter, sampleSize, significance, alpha * 100
+        pValue, fisherPValue, nuisanceParameter, sampleSize, significance, normalizedAlpha * 100
       )
     }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/ChiSquared.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/ChiSquared.groovy
@@ -76,9 +76,9 @@ class ChiSquared {
     double pValue = 1.0 - distribution.cumulativeProbability(chiSquared)
 
     return new ChiSquaredResult(
-      testStatistic: chiSquared,
+      testStatistic: BigDecimal.valueOf(chiSquared),
       degreesOfFreedom: degreesOfFreedom,
-      pValue: pValue,
+      pValue: BigDecimal.valueOf(pValue),
       testType: "Pearson"
     )
   }
@@ -123,9 +123,9 @@ class ChiSquared {
     double pValue = 1.0 - distribution.cumulativeProbability(gStatistic)
 
     return new ChiSquaredResult(
-      testStatistic: gStatistic,
+      testStatistic: BigDecimal.valueOf(gStatistic),
       degreesOfFreedom: degreesOfFreedom,
-      pValue: pValue,
+      pValue: BigDecimal.valueOf(pValue),
       testType: "G-test"
     )
   }
@@ -179,9 +179,9 @@ class ChiSquared {
     double pValue = 1.0 - distribution.cumulativeProbability(chiSquared)
 
     return new ChiSquaredResult(
-      testStatistic: chiSquared,
+      testStatistic: BigDecimal.valueOf(chiSquared),
       degreesOfFreedom: degreesOfFreedom,
-      pValue: pValue,
+      pValue: BigDecimal.valueOf(pValue),
       testType: "Yates"
     )
   }
@@ -239,13 +239,13 @@ class ChiSquared {
    */
   static class ChiSquaredResult {
     /** The chi-squared test statistic (or G statistic for G-test) */
-    Double testStatistic
+    BigDecimal testStatistic
 
     /** Degrees of freedom for the test */
     Integer degreesOfFreedom
 
     /** The p-value of the test */
-    Double pValue
+    BigDecimal pValue
 
     /** The type of test performed */
     String testType

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/ChiSquared.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/ChiSquared.groovy
@@ -75,7 +75,7 @@ class ChiSquared {
     ChiSquaredDistribution distribution = new ChiSquaredDistribution(degreesOfFreedom)
     double pValue = 1.0 - distribution.cumulativeProbability(chiSquared)
 
-    return new ChiSquaredResult(
+    new ChiSquaredResult(
       testStatistic: BigDecimal.valueOf(chiSquared),
       degreesOfFreedom: degreesOfFreedom,
       pValue: BigDecimal.valueOf(pValue),
@@ -122,7 +122,7 @@ class ChiSquared {
     ChiSquaredDistribution distribution = new ChiSquaredDistribution(degreesOfFreedom)
     double pValue = 1.0 - distribution.cumulativeProbability(gStatistic)
 
-    return new ChiSquaredResult(
+    new ChiSquaredResult(
       testStatistic: BigDecimal.valueOf(gStatistic),
       degreesOfFreedom: degreesOfFreedom,
       pValue: BigDecimal.valueOf(pValue),
@@ -178,7 +178,7 @@ class ChiSquared {
     ChiSquaredDistribution distribution = new ChiSquaredDistribution(degreesOfFreedom)
     double pValue = 1.0 - distribution.cumulativeProbability(chiSquared)
 
-    return new ChiSquaredResult(
+    new ChiSquaredResult(
       testStatistic: BigDecimal.valueOf(chiSquared),
       degreesOfFreedom: degreesOfFreedom,
       pValue: BigDecimal.valueOf(pValue),
@@ -219,7 +219,7 @@ class ChiSquared {
       }
     }
 
-    return new TableTotals(rowTotals, colTotals, grandTotal)
+    new TableTotals(rowTotals, colTotals, grandTotal)
   }
 
   private static class TableTotals {
@@ -262,7 +262,7 @@ class ChiSquared {
 
     @Override
     String toString() {
-      return """Chi-Squared Test Result (${testType}):
+      """Chi-Squared Test Result (${testType}):
   test statistic: ${testStatistic}
   degrees of freedom: ${degreesOfFreedom}
   p-value: ${pValue}"""

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/ChiSquared.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/ChiSquared.groovy
@@ -2,6 +2,7 @@ package se.alipsa.matrix.stats.contingency
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * A chi-squared test (also chi-square or χ² test) is a statistical hypothesis test
@@ -255,8 +256,8 @@ class ChiSquared {
      * @param alpha Significance level (default 0.05)
      * @return true if null hypothesis should be rejected (p-value < alpha)
      */
-    boolean evaluate(double alpha = 0.05) {
-      return pValue < alpha
+    boolean evaluate(Number alpha = 0.05) {
+      pValue < NumericConversion.toAlpha(alpha)
     }
 
     @Override

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/ChiSquared.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/ChiSquared.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.contingency
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranArmitage.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranArmitage.groovy
@@ -171,7 +171,7 @@ class CochranArmitage {
     NormalDistribution normalDist = new NormalDistribution(0.0, 1.0)
     double pValue = 2.0 * (1.0 - normalDist.cumulativeProbability(Math.abs(zStatistic)))
 
-    return new CochranArmitagResult(
+    new CochranArmitagResult(
       statistic: BigDecimal.valueOf(zStatistic),
       pValue: BigDecimal.valueOf(pValue),
       sampleSize: grandTotal,
@@ -281,7 +281,7 @@ class CochranArmitage {
       String direction = statistic > 0 ? "increasing" : "decreasing"
       String significance = pValue < alphaValue ? "significant" : "not significant"
 
-      return String.format(
+      String.format(
         "Cochran-Armitage trend test:\n" +
         "Z-statistic: %.4f (direction: %s)\n" +
         "p-value: %.4f\n" +
@@ -293,7 +293,7 @@ class CochranArmitage {
 
     @Override
     String toString() {
-      return """Cochran-Armitage Trend Test
+      """Cochran-Armitage Trend Test
   Categories: ${categories}
   Sample size: ${sampleSize} (${cases} cases, ${controls} controls)
   Scores: ${scores.collect { BigDecimal score -> String.format('%.2f', score as double) }.join(', ')}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranMantelHaenszel.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranMantelHaenszel.groovy
@@ -186,7 +186,7 @@ class CochranMantelHaenszel {
       commonOddsRatio = sumOddsRatioNumerator / sumOddsRatioDenominator
     }
 
-    return new CochranMantelHaenszelResult(
+    new CochranMantelHaenszelResult(
       statistic: BigDecimal.valueOf(cmhStatistic),
       pValue: BigDecimal.valueOf(pValue),
       strata: k,
@@ -292,7 +292,7 @@ class CochranMantelHaenszel {
         }
       }
 
-      return String.format(
+      String.format(
         "Cochran-Mantel-Haenszel test:\n" +
         "χ² statistic: %.4f\n" +
         "p-value: %.4f\n" +
@@ -312,7 +312,7 @@ class CochranMantelHaenszel {
         "undefined" :
         String.format('%.4f', commonOddsRatio)
 
-      return """Cochran-Mantel-Haenszel Test
+      """Cochran-Mantel-Haenszel Test
   Strata: ${strata}
   χ² statistic: ${String.format('%.4f', statistic)}
   p-value: ${String.format('%.4f', pValue)}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranMantelHaenszel.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranMantelHaenszel.groovy
@@ -187,10 +187,10 @@ class CochranMantelHaenszel {
     }
 
     return new CochranMantelHaenszelResult(
-      statistic: cmhStatistic,
-      pValue: pValue,
+      statistic: BigDecimal.valueOf(cmhStatistic),
+      pValue: BigDecimal.valueOf(pValue),
       strata: k,
-      commonOddsRatio: commonOddsRatio,
+      commonOddsRatio: Double.isNaN(commonOddsRatio) ? null : BigDecimal.valueOf(commonOddsRatio),
       continuityCorrection: continuityCorrection
     )
   }
@@ -240,16 +240,16 @@ class CochranMantelHaenszel {
    */
   static class CochranMantelHaenszelResult {
     /** The CMH test statistic (chi-squared) */
-    double statistic
+    BigDecimal statistic
 
     /** The p-value */
-    double pValue
+    BigDecimal pValue
 
     /** The number of strata */
     int strata
 
     /** The common odds ratio (Mantel-Haenszel estimator) */
-    double commonOddsRatio
+    BigDecimal commonOddsRatio
 
     /** Whether continuity correction was applied */
     boolean continuityCorrection
@@ -277,12 +277,12 @@ class CochranMantelHaenszel {
     String evaluate(Number alpha = 0.05) {
       BigDecimal normalizedAlpha = NumericConversion.toAlpha(alpha)
       String significance = pValue < normalizedAlpha ? "significant" : "not significant"
-      String oddsRatioStr = Double.isNaN(commonOddsRatio) ?
+      String oddsRatioStr = commonOddsRatio == null ?
         "undefined" :
         String.format("%.4f", commonOddsRatio)
 
       String direction = ""
-      if (!Double.isNaN(commonOddsRatio)) {
+      if (commonOddsRatio != null) {
         if (commonOddsRatio > 1) {
           direction = " (positive association)"
         } else if (commonOddsRatio < 1) {
@@ -308,7 +308,7 @@ class CochranMantelHaenszel {
 
     @Override
     String toString() {
-      String oddsRatioStr = Double.isNaN(commonOddsRatio) ?
+      String oddsRatioStr = commonOddsRatio == null ?
         "undefined" :
         String.format('%.4f', commonOddsRatio)
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranMantelHaenszel.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranMantelHaenszel.groovy
@@ -1,6 +1,7 @@
 package se.alipsa.matrix.stats.contingency
 
 import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * The Cochran-Mantel-Haenszel (CMH) test is a statistical test for assessing the association between
@@ -259,8 +260,9 @@ class CochranMantelHaenszel {
      * @param alpha The significance level (default: 0.05)
      * @return A string describing whether there is a significant association
      */
-    String interpret(double alpha = 0.05) {
-      if (pValue < alpha) {
+    String interpret(Number alpha = 0.05) {
+      BigDecimal normalizedAlpha = NumericConversion.toAlpha(alpha)
+      if (pValue < normalizedAlpha) {
         return "Reject H0: Significant association detected across strata (χ² = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
       } else {
         return "Fail to reject H0: No significant association detected across strata (χ² = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
@@ -272,8 +274,9 @@ class CochranMantelHaenszel {
      *
      * @return A detailed description of the test result
      */
-    String evaluate(double alpha = 0.05) {
-      String significance = pValue < alpha ? "significant" : "not significant"
+    String evaluate(Number alpha = 0.05) {
+      BigDecimal normalizedAlpha = NumericConversion.toAlpha(alpha)
+      String significance = pValue < normalizedAlpha ? "significant" : "not significant"
       String oddsRatioStr = Double.isNaN(commonOddsRatio) ?
         "undefined" :
         String.format("%.4f", commonOddsRatio)
@@ -299,7 +302,7 @@ class CochranMantelHaenszel {
         "Conclusion: Association is %s at %.0f%% significance level",
         statistic, pValue, oddsRatioStr, direction, strata,
         continuityCorrection ? "yes" : "no",
-        significance, alpha * 100
+        significance, normalizedAlpha * 100
       )
     }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
@@ -2,6 +2,7 @@ package se.alipsa.matrix.stats.contingency
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.distribution.HypergeometricDistribution
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * Fisher's exact test is a statistical significance test used in the analysis of contingency tables.
@@ -214,8 +215,8 @@ class Fisher {
      * @param alpha Significance level (default 0.05)
      * @return true if null hypothesis should be rejected (p-value < alpha)
      */
-    boolean evaluate(double alpha = 0.05) {
-      return pValue < alpha
+    boolean evaluate(Number alpha = 0.05) {
+      pValue < NumericConversion.toAlpha(alpha)
     }
 
     @Override

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
@@ -118,9 +118,9 @@ class Fisher {
     double[] confInt = calculateConfidenceInterval(a, b, c, d, 0.95)
 
     return new FisherResult(
-      pValue: pValue,
-      oddsRatio: oddsRatio,
-      confidenceInterval: confInt,
+      pValue: BigDecimal.valueOf(pValue),
+      oddsRatio: BigDecimal.valueOf(oddsRatio),
+      confidenceInterval: NumericConversion.toBigDecimalList(confInt, 'confidenceInterval'),
       alternative: alternative
     )
   }
@@ -198,13 +198,13 @@ class Fisher {
    */
   static class FisherResult {
     /** The p-value of the test */
-    Double pValue
+    BigDecimal pValue
 
     /** The estimated odds ratio */
-    Double oddsRatio
+    BigDecimal oddsRatio
 
     /** 95% confidence interval for the odds ratio [lower, upper] */
-    double[] confidenceInterval
+    List<BigDecimal> confidenceInterval
 
     /** The alternative hypothesis used */
     String alternative

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
@@ -41,7 +41,7 @@ class Fisher {
     int c = table[1][0]
     int d = table[1][1]
 
-    return calculateFisherTest(a, b, c, d, alternative)
+    calculateFisherTest(a, b, c, d, alternative)
   }
 
   /**
@@ -62,7 +62,7 @@ class Fisher {
     int c = table.get(1, 0) as int
     int d = table.get(1, 1) as int
 
-    return calculateFisherTest(a, b, c, d, alternative)
+    calculateFisherTest(a, b, c, d, alternative)
   }
 
   private static void validateTable(List<List<Integer>> table) {
@@ -84,9 +84,7 @@ class Fisher {
   private static FisherResult calculateFisherTest(int a, int b, int c, int d, String alternative) {
     int n = a + b + c + d
     int rowSum1 = a + b
-    int rowSum2 = c + d
     int colSum1 = a + c
-    int colSum2 = b + d
 
     // Calculate odds ratio
     double oddsRatio = calculateOddsRatio(a, b, c, d)
@@ -117,7 +115,7 @@ class Fisher {
     // Calculate confidence interval for odds ratio (95% by default)
     double[] confInt = calculateConfidenceInterval(a, b, c, d, 0.95)
 
-    return new FisherResult(
+    new FisherResult(
       pValue: BigDecimal.valueOf(pValue),
       oddsRatio: BigDecimal.valueOf(oddsRatio),
       confidenceInterval: NumericConversion.toBigDecimalList(confInt, 'confidenceInterval'),
@@ -130,7 +128,7 @@ class Fisher {
       // Avoid division by zero - add 0.5 to all cells (Haldane-Anscombe correction)
       return ((a + 0.5) * (d + 0.5)) / ((b + 0.5) * (c + 0.5))
     }
-    return (a * d) / (b * c) as double
+    (a * d) / (b * c) as double
   }
 
   private static double calculateTwoSidedPValue(HypergeometricDistribution dist, int observed) {
@@ -145,7 +143,7 @@ class Fisher {
       }
     }
 
-    return Math.min(pValue, 1.0)  // Ensure p-value doesn't exceed 1 due to rounding
+    Math.min(pValue, 1.0)  // Ensure p-value doesn't exceed 1 due to rounding
   }
 
   private static double[] calculateConfidenceInterval(int a, int b, int c, int d, double confidenceLevel) {
@@ -173,7 +171,7 @@ class Fisher {
     double lower = Math.exp(logOddsRatio - z * se)
     double upper = Math.exp(logOddsRatio + z * se)
 
-    return [lower, upper] as double[]
+    [lower, upper] as double[]
   }
 
   private static double getZScore(double alpha) {
@@ -190,7 +188,7 @@ class Fisher {
     }
 
     // Default approximation
-    return 1.96
+    1.96
   }
 
   /**
@@ -221,7 +219,7 @@ class Fisher {
 
     @Override
     String toString() {
-      return """Fisher's Exact Test Result:
+      """Fisher's Exact Test Result:
   p-value: ${pValue}
   odds ratio: ${oddsRatio}
   ${confidenceInterval ? sprintf('95%% CI: [%.4f, %.4f]', confidenceInterval[0], confidenceInterval[1]) : '95% CI: N/A'}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/ChiSquaredDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/ChiSquaredDistribution.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.distribution
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Chi-squared distribution implementation backed by the regularized incomplete gamma function.
  */
@@ -8,28 +10,47 @@ class ChiSquaredDistribution implements ContinuousDistribution {
 
   private static final int MAX_INVERSE_ITERATIONS = 80
 
-  private final double degreesOfFreedom
+  private final BigDecimal degreesOfFreedom
 
-  ChiSquaredDistribution(double degreesOfFreedom) {
-    if (degreesOfFreedom <= 0.0d) {
+  ChiSquaredDistribution(Number degreesOfFreedom) {
+    BigDecimal normalizedDegreesOfFreedom = NumericConversion.toBigDecimal(degreesOfFreedom, 'degreesOfFreedom')
+    if (normalizedDegreesOfFreedom <= 0.0d) {
       throw new IllegalArgumentException("Degrees of freedom must be positive, got: $degreesOfFreedom")
     }
-    this.degreesOfFreedom = degreesOfFreedom
+    this.degreesOfFreedom = normalizedDegreesOfFreedom
   }
 
-  double getDegreesOfFreedom() {
+  BigDecimal getDegreesOfFreedom() {
     degreesOfFreedom
   }
 
+  BigDecimal cumulativeProbability(Number x) {
+    BigDecimal.valueOf(cumulativeProbabilityValue(NumericConversion.toFiniteDouble(x, 'x')))
+  }
+
   @Override
+  @Deprecated
   double cumulativeProbability(double x) {
+    cumulativeProbabilityValue(x)
+  }
+
+  BigDecimal inverseCumulativeProbability(Number p) {
+    BigDecimal.valueOf(inverseCumulativeProbabilityValue(NumericConversion.toFiniteDouble(p, 'p')))
+  }
+
+  @Deprecated
+  double inverseCumulativeProbability(double p) {
+    inverseCumulativeProbabilityValue(p)
+  }
+
+  private double cumulativeProbabilityValue(double x) {
     if (x <= 0.0d) {
       return 0.0d
     }
-    return SpecialFunctions.regularizedIncompleteGammaP(degreesOfFreedom / 2.0d, x / 2.0d)
+    return SpecialFunctions.regularizedIncompleteGammaP((degreesOfFreedom as double) / 2.0d, x / 2.0d)
   }
 
-  double inverseCumulativeProbability(double p) {
+  private double inverseCumulativeProbabilityValue(double p) {
     if (p < 0.0d || p > 1.0d) {
       throw new IllegalArgumentException("p must be between 0 and 1, got: $p")
     }
@@ -42,12 +63,13 @@ class ChiSquaredDistribution implements ContinuousDistribution {
 
     double guess = initialQuantileGuess(p)
     double low = 0.0d
-    double high = Math.max(guess, degreesOfFreedom)
+    double degrees = degreesOfFreedom as double
+    double high = Math.max(guess, degrees)
     if (high <= 0.0d || !Double.isFinite(high)) {
-      high = degreesOfFreedom
+      high = degrees
     }
 
-    while (cumulativeProbability(high) < p) {
+    while (cumulativeProbabilityValue(high) < p) {
       low = high
       high *= 2.0d
       if (high > Double.MAX_VALUE / 4.0d) {
@@ -57,7 +79,7 @@ class ChiSquaredDistribution implements ContinuousDistribution {
 
     for (int i = 0; i < MAX_INVERSE_ITERATIONS; i++) {
       double mid = 0.5d * (low + high)
-      double cdf = cumulativeProbability(mid)
+      double cdf = cumulativeProbabilityValue(mid)
       if (Math.abs(cdf - p) < 1e-12d || high - low < 1e-12d * Math.max(1.0d, mid)) {
         return mid
       }
@@ -74,11 +96,12 @@ class ChiSquaredDistribution implements ContinuousDistribution {
   private double initialQuantileGuess(double p) {
     NormalDistribution standardNormal = new NormalDistribution()
     double z = standardNormal.inverseCumulativeProbability(p)
-    double a = 2.0d / (9.0d * degreesOfFreedom)
+    double degrees = degreesOfFreedom as double
+    double a = 2.0d / (9.0d * degrees)
     double term = 1.0d - a + z * Math.sqrt(a)
     if (term <= 0.0d) {
-      return degreesOfFreedom * 0.25d
+      return degrees * 0.25d
     }
-    return degreesOfFreedom * term * term * term
+    return degrees * term * term * term
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/ChiSquaredDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/ChiSquaredDistribution.groovy
@@ -47,7 +47,7 @@ class ChiSquaredDistribution implements ContinuousDistribution {
     if (x <= 0.0d) {
       return 0.0d
     }
-    return SpecialFunctions.regularizedIncompleteGammaP((degreesOfFreedom as double) / 2.0d, x / 2.0d)
+    SpecialFunctions.regularizedIncompleteGammaP((degreesOfFreedom as double) / 2.0d, x / 2.0d)
   }
 
   private double inverseCumulativeProbabilityValue(double p) {
@@ -90,7 +90,7 @@ class ChiSquaredDistribution implements ContinuousDistribution {
       }
     }
 
-    return 0.5d * (low + high)
+    0.5d * (low + high)
   }
 
   private double initialQuantileGuess(double p) {
@@ -102,6 +102,6 @@ class ChiSquaredDistribution implements ContinuousDistribution {
     if (term <= 0.0d) {
       return degrees * 0.25d
     }
-    return degrees * term * term * term
+    degrees * term * term * term
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/ContinuousDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/ContinuousDistribution.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.distribution
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Minimal interface for continuous distributions that expose a cumulative distribution function.
  */
@@ -11,5 +13,17 @@ interface ContinuousDistribution {
    * @param x the evaluation point
    * @return cumulative probability at {@code x}
    */
-  double cumulativeProbability(double x)
+  BigDecimal cumulativeProbability(Number x)
+
+  /**
+   * Primitive compatibility bridge retained during the idiomatic API transition.
+   *
+   * @param x the evaluation point
+   * @return cumulative probability at {@code x}
+   * @deprecated Prefer {@link #cumulativeProbability(Number)}
+   */
+  @Deprecated
+  default double cumulativeProbability(double x) {
+    cumulativeProbability(NumericConversion.toBigDecimal(x, 'x')) as double
+  }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/FDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/FDistribution.groovy
@@ -13,6 +13,8 @@ class FDistribution implements ContinuousDistribution {
 
   private final BigDecimal dfNumerator
   private final BigDecimal dfDenominator
+  private final double dfNumeratorValue
+  private final double dfDenominatorValue
 
   /**
    * Creates an F-distribution with the specified degrees of freedom.
@@ -30,6 +32,8 @@ class FDistribution implements ContinuousDistribution {
     }
     this.dfNumerator = normalizedDfNumerator
     this.dfDenominator = normalizedDfDenominator
+    this.dfNumeratorValue = normalizedDfNumerator as double
+    this.dfDenominatorValue = normalizedDfDenominator as double
   }
 
   BigDecimal getDfNumerator() { dfNumerator }
@@ -63,10 +67,8 @@ class FDistribution implements ContinuousDistribution {
     // F-distribution CDF in terms of incomplete beta function
     // F ~ (dfNum/dfDen) * (B/A) where A,B are chi-squared
     // CDF = I_x(dfNum/2, dfDen/2) where x = (dfNum*f)/(dfNum*f + dfDen)
-    double numerator = dfNumerator as double
-    double denominator = dfDenominator as double
-    double x = (numerator * f) / (numerator * f + denominator)
-    SpecialFunctions.regularizedIncompleteBeta(x, numerator / 2.0d, denominator / 2.0d)
+    double x = (dfNumeratorValue * f) / (dfNumeratorValue * f + dfDenominatorValue)
+    SpecialFunctions.regularizedIncompleteBeta(x, dfNumeratorValue / 2.0d, dfDenominatorValue / 2.0d)
   }
 
   /**
@@ -124,8 +126,38 @@ class FDistribution implements ContinuousDistribution {
    * @param groups list of double arrays, each representing a group
    * @return the F-statistic
    */
+  @Deprecated
   static BigDecimal oneWayAnovaFValue(List<?> groups) {
-    BigDecimal.valueOf(oneWayAnovaFValueInternal(normalizeGroups(groups)))
+    if (groups == null) {
+      return oneWayAnovaFValueArrays(null)
+    }
+    if (groups.isEmpty() || groups.every { Object group -> group instanceof double[] }) {
+      return oneWayAnovaFValueArrays(groups as List<double[]>)
+    }
+    if (groups.every { Object group -> group instanceof List<?> }) {
+      return oneWayAnovaFValueFromLists(groups as Collection<? extends List<? extends Number>>)
+    }
+    throw new IllegalArgumentException("Each group must be a List<Number> or double[], got mixed input types")
+  }
+
+  /**
+   * Computes the one-way ANOVA F-statistic from primitive group arrays.
+   *
+   * @param groups list of primitive group arrays
+   * @return the F-statistic
+   */
+  static BigDecimal oneWayAnovaFValueArrays(List<double[]> groups) {
+    BigDecimal.valueOf(oneWayAnovaFValueInternal(copyPrimitiveGroups(groups)))
+  }
+
+  /**
+   * Computes the one-way ANOVA F-statistic from idiomatic Groovy numeric lists.
+   *
+   * @param groups collection of numeric group values
+   * @return the F-statistic
+   */
+  static BigDecimal oneWayAnovaFValueFromLists(Collection<? extends List<? extends Number>> groups) {
+    BigDecimal.valueOf(oneWayAnovaFValueInternal(normalizeListGroups(groups)))
   }
 
   private static double oneWayAnovaFValueInternal(List<double[]> groups) {
@@ -179,26 +211,73 @@ class FDistribution implements ContinuousDistribution {
    * @param groups list of double arrays, each representing a group
    * @return the p-value for the ANOVA test
    */
+  @Deprecated
   static BigDecimal oneWayAnovaPValue(List<?> groups) {
-    int k = groups.size()
-    int n = normalizeGroups(groups).sum { double[] group -> group.length } as int
+    if (groups == null) {
+      return oneWayAnovaPValueArrays(null)
+    }
+    if (groups.isEmpty() || groups.every { Object group -> group instanceof double[] }) {
+      return oneWayAnovaPValueArrays(groups as List<double[]>)
+    }
+    if (groups.every { Object group -> group instanceof List<?> }) {
+      return oneWayAnovaPValueFromLists(groups as Collection<? extends List<? extends Number>>)
+    }
+    throw new IllegalArgumentException("Each group must be a List<Number> or double[], got mixed input types")
+  }
 
-    BigDecimal f = oneWayAnovaFValue(groups)
+  /**
+   * Computes the one-way ANOVA p-value from primitive group arrays.
+   *
+   * @param groups list of primitive group arrays
+   * @return the p-value for the ANOVA test
+   */
+  static BigDecimal oneWayAnovaPValueArrays(List<double[]> groups) {
+    List<double[]> normalizedGroups = copyPrimitiveGroups(groups)
+    int k = normalizedGroups.size()
+    int n = normalizedGroups.sum { double[] group -> group.length } as int
+
+    BigDecimal f = oneWayAnovaFValueArrays(normalizedGroups)
     BigDecimal dfBetween = k - 1
     BigDecimal dfWithin = n - k
 
     pValue(f, dfBetween, dfWithin)
   }
 
-  private static List<double[]> normalizeGroups(List<?> groups) {
-    groups.collect { Object group ->
-      if (group instanceof double[]) {
-        group as double[]
-      } else if (group instanceof List) {
-        NumericConversion.toDoubleArray(group as List<? extends Number>, 'group')
-      } else {
-        throw new IllegalArgumentException("Each group must be a List<Number> or double[], got ${group?.class?.simpleName}")
-      }
+  /**
+   * Computes the one-way ANOVA p-value from idiomatic Groovy numeric lists.
+   *
+   * @param groups collection of numeric group values
+   * @return the p-value for the ANOVA test
+   */
+  static BigDecimal oneWayAnovaPValueFromLists(Collection<? extends List<? extends Number>> groups) {
+    List<double[]> normalizedGroups = normalizeListGroups(groups)
+    int k = normalizedGroups.size()
+    int n = normalizedGroups.sum { double[] group -> group.length } as int
+
+    BigDecimal f = oneWayAnovaFValueFromLists(groups)
+    BigDecimal dfBetween = k - 1
+    BigDecimal dfWithin = n - k
+
+    pValue(f, dfBetween, dfWithin)
+  }
+
+  private static List<double[]> copyPrimitiveGroups(List<double[]> groups) {
+    if (groups == null) {
+      return []
+    }
+    List<double[]> normalized = []
+    for (double[] group : groups) {
+      normalized << (group == null ? null : (group.clone() as double[]))
+    }
+    normalized
+  }
+
+  private static List<double[]> normalizeListGroups(Collection<? extends List<? extends Number>> groups) {
+    if (groups == null) {
+      return []
+    }
+    groups.collect { List<? extends Number> group ->
+      NumericConversion.toDoubleArray(group, 'group')
     }
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/FDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/FDistribution.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.distribution
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * F-distribution (Fisher-Snedecor distribution) implementation.
  * Provides CDF and p-value calculations for ANOVA and variance ratio tests.
@@ -9,8 +11,8 @@ package se.alipsa.matrix.stats.distribution
 @SuppressWarnings('DuplicateNumberLiteral')
 class FDistribution implements ContinuousDistribution {
 
-  private final double dfNumerator
-  private final double dfDenominator
+  private final BigDecimal dfNumerator
+  private final BigDecimal dfDenominator
 
   /**
    * Creates an F-distribution with the specified degrees of freedom.
@@ -18,15 +20,21 @@ class FDistribution implements ContinuousDistribution {
    * @param dfNumerator degrees of freedom for the numerator (between groups)
    * @param dfDenominator degrees of freedom for the denominator (within groups)
    */
-  FDistribution(double dfNumerator, double dfDenominator) {
-    if (dfNumerator <= 0 || dfDenominator <= 0) {
+  FDistribution(Number dfNumerator, Number dfDenominator) {
+    BigDecimal normalizedDfNumerator = NumericConversion.toBigDecimal(dfNumerator, 'dfNumerator')
+    BigDecimal normalizedDfDenominator = NumericConversion.toBigDecimal(dfDenominator, 'dfDenominator')
+    if (normalizedDfNumerator <= 0 || normalizedDfDenominator <= 0) {
       throw new IllegalArgumentException(
           "Degrees of freedom must be positive, got: dfNumerator=$dfNumerator, dfDenominator=$dfDenominator"
       )
     }
-    this.dfNumerator = dfNumerator
-    this.dfDenominator = dfDenominator
+    this.dfNumerator = normalizedDfNumerator
+    this.dfDenominator = normalizedDfDenominator
   }
+
+  BigDecimal getDfNumerator() { dfNumerator }
+
+  BigDecimal getDfDenominator() { dfDenominator }
 
   /**
    * Computes the cumulative distribution function (CDF) of the F-distribution.
@@ -35,7 +43,16 @@ class FDistribution implements ContinuousDistribution {
    * @param f the F-value (must be >= 0)
    * @return probability P(F <= f)
    */
+  BigDecimal cdf(Number f) {
+    BigDecimal.valueOf(cdfValue(NumericConversion.toFiniteDouble(f, 'f')))
+  }
+
+  @Deprecated
   double cdf(double f) {
+    cdfValue(f)
+  }
+
+  private double cdfValue(double f) {
     if (f < 0) {
       throw new IllegalArgumentException("f must be non-negative, got: $f")
     }
@@ -46,8 +63,10 @@ class FDistribution implements ContinuousDistribution {
     // F-distribution CDF in terms of incomplete beta function
     // F ~ (dfNum/dfDen) * (B/A) where A,B are chi-squared
     // CDF = I_x(dfNum/2, dfDen/2) where x = (dfNum*f)/(dfNum*f + dfDen)
-    double x = (dfNumerator * f) / (dfNumerator * f + dfDenominator)
-    return SpecialFunctions.regularizedIncompleteBeta(x, dfNumerator / 2.0d, dfDenominator / 2.0d)
+    double numerator = dfNumerator as double
+    double denominator = dfDenominator as double
+    double x = (numerator * f) / (numerator * f + denominator)
+    return SpecialFunctions.regularizedIncompleteBeta(x, numerator / 2.0d, denominator / 2.0d)
   }
 
   /**
@@ -56,8 +75,14 @@ class FDistribution implements ContinuousDistribution {
    * @param f the F-value (must be >= 0)
    * @return probability P(F <= f)
    */
-  double cumulativeProbability(double f) {
+  BigDecimal cumulativeProbability(Number f) {
     cdf(f)
+  }
+
+  @Override
+  @Deprecated
+  double cumulativeProbability(double f) {
+    cdfValue(f)
   }
 
   /**
@@ -67,8 +92,13 @@ class FDistribution implements ContinuousDistribution {
    * @param f the F-statistic
    * @return p-value (probability of observing a value at least as extreme)
    */
+  BigDecimal pValue(Number f) {
+    1.0 - cdf(f)
+  }
+
+  @Deprecated
   double pValue(double f) {
-    return 1.0 - cdf(f)
+    1.0d - cdfValue(f)
   }
 
   /**
@@ -79,8 +109,13 @@ class FDistribution implements ContinuousDistribution {
    * @param dfDenominator degrees of freedom for the denominator
    * @return p-value
    */
+  static BigDecimal pValue(Number f, Number dfNumerator, Number dfDenominator) {
+    new FDistribution(dfNumerator, dfDenominator).pValue(f)
+  }
+
+  @Deprecated
   static double pValue(double f, double dfNumerator, double dfDenominator) {
-    return new FDistribution(dfNumerator, dfDenominator).pValue(f)
+    new FDistribution(dfNumerator, dfDenominator).pValue(f) as double
   }
 
   /**
@@ -89,7 +124,11 @@ class FDistribution implements ContinuousDistribution {
    * @param groups list of double arrays, each representing a group
    * @return the F-statistic
    */
-  static double oneWayAnovaFValue(List<double[]> groups) {
+  static BigDecimal oneWayAnovaFValue(List<?> groups) {
+    BigDecimal.valueOf(oneWayAnovaFValueInternal(normalizeGroups(groups)))
+  }
+
+  private static double oneWayAnovaFValueInternal(List<double[]> groups) {
     int k = groups.size()  // number of groups
     double grandSum = 0.0
     List<Integer> groupSizes = groups.collect { double[] group -> group.length }
@@ -131,7 +170,7 @@ class FDistribution implements ContinuousDistribution {
     double msw = ssw / dfWithin
 
     // F-statistic
-    return msb / msw
+    msb / msw
   }
 
   /**
@@ -140,14 +179,26 @@ class FDistribution implements ContinuousDistribution {
    * @param groups list of double arrays, each representing a group
    * @return the p-value for the ANOVA test
    */
-  static double oneWayAnovaPValue(List<double[]> groups) {
+  static BigDecimal oneWayAnovaPValue(List<?> groups) {
     int k = groups.size()
-    int n = groups.sum { double[] group -> group.length } as int
+    int n = normalizeGroups(groups).sum { double[] group -> group.length } as int
 
-    double f = oneWayAnovaFValue(groups)
-    double dfBetween = k - 1
-    double dfWithin = n - k
+    BigDecimal f = oneWayAnovaFValue(groups)
+    BigDecimal dfBetween = k - 1
+    BigDecimal dfWithin = n - k
 
-    return pValue(f, dfBetween, dfWithin)
+    pValue(f, dfBetween, dfWithin)
+  }
+
+  private static List<double[]> normalizeGroups(List<?> groups) {
+    groups.collect { Object group ->
+      if (group instanceof double[]) {
+        group as double[]
+      } else if (group instanceof List) {
+        NumericConversion.toDoubleArray(group as List<? extends Number>, 'group')
+      } else {
+        throw new IllegalArgumentException("Each group must be a List<Number> or double[], got ${group?.class?.simpleName}")
+      }
+    }
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/FDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/FDistribution.groovy
@@ -66,7 +66,7 @@ class FDistribution implements ContinuousDistribution {
     double numerator = dfNumerator as double
     double denominator = dfDenominator as double
     double x = (numerator * f) / (numerator * f + denominator)
-    return SpecialFunctions.regularizedIncompleteBeta(x, numerator / 2.0d, denominator / 2.0d)
+    SpecialFunctions.regularizedIncompleteBeta(x, numerator / 2.0d, denominator / 2.0d)
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/FDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/FDistribution.groovy
@@ -126,18 +126,15 @@ class FDistribution implements ContinuousDistribution {
    * @param groups list of double arrays, each representing a group
    * @return the F-statistic
    */
+  /** @deprecated Use {@link #oneWayAnovaFValueArrays} or {@link #oneWayAnovaFValueFromLists} instead. */
   @Deprecated
   static BigDecimal oneWayAnovaFValue(List<?> groups) {
-    if (groups == null) {
-      return oneWayAnovaFValueArrays(null)
-    }
-    if (groups.isEmpty() || groups.every { Object group -> group instanceof double[] }) {
-      return oneWayAnovaFValueArrays(groups as List<double[]>)
-    }
-    if (groups.every { Object group -> group instanceof List<?> }) {
-      return oneWayAnovaFValueFromLists(groups as Collection<? extends List<? extends Number>>)
-    }
-    throw new IllegalArgumentException("Each group must be a List<Number> or double[], got mixed input types")
+    NumericConversion.<BigDecimal> dispatchPrimitiveOrList(
+      groups,
+      { List<?> g -> oneWayAnovaFValueArrays(g as List<double[]>) },
+      { List<?> g -> oneWayAnovaFValueFromLists(g as Collection<? extends List<? extends Number>>) },
+      'group'
+    )
   }
 
   /**
@@ -211,18 +208,15 @@ class FDistribution implements ContinuousDistribution {
    * @param groups list of double arrays, each representing a group
    * @return the p-value for the ANOVA test
    */
+  /** @deprecated Use {@link #oneWayAnovaPValueArrays} or {@link #oneWayAnovaPValueFromLists} instead. */
   @Deprecated
   static BigDecimal oneWayAnovaPValue(List<?> groups) {
-    if (groups == null) {
-      return oneWayAnovaPValueArrays(null)
-    }
-    if (groups.isEmpty() || groups.every { Object group -> group instanceof double[] }) {
-      return oneWayAnovaPValueArrays(groups as List<double[]>)
-    }
-    if (groups.every { Object group -> group instanceof List<?> }) {
-      return oneWayAnovaPValueFromLists(groups as Collection<? extends List<? extends Number>>)
-    }
-    throw new IllegalArgumentException("Each group must be a List<Number> or double[], got mixed input types")
+    NumericConversion.<BigDecimal> dispatchPrimitiveOrList(
+      groups,
+      { List<?> g -> oneWayAnovaPValueArrays(g as List<double[]>) },
+      { List<?> g -> oneWayAnovaPValueFromLists(g as Collection<? extends List<? extends Number>>) },
+      'group'
+    )
   }
 
   /**
@@ -254,7 +248,7 @@ class FDistribution implements ContinuousDistribution {
     int k = normalizedGroups.size()
     int n = normalizedGroups.sum { double[] group -> group.length } as int
 
-    BigDecimal f = oneWayAnovaFValueFromLists(groups)
+    BigDecimal f = BigDecimal.valueOf(oneWayAnovaFValueInternal(normalizedGroups))
     BigDecimal dfBetween = k - 1
     BigDecimal dfWithin = n - k
 
@@ -266,8 +260,12 @@ class FDistribution implements ContinuousDistribution {
       return []
     }
     List<double[]> normalized = []
-    for (double[] group : groups) {
-      normalized << (group == null ? null : (group.clone() as double[]))
+    for (int i = 0; i < groups.size(); i++) {
+      double[] group = groups[i]
+      if (group == null) {
+        throw new IllegalArgumentException("Group at index ${i} cannot be null")
+      }
+      normalized << (group.clone() as double[])
     }
     normalized
   }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/HypergeometricDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/HypergeometricDistribution.groovy
@@ -56,7 +56,7 @@ class HypergeometricDistribution {
         logCombination(populationSize - numberOfSuccesses, sampleSize - x) -
         logCombination(populationSize, sampleSize)
 
-    return Math.exp(logProbability)
+    Math.exp(logProbability)
   }
 
   BigDecimal cumulativeProbability(Number x) {
@@ -76,7 +76,7 @@ class HypergeometricDistribution {
     for (int k = supportLowerBound; k <= x; k++) {
       sum += probability(k)
     }
-    return Math.min(1.0d, sum)
+    Math.min(1.0d, sum)
   }
 
   BigDecimal upperCumulativeProbability(Number x) {
@@ -96,14 +96,14 @@ class HypergeometricDistribution {
     for (int k = x; k <= supportUpperBound; k++) {
       sum += probability(k)
     }
-    return Math.min(1.0d, sum)
+    Math.min(1.0d, sum)
   }
 
   private static double logCombination(int n, int k) {
     if (k < 0 || k > n) {
       return Double.NEGATIVE_INFINITY
     }
-    return SpecialFunctions.logGamma(n + 1.0d) -
+    SpecialFunctions.logGamma(n + 1.0d) -
         SpecialFunctions.logGamma(k + 1.0d) -
         SpecialFunctions.logGamma(n - k + 1.0d)
   }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/HypergeometricDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/HypergeometricDistribution.groovy
@@ -43,7 +43,7 @@ class HypergeometricDistribution {
   }
 
   BigDecimal probability(Number x) {
-    BigDecimal.valueOf(probability(NumericConversion.toBigDecimal(x, 'x').intValue()))
+    BigDecimal.valueOf(probability(NumericConversion.toExactInt(x, 'x')))
   }
 
   @Deprecated
@@ -60,7 +60,7 @@ class HypergeometricDistribution {
   }
 
   BigDecimal cumulativeProbability(Number x) {
-    BigDecimal.valueOf(cumulativeProbability(NumericConversion.toBigDecimal(x, 'x').intValue()))
+    BigDecimal.valueOf(cumulativeProbability(NumericConversion.toExactInt(x, 'x')))
   }
 
   @Deprecated
@@ -80,7 +80,7 @@ class HypergeometricDistribution {
   }
 
   BigDecimal upperCumulativeProbability(Number x) {
-    BigDecimal.valueOf(upperCumulativeProbability(NumericConversion.toBigDecimal(x, 'x').intValue()))
+    BigDecimal.valueOf(upperCumulativeProbability(NumericConversion.toExactInt(x, 'x')))
   }
 
   @Deprecated

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/HypergeometricDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/HypergeometricDistribution.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.distribution
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Hypergeometric distribution implementation for exact contingency-table calculations.
  */
@@ -40,6 +42,11 @@ class HypergeometricDistribution {
     supportUpperBound
   }
 
+  BigDecimal probability(Number x) {
+    BigDecimal.valueOf(probability(NumericConversion.toBigDecimal(x, 'x').intValue()))
+  }
+
+  @Deprecated
   double probability(int x) {
     if (x < supportLowerBound || x > supportUpperBound) {
       return 0.0d
@@ -52,6 +59,11 @@ class HypergeometricDistribution {
     return Math.exp(logProbability)
   }
 
+  BigDecimal cumulativeProbability(Number x) {
+    BigDecimal.valueOf(cumulativeProbability(NumericConversion.toBigDecimal(x, 'x').intValue()))
+  }
+
+  @Deprecated
   double cumulativeProbability(int x) {
     if (x < supportLowerBound) {
       return 0.0d
@@ -67,6 +79,11 @@ class HypergeometricDistribution {
     return Math.min(1.0d, sum)
   }
 
+  BigDecimal upperCumulativeProbability(Number x) {
+    BigDecimal.valueOf(upperCumulativeProbability(NumericConversion.toBigDecimal(x, 'x').intValue()))
+  }
+
+  @Deprecated
   double upperCumulativeProbability(int x) {
     if (x <= supportLowerBound) {
       return 1.0d

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/NormalDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/NormalDistribution.groovy
@@ -102,7 +102,7 @@ class NormalDistribution implements ContinuousDistribution {
     if (z >= 0.0d) {
       return 0.5d * (1.0d + gamma)
     }
-    return 0.5d * (1.0d - gamma)
+    0.5d * (1.0d - gamma)
   }
 
   private double inverseCumulativeProbabilityValue(double p) {
@@ -134,7 +134,7 @@ class NormalDistribution implements ContinuousDistribution {
     double density = Math.exp(-0.5d * x * x) / Math.sqrt(2.0d * Math.PI)
     x -= error / density
 
-    return (mean as double) + (standardDeviation as double) * x
+    (mean as double) + (standardDeviation as double) * x
   }
 
   private static double polynomial(double[] coefficients, double x) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/NormalDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/NormalDistribution.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.distribution
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Normal (Gaussian) distribution implementation with cumulative and inverse cumulative probability.
  */
@@ -46,28 +48,48 @@ class NormalDistribution implements ContinuousDistribution {
   private static final double P_LOW = 0.02425d
   private static final double P_HIGH = 1.0d - P_LOW
 
-  private final double mean
-  private final double standardDeviation
+  private final BigDecimal mean
+  private final BigDecimal standardDeviation
 
-  NormalDistribution(double mean = 0.0d, double standardDeviation = 1.0d) {
-    if (standardDeviation <= 0.0d) {
+  NormalDistribution(Number mean = 0.0d, Number standardDeviation = 1.0d) {
+    BigDecimal normalizedMean = NumericConversion.toBigDecimal(mean, 'mean')
+    BigDecimal normalizedStandardDeviation = NumericConversion.toBigDecimal(standardDeviation, 'standardDeviation')
+    if (normalizedStandardDeviation <= 0.0d) {
       throw new IllegalArgumentException("Standard deviation must be positive, got: $standardDeviation")
     }
-    this.mean = mean
-    this.standardDeviation = standardDeviation
+    this.mean = normalizedMean
+    this.standardDeviation = normalizedStandardDeviation
   }
 
-  double getMean() {
+  BigDecimal getMean() {
     mean
   }
 
-  double getStandardDeviation() {
+  BigDecimal getStandardDeviation() {
     standardDeviation
   }
 
+  BigDecimal cumulativeProbability(Number x) {
+    BigDecimal.valueOf(cumulativeProbabilityValue(NumericConversion.toFiniteDouble(x, 'x')))
+  }
+
   @Override
+  @Deprecated
   double cumulativeProbability(double x) {
-    double standardized = (x - mean) / standardDeviation
+    cumulativeProbabilityValue(x)
+  }
+
+  BigDecimal inverseCumulativeProbability(Number p) {
+    BigDecimal.valueOf(inverseCumulativeProbabilityValue(NumericConversion.toFiniteDouble(p, 'p')))
+  }
+
+  @Deprecated
+  double inverseCumulativeProbability(double p) {
+    inverseCumulativeProbabilityValue(p)
+  }
+
+  private double cumulativeProbabilityValue(double x) {
+    double standardized = (x - (mean as double)) / (standardDeviation as double)
     if (standardized == Double.NEGATIVE_INFINITY) {
       return 0.0d
     }
@@ -83,7 +105,7 @@ class NormalDistribution implements ContinuousDistribution {
     return 0.5d * (1.0d - gamma)
   }
 
-  double inverseCumulativeProbability(double p) {
+  private double inverseCumulativeProbabilityValue(double p) {
     if (p < 0.0d || p > 1.0d) {
       throw new IllegalArgumentException("p must be between 0 and 1, got: $p")
     }
@@ -108,11 +130,11 @@ class NormalDistribution implements ContinuousDistribution {
     }
 
     // One Newton refinement step brings the approximation close to machine precision.
-    double error = cumulativeProbability(mean + standardDeviation * x) - p
+    double error = cumulativeProbabilityValue((mean as double) + (standardDeviation as double) * x) - p
     double density = Math.exp(-0.5d * x * x) / Math.sqrt(2.0d * Math.PI)
     x -= error / density
 
-    return mean + standardDeviation * x
+    return (mean as double) + (standardDeviation as double) * x
   }
 
   private static double polynomial(double[] coefficients, double x) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/SpecialFunctions.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/SpecialFunctions.groovy
@@ -3,6 +3,8 @@ package se.alipsa.matrix.stats.distribution
 import static java.math.BigDecimal.*
 import static se.alipsa.matrix.ext.NumberExtension.*
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 import java.math.MathContext
 import java.math.RoundingMode
 
@@ -65,6 +67,22 @@ class SpecialFunctions {
     )
 
     return bt * betaContinuedFraction(x, a, b) / a
+  }
+
+  /**
+   * BigDecimal-friendly incomplete beta function.
+   *
+   * @param x the evaluation point
+   * @param a the first shape parameter
+   * @param b the second shape parameter
+   * @return the regularized incomplete beta value
+   */
+  static BigDecimal regularizedIncompleteBeta(Number x, Number a, Number b) {
+    BigDecimal.valueOf(regularizedIncompleteBeta(
+      NumericConversion.toFiniteDouble(x, 'x'),
+      NumericConversion.toFiniteDouble(a, 'a'),
+      NumericConversion.toFiniteDouble(b, 'b')
+    ))
   }
 
   static BigDecimal regularizedIncompleteBeta(BigDecimal x, BigDecimal a, BigDecimal b) {
@@ -330,6 +348,20 @@ class SpecialFunctions {
   }
 
   /**
+   * BigDecimal-friendly lower regularized incomplete gamma function.
+   *
+   * @param a the shape parameter
+   * @param x the evaluation point
+   * @return the regularized incomplete gamma value
+   */
+  static BigDecimal regularizedIncompleteGammaP(Number a, Number x) {
+    BigDecimal.valueOf(regularizedIncompleteGammaP(
+      NumericConversion.toFiniteDouble(a, 'a'),
+      NumericConversion.toFiniteDouble(x, 'x')
+    ))
+  }
+
+  /**
    * Computes the regularized upper incomplete gamma function Q(a, x).
    *
    * @param a shape parameter (a > 0)
@@ -354,6 +386,20 @@ class SpecialFunctions {
       return 1.0d - gammaSeries(a, x)
     }
     return gammaContinuedFraction(a, x)
+  }
+
+  /**
+   * BigDecimal-friendly upper regularized incomplete gamma function.
+   *
+   * @param a the shape parameter
+   * @param x the evaluation point
+   * @return the upper-tail regularized incomplete gamma value
+   */
+  static BigDecimal regularizedIncompleteGammaQ(Number a, Number x) {
+    BigDecimal.valueOf(regularizedIncompleteGammaQ(
+      NumericConversion.toFiniteDouble(a, 'a'),
+      NumericConversion.toFiniteDouble(x, 'x')
+    ))
   }
 
   private static double gammaSeries(double a, double x) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/SpecialFunctions.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/SpecialFunctions.groovy
@@ -5,6 +5,7 @@ import static se.alipsa.matrix.ext.NumberExtension.*
 
 import java.math.MathContext
 import java.math.RoundingMode
+
 /**
  * Special mathematical functions used in statistical distributions.
  * Implementation based on algorithms from Numerical Recipes and NIST.

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/SpecialFunctions.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/SpecialFunctions.groovy
@@ -66,7 +66,7 @@ class SpecialFunctions {
         a * Math.log(x) + b * Math.log(1.0d - x)
     )
 
-    return bt * betaContinuedFraction(x, a, b) / a
+    bt * betaContinuedFraction(x, a, b) / a
   }
 
   /**
@@ -260,7 +260,7 @@ class SpecialFunctions {
       a += coef[i] / (x + i)
     }
 
-    return 0.5 * Math.log(2.0 * Math.PI) + (x + 0.5) * Math.log(t) - t + Math.log(a)
+    0.5 * Math.log(2.0 * Math.PI) + (x + 0.5) * Math.log(t) - t + Math.log(a)
   }
 
   static BigDecimal logGamma(BigDecimal x) {
@@ -293,7 +293,7 @@ class SpecialFunctions {
       a += coef[i] / (x + i)
     }
 
-    return 0.5 * (2.0 * PI).log() + (x + 0.5) * t.log() - t + a.log()
+    0.5 * (2.0 * PI).log() + (x + 0.5) * t.log() - t + a.log()
   }
 
   /**
@@ -310,14 +310,14 @@ class SpecialFunctions {
       throw new IllegalArgumentException("x must be positive, got: $x")
     }
 
-    return Math.exp(logGamma(x))
+    Math.exp(logGamma(x))
   }
 
   static BigDecimal gamma(BigDecimal x) {
     if (x <= 0.0) {
       throw new IllegalArgumentException("x must be positive, got: $x")
     }
-    return logGamma(x).exp()
+    logGamma(x).exp()
   }
 
   /**
@@ -344,7 +344,7 @@ class SpecialFunctions {
     if (x < a + 1.0d) {
       return gammaSeries(a, x)
     }
-    return 1.0d - regularizedIncompleteGammaQ(a, x)
+    1.0d - regularizedIncompleteGammaQ(a, x)
   }
 
   /**
@@ -385,7 +385,7 @@ class SpecialFunctions {
     if (x < a + 1.0d) {
       return 1.0d - gammaSeries(a, x)
     }
-    return gammaContinuedFraction(a, x)
+    gammaContinuedFraction(a, x)
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/TDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/TDistribution.groovy
@@ -1,6 +1,7 @@
 package se.alipsa.matrix.stats.distribution
 
 import se.alipsa.matrix.core.Stat
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * Student's t-distribution implementation.
@@ -22,6 +23,10 @@ class TDistribution {
 
   TDistribution(double degreesOfFreedom) {
     this(degreesOfFreedom as BigDecimal)
+  }
+
+  TDistribution(Number degreesOfFreedom) {
+    this(NumericConversion.toBigDecimal(degreesOfFreedom, 'degreesOfFreedom'))
   }
 
   /**
@@ -54,6 +59,10 @@ class TDistribution {
     }
   }
 
+  BigDecimal cdf(Number t) {
+    cdf(NumericConversion.toBigDecimal(t, 't'))
+  }
+
   /**
    * Computes the two-tailed p-value for a t-statistic.
    * This is 2 * P(T > |t|) = 2 * (1 - CDF(|t|))
@@ -71,6 +80,10 @@ class TDistribution {
     return BigDecimal.TWO * (BigDecimal.ONE - cdf(absT))
   }
 
+  BigDecimal twoTailedPValue(Number t) {
+    twoTailedPValue(NumericConversion.toBigDecimal(t, 't'))
+  }
+
   /**
    * Computes the one-tailed p-value for a t-statistic (upper tail).
    * This is P(T > t) = 1 - CDF(t)
@@ -80,6 +93,10 @@ class TDistribution {
    */
   BigDecimal oneTailedPValueUpper(BigDecimal t) {
     return BigDecimal.ONE - cdf(t)
+  }
+
+  BigDecimal oneTailedPValueUpper(Number t) {
+    oneTailedPValueUpper(NumericConversion.toBigDecimal(t, 't'))
   }
 
   double oneTailedPValueUpper(double t) {
@@ -97,6 +114,10 @@ class TDistribution {
     return cdf(t)
   }
 
+  BigDecimal oneTailedPValueLower(Number t) {
+    cdf(NumericConversion.toBigDecimal(t, 't'))
+  }
+
   /**
    * Static convenience method for computing two-tailed p-value.
    *
@@ -110,6 +131,10 @@ class TDistribution {
 
   static BigDecimal pValue(BigDecimal t, BigDecimal df) {
     return new TDistribution(df).twoTailedPValue(t)
+  }
+
+  static BigDecimal pValue(Number t, Number df) {
+    new TDistribution(df).twoTailedPValue(t)
   }
 
   /**
@@ -161,6 +186,12 @@ class TDistribution {
     return pValue(t, df)
   }
 
+  static BigDecimal twoSampleTTest(List<? extends Number> sample1, List<? extends Number> sample2) {
+    BigDecimal[] left = sample1.collect { Number value -> NumericConversion.toBigDecimal(value, 'sample1 value') } as BigDecimal[]
+    BigDecimal[] right = sample2.collect { Number value -> NumericConversion.toBigDecimal(value, 'sample2 value') } as BigDecimal[]
+    twoSampleTTest(left, right)
+  }
+
   /**
    * Computes the one-sample t-test p-value (two-tailed).
    *
@@ -184,6 +215,11 @@ class TDistribution {
     BigDecimal t = (mean - mu) / (sd / n.sqrt())
     BigDecimal df = n - 1
     return pValue(t, df)
+  }
+
+  static BigDecimal oneSampleTTest(Number mu, List<? extends Number> sample) {
+    BigDecimal[] values = sample.collect { Number value -> NumericConversion.toBigDecimal(value, 'sample value') } as BigDecimal[]
+    oneSampleTTest(NumericConversion.toBigDecimal(mu, 'mu'), values)
   }
 
   private static double mean(double[] values) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/TDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/TDistribution.groovy
@@ -72,12 +72,12 @@ class TDistribution {
    */
   double twoTailedPValue(double t) {
     double absT = Math.abs(t)
-    return 2.0d * (1.0d - cdf(absT))
+    2.0d * (1.0d - cdf(absT))
   }
 
   BigDecimal twoTailedPValue(BigDecimal t) {
     BigDecimal absT = t.abs()
-    return BigDecimal.TWO * (BigDecimal.ONE - cdf(absT))
+    BigDecimal.TWO * (BigDecimal.ONE - cdf(absT))
   }
 
   BigDecimal twoTailedPValue(Number t) {
@@ -92,7 +92,7 @@ class TDistribution {
    * @return one-tailed p-value (upper)
    */
   BigDecimal oneTailedPValueUpper(BigDecimal t) {
-    return BigDecimal.ONE - cdf(t)
+    BigDecimal.ONE - cdf(t)
   }
 
   BigDecimal oneTailedPValueUpper(Number t) {
@@ -100,7 +100,7 @@ class TDistribution {
   }
 
   double oneTailedPValueUpper(double t) {
-    return 1.0d - cdf(t)
+    1.0d - cdf(t)
   }
 
   /**
@@ -111,7 +111,7 @@ class TDistribution {
    * @return one-tailed p-value (lower)
    */
   double oneTailedPValueLower(double t) {
-    return cdf(t)
+    cdf(t)
   }
 
   BigDecimal oneTailedPValueLower(Number t) {
@@ -126,11 +126,11 @@ class TDistribution {
    * @return two-tailed p-value
    */
   static double pValue(double t, double df) {
-    return new TDistribution(df).twoTailedPValue(t)
+    new TDistribution(df).twoTailedPValue(t)
   }
 
   static BigDecimal pValue(BigDecimal t, BigDecimal df) {
-    return new TDistribution(df).twoTailedPValue(t)
+    new TDistribution(df).twoTailedPValue(t)
   }
 
   static BigDecimal pValue(Number t, Number df) {
@@ -162,7 +162,7 @@ class TDistribution {
     double denom = Math.pow(var1 / n1 as double, 2) / (n1 - 1) + Math.pow(var2 / n2 as double, 2) / (n2 - 1)
     double df = num / denom
 
-    return pValue(t, df)
+    pValue(t, df)
   }
 
   static BigDecimal twoSampleTTest(BigDecimal[] sample1, BigDecimal[] sample2) {
@@ -183,7 +183,7 @@ class TDistribution {
     BigDecimal denom = ((var1 / n1) ** 2) / (n1 - 1) + ((var2 / n2) ** 2) / (n2 - 1)
     BigDecimal df = num / denom
 
-    return pValue(t, df)
+    pValue(t, df)
   }
 
   static BigDecimal twoSampleTTest(List<? extends Number> sample1, List<? extends Number> sample2) {
@@ -205,7 +205,7 @@ class TDistribution {
     double sd = Math.sqrt(variance(sample, mean))
     double t = (mean - mu) / (sd / Math.sqrt(n))
     double df = n - 1
-    return pValue(t, df)
+    pValue(t, df)
   }
 
   static BigDecimal oneSampleTTest(BigDecimal mu, BigDecimal[] sample) {
@@ -214,7 +214,7 @@ class TDistribution {
     BigDecimal sd = Stat.variance(sample, mean).sqrt()
     BigDecimal t = (mean - mu) / (sd / n.sqrt())
     BigDecimal df = n - 1
-    return pValue(t, df)
+    pValue(t, df)
   }
 
   static BigDecimal oneSampleTTest(Number mu, List<? extends Number> sample) {
@@ -227,7 +227,7 @@ class TDistribution {
     for (double v : values) {
       sum += v
     }
-    return sum / values.length
+    sum / values.length
   }
 
   private static double variance(double[] values, double mean) {
@@ -236,6 +236,6 @@ class TDistribution {
       double diff = v - mean
       sum += diff * diff
     }
-    return sum / (values.length - 1)
+    sum / (values.length - 1)
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/CategoricalEncoder.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/CategoricalEncoder.groovy
@@ -1,13 +1,10 @@
 package se.alipsa.matrix.stats.formula
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 
 /**
  * Encodes categorical columns using configurable contrasts.
  */
-@CompileStatic
 final class CategoricalEncoder {
 
   private final Matrix data

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ContrastType.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ContrastType.groovy
@@ -1,11 +1,8 @@
 package se.alipsa.matrix.stats.formula
 
-import groovy.transform.CompileStatic
-
 /**
  * Supported contrast types for categorical predictor encoding.
  */
-@CompileStatic
 enum ContrastType {
   /**
    * Treatment contrasts (dummy coding): one level is the reference and omitted.

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/DesignMatrixBuilder.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/DesignMatrixBuilder.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.formula
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 
 /**
@@ -17,7 +15,6 @@ import se.alipsa.matrix.core.Matrix
  * only a reference level after filtering, the returned {@link Terms} metadata preserves
  * that dropped-term state even though no predictor column is emitted.
  */
-@CompileStatic
 final class DesignMatrixBuilder {
 
   private final Matrix data
@@ -347,7 +344,6 @@ final class DesignMatrixBuilder {
       .build()
   }
 
-  @CompileStatic
   static final class DesignMatrix {
     final Matrix data
     final List<String> predictorNames
@@ -360,7 +356,6 @@ final class DesignMatrixBuilder {
     }
   }
 
-  @CompileStatic
   private static final class ColumnInfo {
     final String name
     final List<BigDecimal> values

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ExpressionEvaluator.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ExpressionEvaluator.groovy
@@ -80,21 +80,21 @@ final class ExpressionEvaluator {
         throw new IllegalArgumentException("log() requires exactly 1 argument, got ${call.arguments.size()}")
       }
       BigDecimal value = evaluateRow(call.arguments[0], rowIndex)
-      return Math.log(value as double) as BigDecimal
+      return value.log()
     }
     if (name == 'sqrt') {
       if (call.arguments.size() != 1) {
         throw new IllegalArgumentException("sqrt() requires exactly 1 argument, got ${call.arguments.size()}")
       }
       BigDecimal value = evaluateRow(call.arguments[0], rowIndex)
-      return Math.sqrt(value as double) as BigDecimal
+      return value.sqrt()
     }
     if (name == 'exp') {
       if (call.arguments.size() != 1) {
         throw new IllegalArgumentException("exp() requires exactly 1 argument, got ${call.arguments.size()}")
       }
       BigDecimal value = evaluateRow(call.arguments[0], rowIndex)
-      return Math.exp(value as double) as BigDecimal
+      return value.exp()
     }
     if (name == 'i') {
       if (call.arguments.size() != 1) {
@@ -127,7 +127,7 @@ final class ExpressionEvaluator {
         }
         left / right
       }
-      case '^' -> (Math.pow(left as double, right as double)) as BigDecimal
+      case '^' -> left ** right
       default -> throw new IllegalArgumentException("Unsupported binary operator: ${binary.operator}")
     }
   }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ExpressionEvaluator.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ExpressionEvaluator.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.formula
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 
 /**
@@ -11,7 +9,6 @@ import se.alipsa.matrix.core.Matrix
  * such as {@code log}, {@code sqrt}, and {@code exp}. The {@code I(...)} function is
  * treated as an arithmetic expression wrapper.
  */
-@CompileStatic
 final class ExpressionEvaluator {
 
   private final Matrix data

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/FormulaSupport.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/FormulaSupport.groovy
@@ -1,12 +1,10 @@
 package se.alipsa.matrix.stats.formula
 
-import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 
 /**
  * Internal parsing and normalization support for formula handling.
  */
-@CompileStatic
 @PackageScope
 @SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
 final class FormulaSupport {
@@ -446,7 +444,6 @@ final class FormulaSupport {
     } as List<FormulaTerm>
   }
 
-  @CompileStatic
   private static final class SignedExpression {
     final int sign
     final FormulaExpression expression
@@ -457,7 +454,6 @@ final class FormulaSupport {
     }
   }
 
-  @CompileStatic
   private enum TokenType {
     IDENTIFIER,
     BACKTICK_IDENTIFIER,
@@ -476,7 +472,6 @@ final class FormulaSupport {
     EOF
   }
 
-  @CompileStatic
   private static final class FormulaToken {
     final TokenType type
     final String text
@@ -491,7 +486,6 @@ final class FormulaSupport {
     }
   }
 
-  @CompileStatic
   private static final class Tokenizer {
     private final String source
     private int index = 0
@@ -631,7 +625,6 @@ final class FormulaSupport {
     }
   }
 
-  @CompileStatic
   private static final class Parser {
     private final String source
     private final List<FormulaToken> tokens

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/FormulaTerm.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/FormulaTerm.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.formula
 
-import groovy.transform.CompileStatic
-
 /**
  * A normalized predictor term made up of one or more factors.
  */

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ModelFrame.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ModelFrame.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.formula
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Row
 
@@ -33,7 +31,6 @@ import se.alipsa.matrix.core.Row
  * <p>No pass-through NA mode exists today. Rows containing nulls in formula-referenced
  * columns are either omitted or rejected depending on {@code na.action}.
  */
-@CompileStatic
 @SuppressWarnings('DuplicateStringLiteral')
 final class ModelFrame {
   private final ParsedFormula parsedFormula
@@ -735,7 +732,6 @@ final class ModelFrame {
     value
   }
 
-  @CompileStatic
   private static final class SubsetResult {
 
     final Matrix data
@@ -748,7 +744,6 @@ final class ModelFrame {
 
   }
 
-  @CompileStatic
   private static final class NaResult {
 
     final Matrix data

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ModelFrame.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ModelFrame.groovy
@@ -669,6 +669,7 @@ final class ModelFrame {
     }
   }
 
+  @SuppressWarnings('ReturnsNullInsteadOfEmptyCollection')
   private static List<Number> filterToSurvivors(List<Number> values, List<Integer> survivingOriginalIndices) {
     if (values == null) {
       return null
@@ -676,6 +677,7 @@ final class ModelFrame {
     survivingOriginalIndices.collect { Integer originalIdx -> values[originalIdx] } as List<Number>
   }
 
+  @SuppressWarnings('ReturnsNullInsteadOfEmptyCollection')
   private static Map<String, List<?>> filterEnvToSurvivors(Map<String, List<?>> env, List<Integer> survivingOriginalIndices) {
     if (env == null) {
       return null
@@ -706,6 +708,7 @@ final class ModelFrame {
     nullRows
   }
 
+  @SuppressWarnings('ReturnsNullInsteadOfEmptyCollection')
   private static List<Number> filterByIndices(List<Number> values, List<Integer> indices) {
     if (values == null) {
       return null
@@ -713,6 +716,7 @@ final class ModelFrame {
     indices.collect { int i -> values[i] } as List<Number>
   }
 
+  @SuppressWarnings('ReturnsNullInsteadOfEmptyCollection')
   private static Map<String, List<?>> filterEnvByIndices(Map<String, List<?>> env, List<Integer> indices) {
     if (env == null) {
       return null

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ModelFrameResult.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ModelFrameResult.groovy
@@ -1,14 +1,11 @@
 package se.alipsa.matrix.stats.formula
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 
 /**
  * Immutable result of model frame evaluation, containing the expanded design matrix
  * and associated metadata.
  */
-@CompileStatic
 final class ModelFrameResult {
 
   final Matrix data

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ModelFrameResult.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ModelFrameResult.groovy
@@ -36,6 +36,7 @@ final class ModelFrameResult {
    * @param formula the fully resolved normalized formula
    * @param terms metadata mapping formula terms to design matrix columns
    */
+  @SuppressWarnings('ParameterCount')
   ModelFrameResult(
     Matrix data,
     List<Number> response,

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/NormalizedFormula.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/NormalizedFormula.groovy
@@ -1,11 +1,8 @@
 package se.alipsa.matrix.stats.formula
 
-import groovy.transform.CompileStatic
-
 /**
  * Canonical formula representation with explicit intercept handling and normalized predictor terms.
  */
-@CompileStatic
 final class NormalizedFormula {
 
   final FormulaExpression response

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/SplineBasisExpander.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/SplineBasisExpander.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.formula
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
@@ -13,7 +11,6 @@ import se.alipsa.matrix.stats.util.NumericConversion
  * {@code y ~ x + s(x)} can combine an unpenalized linear effect with a
  * separate smooth component without duplicating columns.
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 final class SplineBasisExpander {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/SplineBasisExpander.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/SplineBasisExpander.groovy
@@ -41,8 +41,12 @@ final class SplineBasisExpander {
     double xMin = Double.MAX_VALUE
     double xMax = -Double.MAX_VALUE
     for (double v : x) {
-      if (v < xMin) xMin = v
-      if (v > xMax) xMax = v
+      if (v < xMin) {
+        xMin = v
+      }
+      if (v > xMax) {
+        xMax = v
+      }
     }
 
     if (xMax == xMin) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/SplineBasisExpander.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/SplineBasisExpander.groovy
@@ -2,6 +2,8 @@ package se.alipsa.matrix.stats.formula
 
 import groovy.transform.CompileStatic
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Generates natural cubic spline basis functions for use in GAM smooth terms.
  * Uses equally-spaced interior knots and the truncated-power basis with the
@@ -81,6 +83,17 @@ final class SplineBasisExpander {
 
     centerColumns(basis)
     basis
+  }
+
+  /**
+   * Generates a centered natural cubic spline basis matrix without the raw {@code x} term.
+   *
+   * @param x the predictor values (length n)
+   * @param df degrees of freedom (number of basis columns, must be >= 1)
+   * @return an n x df matrix of basis function evaluations
+   */
+  static double[][] naturalCubicSplineBasis(List<? extends Number> x, int df) {
+    naturalCubicSplineBasis(NumericConversion.toDoubleArray(x, 'x'), df)
   }
 
   private static double truncPow3(double v) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/Terms.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/Terms.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.formula
 
-import groovy.transform.CompileStatic
-
 /**
  * Immutable metadata describing the mapping from formula terms to design matrix columns.
  *
@@ -9,7 +7,6 @@ import groovy.transform.CompileStatic
  * which design matrix columns belong to which predictor term, whether a term is categorical,
  * and what factor levels were detected.
  */
-@CompileStatic
 final class Terms {
 
   final FormulaExpression response
@@ -25,7 +22,6 @@ final class Terms {
   /**
    * Metadata for a single predictor term.
    */
-  @CompileStatic
   static final class TermInfo {
     final FormulaTerm sourceTerm
     final String label

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/Terms.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/Terms.groovy
@@ -36,6 +36,7 @@ final class Terms {
     final boolean isDropped
     final String droppedReason
 
+    @SuppressWarnings('ParameterCount')
     TermInfo(
       FormulaTerm sourceTerm,
       String label,

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/interpolation/Interpolation.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/interpolation/Interpolation.groovy
@@ -50,8 +50,8 @@ final class Interpolation {
     List<BigDecimal> range = InterpolationAdapters.validateRange(ListConverter.toBigDecimals(y), domain.size())
     BigDecimal target = InterpolationAdapters.validateTarget(targetX, TARGET_X_LABEL)
 
-    if (target < domain[0] || target > domain[domain.size() - 1]) {
-      throw new IllegalArgumentException("TargetX ${target} is outside the interpolation domain [${domain[0]}, ${domain[domain.size() - 1]}]")
+    if (target < domain[0] || target > domain[-1]) {
+      throw new IllegalArgumentException("TargetX ${target} is outside the interpolation domain [${domain[0]}, ${domain[-1]}]")
     }
 
     if (domain.size() == 1) {
@@ -70,7 +70,7 @@ final class Interpolation {
         return interpolate(domain[i - 1], range[i - 1], domain[i], range[i], target)
       }
     }
-    range[range.size() - 1]
+    range[-1]
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/BandwidthSelector.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/BandwidthSelector.groovy
@@ -97,7 +97,7 @@ class BandwidthSelector {
     }
     variance /= (n - 1)  // Sample variance (Bessel's correction)
 
-    return Math.sqrt(variance)
+    Math.sqrt(variance)
   }
 
   /**
@@ -107,11 +107,10 @@ class BandwidthSelector {
    * @return the interquartile range
    */
   private static double computeIQR(double[] data) {
-    int n = data.length
     // Simple quartile calculation using linear interpolation
     double q1 = percentile(data, 0.25)
     double q3 = percentile(data, 0.75)
-    return q3 - q1
+    q3 - q1
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/Kernel.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/Kernel.groovy
@@ -112,7 +112,7 @@ enum Kernel {
 
     @Override
     double evaluateValue(double u) {
-      return Math.exp(-0.5 * u * u) / Math.sqrt(2 * Math.PI)
+      Math.exp(-0.5 * u * u) / Math.sqrt(2 * Math.PI)
     }
 
   },
@@ -129,7 +129,7 @@ enum Kernel {
       if (Math.abs(u) > 1) {
         return 0.0
       }
-      return 0.75 * (1.0 - u * u)
+      0.75 * (1.0 - u * u)
     }
 
   },
@@ -145,7 +145,7 @@ enum Kernel {
       if (Math.abs(u) > 1) {
         return 0.0
       }
-      return 0.5
+      0.5
     }
 
   },
@@ -162,7 +162,7 @@ enum Kernel {
       if (absU > 1) {
         return 0.0
       }
-      return 1.0 - absU
+      1.0 - absU
     }
 
   }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/KernelDensity.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/KernelDensity.groovy
@@ -313,7 +313,7 @@ class KernelDensity {
       double u = (point - xi) / this.bandwidthValue
       sum += this.kernel.evaluateValue(u)
     }
-    return sum / (this.data.length * this.bandwidthValue)
+    sum / (this.data.length * this.bandwidthValue)
   }
 
   /**
@@ -397,7 +397,7 @@ class KernelDensity {
    * @return the number of data points
    */
   int getDataCount() {
-    return data.length
+    data.length
   }
 
   /**
@@ -409,7 +409,7 @@ class KernelDensity {
     List<BigDecimal> xList = x
     List<BigDecimal> densityList = density
 
-    return Matrix.builder()
+    Matrix.builder()
         .matrixName('KernelDensity')
         .columns([
             'x': xList,
@@ -436,7 +436,7 @@ class KernelDensity {
 
   @Override
   String toString() {
-    return "KernelDensity(kernel=${kernel}, n=${n}, bandwidth=${getBandwidth(6)})"
+    "KernelDensity(kernel=${kernel}, n=${n}, bandwidth=${getBandwidth(6)})"
   }
 
   /**
@@ -454,7 +454,7 @@ class KernelDensity {
       }
     }
 
-    return """
+    """
 Kernel Density Estimation
 =========================
 Kernel:      ${kernel}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linalg/Linalg.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linalg/Linalg.groovy
@@ -40,7 +40,7 @@ final class Linalg {
    * @throws LinalgSingularMatrixException if the matrix is singular
    */
   static Matrix inverse(Matrix matrix) {
-    LinalgAdapters.toMatrix(inverseValues(LinalgAdapters.toDoubleArray(matrix)))
+    LinalgAdapters.toMatrix(inverseValues(NumericConversion.toDoubleArray(matrix)))
   }
 
   /**
@@ -52,7 +52,7 @@ final class Linalg {
    * @throws LinalgSingularMatrixException if the grid is singular
    */
   static Grid<BigDecimal> inverse(Grid<?> grid) {
-    LinalgAdapters.toGrid(inverseValues(LinalgAdapters.toDoubleArray(grid)))
+    LinalgAdapters.toGrid(inverseValues(NumericConversion.toDoubleArray(grid)))
   }
 
   /**
@@ -63,7 +63,7 @@ final class Linalg {
    * @throws IllegalArgumentException if the matrix is null, empty, contains non-numeric values, or is not square
    */
   static BigDecimal det(Matrix matrix) {
-    BigDecimal.valueOf(detValue(LinalgAdapters.toDoubleArray(matrix)))
+    BigDecimal.valueOf(detValue(NumericConversion.toDoubleArray(matrix)))
   }
 
   /**
@@ -74,7 +74,7 @@ final class Linalg {
    * @throws IllegalArgumentException if the grid is null, empty, ragged, contains non-numeric values, or is not square
    */
   static BigDecimal det(Grid<?> grid) {
-    BigDecimal.valueOf(detValue(LinalgAdapters.toDoubleArray(grid)))
+    BigDecimal.valueOf(detValue(NumericConversion.toDoubleArray(grid)))
   }
 
   /**
@@ -87,7 +87,7 @@ final class Linalg {
    * @throws LinalgSingularMatrixException if the coefficient matrix is singular
    */
   static List<BigDecimal> solve(Matrix matrix, List<? extends Number> vector) {
-    LinalgAdapters.toBigDecimalVector(solveValues(LinalgAdapters.toDoubleArray(matrix), vector))
+    LinalgAdapters.toBigDecimalVector(solveValues(NumericConversion.toDoubleArray(matrix), vector))
   }
 
   /**
@@ -100,7 +100,7 @@ final class Linalg {
    * @throws LinalgSingularMatrixException if the coefficient matrix is singular
    */
   static List<BigDecimal> solve(Grid<?> grid, List<? extends Number> vector) {
-    LinalgAdapters.toBigDecimalVector(solveValues(LinalgAdapters.toDoubleArray(grid), vector))
+    LinalgAdapters.toBigDecimalVector(solveValues(NumericConversion.toDoubleArray(grid), vector))
   }
 
   /**
@@ -116,7 +116,7 @@ final class Linalg {
    * @throws IllegalArgumentException if the matrix is invalid, not square, or has complex eigenvalues
    */
   static List<BigDecimal> eigenvalues(Matrix matrix) {
-    LinalgAdapters.toBigDecimalVector(eigenvaluesValues(LinalgAdapters.toDoubleArray(matrix)))
+    LinalgAdapters.toBigDecimalVector(eigenvaluesValues(NumericConversion.toDoubleArray(matrix)))
   }
 
   /**
@@ -127,7 +127,7 @@ final class Linalg {
    * @throws IllegalArgumentException if the grid is invalid, not square, or has complex eigenvalues
    */
   static List<BigDecimal> eigenvalues(Grid<?> grid) {
-    LinalgAdapters.toBigDecimalVector(eigenvaluesValues(LinalgAdapters.toDoubleArray(grid)))
+    LinalgAdapters.toBigDecimalVector(eigenvaluesValues(NumericConversion.toDoubleArray(grid)))
   }
 
   /**
@@ -163,7 +163,7 @@ final class Linalg {
    * @throws IllegalArgumentException if the matrix is null, empty, or contains non-numeric values
    */
   static SvdResult svd(Matrix matrix) {
-    svdValues(LinalgAdapters.toDoubleArray(matrix))
+    svdValues(NumericConversion.toDoubleArray(matrix))
   }
 
   /**
@@ -174,7 +174,7 @@ final class Linalg {
    * @throws IllegalArgumentException if the grid is null, empty, ragged, or contains non-numeric values
    */
   static SvdResult svd(Grid<?> grid) {
-    svdValues(LinalgAdapters.toDoubleArray(grid))
+    svdValues(NumericConversion.toDoubleArray(grid))
   }
 
   private static double[][] inverseValues(double[][] matrix) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linalg/Linalg.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linalg/Linalg.groovy
@@ -220,7 +220,7 @@ final class Linalg {
       }
       values << eigenvalue.getReal()
     }
-    List<Double> sorted = [*values] as List<Double>
+    List<Double> sorted = [*values]
     sorted.sort { Double a, Double b -> b <=> a }
     double[] eigenvalues = new double[sorted.size()]
     for (int i = 0; i < sorted.size(); i++) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linalg/LinalgAdapters.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linalg/LinalgAdapters.groovy
@@ -24,26 +24,6 @@ final class LinalgAdapters {
   }
 
   /**
-   * Convert a rectangular numeric matrix into a {@code double[][]}.
-   *
-   * @param matrix the source matrix
-   * @return a dense numeric array with the same shape and column order
-   */
-  static double[][] toDoubleArray(Matrix matrix) {
-    NumericConversion.toDoubleArray(matrix)
-  }
-
-  /**
-   * Convert a rectangular numeric grid into a {@code double[][]}.
-   *
-   * @param grid the source grid
-   * @return a dense numeric array with the same shape
-   */
-  static double[][] toDoubleArray(Grid<?> grid) {
-    NumericConversion.toDoubleArray(grid)
-  }
-
-  /**
    * Convert an EJML matrix into a dense {@code double[][]} array.
    *
    * @param matrix the source EJML matrix

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linalg/SvdResult.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linalg/SvdResult.groovy
@@ -60,9 +60,9 @@ class SvdResult {
    * @return the reconstructed matrix with synthetic column names
    */
   Matrix reconstruct() {
-    SimpleMatrix denseU = new SimpleMatrix(LinalgAdapters.toDoubleArray(u))
-    SimpleMatrix denseSigma = new SimpleMatrix(LinalgAdapters.toDoubleArray(sigma()))
-    SimpleMatrix denseVt = new SimpleMatrix(LinalgAdapters.toDoubleArray(vt))
+    SimpleMatrix denseU = new SimpleMatrix(NumericConversion.toDoubleArray(u))
+    SimpleMatrix denseSigma = new SimpleMatrix(NumericConversion.toDoubleArray(sigma()))
+    SimpleMatrix denseVt = new SimpleMatrix(NumericConversion.toDoubleArray(vt))
     LinalgAdapters.toMatrix(LinalgAdapters.toDoubleArray(denseU.mult(denseSigma).mult(denseVt)))
   }
 
@@ -91,7 +91,7 @@ class SvdResult {
     if (matrix == null) {
       throw new IllegalArgumentException("${label.capitalize()} cannot be null")
     }
-    LinalgAdapters.toMatrix(LinalgAdapters.toDoubleArray(matrix))
+    LinalgAdapters.toMatrix(NumericConversion.toDoubleArray(matrix))
   }
 
   private static List<BigDecimal> copyVector(List<? extends Number> values, String label) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/AndersonDarling.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/AndersonDarling.groovy
@@ -64,7 +64,7 @@ class AndersonDarling {
     // Calculate p-value using the adjusted statistic
     double pValue = calculatePValue(adjustedASquared)
 
-    return new AndersonDarlingResult(
+    new AndersonDarlingResult(
       statistic: BigDecimal.valueOf(aSquared),
       adjustedStatistic: BigDecimal.valueOf(adjustedASquared),
       pValue: BigDecimal.valueOf(pValue),
@@ -98,7 +98,7 @@ class AndersonDarling {
       sum += term
     }
 
-    return -n - sum / n
+    -n - sum / n
   }
 
   /**
@@ -180,7 +180,7 @@ class AndersonDarling {
 
     @Override
     String toString() {
-      return """Anderson-Darling Normality Test
+      """Anderson-Darling Normality Test
   Sample size: ${sampleSize}
   Sample mean: ${String.format("%.4f", mean)}
   Sample SD: ${String.format("%.4f", stdDev)}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/CramerVonMises.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/CramerVonMises.groovy
@@ -35,7 +35,7 @@ class CramerVonMises {
    */
   static CramerVonMisesResult testNormality(List<? extends Number> data, Number alpha = 0.05) {
     BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
-    validateInput(data, alphaValue)
+    validateInput(data)
 
     int n = data.size()
 
@@ -156,7 +156,7 @@ class CramerVonMises {
     }
   }
 
-  private static void validateInput(List<? extends Number> data, BigDecimal alpha) {
+  private static void validateInput(List<? extends Number> data) {
     if (data == null) {
       throw new IllegalArgumentException("Data cannot be null")
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/CramerVonMises.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/CramerVonMises.groovy
@@ -92,7 +92,7 @@ class CramerVonMises {
     double pValue = calculatePValue(modifiedWSquared)
     double criticalValue = getCriticalValue(alphaValue as double)
 
-    return new CramerVonMisesResult(
+    new CramerVonMisesResult(
       statistic: BigDecimal.valueOf(modifiedWSquared),
       rawStatistic: BigDecimal.valueOf(wSquared),
       sampleSize: n,
@@ -225,7 +225,7 @@ class CramerVonMises {
         "not normally distributed" :
         "consistent with a normal distribution"
 
-      return String.format(
+      String.format(
         "Cramér-von Mises W²*: %.4f (critical value: %.3f at %.0f%% level)\n" +
         "p-value: %.4f\n" +
         "Sample: n=%d, mean=%.4f, sd=%.4f\n" +
@@ -237,7 +237,7 @@ class CramerVonMises {
 
     @Override
     String toString() {
-      return """Cramér-von Mises Normality Test
+      """Cramér-von Mises Normality Test
   Sample size: ${sampleSize}
   Mean: ${String.format('%.4f', mean)}
   Std Dev: ${String.format('%.4f', stdDev)}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/JarqueBera.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/JarqueBera.groovy
@@ -144,7 +144,7 @@ class JarqueBera {
     ChiSquaredDistribution chiSq = new ChiSquaredDistribution(2)
     double pValue = 1.0 - chiSq.cumulativeProbability(jbStatistic)
 
-    return new JarqueBeraResult(
+    new JarqueBeraResult(
       jbStatistic: BigDecimal.valueOf(jbStatistic),
       skewness: BigDecimal.valueOf(skewness),
       kurtosis: BigDecimal.valueOf(kurtosis),
@@ -211,7 +211,7 @@ class JarqueBera {
 
     @Override
     String toString() {
-      return """Jarque-Bera Normality Test Result:
+      """Jarque-Bera Normality Test Result:
   JB statistic: ${jbStatistic}
   skewness: ${skewness}
   kurtosis: ${kurtosis} (excess: ${excessKurtosis})

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KSquared.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KSquared.groovy
@@ -175,7 +175,7 @@ class KSquared {
     ChiSquaredDistribution chiSq = new ChiSquaredDistribution(2)
     double pValue = 1.0 - chiSq.cumulativeProbability(kSquared)
 
-    return new KSquaredResult(
+    new KSquaredResult(
       statistic: BigDecimal.valueOf(kSquared),
       pValue: BigDecimal.valueOf(pValue),
       skewness: BigDecimal.valueOf(b1),
@@ -285,7 +285,7 @@ class KSquared {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       String conclusion = pValue < alphaValue ? "significant departure from normality" : "consistent with normality"
 
-      return String.format(
+      String.format(
         "D'Agostino's K² test:\\n" +
         "K² statistic: %.4f\\n" +
         "p-value: %.4f\\n" +
@@ -300,7 +300,7 @@ class KSquared {
 
     @Override
     String toString() {
-      return """D'Agostino's K² Test
+      """D'Agostino's K² Test
   Sample size: ${sampleSize}
   K² statistic: ${String.format('%.4f', statistic)}
   p-value: ${String.format('%.4f', pValue)}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KolmogorovSmirnov.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KolmogorovSmirnov.groovy
@@ -315,7 +315,7 @@ class KolmogorovSmirnov {
     int effectiveK = Math.min(k, n - k)
     BigInteger result = BigInteger.ONE
     for (int i = 1; i <= effectiveK; i++) {
-      result = result.multiply(BigInteger.valueOf(n - effectiveK + i))
+      result *= BigInteger.valueOf(n - effectiveK + i)
       result = result.divide(BigInteger.valueOf(i))
     }
     result
@@ -326,7 +326,7 @@ class KolmogorovSmirnov {
 
     for (int j = 1; j <= 100; j++) {
       double term = Math.exp(-2.0d * j * j * lambda * lambda)
-      sum += (j % 2 == 1 ? 1.0d : -1.0d) * term
+      sum += (j % 2 != 0 ? 1.0d : -1.0d) * term
       if (term < 1e-12d) {
         break
       }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KolmogorovSmirnov.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KolmogorovSmirnov.groovy
@@ -131,7 +131,7 @@ class KolmogorovSmirnov {
     // Create normal distribution with sample mean and std dev
     NormalDistribution normalDist = new NormalDistribution(mean, stdDev)
 
-    return testAgainstDistribution(data, normalDist, "Normality")
+    testAgainstDistribution(data, normalDist, "Normality")
   }
 
   /**
@@ -144,7 +144,7 @@ class KolmogorovSmirnov {
   static KSResult testStandardNormality(List<? extends Number> data) {
     validateData(data)
     NormalDistribution standardNormal = new NormalDistribution(0, 1)
-    return testAgainstDistribution(data, standardNormal, "Standard Normality")
+    testAgainstDistribution(data, standardNormal, "Standard Normality")
   }
 
   /**
@@ -163,7 +163,7 @@ class KolmogorovSmirnov {
     double dStatistic = calculateOneSampleStatistic(values, distribution)
     double pValue = calculateOneSamplePValue(dStatistic, values.length)
 
-    return new KSResult(
+    new KSResult(
       dStatistic: BigDecimal.valueOf(dStatistic),
       pValue: BigDecimal.valueOf(pValue),
       sampleSize: values.length,
@@ -192,7 +192,7 @@ class KolmogorovSmirnov {
     // Calculate p-value
     double pValue = calculateTwoSamplePValue(dStatistic, values1.length, values2.length)
 
-    return new KSResult(
+    new KSResult(
       dStatistic: BigDecimal.valueOf(dStatistic),
       pValue: BigDecimal.valueOf(pValue),
       sampleSize: values1.length + values2.length,
@@ -213,7 +213,7 @@ class KolmogorovSmirnov {
       dMinus = Math.max(dMinus, theoretical - empiricalLower)
     }
 
-    return Math.max(dPlus, dMinus)
+    Math.max(dPlus, dMinus)
   }
 
   private static double calculateOneSamplePValue(double dStatistic, int sampleSize) {
@@ -332,7 +332,7 @@ class KolmogorovSmirnov {
       }
     }
 
-    return Math.max(0.0d, Math.min(1.0d, 2.0d * sum))
+    Math.max(0.0d, Math.min(1.0d, 2.0d * sum))
   }
 
   private static void validateData(List<? extends Number> data) {
@@ -391,7 +391,7 @@ class KolmogorovSmirnov {
         result = evaluate() ? "Samples appear to differ" : "Samples do not significantly differ"
       }
 
-      return """Kolmogorov-Smirnov Test Result (${testType}):
+      """Kolmogorov-Smirnov Test Result (${testType}):
   D statistic: ${dStatistic}
   p-value: ${pValue}
   sample size: ${sampleSize}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/Lilliefors.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/Lilliefors.groovy
@@ -51,7 +51,7 @@ class Lilliefors {
     // Calculate p-value using Lilliefors-specific approximation
     double pValue = calculatePValue(dStatistic, n)
 
-    return new LillieforsResult(
+    new LillieforsResult(
       statistic: BigDecimal.valueOf(dStatistic),
       pValue: BigDecimal.valueOf(pValue),
       alpha: alphaValue,
@@ -96,7 +96,7 @@ class Lilliefors {
       maxDifference = Math.max(maxDifference, Math.max(diff1, diff2))
     }
 
-    return maxDifference
+    maxDifference
   }
 
   /**
@@ -198,7 +198,7 @@ class Lilliefors {
 
     @Override
     String toString() {
-      return """Lilliefors Normality Test
+      """Lilliefors Normality Test
   Sample size: ${sampleSize}
   Sample mean: ${String.format("%.4f", mean)}
   Sample SD: ${String.format("%.4f", stdDev)}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroFrancia.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroFrancia.groovy
@@ -132,7 +132,7 @@ class ShapiroFrancia {
     // Calculate p-value using approximation
     double pValue = calculatePValue(wPrime, n)
 
-    return new ShapiroFranciaResult(
+    new ShapiroFranciaResult(
       W: BigDecimal.valueOf(wPrime),
       pValue: BigDecimal.valueOf(pValue),
       sampleSize: n,
@@ -200,7 +200,7 @@ class ShapiroFrancia {
     // W' = (Σ mᵢ xᵢ)² / (Σ mᵢ² × Σ(xᵢ - x̄)²)
     double wPrime = (sumMX * sumMX) / (sumM2 * sumSquaredDeviations)
 
-    return wPrime
+    wPrime
   }
 
   /**
@@ -305,7 +305,7 @@ class ShapiroFrancia {
         "not normally distributed" :
         "consistent with a normal distribution"
 
-      return String.format(
+      String.format(
         "Shapiro-Francia W' statistic: %.4f\n" +
         "p-value: %.4f\n" +
         "Sample: n=%d, mean=%.4f, sd=%.4f\n" +
@@ -316,7 +316,7 @@ class ShapiroFrancia {
 
     @Override
     String toString() {
-      return """Shapiro-Francia Normality Test
+      """Shapiro-Francia Normality Test
   Sample size: ${sampleSize}
   Mean: ${String.format('%.4f', mean)}
   Std Dev: ${String.format('%.4f', stdDev)}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroWilk.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroWilk.groovy
@@ -131,7 +131,7 @@ class ShapiroWilk {
     // Calculate p-value using Royston's approximation
     double pValue = calculatePValue(w, n)
 
-    return new ShapiroWilkResult(
+    new ShapiroWilkResult(
       W: BigDecimal.valueOf(w),
       pValue: BigDecimal.valueOf(pValue),
       sampleSize: n
@@ -172,7 +172,7 @@ class ShapiroWilk {
     // Calculate denominator: Σ(xᵢ - x̄)²
     double denominator = variance * (n - 1)
 
-    return numerator / denominator
+    numerator / denominator
   }
 
   /**
@@ -230,7 +230,7 @@ class ShapiroWilk {
       }
     }
 
-    return a
+    a
   }
 
   /**
@@ -248,7 +248,6 @@ class ShapiroWilk {
 
     if (n <= 11) {
       // For small samples (n <= 11)
-      double gamma = 0.459 * n - 2.273
       mu = -0.0006714 * Math.pow(n, 3.0) + 0.025054 * Math.pow(n, 2.0) - 0.39978 * n + 0.544
       sigma = Math.exp(-0.0020322 * Math.pow(n, 3.0) + 0.062767 * Math.pow(n, 2.0) - 0.77857 * n + 1.3822)
     } else {
@@ -263,7 +262,7 @@ class ShapiroWilk {
     NormalDistribution normal = new NormalDistribution(0, 1)
     double pValue = normal.cumulativeProbability(z)
 
-    return Math.max(0.0, Math.min(1.0, pValue))  // Ensure p-value is in [0, 1]
+    Math.max(0.0, Math.min(1.0, pValue))  // Ensure p-value is in [0, 1]
   }
 
   /**
@@ -299,7 +298,7 @@ class ShapiroWilk {
 
     @Override
     String toString() {
-      return """Shapiro-Wilk Normality Test Result:
+      """Shapiro-Wilk Normality Test Result:
   W statistic: ${W}
   p-value: ${pValue}
   sample size: ${sampleSize}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/DecisionTree.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/DecisionTree.groovy
@@ -158,7 +158,7 @@ class DecisionTree {
      * @return true if this is a leaf node (no children)
      */
     boolean isLeaf() {
-      return left == null && right == null
+      left == null && right == null
     }
   }
 
@@ -358,7 +358,7 @@ class DecisionTree {
     node.left = buildTree(leftX, leftY, currentDepth + 1)
     node.right = buildTree(rightX, rightY, currentDepth + 1)
 
-    return node
+    node
   }
 
   /**
@@ -368,7 +368,7 @@ class DecisionTree {
     this.leafCount++
     Node leaf = new Node()
     leaf.value = Stat.mean(yData)
-    return leaf
+    leaf
   }
 
   /**
@@ -428,7 +428,7 @@ class DecisionTree {
       }
     }
 
-    return bestGain > 0 ? bestThreshold : null
+    bestGain > 0 ? bestThreshold : null
   }
 
   /**
@@ -440,7 +440,7 @@ class DecisionTree {
     }
     BigDecimal mean = Stat.mean(values)
     BigDecimal sumSquaredDiff = values.collect { (it - mean) ** 2 }.sum() as BigDecimal
-    return sumSquaredDiff / values.size()
+    sumSquaredDiff / values.size()
   }
 
   /**
@@ -487,7 +487,7 @@ class DecisionTree {
         current = current.right
       }
     }
-    return current.value
+    current.value
   }
 
   /**
@@ -497,7 +497,7 @@ class DecisionTree {
    * @return Predicted value
    */
   BigDecimal predict(Number x) {
-    return predictInternal(x as BigDecimal)
+    predictInternal(x as BigDecimal)
   }
 
   /**
@@ -508,7 +508,7 @@ class DecisionTree {
    * @return Predicted value rounded to specified decimals
    */
   BigDecimal predict(Number x, int numberOfDecimals) {
-    return predict(x).setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    predict(x).setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   /**
@@ -518,7 +518,7 @@ class DecisionTree {
    * @return List of predicted values
    */
   List<BigDecimal> predict(List<? extends Number> xValues) {
-    return xValues.collect { predict(it) }
+    xValues.collect { predict(it) }
   }
 
   /**
@@ -529,7 +529,7 @@ class DecisionTree {
    * @return List of predicted values rounded to specified decimals
    */
   List<BigDecimal> predict(List<? extends Number> xValues, int numberOfDecimals) {
-    return xValues.collect { predict(it, numberOfDecimals) }
+    xValues.collect { predict(it, numberOfDecimals) }
   }
 
   /**
@@ -538,7 +538,7 @@ class DecisionTree {
    * @return R² value (between 0 and 1)
    */
   BigDecimal getRSquared() {
-    return trainingR2
+    trainingR2
   }
 
   /**
@@ -548,7 +548,7 @@ class DecisionTree {
    * @return R² value rounded to specified decimals
    */
   BigDecimal getRSquared(int numberOfDecimals) {
-    return getRSquared().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getRSquared().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   /**
@@ -557,7 +557,7 @@ class DecisionTree {
    * @return MSE value
    */
   BigDecimal getMse() {
-    return trainingMse
+    trainingMse
   }
 
   /**
@@ -567,7 +567,7 @@ class DecisionTree {
    * @return MSE value rounded to specified decimals
    */
   BigDecimal getMse(int numberOfDecimals) {
-    return getMse().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getMse().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   /**
@@ -576,7 +576,7 @@ class DecisionTree {
    * @return RMSE value
    */
   BigDecimal getRmse() {
-    return trainingRmse
+    trainingRmse
   }
 
   /**
@@ -586,7 +586,7 @@ class DecisionTree {
    * @return RMSE value rounded to specified decimals
    */
   BigDecimal getRmse(int numberOfDecimals) {
-    return getRmse().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getRmse().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   /**
@@ -595,7 +595,7 @@ class DecisionTree {
    * @return MAE value
    */
   BigDecimal getMae() {
-    return trainingMae
+    trainingMae
   }
 
   /**
@@ -605,7 +605,7 @@ class DecisionTree {
    * @return MAE value rounded to specified decimals
    */
   BigDecimal getMae(int numberOfDecimals) {
-    return getMae().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getMae().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   /**
@@ -614,7 +614,7 @@ class DecisionTree {
    * @return Tree depth
    */
   int getDepth() {
-    return depth
+    depth
   }
 
   /**
@@ -623,7 +623,7 @@ class DecisionTree {
    * @return Number of leaf nodes
    */
   int getLeafCount() {
-    return leafCount
+    leafCount
   }
 
   /**
@@ -632,7 +632,7 @@ class DecisionTree {
    * @return Maximum depth setting
    */
   int getMaxDepth() {
-    return maxDepth
+    maxDepth
   }
 
   /**
@@ -641,7 +641,7 @@ class DecisionTree {
    * @return Minimum samples per leaf setting
    */
   int getMinSamplesLeaf() {
-    return minSamplesLeaf
+    minSamplesLeaf
   }
 
   /**
@@ -651,7 +651,7 @@ class DecisionTree {
    */
   @Override
   String toString() {
-    return "DecisionTree[depth=${depth}, leaves=${leafCount}, R²=${getRSquared(3)}]"
+    "DecisionTree[depth=${depth}, leaves=${leafCount}, R²=${getRSquared(3)}]"
   }
 
   /**
@@ -676,7 +676,7 @@ class DecisionTree {
     sb.append("  MAE:  ${getMae(4)}\n\n")
     sb.append("Tree Rules:\n")
     appendTreeRules(sb, root, "  ", "root")
-    return sb.toString()
+    sb.toString()
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitMethod.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitMethod.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.formula.ModelFrameResult
 
 /**
@@ -14,7 +12,6 @@ import se.alipsa.matrix.stats.formula.ModelFrameResult
  * Both methods are available through the {@link FitRegistry} without
  * downcasting to a concrete class.
  */
-@CompileStatic
 interface FitMethod {
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitOptions.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitOptions.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 /**
  * Marker interface for method-specific fit options. Each fit method defines its
  * own options class (e.g. {@link LoessOptions}, {@link GamOptions}). Methods that
@@ -9,7 +7,6 @@ import groovy.transform.CompileStatic
  *
  * <p>A singleton {@link #NONE} instance is provided for methods with no options.
  */
-@CompileStatic
 interface FitOptions {
 
   /** Empty options for methods that require no configuration. */

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitOptions.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitOptions.groovy
@@ -14,4 +14,13 @@ interface FitOptions {
 
   /** Empty options for methods that require no configuration. */
   static final FitOptions NONE = new FitOptions() {}
+
+  /**
+   * Indicates whether these options carry configuration beyond {@link #NONE}.
+   *
+   * @return true when this instance is not the sentinel no-options value
+   */
+  default boolean configured() {
+    this != NONE
+  }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitRegistry.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitRegistry.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 /**
  * Registry of named fit methods.
  *
@@ -16,7 +14,6 @@ import groovy.transform.CompileStatic
  * via {@code ModelFrame.of(...).evaluate()} and then dispatch to the chosen fit method
  * through this registry.
  */
-@CompileStatic
 final class FitRegistry {
 
   private static final FitRegistry INSTANCE = new FitRegistry()

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitResult.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitResult.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 /**
  * Immutable result of a model fit, containing coefficients, diagnostics, and fitted values.
  *
@@ -9,7 +7,6 @@ import groovy.transform.CompileStatic
  * for {@code coefficients} and {@code standardErrors}. Consumers should check
  * {@code coefficients.length} before accessing coefficient values.
  */
-@CompileStatic
 final class FitResult {
 
   final double[] coefficients

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitUtils.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitUtils.groovy
@@ -1,13 +1,10 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 
 /**
  * Shared utility methods for fit method implementations.
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 final class FitUtils {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/GamMethod.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/GamMethod.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.util.Logger
 import se.alipsa.matrix.stats.formula.ModelFrameResult
@@ -41,7 +39,6 @@ import se.alipsa.matrix.stats.linear.MatrixAlgebra
  *   <li>Weights and offsets</li>
  * </ul>
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class GamMethod implements FitMethod {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/GamOptions.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/GamOptions.groovy
@@ -1,13 +1,10 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * Typed options for GAM penalized least squares.
  */
-@CompileStatic
 final class GamOptions implements FitOptions {
   final double lambda
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/GamOptions.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/GamOptions.groovy
@@ -2,6 +2,8 @@ package se.alipsa.matrix.stats.regression
 
 import groovy.transform.CompileStatic
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Typed options for GAM penalized least squares.
  */
@@ -9,10 +11,11 @@ import groovy.transform.CompileStatic
 final class GamOptions implements FitOptions {
   final double lambda
 
-  GamOptions(double lambda = 1.0d) {
-    if (lambda < 0.0d) {
+  GamOptions(Number lambda = 1.0) {
+    double normalizedLambda = NumericConversion.toFiniteDouble(lambda, 'lambda')
+    if (normalizedLambda < 0.0d) {
       throw new IllegalArgumentException("lambda must be >= 0, got ${lambda}")
     }
-    this.lambda = lambda
+    this.lambda = normalizedLambda
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
@@ -90,35 +90,35 @@ class LinearRegression {
   }
 
   BigDecimal predict(Number dependentVariable) {
-    return (slope * dependentVariable) + intercept
+    (slope * dependentVariable) + intercept
   }
 
   BigDecimal predict(Number dependentVariable, int numberOfDecimals) {
-    return predict(dependentVariable).setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    predict(dependentVariable).setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   List<BigDecimal> predict(List<Number> dependentVariables) {
-    return dependentVariables.collect { predict(it) }
+    dependentVariables.collect { predict(it) }
   }
 
   List<BigDecimal> predict(List<Number> dependentVariables, int numberOfDecimals) {
-    return dependentVariables.collect { predict(it, numberOfDecimals) }
+    dependentVariables.collect { predict(it, numberOfDecimals) }
   }
 
   BigDecimal getSlope() {
-    return slope
+    slope
   }
 
   BigDecimal getSlope(int numberOfDecimals) {
-    return slope.setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    slope.setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   BigDecimal getIntercept() {
-    return intercept
+    intercept
   }
 
   BigDecimal getIntercept(int numberOfDecimals) {
-    return intercept.setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    intercept.setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   /**
@@ -136,11 +136,11 @@ class LinearRegression {
    * r2 <- summary(model)$r.squared
   */
   BigDecimal getRsquared() {
-    return r2
+    r2
   }
 
   BigDecimal getRsquared(int numberOfDecimals) {
-    return getRsquared().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getRsquared().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   /**
@@ -155,11 +155,11 @@ class LinearRegression {
    * @return the standard error of the estimate for the intercept
    */
   BigDecimal getInterceptStdErr() {
-    return interceptStdErr
+    interceptStdErr
   }
 
   BigDecimal getInterceptStdErr(int numberOfDecimals) {
-    return getInterceptStdErr().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getInterceptStdErr().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   /**
@@ -174,16 +174,16 @@ class LinearRegression {
    * @return the standard error of the estimate for the slope
    */
   BigDecimal getSlopeStdErr() {
-    return slopeStdErr
+    slopeStdErr
   }
 
   BigDecimal getSlopeStdErr(int numberOfDecimals) {
-    return getSlopeStdErr().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getSlopeStdErr().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   @Override
   String toString() {
-    return "Y = ${getSlope(2)}X ${intercept > 0 ? '+' : '-'} ${getIntercept(2).abs()}"
+    "Y = ${getSlope(2)}X ${intercept > 0 ? '+' : '-'} ${getIntercept(2).abs()}"
   }
 
   String summary() {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LmMethod.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LmMethod.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.formula.ModelFrameResult
 
@@ -16,7 +14,6 @@ import se.alipsa.matrix.stats.formula.ModelFrameResult
  * {@code ModelFrame}, including transformed numeric terms and categorical encodings
  * supplied by the formula pipeline.
  */
-@CompileStatic
 class LmMethod implements FitMethod {
 
   @Override

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LoessMethod.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LoessMethod.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.util.Logger
 import se.alipsa.matrix.stats.formula.ModelFrameResult
@@ -27,7 +25,6 @@ import se.alipsa.matrix.stats.linear.MatrixAlgebra
  * <p>Loess is a local method with no global coefficients. {@link FitResult#coefficients}
  * and {@link FitResult#standardErrors} return empty arrays.
  */
-@CompileStatic
 @SuppressWarnings('DuplicateNumberLiteral')
 class LoessMethod implements FitMethod {
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LoessOptions.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LoessOptions.groovy
@@ -2,6 +2,8 @@ package se.alipsa.matrix.stats.regression
 
 import groovy.transform.CompileStatic
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Typed options for loess local regression.
  */
@@ -10,14 +12,15 @@ final class LoessOptions implements FitOptions {
   final double span
   final int degree
 
-  LoessOptions(double span = 0.75d, int degree = 1) {
-    if (span <= 0.0d || span > 1.0d) {
+  LoessOptions(Number span = 0.75, int degree = 1) {
+    double normalizedSpan = NumericConversion.toFiniteDouble(span, 'span')
+    if (normalizedSpan <= 0.0d || normalizedSpan > 1.0d) {
       throw new IllegalArgumentException("span must be in (0, 1], got ${span}")
     }
     if (degree < 1 || degree > 2) {
       throw new IllegalArgumentException("degree must be 1 or 2, got ${degree}")
     }
-    this.span = span
+    this.span = normalizedSpan
     this.degree = degree
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LoessOptions.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LoessOptions.groovy
@@ -1,13 +1,10 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * Typed options for loess local regression.
  */
-@CompileStatic
 final class LoessOptions implements FitOptions {
   final double span
   final int degree

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LogisticRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LogisticRegression.groovy
@@ -297,7 +297,7 @@ class LogisticRegression {
    */
   BigDecimal predictProbability(Number x) {
     double z = (slope * x + intercept).doubleValue()
-    return sigmoid(z) as BigDecimal
+    sigmoid(z) as BigDecimal
   }
 
   /**
@@ -308,7 +308,7 @@ class LogisticRegression {
    * @return Predicted probability rounded to specified decimals
    */
   BigDecimal predictProbability(Number x, int numberOfDecimals) {
-    return predictProbability(x).setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    predictProbability(x).setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   /**
@@ -318,7 +318,7 @@ class LogisticRegression {
    * @return List of predicted probabilities
    */
   List<BigDecimal> predictProbability(List<Number> xValues) {
-    return xValues.collect { predictProbability(it) }
+    xValues.collect { predictProbability(it) }
   }
 
   /**
@@ -329,7 +329,7 @@ class LogisticRegression {
    * @return List of predicted probabilities rounded to specified decimals
    */
   List<BigDecimal> predictProbability(List<Number> xValues, int numberOfDecimals) {
-    return xValues.collect { predictProbability(it, numberOfDecimals) }
+    xValues.collect { predictProbability(it, numberOfDecimals) }
   }
 
   /**
@@ -339,7 +339,7 @@ class LogisticRegression {
    * @return Predicted class: 0 if P(Y=1) < threshold, 1 otherwise
    */
   int predict(Number x) {
-    return predictProbability(x) >= threshold ? 1 : 0
+    predictProbability(x) >= threshold ? 1 : 0
   }
 
   /**
@@ -349,7 +349,7 @@ class LogisticRegression {
    * @return List of predicted classes (0 or 1)
    */
   List<Integer> predict(List<Number> xValues) {
-    return xValues.collect { predict(it) }
+    xValues.collect { predict(it) }
   }
 
   /**
@@ -373,7 +373,7 @@ class LogisticRegression {
    * @return The slope (β1)
    */
   BigDecimal getSlope() {
-    return slope
+    slope
   }
 
   /**
@@ -386,7 +386,7 @@ class LogisticRegression {
     if (numberOfDecimals < 0) {
       return slope
     }
-    return slope.setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    slope.setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   /**
@@ -395,7 +395,7 @@ class LogisticRegression {
    * @return The intercept (β0)
    */
   BigDecimal getIntercept() {
-    return intercept
+    intercept
   }
 
   /**
@@ -408,7 +408,7 @@ class LogisticRegression {
     if (numberOfDecimals < 0) {
       return intercept
     }
-    return intercept.setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    intercept.setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   /**
@@ -418,7 +418,7 @@ class LogisticRegression {
    * @return Log-odds: β0 + β1*x
    */
   BigDecimal logOdds(Number x) {
-    return slope * x + intercept
+    slope * x + intercept
   }
 
   /**
@@ -429,6 +429,6 @@ class LogisticRegression {
   @Override
   String toString() {
     String sign = intercept >= 0 ? '+' : '-'
-    return "P(${y}=1) = 1/(1 + exp(-(${getIntercept(2)} ${sign} ${getSlope(2).abs()}*${x})))"
+    "P(${y}=1) = 1/(1 + exp(-(${getIntercept(2)} ${sign} ${getSlope(2).abs()}*${x})))"
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/MultipleLinearRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/MultipleLinearRegression.groovy
@@ -1,6 +1,6 @@
 package se.alipsa.matrix.stats.regression
 
-import se.alipsa.matrix.stats.linear.MatrixAlgebra
+import se.alipsa.matrix.stats.util.LeastSquaresKernel
 import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
@@ -9,7 +9,9 @@ import se.alipsa.matrix.stats.util.NumericConversion
  * This implementation solves the normal equations {@code (X'X)^-1 X'y}, which is sufficient for the
  * current low-dimensional stats callers such as {@code Adf}. If this class grows into a broader
  * regression utility for higher-dimensional or more ill-conditioned problems, it should move to a
- * QR- or SVD-based solver rather than relying on the normal equations.
+ * QR- or SVD-based solver rather than relying on the normal equations. The public Groovy-facing
+ * API remains idiomatic, while the dense least-squares kernel now runs in Java for the section-4.6
+ * hotspot decision.
  */
 @SuppressWarnings('DuplicateNumberLiteral')
 class MultipleLinearRegression {
@@ -34,22 +36,11 @@ class MultipleLinearRegression {
     observationCount = response.length
     predictorCount = predictors[0].length
 
-    double[][] transpose = MatrixAlgebra.transpose(predictors)
-    double[][] xtx = MatrixAlgebra.multiply(transpose, predictors)
-    double[][] xtxInverse = MatrixAlgebra.inverse(xtx)
-    double[] xty = multiply(transpose, response)
-
-    coefficients = multiply(xtxInverse, xty)
-    residualSumOfSquares = calculateResidualSumOfSquares(response, predictors, coefficients)
-
-    int degreesOfFreedom = observationCount - predictorCount
-    if (degreesOfFreedom <= 0) {
-      throw new IllegalArgumentException(
-        "Ordinary least squares requires more observations (${observationCount}) than predictors (${predictorCount})"
-      )
-    }
-    errorVariance = residualSumOfSquares / degreesOfFreedom
-    standardErrors = calculateStandardErrors(xtxInverse, errorVariance)
+    LeastSquaresKernel.OlsComputation computation = LeastSquaresKernel.fitMultipleLinearRegression(response, predictors)
+    coefficients = computation.coefficients()
+    standardErrors = computation.standardErrors()
+    residualSumOfSquares = computation.residualSumOfSquares()
+    errorVariance = computation.errorVariance()
   }
 
   /**
@@ -183,39 +174,5 @@ class MultipleLinearRegression {
         throw new IllegalArgumentException("Design matrix rows must all have the same length")
       }
     }
-  }
-
-  private static double[] multiply(double[][] matrix, double[] vector) {
-    double[] result = new double[matrix.length]
-    for (int i = 0; i < matrix.length; i++) {
-      double sum = 0.0d
-      for (int j = 0; j < vector.length; j++) {
-        sum += matrix[i][j] * vector[j]
-      }
-      result[i] = sum
-    }
-    result
-  }
-
-  private static double calculateResidualSumOfSquares(double[] response, double[][] predictors, double[] beta) {
-    double rss = 0.0d
-    for (int i = 0; i < response.length; i++) {
-      double fitted = 0.0d
-      for (int j = 0; j < beta.length; j++) {
-        fitted += predictors[i][j] * beta[j]
-      }
-      double residual = response[i] - fitted
-      rss += residual * residual
-    }
-    rss
-  }
-
-  private static double[] calculateStandardErrors(double[][] xtxInverse, double variance) {
-    double[] result = new double[xtxInverse.length]
-    for (int i = 0; i < xtxInverse.length; i++) {
-      double diagonal = Math.max(0.0d, xtxInverse[i][i])
-      result[i] = Math.sqrt(variance * diagonal)
-    }
-    result
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/MultipleLinearRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/MultipleLinearRegression.groovy
@@ -1,6 +1,7 @@
 package se.alipsa.matrix.stats.regression
 
 import se.alipsa.matrix.stats.linear.MatrixAlgebra
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * Ordinary least squares multiple linear regression for a fixed design matrix.
@@ -52,12 +53,35 @@ class MultipleLinearRegression {
   }
 
   /**
+   * Fits an ordinary least squares model from idiomatic Groovy-facing inputs.
+   *
+   * @param response the response vector
+   * @param predictors the design matrix rows
+   * @throws IllegalArgumentException if the inputs are invalid or the model is not estimable
+   */
+  MultipleLinearRegression(List<? extends Number> response, List<? extends List<? extends Number>> predictors) {
+    this(
+      NumericConversion.toDoubleArray(response, 'response'),
+      NumericConversion.toDoubleMatrix(predictors, 'predictors')
+    )
+  }
+
+  /**
    * Returns the fitted regression coefficients.
    *
    * @return a defensive copy of the coefficient vector
    */
   double[] getCoefficients() {
     coefficients.clone()
+  }
+
+  /**
+   * Returns the fitted regression coefficients as immutable {@code BigDecimal} values.
+   *
+   * @return the coefficient values
+   */
+  List<BigDecimal> getCoefficientValues() {
+    NumericConversion.toBigDecimalList(coefficients, 'coefficients')
   }
 
   /**
@@ -70,6 +94,15 @@ class MultipleLinearRegression {
   }
 
   /**
+   * Returns the coefficient standard errors as immutable {@code BigDecimal} values.
+   *
+   * @return the standard-error values
+   */
+  List<BigDecimal> getStandardErrorValues() {
+    NumericConversion.toBigDecimalList(standardErrors, 'standardErrors')
+  }
+
+  /**
    * Returns the residual sum of squares.
    *
    * @return the residual sum of squares
@@ -79,12 +112,30 @@ class MultipleLinearRegression {
   }
 
   /**
+   * Returns the residual sum of squares as {@code BigDecimal}.
+   *
+   * @return the residual sum of squares
+   */
+  BigDecimal getResidualSumOfSquaresValue() {
+    BigDecimal.valueOf(residualSumOfSquares)
+  }
+
+  /**
    * Returns the estimated residual variance.
    *
    * @return the residual variance estimate
    */
   double getErrorVariance() {
     errorVariance
+  }
+
+  /**
+   * Returns the residual variance estimate as {@code BigDecimal}.
+   *
+   * @return the residual variance estimate
+   */
+  BigDecimal getErrorVarianceValue() {
+    BigDecimal.valueOf(errorVariance)
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/PolynomialRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/PolynomialRegression.groovy
@@ -212,19 +212,19 @@ class PolynomialRegression {
     for (int i = degree - 1; i >= 0; i--) {
       result = result * xd + coefficients[i]
     }
-    return BigDecimal.valueOf(result)
+    BigDecimal.valueOf(result)
   }
 
   BigDecimal predict(Number xVal, int numberOfDecimals) {
-    return predict(xVal).setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    predict(xVal).setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   List<BigDecimal> predict(List<Number> xVals) {
-    return xVals.collect { predict(it) }
+    xVals.collect { predict(it) }
   }
 
   List<BigDecimal> predict(List<Number> xVals, int numberOfDecimals) {
-    return xVals.collect { predict(it, numberOfDecimals) }
+    xVals.collect { predict(it, numberOfDecimals) }
   }
 
   /**
@@ -237,19 +237,19 @@ class PolynomialRegression {
     if (power < 0 || power > degree) {
       throw new IllegalArgumentException("Power must be between 0 and $degree (inclusive)")
     }
-    return BigDecimal.valueOf(coefficients[power])
+    BigDecimal.valueOf(coefficients[power])
   }
 
   BigDecimal getRsquared() {
-    return r2
+    r2
   }
 
   BigDecimal getRsquared(int numberOfDecimals) {
-    return getRsquared().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getRsquared().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   int getDegree() {
-    return degree
+    degree
   }
 
   @Override
@@ -269,7 +269,7 @@ class PolynomialRegression {
         }
       }
     }
-    return sb.toString()
+    sb.toString()
   }
 
   String summary() {
@@ -282,6 +282,6 @@ class PolynomialRegression {
       sb.append("  $term: ${getCoefficient(i).setScale(6, RoundingMode.HALF_EVEN)}\n")
     }
     sb.append("\nR-squared: ${getRsquared(4)}\n")
-    return sb.toString()
+    sb.toString()
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/QuantileRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/QuantileRegression.groovy
@@ -301,7 +301,7 @@ class QuantileRegression {
    * @return Predicted value of the dependent variable
    */
   BigDecimal predict(Number x) {
-    return slope * x + intercept
+    slope * x + intercept
   }
 
   /**
@@ -312,7 +312,7 @@ class QuantileRegression {
    * @return Predicted value rounded to specified decimals
    */
   BigDecimal predict(Number x, int numberOfDecimals) {
-    return predict(x).setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    predict(x).setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   /**
@@ -322,7 +322,7 @@ class QuantileRegression {
    * @return List of predicted values
    */
   List<BigDecimal> predict(List<Number> xValues) {
-    return xValues.collect { predict(it) }
+    xValues.collect { predict(it) }
   }
 
   /**
@@ -333,7 +333,7 @@ class QuantileRegression {
    * @return List of predicted values rounded to specified decimals
    */
   List<BigDecimal> predict(List<Number> xValues, int numberOfDecimals) {
-    return xValues.collect { predict(it, numberOfDecimals) }
+    xValues.collect { predict(it, numberOfDecimals) }
   }
 
   /**
@@ -342,7 +342,7 @@ class QuantileRegression {
    * @return The slope
    */
   BigDecimal getSlope() {
-    return slope
+    slope
   }
 
   /**
@@ -355,7 +355,7 @@ class QuantileRegression {
     if (numberOfDecimals < 0) {
       return slope
     }
-    return slope.setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    slope.setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   /**
@@ -364,7 +364,7 @@ class QuantileRegression {
    * @return The intercept
    */
   BigDecimal getIntercept() {
-    return intercept
+    intercept
   }
 
   /**
@@ -377,7 +377,7 @@ class QuantileRegression {
     if (numberOfDecimals < 0) {
       return intercept
     }
-    return intercept.setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    intercept.setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   /**
@@ -388,6 +388,6 @@ class QuantileRegression {
   @Override
   String toString() {
     String sign = intercept >= 0 ? '+' : '-'
-    return "${y} = ${getSlope(2)}${x} ${sign} ${getIntercept(2).abs()} (τ=${tau.setScale(2, RoundingMode.HALF_EVEN)})"
+    "${y} = ${getSlope(2)}${x} ${sign} ${getIntercept(2).abs()} (τ=${tau.setScale(2, RoundingMode.HALF_EVEN)})"
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/RegressionUtils.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/RegressionUtils.groovy
@@ -74,7 +74,7 @@ class RegressionUtils {
     for (int i = 0; i < size; i++) {
       leverage += v[i] * tmp[i]
     }
-    return leverage
+    leverage
   }
 
   static BigDecimal polynomialLeverage(BigDecimal[][] xtxInv, BigDecimal x, int degree) {
@@ -101,6 +101,6 @@ class RegressionUtils {
     for (int i = 0; i < size; i++) {
       leverage += v[i] * tmp[i]
     }
-    return leverage
+    leverage
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/BrentSolver.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/BrentSolver.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.solver
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Bracketing Brent-Dekker root solver for one-dimensional continuous functions.
  *
@@ -148,6 +150,35 @@ final class BrentSolver {
     throw new IllegalStateException("Brent solver failed to converge after $maxIterations iterations")
   }
 
+  /**
+   * Finds a root using idiomatic numeric inputs.
+   *
+   * @param function objective function
+   * @param min lower bracket endpoint
+   * @param max upper bracket endpoint
+   * @param relativeAccuracy relative convergence threshold
+   * @param absoluteAccuracy absolute convergence threshold
+   * @param maxIterations maximum iteration count
+   * @return solver result containing the root and iteration metadata
+   */
+  static SolverResult solve(
+      UnivariateObjective function,
+      Number min,
+      Number max,
+      Number relativeAccuracy,
+      Number absoluteAccuracy,
+      int maxIterations
+  ) {
+    solve(
+      function,
+      NumericConversion.toFiniteDouble(min, 'min'),
+      NumericConversion.toFiniteDouble(max, 'max'),
+      NumericConversion.toFiniteDouble(relativeAccuracy, 'relativeAccuracy'),
+      NumericConversion.toFiniteDouble(absoluteAccuracy, 'absoluteAccuracy'),
+      maxIterations
+    )
+  }
+
   static class SolverResult {
     /** Root value returned by the solver. */
     double root
@@ -159,5 +190,17 @@ final class BrentSolver {
     double lowerBound
     /** Upper bound of the final bracketing interval. */
     double upperBound
+
+    BigDecimal getRootValue() {
+      BigDecimal.valueOf(root)
+    }
+
+    BigDecimal getLowerBoundValue() {
+      BigDecimal.valueOf(lowerBound)
+    }
+
+    BigDecimal getUpperBoundValue() {
+      BigDecimal.valueOf(upperBound)
+    }
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/BrentSolver.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/BrentSolver.groovy
@@ -180,27 +180,39 @@ final class BrentSolver {
   }
 
   static class SolverResult {
-    /** Root value returned by the solver. */
-    double root
+    private double root
     /** Number of function evaluations performed. */
     int evaluations
     /** Number of Brent iterations performed. */
     int iterations
-    /** Lower bound of the final bracketing interval. */
-    double lowerBound
-    /** Upper bound of the final bracketing interval. */
-    double upperBound
+    private double lowerBound
+    private double upperBound
 
+    /** Returns the root as {@code BigDecimal}. */
     BigDecimal getRootValue() {
       BigDecimal.valueOf(root)
     }
 
+    /** Returns the lower bound of the final bracketing interval as {@code BigDecimal}. */
     BigDecimal getLowerBoundValue() {
       BigDecimal.valueOf(lowerBound)
     }
 
+    /** Returns the upper bound of the final bracketing interval as {@code BigDecimal}. */
     BigDecimal getUpperBoundValue() {
       BigDecimal.valueOf(upperBound)
     }
+
+    /** @deprecated Use {@link #getRootValue()} instead. */
+    @Deprecated
+    double getRoot() { root }
+
+    /** @deprecated Use {@link #getLowerBoundValue()} instead. */
+    @Deprecated
+    double getLowerBound() { lowerBound }
+
+    /** @deprecated Use {@link #getUpperBoundValue()} instead. */
+    @Deprecated
+    double getUpperBound() { upperBound }
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/BrentSolver.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/BrentSolver.groovy
@@ -24,6 +24,7 @@ final class BrentSolver {
    * @param maxIterations maximum iteration count
    * @return solver result containing the root and iteration metadata
    */
+  @SuppressWarnings('MethodSize')
   static SolverResult solve(
       UnivariateObjective function,
       double min,

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/GoalSeek.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/GoalSeek.groovy
@@ -58,7 +58,7 @@ class GoalSeek {
     )
     double val = refineRoot(function, solverResult.root, solverResult.lowerBound, solverResult.upperBound, absoluteAccuracy)
     double result = algorithm.call(val) as double
-    return [value: val, result: result, diff: (targetValue-result), iterations: solverResult.evaluations]
+    [value: val, result: result, diff: (targetValue-result), iterations: solverResult.evaluations]
   }
 
   private static double refineRoot(

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/LinearProgramSolver.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/LinearProgramSolver.groovy
@@ -64,7 +64,7 @@ final class LinearProgramSolver {
     for (int i = 0; i < variableCount; i++) {
       objectiveValue += objective[i] * point[i]
     }
-    return new Solution(point: point, value: objectiveValue, iterations: phaseTwo.iterations)
+    new Solution(point: point, value: objectiveValue, iterations: phaseTwo.iterations)
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/LinearProgramSolver.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/LinearProgramSolver.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.solver
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Two-phase simplex solver for linear programs in equality form with non-negative variables.
  *
@@ -63,6 +65,29 @@ final class LinearProgramSolver {
       objectiveValue += objective[i] * point[i]
     }
     return new Solution(point: point, value: objectiveValue, iterations: phaseTwo.iterations)
+  }
+
+  /**
+   * Solves an equality-form linear program from idiomatic Groovy collections.
+   *
+   * @param objective minimization objective coefficients
+   * @param constraints equality constraint matrix rows
+   * @param rhs right-hand-side vector
+   * @param maxIterations maximum simplex iterations per phase
+   * @return optimal solution point and objective value
+   */
+  static Solution minimize(
+      List<? extends Number> objective,
+      List<? extends List<? extends Number>> constraints,
+      List<? extends Number> rhs,
+      int maxIterations = 10_000
+  ) {
+    minimize(
+      NumericConversion.toDoubleArray(objective, 'objective'),
+      NumericConversion.toDoubleMatrix(constraints, 'constraints'),
+      NumericConversion.toDoubleArray(rhs, 'rhs'),
+      maxIterations
+    )
   }
 
   private static PhaseState buildPhaseOne(double[][] constraints, double[] rhs) {
@@ -225,6 +250,14 @@ final class LinearProgramSolver {
     double value
     /** Total simplex iterations performed. */
     int iterations
+
+    List<BigDecimal> getPointValues() {
+      NumericConversion.toBigDecimalList(point, 'point')
+    }
+
+    BigDecimal getObjectiveValue() {
+      BigDecimal.valueOf(value)
+    }
   }
 
   private static class PhaseState {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/MultivariateObjective.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/MultivariateObjective.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.solver
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Objective function for multivariate derivative-free optimization.
  *
@@ -15,4 +17,14 @@ interface MultivariateObjective {
    * @return objective value
    */
   double value(double[] point)
+
+  /**
+   * Evaluates the objective at the supplied point using a Groovy-facing numeric vector.
+   *
+   * @param point current parameter vector
+   * @return objective value
+   */
+  default double value(List<? extends Number> point) {
+    value(NumericConversion.toDoubleArray(point, 'point'))
+  }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/NelderMeadOptimizer.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/NelderMeadOptimizer.groovy
@@ -124,7 +124,7 @@ final class NelderMeadOptimizer {
     }
 
     sortSimplex(simplex, values)
-    return new OptimizationResult(point: simplex[0], value: values[0], evaluations: evaluations, iterations: iterations)
+    new OptimizationResult(point: simplex[0], value: values[0], evaluations: evaluations, iterations: iterations)
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/NelderMeadOptimizer.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/NelderMeadOptimizer.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.solver
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
@@ -242,7 +240,6 @@ final class NelderMeadOptimizer {
     copy
   }
 
-  @CompileStatic
   static class OptimizationResult {
     /** Best parameter vector found. */
     double[] point

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/NelderMeadOptimizer.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/NelderMeadOptimizer.groovy
@@ -2,6 +2,8 @@ package se.alipsa.matrix.stats.solver
 
 import groovy.transform.CompileStatic
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Native Nelder-Mead simplex optimizer for low-dimensional derivative-free minimization.
  *
@@ -127,6 +129,35 @@ final class NelderMeadOptimizer {
     return new OptimizationResult(point: simplex[0], value: values[0], evaluations: evaluations, iterations: iterations)
   }
 
+  /**
+   * Minimizes an objective from idiomatic numeric vectors.
+   *
+   * @param objective objective function to minimize
+   * @param initialGuess initial simplex anchor point
+   * @param stepSizes axis-aligned simplex edge sizes
+   * @param maxEvaluations maximum objective evaluations
+   * @param relativeThreshold relative convergence threshold
+   * @param absoluteThreshold absolute convergence threshold
+   * @return best point and value found by the optimizer
+   */
+  static OptimizationResult minimize(
+      MultivariateObjective objective,
+      List<? extends Number> initialGuess,
+      List<? extends Number> stepSizes,
+      int maxEvaluations,
+      Number relativeThreshold,
+      Number absoluteThreshold
+  ) {
+    minimize(
+      objective,
+      NumericConversion.toDoubleArray(initialGuess, 'initialGuess'),
+      NumericConversion.toDoubleArray(stepSizes, 'stepSizes'),
+      maxEvaluations,
+      NumericConversion.toFiniteDouble(relativeThreshold, 'relativeThreshold'),
+      NumericConversion.toFiniteDouble(absoluteThreshold, 'absoluteThreshold')
+    )
+  }
+
   private static double[] centroid(double[][] simplex, int dimension) {
     double[] centroid = new double[dimension]
     for (int i = 0; i < dimension; i++) {
@@ -221,5 +252,13 @@ final class NelderMeadOptimizer {
     int evaluations
     /** Number of simplex iterations performed. */
     int iterations
+
+    List<BigDecimal> getPointValues() {
+      NumericConversion.toBigDecimalList(point, 'point')
+    }
+
+    BigDecimal getObjectiveValue() {
+      BigDecimal.valueOf(value)
+    }
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/UnivariateObjective.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/UnivariateObjective.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.solver
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Objective function for one-dimensional root-finding.
  *
@@ -15,4 +17,14 @@ interface UnivariateObjective {
    * @return objective value at {@code x}
    */
   double value(double x)
+
+  /**
+   * Evaluates the function at the given point using a Groovy-facing numeric input.
+   *
+   * @param x point to evaluate
+   * @return objective value at {@code x}
+   */
+  default double value(Number x) {
+    value(NumericConversion.toFiniteDouble(x, 'x'))
+  }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Adf.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Adf.groovy
@@ -165,7 +165,7 @@ class Adf {
       }
     }
 
-    return X
+    X
   }
 
   /**
@@ -292,13 +292,13 @@ class Adf {
         "stationary (no unit root)" :
         "non-stationary (unit root present)"
 
-      return String.format("ADF statistic: %.4f (critical value: %.2f at 5%% level)\nγ coefficient: %.6f (SE: %.6f)\nConclusion: Series appears %s",
+      String.format("ADF statistic: %.4f (critical value: %.2f at 5%% level)\nγ coefficient: %.6f (SE: %.6f)\nConclusion: Series appears %s",
                            statistic, criticalValue, gammaCoefficient, gammaStandardError, conclusion)
     }
 
     @Override
     String toString() {
-      return """Augmented Dickey-Fuller Test
+      """Augmented Dickey-Fuller Test
   Type: ${type}
   Lags: ${lag}
   Sample size: ${sampleSize} (effective: ${effectiveSize})

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Adf.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Adf.groovy
@@ -99,14 +99,14 @@ class Adf {
       double criticalValue = getCriticalValue(type, nObs)
 
       return new AdfResult(
-        statistic: tStatistic,
+        statistic: BigDecimal.valueOf(tStatistic),
         lag: lags,
         type: type,
         sampleSize: n,
         effectiveSize: nObs,
-        gammaCoefficient: gammaCoef,
-        gammaStandardError: gammaSE,
-        criticalValue: criticalValue
+        gammaCoefficient: BigDecimal.valueOf(gammaCoef),
+        gammaStandardError: BigDecimal.valueOf(gammaSE),
+        criticalValue: BigDecimal.valueOf(criticalValue)
       )
     } catch (Exception e) {
       throw new IllegalStateException(
@@ -246,7 +246,7 @@ class Adf {
    */
   static class AdfResult {
     /** The ADF test statistic (t-statistic for γ coefficient) */
-    double statistic
+    BigDecimal statistic
 
     /** The number of lags used */
     int lag
@@ -261,13 +261,13 @@ class Adf {
     int effectiveSize
 
     /** The estimated γ coefficient on y_{t-1} */
-    double gammaCoefficient
+    BigDecimal gammaCoefficient
 
     /** The standard error of the γ coefficient */
-    double gammaStandardError
+    BigDecimal gammaStandardError
 
     /** The approximate 5% critical value */
-    double criticalValue
+    BigDecimal criticalValue
 
     /**
      * Interprets the ADF test result.

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/AdfGls.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/AdfGls.groovy
@@ -64,6 +64,7 @@ class AdfGls {
    * @param type The type of test: "drift" (constant only) or "trend" (constant and trend)
    * @return AdfGlsResult containing test statistic and conclusion
    */
+  @SuppressWarnings('MethodSize')
   static AdfGlsResult test(double[] data, Integer lags = null, String type = "drift") {
     if (data == null) {
       throw new IllegalArgumentException("Data cannot be null")
@@ -286,7 +287,7 @@ class AdfGls {
         } else {
           log.debug("Skipping lag $p during ADF-GLS MAIC selection: ${e.message}")
         }
-      } catch (RuntimeException e) {
+      } catch (Exception e) {
         log.error("Potential bug while selecting lag $p for ADF-GLS: ${e.message}", e)
         throw e
       }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/AdfGls.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/AdfGls.groovy
@@ -1,6 +1,7 @@
 package se.alipsa.matrix.stats.timeseries
 
 import se.alipsa.matrix.core.util.Logger
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * The ADF-GLS test (or DF-GLS test) is a test for a unit root in a time series.
@@ -375,9 +376,10 @@ class AdfGls {
      * @param alpha Significance level (default 0.05)
      * @return Interpretation string
      */
-    String interpret(double alpha = 0.05) {
-      double cv = alpha == 0.01 ? criticalValue1pct :
-                  alpha == 0.10 ? criticalValue10pct : criticalValue5pct
+    String interpret(Number alpha = 0.05) {
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
+      double cv = alphaValue == 0.01 ? criticalValue1pct :
+                  alphaValue == 0.10 ? criticalValue10pct : criticalValue5pct
 
       if (statistic < cv) {
         return "Reject H0: Series appears stationary (ADF-GLS = ${String.format('%.4f', statistic)}, CV = ${String.format('%.4f', cv)})"
@@ -389,7 +391,8 @@ class AdfGls {
     /**
      * Evaluates the test result with detailed information.
      */
-    String evaluate(double alpha = 0.05) {
+    String evaluate(Number alpha = 0.05) {
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       String conclusion = statistic < criticalValue5pct ? "stationary" : "non-stationary (unit root present)"
 
       return String.format(
@@ -401,7 +404,7 @@ class AdfGls {
         "Sample size: %d\\n" +
         "Conclusion: Series appears %s at %.0f%% significance level",
         testType, lags, statistic, criticalValue1pct, criticalValue5pct, criticalValue10pct,
-        sampleSize, conclusion, alpha * 100
+        sampleSize, conclusion, (alphaValue * 100) as double
       )
     }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/AdfGls.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/AdfGls.groovy
@@ -185,7 +185,7 @@ class AdfGls {
     double cv5pct = getCriticalValue(type, n, 0.05)
     double cv10pct = getCriticalValue(type, n, 0.10)
 
-    return new AdfGlsResult(
+    new AdfGlsResult(
       statistic: BigDecimal.valueOf(tStatistic),
       gamma: BigDecimal.valueOf(gamma),
       standardError: BigDecimal.valueOf(gammaSE),
@@ -203,7 +203,7 @@ class AdfGls {
    */
   static AdfGlsResult test(List<? extends Number> data, Integer lags = null, String type = "drift") {
     double[] array = data.collect { it.doubleValue() } as double[]
-    return test(array, lags, type)
+    test(array, lags, type)
   }
 
   /**
@@ -256,7 +256,7 @@ class AdfGls {
       detrended[i] = data[i] - fitted[i]
     }
 
-    return detrended
+    detrended
   }
 
   /**
@@ -298,7 +298,7 @@ class AdfGls {
       throw new IllegalArgumentException("Unable to select ADF-GLS lag: all candidate lags 0..${maxLags} failed")
     }
 
-    return bestLag
+    bestLag
   }
 
   private static boolean isNumericalFailure(IllegalArgumentException e) {
@@ -336,7 +336,7 @@ class AdfGls {
 
     // Asymptotic approximation: CV(T) = β₀ + β₁/T + β₂/T² + β₃/T³
     double T = n as double
-    return params[0] + params[1] / T + params[2] / (T * T) + params[3] / (T * T * T)
+    params[0] + params[1] / T + params[2] / (T * T) + params[3] / (T * T * T)
   }
 
   /**
@@ -395,7 +395,7 @@ class AdfGls {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       String conclusion = statistic < criticalValue5pct ? "stationary" : "non-stationary (unit root present)"
 
-      return String.format(
+      String.format(
         "ADF-GLS test:\\n" +
         "Test type: %s\\n" +
         "Lags: %d\\n" +
@@ -410,7 +410,7 @@ class AdfGls {
 
     @Override
     String toString() {
-      return """ADF-GLS Test (Elliott-Rothenberg-Stock)
+      """ADF-GLS Test (Elliott-Rothenberg-Stock)
   Type: ${testType}
   Lags: ${lags}
   Sample size: ${sampleSize}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/AdfGls.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/AdfGls.groovy
@@ -186,15 +186,15 @@ class AdfGls {
     double cv10pct = getCriticalValue(type, n, 0.10)
 
     return new AdfGlsResult(
-      statistic: tStatistic,
-      gamma: gamma,
-      standardError: gammaSE,
+      statistic: BigDecimal.valueOf(tStatistic),
+      gamma: BigDecimal.valueOf(gamma),
+      standardError: BigDecimal.valueOf(gammaSE),
       lags: p,
       sampleSize: n,
       testType: type,
-      criticalValue1pct: cv1pct,
-      criticalValue5pct: cv5pct,
-      criticalValue10pct: cv10pct
+      criticalValue1pct: BigDecimal.valueOf(cv1pct),
+      criticalValue5pct: BigDecimal.valueOf(cv5pct),
+      criticalValue10pct: BigDecimal.valueOf(cv10pct)
     )
   }
 
@@ -344,13 +344,13 @@ class AdfGls {
    */
   static class AdfGlsResult {
     /** The ADF-GLS test statistic (t-statistic for γ) */
-    double statistic
+    BigDecimal statistic
 
     /** The estimated γ coefficient */
-    double gamma
+    BigDecimal gamma
 
     /** Standard error of γ */
-    double standardError
+    BigDecimal standardError
 
     /** Number of lags used */
     int lags
@@ -362,13 +362,13 @@ class AdfGls {
     String testType
 
     /** Critical value at 1% significance */
-    double criticalValue1pct
+    BigDecimal criticalValue1pct
 
     /** Critical value at 5% significance */
-    double criticalValue5pct
+    BigDecimal criticalValue5pct
 
     /** Critical value at 10% significance */
-    double criticalValue10pct
+    BigDecimal criticalValue10pct
 
     /**
      * Interprets the test result.
@@ -378,8 +378,8 @@ class AdfGls {
      */
     String interpret(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
-      double cv = alphaValue == 0.01 ? criticalValue1pct :
-                  alphaValue == 0.10 ? criticalValue10pct : criticalValue5pct
+      BigDecimal cv = alphaValue == 0.01 ? criticalValue1pct :
+        alphaValue == 0.10 ? criticalValue10pct : criticalValue5pct
 
       if (statistic < cv) {
         return "Reject H0: Series appears stationary (ADF-GLS = ${String.format('%.4f', statistic)}, CV = ${String.format('%.4f', cv)})"

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
@@ -133,13 +133,21 @@ class Ccm {
     }
 
     return new CcmResult(
-      xmapY: xmapY,
-      ymapX: ymapX,
-      librarySizes: librarySizes.toArray(new Integer[0]),
+      xmapY: toCorrelationValues(xmapY),
+      ymapX: toCorrelationValues(ymapX),
+      librarySizes: librarySizes.asImmutable() as List<Integer>,
       embeddingDim: E,
       timeLag: tau,
       seriesLength: n
     )
+  }
+
+  private static List<Number> toCorrelationValues(double[] values) {
+    List<Number> converted = []
+    for (double value : values) {
+      converted << (Double.isFinite(value) ? BigDecimal.valueOf(value) : Double.NaN)
+    }
+    converted.asImmutable() as List<Number>
   }
 
   /**
@@ -365,13 +373,13 @@ class Ccm {
    */
   static class CcmResult {
     /** Cross-map skill: X cross-mapped from Y (if positive and increasing, Y causes X) */
-    double[] xmapY
+    List<Number> xmapY
 
     /** Cross-map skill: Y cross-mapped from X (if positive and increasing, X causes Y) */
-    double[] ymapX
+    List<Number> ymapX
 
     /** Library sizes used for testing */
-    Integer[] librarySizes
+    List<Integer> librarySizes
 
     /** Embedding dimension */
     int embeddingDim
@@ -390,11 +398,15 @@ class Ccm {
      */
     boolean xCausesY(Number threshold = 0.3) {
       BigDecimal thresholdValue = NumericConversion.toUnitInterval(threshold, 'threshold')
-      if (ymapX.length < 2) {
+      if (ymapX.size() < 2) {
         return false
       }
-      // Check if correlation is positive and increasing
-      return ymapX[-1] > thresholdValue && ymapX[-1] > ymapX[0]
+      double last = ymapX[-1] as double
+      double first = ymapX[0] as double
+      if (!Double.isFinite(last) || !Double.isFinite(first)) {
+        return false
+      }
+      return last > thresholdValue && last > first
     }
 
     /**
@@ -405,23 +417,27 @@ class Ccm {
      */
     boolean yCausesX(Number threshold = 0.3) {
       BigDecimal thresholdValue = NumericConversion.toUnitInterval(threshold, 'threshold')
-      if (xmapY.length < 2) {
+      if (xmapY.size() < 2) {
         return false
       }
-      // Check if correlation is positive and increasing
-      return xmapY[-1] > thresholdValue && xmapY[-1] > xmapY[0]
+      double last = xmapY[-1] as double
+      double first = xmapY[0] as double
+      if (!Double.isFinite(last) || !Double.isFinite(first)) {
+        return false
+      }
+      return last > thresholdValue && last > first
     }
 
-    List<BigDecimal> getXmapYValues() {
-      NumericConversion.toBigDecimalList(xmapY, 'xmapY')
+    List<Number> getXmapYValues() {
+      xmapY
     }
 
-    List<BigDecimal> getYmapXValues() {
-      NumericConversion.toBigDecimalList(ymapX, 'ymapX')
+    List<Number> getYmapXValues() {
+      ymapX
     }
 
     List<Integer> getLibrarySizeValues() {
-      librarySizes.toList().asImmutable() as List<Integer>
+      librarySizes
     }
 
     /**
@@ -443,7 +459,7 @@ class Ccm {
       sb.append(String.format("%-15s %-20s %-20s\n", "Library Size", "X|M(Y) (Y→X)", "Y|M(X) (X→Y)"))
       sb.append("-" * 60).append("\n")
 
-      for (int i = 0; i < librarySizes.length; i++) {
+      for (int i = 0; i < librarySizes.size(); i++) {
         sb.append(String.format("%-15d %-20.4f %-20.4f\n",
                                 librarySizes[i], xmapY[i], ymapX[i]))
       }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
@@ -428,14 +428,23 @@ class Ccm {
       last > thresholdValue && last > first
     }
 
+    /**
+     * Alias for {@link #getXmapY()} kept to match the `*Values` naming pattern used by other result objects.
+     */
     List<Number> getXmapYValues() {
       xmapY
     }
 
+    /**
+     * Alias for {@link #getYmapX()} kept to match the `*Values` naming pattern used by other result objects.
+     */
     List<Number> getYmapXValues() {
       ymapX
     }
 
+    /**
+     * Alias for {@link #getLibrarySizes()} kept to match the `*Values` naming pattern used by other result objects.
+     */
     List<Integer> getLibrarySizeValues() {
       librarySizes
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
@@ -160,11 +160,11 @@ class Ccm {
       List<? extends Number> librarySizes = null
   ) {
     List<Integer> normalizedLibrarySizes = librarySizes?.collect { Number value ->
-      NumericConversion.toBigDecimal(value, 'library size').intValue()
+      NumericConversion.toExactInt(value, 'library size')
     }
     test(
-      NumericConversion.toDoubleArray(x as List<? extends Number>, 'x'),
-      NumericConversion.toDoubleArray(y as List<? extends Number>, 'y'),
+      NumericConversion.toDoubleArray(x, 'x'),
+      NumericConversion.toDoubleArray(y, 'y'),
       E,
       tau,
       normalizedLibrarySizes

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
@@ -132,7 +132,7 @@ class Ccm {
       ymapX[i] = crossMap(x, y, E, tau, L)
     }
 
-    return new CcmResult(
+    new CcmResult(
       xmapY: toCorrelationValues(xmapY),
       ymapX: toCorrelationValues(ymapX),
       librarySizes: librarySizes.asImmutable() as List<Integer>,
@@ -224,7 +224,7 @@ class Ccm {
     }
 
     // Compute Pearson correlation between predictions and actuals
-    return pearsonCorrelation(predictions as double[], actuals as double[])
+    pearsonCorrelation(predictions as double[], actuals as double[])
   }
 
   /**
@@ -246,7 +246,7 @@ class Ccm {
 
     // Sort by distance and take k nearest
     neighbors.sort { it.distance }
-    return neighbors.take(Math.min(k, neighbors.size()))
+    neighbors.take(Math.min(k, neighbors.size()))
   }
 
   /**
@@ -276,7 +276,7 @@ class Ccm {
       prediction += w * targetVal
     }
 
-    return prediction
+    prediction
   }
 
   /**
@@ -288,7 +288,7 @@ class Ccm {
       double diff = a[i] - b[i]
       sum += diff * diff
     }
-    return Math.sqrt(sum)
+    Math.sqrt(sum)
   }
 
   /**
@@ -304,7 +304,7 @@ class Ccm {
     while (selected.size() < n) {
       selected.add(rnd.nextInt(max))
     }
-    return selected.toList()
+    selected.toList()
   }
 
   /**
@@ -334,7 +334,7 @@ class Ccm {
       return 0.0
     }
 
-    return numerator / denominator
+    numerator / denominator
   }
 
   /**
@@ -357,7 +357,7 @@ class Ccm {
       sizes.add(maxLib)
     }
 
-    return sizes
+    sizes
   }
 
   /**
@@ -406,7 +406,7 @@ class Ccm {
       if (!Double.isFinite(last) || !Double.isFinite(first)) {
         return false
       }
-      return last > thresholdValue && last > first
+      last > thresholdValue && last > first
     }
 
     /**
@@ -425,7 +425,7 @@ class Ccm {
       if (!Double.isFinite(last) || !Double.isFinite(first)) {
         return false
       }
-      return last > thresholdValue && last > first
+      last > thresholdValue && last > first
     }
 
     List<Number> getXmapYValues() {
@@ -484,12 +484,12 @@ class Ccm {
       sb.append("\nNote: CCM detects causality via state space reconstruction.\n")
       sb.append("Positive, increasing cross-map skill indicates causal influence.\n")
 
-      return sb.toString()
+      sb.toString()
     }
 
     @Override
     String toString() {
-      return interpret()
+      interpret()
     }
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.timeseries
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Convergent Cross Mapping (CCM) is a statistical test for detecting causal relationships between variables
  * in dynamical systems. Unlike Granger causality which assumes separable influences, CCM is designed for
@@ -137,6 +139,35 @@ class Ccm {
       embeddingDim: E,
       timeLag: tau,
       seriesLength: n
+    )
+  }
+
+  /**
+   * Performs convergent cross mapping test from Groovy-facing numeric inputs.
+   *
+   * @param x first time series
+   * @param y second time series
+   * @param E embedding dimension
+   * @param tau time delay
+   * @param librarySizes library sizes to test for convergence
+   * @return CCM result
+   */
+  static CcmResult test(
+      List<? extends Number> x,
+      List<? extends Number> y,
+      int E = 3,
+      int tau = 1,
+      List<? extends Number> librarySizes = null
+  ) {
+    List<Integer> normalizedLibrarySizes = librarySizes?.collect { Number value ->
+      NumericConversion.toBigDecimal(value, 'library size').intValue()
+    }
+    test(
+      NumericConversion.toDoubleArray(x as List<? extends Number>, 'x'),
+      NumericConversion.toDoubleArray(y as List<? extends Number>, 'y'),
+      E,
+      tau,
+      normalizedLibrarySizes
     )
   }
 
@@ -357,12 +388,13 @@ class Ccm {
      * @param threshold Minimum correlation for last library size
      * @return true if evidence suggests X causes Y
      */
-    boolean xCausesY(double threshold = 0.3) {
+    boolean xCausesY(Number threshold = 0.3) {
+      BigDecimal thresholdValue = NumericConversion.toUnitInterval(threshold, 'threshold')
       if (ymapX.length < 2) {
         return false
       }
       // Check if correlation is positive and increasing
-      return ymapX[-1] > threshold && ymapX[-1] > ymapX[0]
+      return ymapX[-1] > thresholdValue && ymapX[-1] > ymapX[0]
     }
 
     /**
@@ -371,12 +403,25 @@ class Ccm {
      * @param threshold Minimum correlation for last library size
      * @return true if evidence suggests Y causes X
      */
-    boolean yCausesX(double threshold = 0.3) {
+    boolean yCausesX(Number threshold = 0.3) {
+      BigDecimal thresholdValue = NumericConversion.toUnitInterval(threshold, 'threshold')
       if (xmapY.length < 2) {
         return false
       }
       // Check if correlation is positive and increasing
-      return xmapY[-1] > threshold && xmapY[-1] > xmapY[0]
+      return xmapY[-1] > thresholdValue && xmapY[-1] > xmapY[0]
+    }
+
+    List<BigDecimal> getXmapYValues() {
+      NumericConversion.toBigDecimalList(xmapY, 'xmapY')
+    }
+
+    List<BigDecimal> getYmapXValues() {
+      NumericConversion.toBigDecimalList(ymapX, 'ymapX')
+    }
+
+    List<Integer> getLibrarySizeValues() {
+      librarySizes.toList().asImmutable() as List<Integer>
     }
 
     /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
@@ -142,12 +142,12 @@ class Ccm {
     )
   }
 
-  private static List<Number> toCorrelationValues(double[] values) {
-    List<Number> converted = []
+  private static List<BigDecimal> toCorrelationValues(double[] values) {
+    List<BigDecimal> converted = []
     for (double value : values) {
-      converted << (Double.isFinite(value) ? BigDecimal.valueOf(value) : Double.NaN)
+      converted << (Double.isFinite(value) ? BigDecimal.valueOf(value) : null)
     }
-    converted.asImmutable() as List<Number>
+    converted.asImmutable() as List<BigDecimal>
   }
 
   /**
@@ -372,11 +372,11 @@ class Ccm {
    * Result class for CCM test.
    */
   static class CcmResult {
-    /** Cross-map skill: X cross-mapped from Y (if positive and increasing, Y causes X) */
-    List<Number> xmapY
+    /** Cross-map skill: X cross-mapped from Y (if positive and increasing, Y causes X). Null entries indicate non-finite values. */
+    List<BigDecimal> xmapY
 
-    /** Cross-map skill: Y cross-mapped from X (if positive and increasing, X causes Y) */
-    List<Number> ymapX
+    /** Cross-map skill: Y cross-mapped from X (if positive and increasing, X causes Y). Null entries indicate non-finite values. */
+    List<BigDecimal> ymapX
 
     /** Library sizes used for testing */
     List<Integer> librarySizes
@@ -401,9 +401,9 @@ class Ccm {
       if (ymapX.size() < 2) {
         return false
       }
-      double last = ymapX[-1] as double
-      double first = ymapX[0] as double
-      if (!Double.isFinite(last) || !Double.isFinite(first)) {
+      BigDecimal last = ymapX[-1]
+      BigDecimal first = ymapX[0]
+      if (last == null || first == null) {
         return false
       }
       last > thresholdValue && last > first
@@ -420,9 +420,9 @@ class Ccm {
       if (xmapY.size() < 2) {
         return false
       }
-      double last = xmapY[-1] as double
-      double first = xmapY[0] as double
-      if (!Double.isFinite(last) || !Double.isFinite(first)) {
+      BigDecimal last = xmapY[-1]
+      BigDecimal first = xmapY[0]
+      if (last == null || first == null) {
         return false
       }
       last > thresholdValue && last > first
@@ -431,14 +431,14 @@ class Ccm {
     /**
      * Alias for {@link #getXmapY()} kept to match the `*Values` naming pattern used by other result objects.
      */
-    List<Number> getXmapYValues() {
+    List<BigDecimal> getXmapYValues() {
       xmapY
     }
 
     /**
      * Alias for {@link #getYmapX()} kept to match the `*Values` naming pattern used by other result objects.
      */
-    List<Number> getYmapXValues() {
+    List<BigDecimal> getYmapXValues() {
       ymapX
     }
 
@@ -469,8 +469,9 @@ class Ccm {
       sb.append("-" * 60).append("\n")
 
       for (int i = 0; i < librarySizes.size(); i++) {
-        sb.append(String.format("%-15d %-20.4f %-20.4f\n",
-                                librarySizes[i], xmapY[i], ymapX[i]))
+        String xVal = xmapY[i] != null ? String.format('%.4f', xmapY[i]) : 'NaN'
+        String yVal = ymapX[i] != null ? String.format('%.4f', ymapX[i]) : 'NaN'
+        sb.append(String.format("%-15d %-20s %-20s\n", librarySizes[i], xVal, yVal))
       }
 
       sb.append("\n")

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Chow.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Chow.groovy
@@ -128,14 +128,14 @@ class Chow {
     double pValue = 1.0 - fDist.cumulativeProbability(fStatistic)
 
     return new ChowResult(
-      statistic: fStatistic,
-      pValue: pValue,
+      statistic: BigDecimal.valueOf(fStatistic),
+      pValue: BigDecimal.valueOf(pValue),
       df1: k,
       df2: n - 2 * k,
       breakPoint: breakPoint,
-      rssFull: rssFull,
-      rss1: rss1,
-      rss2: rss2,
+      rssFull: BigDecimal.valueOf(rssFull),
+      rss1: BigDecimal.valueOf(rss1),
+      rss2: BigDecimal.valueOf(rss2),
       sampleSize: n,
       numParameters: k
     )
@@ -155,10 +155,10 @@ class Chow {
    */
   static class ChowResult {
     /** The Chow F-statistic */
-    double statistic
+    BigDecimal statistic
 
     /** The p-value */
-    double pValue
+    BigDecimal pValue
 
     /** Degrees of freedom (numerator) */
     int df1
@@ -170,13 +170,13 @@ class Chow {
     int breakPoint
 
     /** RSS for full model */
-    double rssFull
+    BigDecimal rssFull
 
     /** RSS for first sub-model */
-    double rss1
+    BigDecimal rss1
 
     /** RSS for second sub-model */
-    double rss2
+    BigDecimal rss2
 
     /** Sample size */
     int sampleSize
@@ -191,7 +191,7 @@ class Chow {
      * @return Interpretation string
      */
     String interpret(Number alpha = 0.05) {
-      double alphaValue = NumericConversion.toAlpha(alpha) as double
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       if (pValue < alphaValue) {
         return "Reject H0: Structural break detected at observation ${breakPoint} (F = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
       } else {
@@ -204,7 +204,7 @@ class Chow {
      */
     String evaluate(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
-      String conclusion = pValue < (alphaValue as double) ? "structural break present" : "no structural break detected"
+      String conclusion = pValue < alphaValue ? "structural break present" : "no structural break detected"
 
       return String.format(
         "Chow test:\\n" +

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Chow.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Chow.groovy
@@ -1,6 +1,7 @@
 package se.alipsa.matrix.stats.timeseries
 
 import se.alipsa.matrix.stats.distribution.FDistribution
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * The Chow test, proposed by econometrician Gregory Chow in 1960, tests whether the coefficients
@@ -189,8 +190,9 @@ class Chow {
      * @param alpha Significance level (default 0.05)
      * @return Interpretation string
      */
-    String interpret(double alpha = 0.05) {
-      if (pValue < alpha) {
+    String interpret(Number alpha = 0.05) {
+      double alphaValue = NumericConversion.toAlpha(alpha) as double
+      if (pValue < alphaValue) {
         return "Reject H0: Structural break detected at observation ${breakPoint} (F = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
       } else {
         return "Fail to reject H0: No evidence of structural break at observation ${breakPoint} (F = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
@@ -200,8 +202,9 @@ class Chow {
     /**
      * Evaluates the test result with detailed information.
      */
-    String evaluate(double alpha = 0.05) {
-      String conclusion = pValue < alpha ? "structural break present" : "no structural break detected"
+    String evaluate(Number alpha = 0.05) {
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
+      String conclusion = pValue < (alphaValue as double) ? "structural break present" : "no structural break detected"
 
       return String.format(
         "Chow test:\\n" +
@@ -217,7 +220,7 @@ class Chow {
         breakPoint, statistic, pValue, df1, df2,
         rssFull, rss1, rss2, rss1 + rss2,
         sampleSize, numParameters,
-        conclusion, alpha * 100
+        conclusion, (alphaValue * 100) as double
       )
     }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Chow.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Chow.groovy
@@ -127,7 +127,7 @@ class Chow {
     FDistribution fDist = new FDistribution(k, n - 2 * k)
     double pValue = 1.0 - fDist.cumulativeProbability(fStatistic)
 
-    return new ChowResult(
+    new ChowResult(
       statistic: BigDecimal.valueOf(fStatistic),
       pValue: BigDecimal.valueOf(pValue),
       df1: k,
@@ -147,7 +147,7 @@ class Chow {
   static ChowResult test(List<? extends Number> y, List<List<? extends Number>> X, int breakPoint) {
     double[] yArray = y.collect { it.doubleValue() } as double[]
     double[][] XArray = X.collect { row -> row.collect { it.doubleValue() } as double[] } as double[][]
-    return test(yArray, XArray, breakPoint)
+    test(yArray, XArray, breakPoint)
   }
 
   /**
@@ -206,7 +206,7 @@ class Chow {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       String conclusion = pValue < alphaValue ? "structural break present" : "no structural break detected"
 
-      return String.format(
+      String.format(
         "Chow test:\\n" +
         "Break point: %d\\n" +
         "F-statistic: %.4f\\n" +
@@ -226,7 +226,7 @@ class Chow {
 
     @Override
     String toString() {
-      return """Chow Test for Structural Break
+      """Chow Test for Structural Break
   Break point: ${breakPoint}
   Sample size: ${sampleSize}
   Parameters: ${numParameters}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Df.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Df.groovy
@@ -68,97 +68,15 @@ class Df {
    */
   @SuppressWarnings('MethodSize')
   static DfResult test(double[] data, String type = "drift") {
-    if (data == null) {
-      throw new IllegalArgumentException("Data cannot be null")
-    }
-    if (data.length < 10) {
-      throw new IllegalArgumentException("Data must have at least 10 observations (got ${data.length})")
-    }
-
-    if (type != "none" && type != "drift" && type != "trend") {
-      throw new IllegalArgumentException("Type must be 'none', 'drift', or 'trend' (got '${type}')")
-    }
-
+    validateInput(data, type)
     int n = data.length
-
-    // Check for constant series
-    double yMin = Double.POSITIVE_INFINITY
-    double yMax = Double.NEGATIVE_INFINITY
-    for (double val : data) {
-      if (val < yMin) {
-        yMin = val
-      }
-      if (val > yMax) {
-        yMax = val
-      }
-    }
-
-    if (Math.abs(yMax - yMin) < 1e-10) {
-      throw new IllegalArgumentException("Data has no variation (constant series)")
-    }
-
-    // Calculate first differences: Δy_t = y_t - y_{t-1}
-    double[] dy = new double[n - 1]
-    for (int i = 1; i < n; i++) {
-      dy[i - 1] = data[i] - data[i - 1]
-    }
-
-    // Build regression: Δy_t = α + βt + γy_{t-1} + ε_t
-    // Response: Δy_t for t = 2, ..., n
-    // Predictors: [1, t, y_{t-1}] depending on type
-
-    int nObs = n - 1
-    double[] response = dy
-
-    // Count number of predictors based on type
-    int nPredictors = 1  // Always have y_{t-1}
-    if (type == "drift" || type == "trend") {
-      nPredictors++  // Add intercept
-    }
-    if (type == "trend") {
-      nPredictors++  // Add time trend
-    }
-
-    // Build design matrix
-    double[][] X = new double[nObs][nPredictors]
-    for (int i = 0; i < nObs; i++) {
-      int col = 0
-
-      if (type == "drift" || type == "trend") {
-        X[i][col++] = 1.0  // Intercept
-      }
-
-      if (type == "trend") {
-        X[i][col++] = i + 1.0  // Time trend (1, 2, 3, ...)
-      }
-
-      X[i][col++] = data[i]  // y_{t-1}
-    }
-
-    // Perform OLS regression using simple matrix calculations
-    // β = (X'X)^(-1) X'y
-
-    // Calculate X'X
-    double[][] XtX = new double[nPredictors][nPredictors]
-    for (int i = 0; i < nPredictors; i++) {
-      for (int j = 0; j < nPredictors; j++) {
-        double sum = 0.0
-        for (int k = 0; k < nObs; k++) {
-          sum += X[k][i] * X[k][j]
-        }
-        XtX[i][j] = sum
-      }
-    }
-
-    // Calculate X'y
-    double[] Xty = new double[nPredictors]
-    for (int i = 0; i < nPredictors; i++) {
-      double sum = 0.0
-      for (int k = 0; k < nObs; k++) {
-        sum += X[k][i] * response[k]
-      }
-      Xty[i] = sum
-    }
+    ensureVariation(data)
+    double[] response = firstDifferences(data)
+    int nObs = response.length
+    int nPredictors = predictorCount(type)
+    double[][] X = buildDesignMatrix(data, type, nObs, nPredictors)
+    double[][] XtX = crossProduct(X, nPredictors, nObs)
+    double[] Xty = crossProduct(X, response, nPredictors, nObs)
 
     // Solve for coefficients using Gaussian elimination
     double[] beta = TimeSeriesUtils.solveLinearSystem(XtX, Xty)
@@ -167,21 +85,7 @@ class Df {
     int gammaIndex = nPredictors - 1  // Last coefficient is always y_{t-1}
     double gamma = beta[gammaIndex]
 
-    // Calculate residuals and standard error
-    double[] residuals = new double[nObs]
-    for (int i = 0; i < nObs; i++) {
-      double fitted = 0.0
-      for (int j = 0; j < nPredictors; j++) {
-        fitted += X[i][j] * beta[j]
-      }
-      residuals[i] = response[i] - fitted
-    }
-
-    double rss = 0.0  // Residual sum of squares
-    for (double r : residuals) {
-      rss += r * r
-    }
-
+    double rss = residualSumOfSquares(X, beta, response, nPredictors, nObs)
     int df = nObs - nPredictors
     double sigma2 = rss / df
 
@@ -200,15 +104,120 @@ class Df {
     double cv10pct = getCriticalValue(type, n, 0.10)
 
     return new DfResult(
-      statistic: dfStatistic,
-      gamma: gamma,
-      standardError: gammaSE,
+      statistic: toBigDecimalOrNull(dfStatistic),
+      gamma: toBigDecimalOrNull(gamma),
+      standardError: toBigDecimalOrNull(gammaSE),
       sampleSize: n,
       testType: type,
-      criticalValue1pct: cv1pct,
-      criticalValue5pct: cv5pct,
-      criticalValue10pct: cv10pct
+      criticalValue1pct: BigDecimal.valueOf(cv1pct),
+      criticalValue5pct: BigDecimal.valueOf(cv5pct),
+      criticalValue10pct: BigDecimal.valueOf(cv10pct)
     )
+  }
+
+  private static BigDecimal toBigDecimalOrNull(double value) {
+    Double.isFinite(value) ? BigDecimal.valueOf(value) : null
+  }
+
+  private static void validateInput(double[] data, String type) {
+    if (data == null) {
+      throw new IllegalArgumentException("Data cannot be null")
+    }
+    if (data.length < 10) {
+      throw new IllegalArgumentException("Data must have at least 10 observations (got ${data.length})")
+    }
+    if (!(type in ["none", "drift", "trend"])) {
+      throw new IllegalArgumentException("Type must be 'none', 'drift', or 'trend' (got '${type}')")
+    }
+  }
+
+  private static void ensureVariation(double[] data) {
+    double yMin = Double.POSITIVE_INFINITY
+    double yMax = Double.NEGATIVE_INFINITY
+    for (double value : data) {
+      if (value < yMin) {
+        yMin = value
+      }
+      if (value > yMax) {
+        yMax = value
+      }
+    }
+    if (Math.abs(yMax - yMin) < 1e-10) {
+      throw new IllegalArgumentException("Data has no variation (constant series)")
+    }
+  }
+
+  private static double[] firstDifferences(double[] data) {
+    double[] differences = new double[data.length - 1]
+    for (int i = 1; i < data.length; i++) {
+      differences[i - 1] = data[i] - data[i - 1]
+    }
+    differences
+  }
+
+  private static int predictorCount(String type) {
+    int count = 1
+    if (type == "drift" || type == "trend") {
+      count++
+    }
+    if (type == "trend") {
+      count++
+    }
+    count
+  }
+
+  private static double[][] buildDesignMatrix(double[] data, String type, int nObs, int nPredictors) {
+    double[][] designMatrix = new double[nObs][nPredictors]
+    for (int i = 0; i < nObs; i++) {
+      int column = 0
+      if (type == "drift" || type == "trend") {
+        designMatrix[i][column++] = 1.0
+      }
+      if (type == "trend") {
+        designMatrix[i][column++] = i + 1.0
+      }
+      designMatrix[i][column] = data[i]
+    }
+    designMatrix
+  }
+
+  private static double[][] crossProduct(double[][] X, int nPredictors, int nObs) {
+    double[][] XtX = new double[nPredictors][nPredictors]
+    for (int i = 0; i < nPredictors; i++) {
+      for (int j = 0; j < nPredictors; j++) {
+        double sum = 0.0
+        for (int k = 0; k < nObs; k++) {
+          sum += X[k][i] * X[k][j]
+        }
+        XtX[i][j] = sum
+      }
+    }
+    XtX
+  }
+
+  private static double[] crossProduct(double[][] X, double[] response, int nPredictors, int nObs) {
+    double[] Xty = new double[nPredictors]
+    for (int i = 0; i < nPredictors; i++) {
+      double sum = 0.0
+      for (int k = 0; k < nObs; k++) {
+        sum += X[k][i] * response[k]
+      }
+      Xty[i] = sum
+    }
+    Xty
+  }
+
+  private static double residualSumOfSquares(double[][] X, double[] beta, double[] response, int nPredictors, int nObs) {
+    double rss = 0.0
+    for (int i = 0; i < nObs; i++) {
+      double fitted = 0.0
+      for (int j = 0; j < nPredictors; j++) {
+        fitted += X[i][j] * beta[j]
+      }
+      double residual = response[i] - fitted
+      rss += residual * residual
+    }
+    rss
   }
 
   /**
@@ -264,13 +273,13 @@ class Df {
    */
   static class DfResult {
     /** The Dickey-Fuller test statistic (t-statistic for γ) */
-    double statistic
+    BigDecimal statistic
 
     /** The estimated γ coefficient */
-    double gamma
+    BigDecimal gamma
 
     /** Standard error of γ */
-    double standardError
+    BigDecimal standardError
 
     /** Sample size */
     int sampleSize
@@ -279,13 +288,13 @@ class Df {
     String testType
 
     /** Critical value at 1% significance */
-    double criticalValue1pct
+    BigDecimal criticalValue1pct
 
     /** Critical value at 5% significance */
-    double criticalValue5pct
+    BigDecimal criticalValue5pct
 
     /** Critical value at 10% significance */
-    double criticalValue10pct
+    BigDecimal criticalValue10pct
 
     /**
      * Interprets the test result.
@@ -295,13 +304,13 @@ class Df {
      */
     String interpret(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
-      double cv = alphaValue == 0.01 ? criticalValue1pct :
-                  alphaValue == 0.10 ? criticalValue10pct : criticalValue5pct
+      BigDecimal cv = alphaValue == 0.01 ? criticalValue1pct :
+        alphaValue == 0.10 ? criticalValue10pct : criticalValue5pct
 
-      if (statistic < cv) {
-        return "Reject H0: Series appears stationary (DF = ${String.format('%.4f', statistic)}, CV = ${String.format('%.4f', cv)})"
+      if (statistic != null && statistic < cv) {
+        return "Reject H0: Series appears stationary (DF = ${format(statistic, '%.4f')}, CV = ${format(cv, '%.4f')})"
       } else {
-        return "Fail to reject H0: Unit root likely present, series appears non-stationary (DF = ${String.format('%.4f', statistic)}, CV = ${String.format('%.4f', cv)})"
+        return "Fail to reject H0: Unit root likely present, series appears non-stationary (DF = ${format(statistic, '%.4f')}, CV = ${format(cv, '%.4f')})"
       }
     }
 
@@ -310,7 +319,7 @@ class Df {
      */
     String evaluate(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
-      String conclusion = statistic < criticalValue5pct ? "stationary" : "non-stationary (unit root present)"
+      String conclusion = statistic != null && statistic < criticalValue5pct ? "stationary" : "non-stationary (unit root present)"
 
       return String.format(
         "Dickey-Fuller test:\\n" +
@@ -319,7 +328,7 @@ class Df {
         "Critical values: 1%% = %.4f, 5%% = %.4f, 10%% = %.4f\\n" +
         "Sample size: %d\\n" +
         "Conclusion: Series appears %s at %.0f%% significance level",
-        testType, statistic, criticalValue1pct, criticalValue5pct, criticalValue10pct,
+        testType, statistic ?: Double.NaN, criticalValue1pct, criticalValue5pct, criticalValue10pct,
         sampleSize, conclusion, (alphaValue * 100) as double
       )
     }
@@ -329,15 +338,19 @@ class Df {
       return """Dickey-Fuller Test
   Type: ${testType}
   Sample size: ${sampleSize}
-  DF statistic: ${String.format('%.4f', statistic)}
-  γ coefficient: ${String.format('%.6f', gamma)}
-  Standard error: ${String.format('%.6f', standardError)}
+  DF statistic: ${format(statistic, '%.4f')}
+  γ coefficient: ${format(gamma, '%.6f')}
+  Standard error: ${format(standardError, '%.6f')}
   Critical values:
-    1%: ${String.format('%.4f', criticalValue1pct)}
-    5%: ${String.format('%.4f', criticalValue5pct)}
-   10%: ${String.format('%.4f', criticalValue10pct)}
+    1%: ${format(criticalValue1pct, '%.4f')}
+    5%: ${format(criticalValue5pct, '%.4f')}
+   10%: ${format(criticalValue10pct, '%.4f')}
 
   ${interpret()}"""
+    }
+
+    private static String format(Number value, String pattern) {
+      value == null ? 'NaN' : String.format(pattern, value)
     }
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Df.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Df.groovy
@@ -66,7 +66,6 @@ class Df {
    * @param type The type of test: "none" (no intercept/trend), "drift" (intercept only), or "trend" (intercept and trend)
    * @return DfResult containing test statistic and conclusion
    */
-  @SuppressWarnings('MethodSize')
   static DfResult test(double[] data, String type = "drift") {
     validateInput(data, type)
     int n = data.length

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Df.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Df.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.timeseries
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * The Dickey-Fuller (DF) test is the foundational statistical test for detecting unit roots in time series.
  * A unit root indicates non-stationarity, meaning the series has no tendency to return to a long-run mean
@@ -291,9 +293,10 @@ class Df {
      * @param alpha Significance level (default 0.05)
      * @return Interpretation string
      */
-    String interpret(double alpha = 0.05) {
-      double cv = alpha == 0.01 ? criticalValue1pct :
-                  alpha == 0.10 ? criticalValue10pct : criticalValue5pct
+    String interpret(Number alpha = 0.05) {
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
+      double cv = alphaValue == 0.01 ? criticalValue1pct :
+                  alphaValue == 0.10 ? criticalValue10pct : criticalValue5pct
 
       if (statistic < cv) {
         return "Reject H0: Series appears stationary (DF = ${String.format('%.4f', statistic)}, CV = ${String.format('%.4f', cv)})"
@@ -305,7 +308,8 @@ class Df {
     /**
      * Evaluates the test result with detailed information.
      */
-    String evaluate(double alpha = 0.05) {
+    String evaluate(Number alpha = 0.05) {
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       String conclusion = statistic < criticalValue5pct ? "stationary" : "non-stationary (unit root present)"
 
       return String.format(
@@ -316,7 +320,7 @@ class Df {
         "Sample size: %d\\n" +
         "Conclusion: Series appears %s at %.0f%% significance level",
         testType, statistic, criticalValue1pct, criticalValue5pct, criticalValue10pct,
-        sampleSize, conclusion, alpha * 100
+        sampleSize, conclusion, (alphaValue * 100) as double
       )
     }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Df.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Df.groovy
@@ -103,7 +103,7 @@ class Df {
     double cv5pct = getCriticalValue(type, n, 0.05)
     double cv10pct = getCriticalValue(type, n, 0.10)
 
-    return new DfResult(
+    new DfResult(
       statistic: toBigDecimalOrNull(dfStatistic),
       gamma: toBigDecimalOrNull(gamma),
       standardError: toBigDecimalOrNull(gammaSE),
@@ -225,7 +225,7 @@ class Df {
    */
   static DfResult test(List<? extends Number> data, String type = "drift") {
     double[] array = data.collect { it.doubleValue() } as double[]
-    return test(array, type)
+    test(array, type)
   }
 
   /**
@@ -265,7 +265,7 @@ class Df {
 
     // MacKinnon approximation: CV(T) = β₀ + β₁/T + β₂/T² + β₃/T³
     double T = n as double
-    return params[0] + params[1] / T + params[2] / (T * T) + params[3] / (T * T * T)
+    params[0] + params[1] / T + params[2] / (T * T) + params[3] / (T * T * T)
   }
 
   /**
@@ -321,7 +321,7 @@ class Df {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       String conclusion = statistic != null && statistic < criticalValue5pct ? "stationary" : "non-stationary (unit root present)"
 
-      return String.format(
+      String.format(
         "Dickey-Fuller test:\\n" +
         "Test type: %s\\n" +
         "DF statistic: %.4f\\n" +
@@ -335,7 +335,7 @@ class Df {
 
     @Override
     String toString() {
-      return """Dickey-Fuller Test
+      """Dickey-Fuller Test
   Type: ${testType}
   Sample size: ${sampleSize}
   DF statistic: ${format(statistic, '%.4f')}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Df.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Df.groovy
@@ -64,6 +64,7 @@ class Df {
    * @param type The type of test: "none" (no intercept/trend), "drift" (intercept only), or "trend" (intercept and trend)
    * @return DfResult containing test statistic and conclusion
    */
+  @SuppressWarnings('MethodSize')
   static DfResult test(double[] data, String type = "drift") {
     if (data == null) {
       throw new IllegalArgumentException("Data cannot be null")

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/DurbinWatson.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/DurbinWatson.groovy
@@ -58,8 +58,8 @@ class DurbinWatson {
     double autocorrelation = 1.0 - (dwStatistic / 2.0)
 
     return new DurbinWatsonResult(
-      statistic: dwStatistic,
-      autocorrelation: autocorrelation,
+      statistic: BigDecimal.valueOf(dwStatistic),
+      autocorrelation: BigDecimal.valueOf(autocorrelation),
       sampleSize: n
     )
   }
@@ -107,10 +107,10 @@ class DurbinWatson {
    */
   static class DurbinWatsonResult {
     /** The Durbin-Watson test statistic */
-    double statistic
+    BigDecimal statistic
 
     /** The estimated first-order autocorrelation coefficient */
-    double autocorrelation
+    BigDecimal autocorrelation
 
     /** The sample size */
     int sampleSize

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/DurbinWatson.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/DurbinWatson.groovy
@@ -57,7 +57,7 @@ class DurbinWatson {
     // ρ ≈ 1 - (DW / 2)
     double autocorrelation = 1.0 - (dwStatistic / 2.0)
 
-    return new DurbinWatsonResult(
+    new DurbinWatsonResult(
       statistic: BigDecimal.valueOf(dwStatistic),
       autocorrelation: BigDecimal.valueOf(autocorrelation),
       sampleSize: n
@@ -75,7 +75,7 @@ class DurbinWatson {
     validateAlternative(alternative)
     DurbinWatsonResult result = test(residuals)
     result.alternative = alternative
-    return result
+    result
   }
 
   private static void validateInput(List<? extends Number> residuals) {
@@ -152,13 +152,13 @@ class DurbinWatson {
         autocorrType = "negligible"
       }
 
-      return String.format("Durbin-Watson statistic: %.4f (ρ ≈ %.4f, %s autocorrelation)\n%s",
+      String.format("Durbin-Watson statistic: %.4f (ρ ≈ %.4f, %s autocorrelation)\n%s",
                            statistic, autocorrelation, autocorrType, interpret())
     }
 
     @Override
     String toString() {
-      return """Durbin-Watson Test
+      """Durbin-Watson Test
   Sample size: ${sampleSize}
   Test statistic (DW): ${String.format("%.4f", statistic)}
   Autocorrelation (ρ): ${String.format("%.4f", autocorrelation)}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Granger.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Granger.groovy
@@ -2,6 +2,7 @@ package se.alipsa.matrix.stats.timeseries
 
 import se.alipsa.matrix.core.util.Logger
 import se.alipsa.matrix.stats.distribution.FDistribution
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * The Granger causality test determines whether one time series is useful in forecasting another.
@@ -260,8 +261,9 @@ class Granger {
      * @param alpha Significance level (default 0.05)
      * @return Interpretation string
      */
-    String interpret(double alpha = 0.05) {
-      if (pValue < alpha) {
+    String interpret(Number alpha = 0.05) {
+      double alphaValue = NumericConversion.toAlpha(alpha) as double
+      if (pValue < alphaValue) {
         return "Reject H0: X Granger-causes Y (F = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
       } else {
         return "Fail to reject H0: X does not Granger-cause Y (F = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
@@ -271,8 +273,9 @@ class Granger {
     /**
      * Evaluates the test result with detailed information.
      */
-    String evaluate(double alpha = 0.05) {
-      String conclusion = pValue < alpha ? "X Granger-causes Y" : "X does not Granger-cause Y"
+    String evaluate(Number alpha = 0.05) {
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
+      String conclusion = pValue < (alphaValue as double) ? "X Granger-causes Y" : "X does not Granger-cause Y"
 
       return String.format(
         "Granger causality test:\\n" +
@@ -287,7 +290,7 @@ class Granger {
         lags, statistic, pValue, df1, df2,
         rssRestricted, rssUnrestricted,
         sampleSize, effectiveSampleSize,
-        conclusion, alpha * 100
+        conclusion, (alphaValue * 100) as double
       )
     }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Granger.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Granger.groovy
@@ -158,7 +158,7 @@ class Granger {
     FDistribution fDist = new FDistribution(df1, df2)
     double pValue = 1.0 - fDist.cumulativeProbability(fStatistic)
 
-    return new GrangerResult(
+    new GrangerResult(
       statistic: BigDecimal.valueOf(fStatistic),
       pValue: BigDecimal.valueOf(pValue),
       lags: p,
@@ -177,7 +177,7 @@ class Granger {
   static GrangerResult test(List<? extends Number> x, List<? extends Number> y, Integer maxLag = null) {
     double[] xArray = x.collect { it.doubleValue() } as double[]
     double[] yArray = y.collect { it.doubleValue() } as double[]
-    return test(xArray, yArray, maxLag)
+    test(xArray, yArray, maxLag)
   }
 
   /**
@@ -216,7 +216,7 @@ class Granger {
       throw new IllegalArgumentException("Unable to select Granger lag: all candidate lags 1..${maxPossibleLag} failed")
     }
 
-    return bestLag
+    bestLag
   }
 
   private static boolean isNumericalFailure(IllegalArgumentException e) {
@@ -277,7 +277,7 @@ class Granger {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       String conclusion = pValue < alphaValue ? "X Granger-causes Y" : "X does not Granger-cause Y"
 
-      return String.format(
+      String.format(
         "Granger causality test:\\n" +
         "Lags: %d\\n" +
         "F-statistic: %.4f\\n" +
@@ -296,7 +296,7 @@ class Granger {
 
     @Override
     String toString() {
-      return """Granger Causality Test
+      """Granger Causality Test
   Lags: ${lags}
   Sample size: ${sampleSize} (effective: ${effectiveSampleSize})
   F-statistic: ${String.format('%.4f', statistic)}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Granger.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Granger.groovy
@@ -159,13 +159,13 @@ class Granger {
     double pValue = 1.0 - fDist.cumulativeProbability(fStatistic)
 
     return new GrangerResult(
-      statistic: fStatistic,
-      pValue: pValue,
+      statistic: BigDecimal.valueOf(fStatistic),
+      pValue: BigDecimal.valueOf(pValue),
       lags: p,
       df1: df1,
       df2: df2,
-      rssRestricted: rssRestricted,
-      rssUnrestricted: rssUnrestricted,
+      rssRestricted: BigDecimal.valueOf(rssRestricted),
+      rssUnrestricted: BigDecimal.valueOf(rssUnrestricted),
       sampleSize: n,
       effectiveSampleSize: nObs
     )
@@ -229,10 +229,10 @@ class Granger {
    */
   static class GrangerResult {
     /** The F-statistic */
-    double statistic
+    BigDecimal statistic
 
     /** The p-value */
-    double pValue
+    BigDecimal pValue
 
     /** Number of lags used */
     int lags
@@ -244,10 +244,10 @@ class Granger {
     int df2
 
     /** RSS for restricted model */
-    double rssRestricted
+    BigDecimal rssRestricted
 
     /** RSS for unrestricted model */
-    double rssUnrestricted
+    BigDecimal rssUnrestricted
 
     /** Original sample size */
     int sampleSize
@@ -262,7 +262,7 @@ class Granger {
      * @return Interpretation string
      */
     String interpret(Number alpha = 0.05) {
-      double alphaValue = NumericConversion.toAlpha(alpha) as double
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       if (pValue < alphaValue) {
         return "Reject H0: X Granger-causes Y (F = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
       } else {
@@ -275,7 +275,7 @@ class Granger {
      */
     String evaluate(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
-      String conclusion = pValue < (alphaValue as double) ? "X Granger-causes Y" : "X does not Granger-cause Y"
+      String conclusion = pValue < alphaValue ? "X Granger-causes Y" : "X does not Granger-cause Y"
 
       return String.format(
         "Granger causality test:\\n" +

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Granger.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Granger.groovy
@@ -205,7 +205,7 @@ class Granger {
         } else {
           log.debug("Skipping lag $p during Granger AIC selection: ${e.message}")
         }
-      } catch (RuntimeException e) {
+      } catch (Exception e) {
         log.error("Potential bug while selecting lag $p for Granger causality: ${e.message}", e)
         throw e
       }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
@@ -348,8 +348,13 @@ class Johansen {
 
       int cointRank = 0
       for (int r = 0; r < numVariables; r++) {
-        Number critVal = r < criticalValues5pct.size() && numVariables - 1 < criticalValues5pct[r].size() ?
-                         criticalValues5pct[r][numVariables - 1] : Double.NaN
+        BigDecimal critVal = r < criticalValues5pct.size() && numVariables - 1 < criticalValues5pct[r].size() ?
+                             criticalValues5pct[r][numVariables - 1] : null
+
+        if (critVal == null) {
+          sb.append("H0: r = ${r} — no critical value available\n")
+          break
+        }
 
         if (traceStatistics[r] > critVal) {
           cointRank = r + 1
@@ -364,14 +369,20 @@ class Johansen {
       sb.toString()
     }
 
+    /** @deprecated Use the {@code eigenvalues} property directly. */
+    @Deprecated
     List<BigDecimal> getEigenvalueValues() {
       eigenvalues
     }
 
+    /** @deprecated Use the {@code traceStatistics} property directly. */
+    @Deprecated
     List<BigDecimal> getTraceStatisticValues() {
       traceStatistics
     }
 
+    /** @deprecated Use the {@code criticalValues5pct} property directly. */
+    @Deprecated
     List<List<BigDecimal>> getCriticalValueRows5pct() {
       criticalValues5pct
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
@@ -84,18 +84,15 @@ class Johansen {
    * @param type Type of deterministic component ('none', 'const', 'trend')
    * @return JohansenResult containing test statistics and eigenvalues
    */
+  /** @deprecated Use {@link #testArrays} or {@link #testSeries} instead. */
   @Deprecated
   static JohansenResult test(List<?> data, int lags = 1, String type = 'const') {
-    if (data == null) {
-      return testArrays(null, lags, type)
-    }
-    if (data.isEmpty() || data.every { Object item -> item instanceof double[] }) {
-      return testArrays(data as List<double[]>, lags, type)
-    }
-    if (data.every { Object item -> item instanceof List<?> }) {
-      return testSeries(data as Collection<? extends List<? extends Number>>, lags, type)
-    }
-    throw new IllegalArgumentException("Each series must be a List<Number> or double[], got mixed input types")
+    NumericConversion.<JohansenResult> dispatchPrimitiveOrList(
+      data,
+      { List<?> d -> testArrays(d as List<double[]>, lags, type) },
+      { List<?> d -> testSeries(d as Collection<? extends List<? extends Number>>, lags, type) },
+      'series'
+    )
   }
 
   /**
@@ -153,8 +150,12 @@ class Johansen {
       return []
     }
     List<double[]> normalized = []
-    for (double[] series : data) {
-      normalized << (series == null ? null : (series.clone() as double[]))
+    for (int i = 0; i < data.size(); i++) {
+      double[] series = data[i]
+      if (series == null) {
+        throw new IllegalArgumentException("Series at index ${i} cannot be null")
+      }
+      normalized << (series.clone() as double[])
     }
     normalized
   }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
@@ -101,9 +101,9 @@ class Johansen {
     double[][] criticalValues = getCriticalValues(type)
 
     return new JohansenResult(
-      eigenvalues: sortedEigenvalues,
-      traceStatistics: traceStats,
-      criticalValues5pct: criticalValues,
+      eigenvalues: NumericConversion.toBigDecimalList(sortedEigenvalues, 'eigenvalues'),
+      traceStatistics: NumericConversion.toBigDecimalList(traceStats, 'traceStatistics'),
+      criticalValues5pct: NumericConversion.toBigDecimalRows(criticalValues, 'criticalValues5pct'),
       sampleSize: differencedData.effectiveN,
       numVariables: k,
       lags: lags,
@@ -317,13 +317,13 @@ class Johansen {
    */
   static class JohansenResult {
     /** Eigenvalues (sorted in descending order) */
-    double[] eigenvalues
+    List<BigDecimal> eigenvalues
 
     /** Trace statistics for different cointegration ranks */
-    double[] traceStatistics
+    List<BigDecimal> traceStatistics
 
     /** Critical values at 5% significance level [r][k-1] */
-    double[][] criticalValues5pct
+    List<List<BigDecimal>> criticalValues5pct
 
     /** Effective sample size */
     int sampleSize
@@ -348,7 +348,7 @@ class Johansen {
 
       int cointRank = 0
       for (int r = 0; r < numVariables; r++) {
-        double critVal = r < criticalValues5pct.length && numVariables - 1 < criticalValues5pct[r].length ?
+        Number critVal = r < criticalValues5pct.size() && numVariables - 1 < criticalValues5pct[r].size() ?
                          criticalValues5pct[r][numVariables - 1] : Double.NaN
 
         if (traceStatistics[r] > critVal) {
@@ -365,15 +365,15 @@ class Johansen {
     }
 
     List<BigDecimal> getEigenvalueValues() {
-      NumericConversion.toBigDecimalList(eigenvalues, 'eigenvalues')
+      eigenvalues
     }
 
     List<BigDecimal> getTraceStatisticValues() {
-      NumericConversion.toBigDecimalList(traceStatistics, 'traceStatistics')
+      traceStatistics
     }
 
     List<List<BigDecimal>> getCriticalValueRows5pct() {
-      NumericConversion.toBigDecimalRows(criticalValues5pct, 'criticalValues5pct')
+      criticalValues5pct
     }
 
     @Override

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
@@ -2,6 +2,7 @@ package se.alipsa.matrix.stats.timeseries
 
 import se.alipsa.matrix.stats.linear.MatrixAlgebra
 import se.alipsa.matrix.stats.linear.SingularMatrixException
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * The Johansen cointegration test, named after Søren Johansen, is a procedure for testing cointegration
@@ -83,13 +84,14 @@ class Johansen {
    * @param type Type of deterministic component ('none', 'const', 'trend')
    * @return JohansenResult containing test statistics and eigenvalues
    */
-  static JohansenResult test(List<double[]> data, int lags = 1, String type = 'const') {
-    validateInputs(data, lags, type)
+  static JohansenResult test(List<?> data, int lags = 1, String type = 'const') {
+    List<double[]> numericData = normalizeInputs(data)
+    validateInputs(numericData, lags, type)
 
-    int k = data.size()
-    int n = data[0].length
-    DifferencedData differencedData = createDifferencedData(data, lags, n, k)
-    ResidualMatrices residualMatrices = createResidualMatrices(data, lags, type, k, differencedData)
+    int k = numericData.size()
+    int n = numericData[0].length
+    DifferencedData differencedData = createDifferencedData(numericData, lags, n, k)
+    ResidualMatrices residualMatrices = createResidualMatrices(numericData, lags, type, k, differencedData)
     MomentMatrices momentMatrices = computeMomentMatrices(residualMatrices, differencedData.effectiveN)
     double[] sortedEigenvalues = solveEigenvalues(momentMatrices)
     double[] traceStats = computeTraceStatistics(sortedEigenvalues, k, differencedData.effectiveN)
@@ -107,6 +109,24 @@ class Johansen {
       lags: lags,
       type: type
     )
+  }
+
+  private static List<double[]> normalizeInputs(List<?> data) {
+    if (data == null) {
+      return []
+    }
+    List<double[]> normalized = []
+    for (int i = 0; i < data.size(); i++) {
+      Object series = data[i]
+      if (series instanceof double[]) {
+        normalized << (((double[]) series).clone() as double[])
+      } else if (series instanceof List) {
+        normalized << NumericConversion.toDoubleArray(series as List<? extends Number>, "data series ${i}")
+      } else {
+        throw new IllegalArgumentException("Each series must be a List<Number> or double[], got ${series?.class?.simpleName}")
+      }
+    }
+    normalized
   }
 
   private static void validateInputs(List<double[]> data, int lags, String type) {
@@ -342,6 +362,18 @@ class Johansen {
 
       sb.append("\nConclusion: Evidence suggests ${cointRank} cointegrating relationship(s)")
       return sb.toString()
+    }
+
+    List<BigDecimal> getEigenvalueValues() {
+      NumericConversion.toBigDecimalList(eigenvalues, 'eigenvalues')
+    }
+
+    List<BigDecimal> getTraceStatisticValues() {
+      NumericConversion.toBigDecimalList(traceStatistics, 'traceStatistics')
+    }
+
+    List<List<BigDecimal>> getCriticalValueRows5pct() {
+      NumericConversion.toBigDecimalRows(criticalValues5pct, 'criticalValues5pct')
     }
 
     @Override

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
@@ -100,7 +100,7 @@ class Johansen {
     // These are approximate values for comparison
     double[][] criticalValues = getCriticalValues(type)
 
-    return new JohansenResult(
+    new JohansenResult(
       eigenvalues: NumericConversion.toBigDecimalList(sortedEigenvalues, 'eigenvalues'),
       traceStatistics: NumericConversion.toBigDecimalList(traceStats, 'traceStatistics'),
       criticalValues5pct: NumericConversion.toBigDecimalRows(criticalValues, 'criticalValues5pct'),
@@ -164,7 +164,7 @@ class Johansen {
       }
     }
 
-    return new DifferencedData(deltaY: deltaY, laggedY: laggedY, effectiveN: effectiveN)
+    new DifferencedData(deltaY: deltaY, laggedY: laggedY, effectiveN: effectiveN)
   }
 
   private static ResidualMatrices createResidualMatrices(List<double[]> data, int lags, String type, int k,
@@ -178,11 +178,11 @@ class Johansen {
     }
 
     double[][] designMatrix = buildShortRunDesignMatrix(data, lags, type, k, differencedData.effectiveN, numRegressors)
-    return projectResiduals(designMatrix, differencedData.deltaY, differencedData.laggedY)
+    projectResiduals(designMatrix, differencedData.deltaY, differencedData.laggedY)
   }
 
   private static int countRegressors(int lags, String type, int k) {
-    return (lags > 1 ? k * (lags - 1) : 0) + (type == 'const' ? 1 : 0) + (type == 'trend' ? 1 : 0)
+    (lags > 1 ? k * (lags - 1) : 0) + (type == 'const' ? 1 : 0) + (type == 'trend' ? 1 : 0)
   }
 
   private static double[][] buildShortRunDesignMatrix(List<double[]> data, int lags, String type, int k,
@@ -206,7 +206,7 @@ class Johansen {
         z[t][col++] = t + 1
       }
     }
-    return z
+    z
   }
 
   private static ResidualMatrices projectResiduals(double[][] designMatrix, double[][] deltaY, double[][] laggedY) {
@@ -222,7 +222,7 @@ class Johansen {
         MatrixAlgebra.multiply(designMatrix, ztZInv),
         MatrixAlgebra.transpose(designMatrix)
     )
-    return new ResidualMatrices(
+    new ResidualMatrices(
       r0: MatrixAlgebra.subtract(deltaY, MatrixAlgebra.multiply(projection, deltaY)),
       r1: MatrixAlgebra.subtract(laggedY, MatrixAlgebra.multiply(projection, laggedY))
     )
@@ -230,7 +230,7 @@ class Johansen {
 
   private static MomentMatrices computeMomentMatrices(ResidualMatrices residualMatrices, int effectiveN) {
     double scale = 1.0d / effectiveN
-    return new MomentMatrices(
+    new MomentMatrices(
       s00: MatrixAlgebra.scale(MatrixAlgebra.multiply(MatrixAlgebra.transpose(residualMatrices.r0), residualMatrices.r0), scale),
       s11: MatrixAlgebra.scale(MatrixAlgebra.multiply(MatrixAlgebra.transpose(residualMatrices.r1), residualMatrices.r1), scale),
       s01: MatrixAlgebra.scale(MatrixAlgebra.multiply(MatrixAlgebra.transpose(residualMatrices.r0), residualMatrices.r1), scale)
@@ -250,7 +250,7 @@ class Johansen {
         MatrixAlgebra.transpose(s11CholeskyInv)
     )
 
-    return sortDescending(MatrixAlgebra.symmetricEigenvalues(symmetricProduct).collect { double eigenvalue ->
+    sortDescending(MatrixAlgebra.symmetricEigenvalues(symmetricProduct).collect { double eigenvalue ->
       Math.max(0.0d, Math.min(1.0d - 1e-12d, eigenvalue))
     } as double[])
   }
@@ -261,7 +261,7 @@ class Johansen {
     for (int i = 0; i < eigenvalues.length; i++) {
       sortedEigenvalues[i] = eigenvalues[eigenvalues.length - 1 - i]
     }
-    return sortedEigenvalues
+    sortedEigenvalues
   }
 
   private static double[] computeTraceStatistics(double[] sortedEigenvalues, int k, int effectiveN) {
@@ -273,7 +273,7 @@ class Johansen {
       }
       traceStats[r] = -effectiveN * sum
     }
-    return traceStats
+    traceStats
   }
 
   /**
@@ -361,7 +361,7 @@ class Johansen {
       }
 
       sb.append("\nConclusion: Evidence suggests ${cointRank} cointegrating relationship(s)")
-      return sb.toString()
+      sb.toString()
     }
 
     List<BigDecimal> getEigenvalueValues() {
@@ -378,7 +378,7 @@ class Johansen {
 
     @Override
     String toString() {
-      return """Johansen Cointegration Test
+      """Johansen Cointegration Test
   Number of variables: ${numVariables}
   Sample size: ${sampleSize}
   Lags: ${lags}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
@@ -84,8 +84,45 @@ class Johansen {
    * @param type Type of deterministic component ('none', 'const', 'trend')
    * @return JohansenResult containing test statistics and eigenvalues
    */
+  @Deprecated
   static JohansenResult test(List<?> data, int lags = 1, String type = 'const') {
-    List<double[]> numericData = normalizeInputs(data)
+    if (data == null) {
+      return testArrays(null, lags, type)
+    }
+    if (data.isEmpty() || data.every { Object item -> item instanceof double[] }) {
+      return testArrays(data as List<double[]>, lags, type)
+    }
+    if (data.every { Object item -> item instanceof List<?> }) {
+      return testSeries(data as Collection<? extends List<? extends Number>>, lags, type)
+    }
+    throw new IllegalArgumentException("Each series must be a List<Number> or double[], got mixed input types")
+  }
+
+  /**
+   * Performs the Johansen cointegration test from primitive series arrays.
+   *
+   * @param data list of time series, each series represented as {@code double[]}
+   * @param lags Number of lags in the VAR model
+   * @param type Type of deterministic component ('none', 'const', 'trend')
+   * @return JohansenResult containing test statistics and eigenvalues
+   */
+  static JohansenResult testArrays(List<double[]> data, int lags = 1, String type = 'const') {
+    runTest(copyPrimitiveInputs(data), lags, type)
+  }
+
+  /**
+   * Performs the Johansen cointegration test from idiomatic Groovy numeric lists.
+   *
+   * @param data collection of time series, each series represented as numeric list values
+   * @param lags Number of lags in the VAR model
+   * @param type Type of deterministic component ('none', 'const', 'trend')
+   * @return JohansenResult containing test statistics and eigenvalues
+   */
+  static JohansenResult testSeries(Collection<? extends List<? extends Number>> data, int lags = 1, String type = 'const') {
+    runTest(normalizeListInputs(data), lags, type)
+  }
+
+  private static JohansenResult runTest(List<double[]> numericData, int lags, String type) {
     validateInputs(numericData, lags, type)
 
     int k = numericData.size()
@@ -111,20 +148,26 @@ class Johansen {
     )
   }
 
-  private static List<double[]> normalizeInputs(List<?> data) {
+  private static List<double[]> copyPrimitiveInputs(List<double[]> data) {
     if (data == null) {
       return []
     }
     List<double[]> normalized = []
-    for (int i = 0; i < data.size(); i++) {
-      Object series = data[i]
-      if (series instanceof double[]) {
-        normalized << (((double[]) series).clone() as double[])
-      } else if (series instanceof List) {
-        normalized << NumericConversion.toDoubleArray(series as List<? extends Number>, "data series ${i}")
-      } else {
-        throw new IllegalArgumentException("Each series must be a List<Number> or double[], got ${series?.class?.simpleName}")
-      }
+    for (double[] series : data) {
+      normalized << (series == null ? null : (series.clone() as double[]))
+    }
+    normalized
+  }
+
+  private static List<double[]> normalizeListInputs(Collection<? extends List<? extends Number>> data) {
+    if (data == null) {
+      return []
+    }
+    List<double[]> normalized = []
+    int index = 0
+    for (List<? extends Number> row : data) {
+      normalized << NumericConversion.toDoubleArray(row, "data series ${index}")
+      index++
     }
     normalized
   }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Kpss.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Kpss.groovy
@@ -63,7 +63,7 @@ class Kpss {
     // Get critical value
     double criticalValue = getCriticalValue(type)
 
-    return new KpssResult(
+    new KpssResult(
       statistic: BigDecimal.valueOf(kpssStatistic),
       type: type,
       lags: l,
@@ -114,7 +114,7 @@ class Kpss {
       }
     }
 
-    return residuals
+    residuals
   }
 
   /**
@@ -143,7 +143,7 @@ class Kpss {
       variance += 2.0 * weight * autocovariance
     }
 
-    return variance
+    variance
   }
 
   /**
@@ -221,13 +221,13 @@ class Kpss {
         "non-stationary (unit root present)" :
         "${type}-stationary"
 
-      return String.format("KPSS statistic: %.4f (critical value: %.3f at 5%% level)\nLags used: %d\nConclusion: Series appears %s",
+      String.format("KPSS statistic: %.4f (critical value: %.3f at 5%% level)\nLags used: %d\nConclusion: Series appears %s",
                            statistic, criticalValue, lags, conclusion)
     }
 
     @Override
     String toString() {
-      return """KPSS Stationarity Test
+      """KPSS Stationarity Test
   Type: ${type}
   Sample size: ${sampleSize}
   Lags: ${lags}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Kpss.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Kpss.groovy
@@ -64,11 +64,11 @@ class Kpss {
     double criticalValue = getCriticalValue(type)
 
     return new KpssResult(
-      statistic: kpssStatistic,
+      statistic: BigDecimal.valueOf(kpssStatistic),
       type: type,
       lags: l,
       sampleSize: n,
-      criticalValue: criticalValue
+      criticalValue: BigDecimal.valueOf(criticalValue)
     )
   }
 
@@ -184,7 +184,7 @@ class Kpss {
    */
   static class KpssResult {
     /** The KPSS test statistic */
-    double statistic
+    BigDecimal statistic
 
     /** The type of test performed */
     String type
@@ -196,7 +196,7 @@ class Kpss {
     int sampleSize
 
     /** The approximate 5% critical value */
-    double criticalValue
+    BigDecimal criticalValue
 
     /**
      * Interprets the KPSS test result.

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Portmanteau.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Portmanteau.groovy
@@ -1,6 +1,7 @@
 package se.alipsa.matrix.stats.timeseries
 
 import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * A portmanteau test is a type of statistical hypothesis test in which the null hypothesis is well specified,
@@ -173,8 +174,9 @@ class Portmanteau {
      * @param alpha The significance level (default: 0.05)
      * @return A string describing whether the series appears to be independent
      */
-    String interpret(double alpha = 0.05) {
-      if (pValue < alpha) {
+    String interpret(Number alpha = 0.05) {
+      double alphaValue = NumericConversion.toAlpha(alpha) as double
+      if (pValue < alphaValue) {
         return "Reject H0: Series shows significant autocorrelation (p = ${String.format('%.4f', pValue)})"
       } else {
         return "Fail to reject H0: No significant autocorrelation detected (p = ${String.format('%.4f', pValue)})"
@@ -186,8 +188,9 @@ class Portmanteau {
      *
      * @return A description of the test result with interpretation
      */
-    String evaluate(double alpha = 0.05) {
-      String conclusion = pValue < alpha ?
+    String evaluate(Number alpha = 0.05) {
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
+      String conclusion = pValue < (alphaValue as double) ?
         "significant autocorrelation present" :
         "no significant autocorrelation"
 
@@ -197,7 +200,7 @@ class Portmanteau {
       if (fitdf > 0) {
         sb.append(String.format("Model fit df: %d\n", fitdf))
       }
-      sb.append(String.format("Conclusion: %s at %.0f%% significance level", conclusion, alpha * 100))
+      sb.append(String.format("Conclusion: %s at %.0f%% significance level", conclusion, (alphaValue * 100) as double))
 
       return sb.toString()
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Portmanteau.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Portmanteau.groovy
@@ -109,13 +109,13 @@ class Portmanteau {
     double pValue = 1.0 - chiSquared.cumulativeProbability(qStatistic)
 
     return new LjungBoxResult(
-      statistic: qStatistic,
+      statistic: BigDecimal.valueOf(qStatistic),
       lags: h,
       fitdf: fitdf,
       degreesOfFreedom: degreesOfFreedom,
       sampleSize: n,
-      pValue: pValue,
-      autocorrelations: autocorrelations.toList()
+      pValue: BigDecimal.valueOf(pValue),
+      autocorrelations: NumericConversion.toBigDecimalList(autocorrelations, 'autocorrelations')
     )
   }
 
@@ -148,7 +148,7 @@ class Portmanteau {
    */
   static class LjungBoxResult {
     /** The Ljung-Box Q test statistic */
-    double statistic
+    BigDecimal statistic
 
     /** The number of lags tested */
     int lags
@@ -163,10 +163,10 @@ class Portmanteau {
     int sampleSize
 
     /** The p-value from the chi-squared distribution */
-    double pValue
+    BigDecimal pValue
 
     /** The sample autocorrelations at each lag */
-    List<Double> autocorrelations
+    List<BigDecimal> autocorrelations
 
     /**
      * Interprets the Ljung-Box test result at the 5% significance level.
@@ -175,7 +175,7 @@ class Portmanteau {
      * @return A string describing whether the series appears to be independent
      */
     String interpret(Number alpha = 0.05) {
-      double alphaValue = NumericConversion.toAlpha(alpha) as double
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       if (pValue < alphaValue) {
         return "Reject H0: Series shows significant autocorrelation (p = ${String.format('%.4f', pValue)})"
       } else {
@@ -190,7 +190,7 @@ class Portmanteau {
      */
     String evaluate(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
-      String conclusion = pValue < (alphaValue as double) ?
+      String conclusion = pValue < alphaValue ?
         "significant autocorrelation present" :
         "no significant autocorrelation"
 
@@ -211,7 +211,7 @@ class Portmanteau {
      * @param lag The lag (1-indexed)
      * @return The autocorrelation coefficient
      */
-    double getAutocorrelation(int lag) {
+    BigDecimal getAutocorrelation(int lag) {
       if (lag < 1 || lag > lags) {
         throw new IllegalArgumentException("Lag must be between 1 and ${lags}, got ${lag}")
       }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Portmanteau.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Portmanteau.groovy
@@ -108,7 +108,7 @@ class Portmanteau {
     ChiSquaredDistribution chiSquared = new ChiSquaredDistribution(degreesOfFreedom)
     double pValue = 1.0 - chiSquared.cumulativeProbability(qStatistic)
 
-    return new LjungBoxResult(
+    new LjungBoxResult(
       statistic: BigDecimal.valueOf(qStatistic),
       lags: h,
       fitdf: fitdf,
@@ -202,7 +202,7 @@ class Portmanteau {
       }
       sb.append(String.format("Conclusion: %s at %.0f%% significance level", conclusion, (alphaValue * 100) as double))
 
-      return sb.toString()
+      sb.toString()
     }
 
     /**
@@ -215,7 +215,7 @@ class Portmanteau {
       if (lag < 1 || lag > lags) {
         throw new IllegalArgumentException("Lag must be between 1 and ${lags}, got ${lag}")
       }
-      return autocorrelations[lag - 1]
+      autocorrelations[lag - 1]
     }
 
     @Override
@@ -239,7 +239,7 @@ class Portmanteau {
         sb.append("  ... (${lags - 10} more lags)\n")
       }
 
-      return sb.toString()
+      sb.toString()
     }
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtils.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtils.groovy
@@ -194,27 +194,27 @@ final class TimeSeriesUtils {
       throw new IllegalArgumentException("Design matrix rows must all have the same length")
     }
 
-    double[][] XtX = new double[k][k]
+    double[][] xtx = new double[k][k]
     for (int i = 0; i < k; i++) {
       for (int j = 0; j < k; j++) {
         double sum = 0.0
         for (int m = 0; m < n; m++) {
           sum += X[m][i] * X[m][j]
         }
-        XtX[i][j] = sum
+        xtx[i][j] = sum
       }
     }
 
-    double[] Xty = new double[k]
+    double[] xty = new double[k]
     for (int i = 0; i < k; i++) {
       double sum = 0.0
       for (int m = 0; m < n; m++) {
         sum += X[m][i] * y[m]
       }
-      Xty[i] = sum
+      xty[i] = sum
     }
 
-    solveLinearSystem(XtX, Xty)
+    solveLinearSystem(xtx, xty)
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtils.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtils.groovy
@@ -3,11 +3,14 @@ package se.alipsa.matrix.stats.timeseries
 import groovy.transform.PackageScope
 
 import se.alipsa.matrix.core.util.Logger
+import se.alipsa.matrix.stats.util.LeastSquaresKernel
 
 /**
  * Shared linear algebra helpers for the time-series test implementations in this package.
  * The solving routines support the current time-series callers while adding
  * consistent validation, singularity checks, and diagnostic logging for numerical edge cases.
+ * The section-4.6 hotspot decision keeps the Groovy-facing package helpers here while routing
+ * dense OLS loops through a shared Java kernel.
  */
 @PackageScope
 @SuppressWarnings(['ParameterName'])
@@ -178,43 +181,7 @@ final class TimeSeriesUtils {
    * @throws IllegalArgumentException if the inputs are invalid or the normal equations cannot be solved
    */
   static double[] fitOLS(double[] y, double[][] X) {
-    if (y == null || X == null) {
-      throw new IllegalArgumentException("Response vector and design matrix cannot be null")
-    }
-    if (X.length == 0 || X[0].length == 0) {
-      throw new IllegalArgumentException("Design matrix must contain at least one row and one column")
-    }
-    if (X.length != y.length) {
-      throw new IllegalArgumentException("Design matrix row count (${X.length}) must match response length (${y.length})")
-    }
-
-    int n = y.length
-    int k = X[0].length
-    if (X.any { double[] row -> row.length != k }) {
-      throw new IllegalArgumentException("Design matrix rows must all have the same length")
-    }
-
-    double[][] xtx = new double[k][k]
-    for (int i = 0; i < k; i++) {
-      for (int j = 0; j < k; j++) {
-        double sum = 0.0
-        for (int m = 0; m < n; m++) {
-          sum += X[m][i] * X[m][j]
-        }
-        xtx[i][j] = sum
-      }
-    }
-
-    double[] xty = new double[k]
-    for (int i = 0; i < k; i++) {
-      double sum = 0.0
-      for (int m = 0; m < n; m++) {
-        sum += X[m][i] * y[m]
-      }
-      xty[i] = sum
-    }
-
-    solveLinearSystem(xtx, xty)
+    LeastSquaresKernel.fitOls(y, X)
   }
 
   /**
@@ -227,33 +194,7 @@ final class TimeSeriesUtils {
    * @throws IllegalArgumentException if the inputs are invalid
    */
   static double calculateRSS(double[] y, double[][] X, double[] beta) {
-    if (y == null || X == null || beta == null) {
-      throw new IllegalArgumentException("Response vector, design matrix, and coefficients cannot be null")
-    }
-    if (X.length == 0) {
-      throw new IllegalArgumentException("Design matrix must contain at least one row")
-    }
-    if (X.length != y.length) {
-      throw new IllegalArgumentException("Design matrix row count (${X.length}) must match response length (${y.length})")
-    }
-    if (X[0].length != beta.length) {
-      throw new IllegalArgumentException("Coefficient count (${beta.length}) must match design matrix column count (${X[0].length})")
-    }
-    if (X.any { double[] row -> row.length != beta.length }) {
-      throw new IllegalArgumentException("Design matrix rows must all have the same length")
-    }
-
-    int n = y.length
-    double rss = 0.0
-    for (int i = 0; i < n; i++) {
-      double fitted = 0.0
-      for (int j = 0; j < beta.length; j++) {
-        fitted += X[i][j] * beta[j]
-      }
-      double residual = y[i] - fitted
-      rss += residual * residual
-    }
-    rss
+    LeastSquaresKernel.calculateResidualSumOfSquares(y, X, beta)
   }
 
   private static int findPivotRow(double[][] matrix, int pivotColumn, int rowCount) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TurningPoint.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TurningPoint.groovy
@@ -122,11 +122,11 @@ class TurningPoint {
     double pValue = 2.0 * (1.0 - normal.cumulativeProbability(Math.abs(zStatistic)))
 
     return new TurningPointResult(
-      statistic: zStatistic,
-      pValue: pValue,
+      statistic: BigDecimal.valueOf(zStatistic),
+      pValue: BigDecimal.valueOf(pValue),
       turningPoints: turningPoints,
-      expectedTurningPoints: expectedTurningPoints,
-      variance: variance,
+      expectedTurningPoints: BigDecimal.valueOf(expectedTurningPoints),
+      variance: BigDecimal.valueOf(variance),
       peaks: peaks,
       troughs: troughs,
       sampleSize: n,
@@ -147,19 +147,19 @@ class TurningPoint {
    */
   static class TurningPointResult {
     /** The Z-statistic (standardized test statistic) */
-    double statistic
+    BigDecimal statistic
 
     /** The p-value */
-    double pValue
+    BigDecimal pValue
 
     /** Observed number of turning points */
     int turningPoints
 
     /** Expected number of turning points under H0 */
-    double expectedTurningPoints
+    BigDecimal expectedTurningPoints
 
     /** Variance of turning points under H0 */
-    double variance
+    BigDecimal variance
 
     /** Number of peaks (local maxima) */
     int peaks
@@ -180,7 +180,7 @@ class TurningPoint {
      * @return Interpretation string
      */
     String interpret(Number alpha = 0.05) {
-      double alphaValue = NumericConversion.toAlpha(alpha) as double
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       if (pValue < alphaValue) {
         String direction = turningPoints > expectedTurningPoints ? "more" : "fewer"
         return "Reject H0: Data shows ${direction} turning points than expected under randomness (Z = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
@@ -194,7 +194,7 @@ class TurningPoint {
      */
     String evaluate(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
-      String conclusion = pValue < (alphaValue as double) ? "data is not random" : "data is consistent with randomness"
+      String conclusion = pValue < alphaValue ? "data is not random" : "data is consistent with randomness"
       String direction = turningPoints > expectedTurningPoints ? "cyclicity" : "trend"
 
       return String.format(

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TurningPoint.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TurningPoint.groovy
@@ -121,7 +121,7 @@ class TurningPoint {
     NormalDistribution normal = new NormalDistribution(0, 1)
     double pValue = 2.0 * (1.0 - normal.cumulativeProbability(Math.abs(zStatistic)))
 
-    return new TurningPointResult(
+    new TurningPointResult(
       statistic: BigDecimal.valueOf(zStatistic),
       pValue: BigDecimal.valueOf(pValue),
       turningPoints: turningPoints,
@@ -139,7 +139,7 @@ class TurningPoint {
    */
   static TurningPointResult test(List<? extends Number> data) {
     double[] array = data.collect { it.doubleValue() } as double[]
-    return test(array)
+    test(array)
   }
 
   /**
@@ -197,7 +197,7 @@ class TurningPoint {
       String conclusion = pValue < alphaValue ? "data is not random" : "data is consistent with randomness"
       String direction = turningPoints > expectedTurningPoints ? "cyclicity" : "trend"
 
-      return String.format(
+      String.format(
         "Turning Point test:\\n" +
         "Sample size: %d\\n" +
         "Turning points observed: %d (peaks: %d, troughs: %d)\\n" +
@@ -218,7 +218,7 @@ class TurningPoint {
 
     @Override
     String toString() {
-      return """Turning Point Test
+      """Turning Point Test
   Sample size: ${sampleSize}
   Turning points: ${turningPoints} (peaks: ${peaks}, troughs: ${troughs})
   Expected: ${String.format('%.4f', expectedTurningPoints)}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TurningPoint.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TurningPoint.groovy
@@ -1,6 +1,7 @@
 package se.alipsa.matrix.stats.timeseries
 
 import se.alipsa.matrix.stats.distribution.NormalDistribution
+import se.alipsa.matrix.stats.util.NumericConversion
 
 /**
  * The Turning Point test is a non-parametric statistical test for randomness (independence) in a time series
@@ -178,8 +179,9 @@ class TurningPoint {
      * @param alpha Significance level (default 0.05)
      * @return Interpretation string
      */
-    String interpret(double alpha = 0.05) {
-      if (pValue < alpha) {
+    String interpret(Number alpha = 0.05) {
+      double alphaValue = NumericConversion.toAlpha(alpha) as double
+      if (pValue < alphaValue) {
         String direction = turningPoints > expectedTurningPoints ? "more" : "fewer"
         return "Reject H0: Data shows ${direction} turning points than expected under randomness (Z = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
       } else {
@@ -190,8 +192,9 @@ class TurningPoint {
     /**
      * Evaluates the test result with detailed information.
      */
-    String evaluate(double alpha = 0.05) {
-      String conclusion = pValue < alpha ? "data is not random" : "data is consistent with randomness"
+    String evaluate(Number alpha = 0.05) {
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
+      String conclusion = pValue < (alphaValue as double) ? "data is not random" : "data is consistent with randomness"
       String direction = turningPoints > expectedTurningPoints ? "cyclicity" : "trend"
 
       return String.format(
@@ -207,7 +210,7 @@ class TurningPoint {
         sampleSize, turningPoints, peaks, troughs,
         expectedTurningPoints, variance,
         statistic, pValue,
-        conclusion, alpha * 100,
+        conclusion, (alphaValue * 100) as double,
         turningPoints > expectedTurningPoints ? "More" : "Fewer",
         direction
       )

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/UnitRoot.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/UnitRoot.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.timeseries
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Comprehensive unit root testing framework that runs multiple complementary tests and synthesizes
  * their results into a unified assessment. Unit roots indicate non-stationarity where shocks have
@@ -174,20 +176,21 @@ class UnitRoot {
      * @param alpha Significance level (default 0.05)
      * @return Summary string with all test conclusions
      */
-    String summary(double alpha = 0.05) {
+    String summary(Number alpha = 0.05) {
+      BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       StringBuilder sb = new StringBuilder()
       sb.append("Unit Root Test Summary\n")
       sb.append("=" * 60).append("\n")
       sb.append("Sample size: ${sampleSize}\n")
       sb.append("Type: ${type}\n")
-      sb.append("Significance level: ${alpha * 100}%\n")
+      sb.append("Significance level: ${alphaValue * 100}%\n")
       sb.append("=" * 60).append("\n\n")
 
       // DF Test
       sb.append("1. Dickey-Fuller Test:\n")
       sb.append("   Statistic: ${String.format('%.4f', dfResult.statistic)}\n")
       sb.append("   Critical value (5%): ${String.format('%.4f', dfResult.criticalValue5pct)}\n")
-      sb.append("   Conclusion: ${dfResult.interpret()}\n\n")
+      sb.append("   Conclusion: ${dfResult.interpret(alphaValue)}\n\n")
 
       // ADF Test
       sb.append("2. Augmented Dickey-Fuller Test:\n")
@@ -201,7 +204,7 @@ class UnitRoot {
       sb.append("   Lags: ${adfGlsResult.lags}\n")
       sb.append("   Statistic: ${String.format('%.4f', adfGlsResult.statistic)}\n")
       sb.append("   Critical value (5%): ${String.format('%.4f', adfGlsResult.criticalValue5pct)}\n")
-      sb.append("   Conclusion: ${adfGlsResult.interpret()}\n\n")
+      sb.append("   Conclusion: ${adfGlsResult.interpret(alphaValue)}\n\n")
 
       // KPSS Test (note: opposite null hypothesis)
       sb.append("4. KPSS Test (tests stationarity, opposite null):\n")
@@ -214,7 +217,7 @@ class UnitRoot {
       sb.append("=" * 60).append("\n")
       sb.append("Overall Assessment:\n")
       sb.append("=" * 60).append("\n")
-      sb.append(getConsensus(alpha))
+      sb.append(getConsensus(alphaValue))
 
       return sb.toString()
     }
@@ -225,13 +228,14 @@ class UnitRoot {
      * @param alpha Significance level
      * @return Consensus interpretation
      */
-    String getConsensus(double alpha = 0.05) {
+    String getConsensus(Number alpha = 0.05) {
+      double alphaValue = NumericConversion.toAlpha(alpha) as double
       int unitRootTests = 0  // DF, ADF, ADF-GLS reject null → stationary
 
       // Get critical values based on alpha
-      double dfCritical = getCriticalValue(dfResult, alpha)
-      double adfCritical = getCriticalValue(adfResult, alpha)
-      double adfGlsCritical = getCriticalValue(adfGlsResult, alpha)
+      double dfCritical = getCriticalValue(dfResult, alphaValue)
+      double adfCritical = getCriticalValue(adfResult, alphaValue)
+      double adfGlsCritical = getCriticalValue(adfGlsResult, alphaValue)
 
       // Count how many tests reject unit root (suggesting stationarity)
       // For DF/ADF/ADF-GLS: reject if statistic < critical value (more negative)
@@ -317,11 +321,12 @@ class UnitRoot {
      * @param alpha Significance level
      * @return true if consensus suggests stationarity
      */
-    boolean isStationary(double alpha = 0.05) {
+    boolean isStationary(Number alpha = 0.05) {
+      double alphaValue = NumericConversion.toAlpha(alpha) as double
       int unitRootTests = 0
-      double dfCritical = getCriticalValue(dfResult, alpha)
-      double adfCritical = getCriticalValue(adfResult, alpha)
-      double adfGlsCritical = getCriticalValue(adfGlsResult, alpha)
+      double dfCritical = getCriticalValue(dfResult, alphaValue)
+      double adfCritical = getCriticalValue(adfResult, alphaValue)
+      double adfGlsCritical = getCriticalValue(adfGlsResult, alphaValue)
 
       if (dfResult.statistic < dfCritical) {
         unitRootTests++
@@ -345,11 +350,12 @@ class UnitRoot {
      * @param alpha Significance level
      * @return true if consensus suggests unit root
      */
-    boolean hasUnitRoot(double alpha = 0.05) {
+    boolean hasUnitRoot(Number alpha = 0.05) {
+      double alphaValue = NumericConversion.toAlpha(alpha) as double
       int unitRootTests = 0
-      double dfCritical = getCriticalValue(dfResult, alpha)
-      double adfCritical = getCriticalValue(adfResult, alpha)
-      double adfGlsCritical = getCriticalValue(adfGlsResult, alpha)
+      double dfCritical = getCriticalValue(dfResult, alphaValue)
+      double adfCritical = getCriticalValue(adfResult, alphaValue)
+      double adfGlsCritical = getCriticalValue(adfGlsResult, alphaValue)
 
       if (dfResult.statistic < dfCritical) {
         unitRootTests++

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/UnitRoot.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/UnitRoot.groovy
@@ -130,7 +130,7 @@ class UnitRoot {
     // Run KPSS test (note: KPSS tests stationarity, opposite null hypothesis)
     Kpss.KpssResult kpssResult = Kpss.test(dataList, kpssType)
 
-    return new UnitRootResult(
+    new UnitRootResult(
       dfResult: dfResult,
       adfResult: adfResult,
       adfGlsResult: adfGlsResult,
@@ -145,7 +145,7 @@ class UnitRoot {
    */
   static UnitRootResult test(List<? extends Number> data, String type = 'drift', Integer lags = 0) {
     double[] array = data.collect { it.doubleValue() } as double[]
-    return test(array, type, lags)
+    test(array, type, lags)
   }
 
   /**
@@ -219,7 +219,7 @@ class UnitRoot {
       sb.append("=" * 60).append("\n")
       sb.append(getConsensus(alphaValue))
 
-      return sb.toString()
+      sb.toString()
     }
 
     /**
@@ -281,7 +281,7 @@ class UnitRoot {
         consensus.append("Conclusion: Results are mixed, consider additional analysis")
       }
 
-      return consensus.toString()
+      consensus.toString()
     }
 
     /**
@@ -341,7 +341,7 @@ class UnitRoot {
       boolean kpssRejectsStationarity = kpssResult.statistic > kpssResult.criticalValue
 
       // Consider stationary if majority of unit root tests reject AND KPSS doesn't reject stationarity
-      return unitRootTests >= 2 && !kpssRejectsStationarity
+      unitRootTests >= 2 && !kpssRejectsStationarity
     }
 
     /**
@@ -370,12 +370,12 @@ class UnitRoot {
       boolean kpssRejectsStationarity = kpssResult.statistic > kpssResult.criticalValue
 
       // Consider unit root if no unit root tests reject AND KPSS rejects stationarity
-      return unitRootTests == 0 && kpssRejectsStationarity
+      unitRootTests == 0 && kpssRejectsStationarity
     }
 
     @Override
     String toString() {
-      return summary()
+      summary()
     }
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Student.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Student.groovy
@@ -97,7 +97,7 @@ class Student {
     result.sd2 = sd2
     result.pVal = p
     result.df = df
-    return result
+    result
   }
 
   /**
@@ -180,7 +180,7 @@ class Student {
 
     // Use native TDistribution for p-value calculation
     result.pVal = TDistribution.pValue(result.tVal as double, result.df as double)
-    return result
+    result
   }
 
   /**
@@ -228,7 +228,7 @@ class Student {
     result.df = n - 1
     // Use native TDistribution for p-value calculation
     result.pVal = TDistribution.pValue(result.tVal as double, result.df as double)
-    return result
+    result
   }
 
   /**
@@ -254,61 +254,61 @@ class Student {
     }
 
     BigDecimal getT() {
-      return tVal
+      tVal
     }
 
     BigDecimal getT(int numberOfDecimals) {
-      return getT().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+      getT().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
     }
 
     BigDecimal getP() {
-      return pVal
+      pVal
     }
 
     BigDecimal getP(int numberOfDecimals) {
-      return getP().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+      getP().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
     }
 
     Integer getDf() {
-      return df
+      df
     }
 
     BigDecimal getMean() {
-      return mean
+      mean
     }
 
     BigDecimal getMean(int numberOfDecimals) {
-      return getMean().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+      getMean().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
     }
 
 
     BigDecimal getVar() {
-      return var
+      var
     }
 
     BigDecimal getVar(int numberOfDecimals) {
-      return getVar().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+      getVar().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
     }
 
     BigDecimal getSd() {
-      return sd
+      sd
     }
 
     BigDecimal getSd(int numberOfDecimals) {
-      return getSd().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+      getSd().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
     }
 
     Integer getN() {
-      return n
+      n
     }
 
     String getDescription() {
-      return description
+      description
     }
 
     @Override
     String toString() {
-      return """
+      """
       ${getDescription()}
       t = ${getT(3)}, df = ${getDf()}, p = ${getP(3)}
       mean = ${getMean(3)}, size = ${getN()}, sd = ${getSd(3)}
@@ -323,16 +323,16 @@ class Student {
      * @return the sample standard deviation of the differences
      */
     BigDecimal getSd() {
-      return sd
+      sd
     }
 
     BigDecimal getSd(int numberOfDecimals) {
-      return getSd().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+      getSd().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
     }
 
     @Override
     String toString() {
-      return """
+      """
       ${getDescription()}
       t = ${getT(3)}, df = ${getDf()}, p = ${getP(4)}, sd diff = ${getSd(3)}
       x: mean = ${getMean1(3)}, size = ${getN1()}, sd = ${getSd1(3)}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/TtestResult.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/TtestResult.groovy
@@ -22,92 +22,92 @@ class TtestResult {
   String description
 
   BigDecimal getT() {
-    return tVal
+    tVal
   }
 
   BigDecimal getT(int numberOfDecimals) {
-    return getT().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getT().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   BigDecimal getP() {
-    return pVal
+    pVal
   }
 
   BigDecimal getP(int numberOfDecimals) {
-    return getP().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getP().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   BigDecimal getDf() {
-    return df
+    df
   }
 
   BigDecimal getDf(int numberOfDecimals) {
-    return getDf().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getDf().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   BigDecimal getMean1() {
-    return mean1
+    mean1
   }
 
   BigDecimal getMean1(int numberOfDecimals) {
-    return getMean1().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getMean1().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   BigDecimal getMean2() {
-    return mean2
+    mean2
   }
 
   BigDecimal getMean2(int numberOfDecimals) {
-    return getMean2().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getMean2().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   BigDecimal getVar1() {
-    return var1
+    var1
   }
 
   BigDecimal getVar1(int numberOfDecimals) {
-    return getVar1().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getVar1().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   BigDecimal getVar2() {
-    return var2
+    var2
   }
 
   BigDecimal getVar2(int numberOfDecimals) {
-    return getVar2().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getVar2().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   BigDecimal getSd1() {
-    return sd1
+    sd1
   }
 
   BigDecimal getSd1(int numberOfDecimals) {
-    return getSd1().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getSd1().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   BigDecimal getSd2() {
-    return sd2
+    sd2
   }
 
   BigDecimal getSd2(int numberOfDecimals) {
-    return getSd2().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
+    getSd2().setScale(numberOfDecimals, RoundingMode.HALF_EVEN)
   }
 
   Integer getN1() {
-    return n1
+    n1
   }
 
   Integer getN2() {
-    return n2
+    n2
   }
 
   String getDescription() {
-    return description
+    description
   }
 
   @Override
   String toString() {
-    return """
+    """
       ${getDescription()}
       t = ${getT(3)}, df = ${getDf(3)}, p = ${getP(3)}
       x: mean = ${getMean1(3)}, size = ${getN1()}, sd = ${getSd1(3)}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Welch.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Welch.groovy
@@ -78,6 +78,6 @@ class Welch {
 
     // Use native TDistribution for p-value calculation
     result.pVal = TDistribution.pValue(t as double, result.df as double)
-    return result
+    result
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/util/NumericConversion.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/util/NumericConversion.groovy
@@ -415,6 +415,33 @@ final class NumericConversion {
     [rows, columns] as int[]
   }
 
+  /**
+   * Dispatch a mixed {@code List<?>} to either a primitive-array handler or a list handler.
+   *
+   * <p>This is a shared helper for legacy bridge methods that accept untyped lists and need to
+   * determine whether the caller passed {@code List<double[]>} or {@code List<List<Number>>}.</p>
+   *
+   * @param data the untyped input list
+   * @param arrayHandler called when every element is a {@code double[]}
+   * @param listHandler called when every element is a {@code List}
+   * @param label used in the error message for mixed-type inputs
+   * @return the result of whichever handler was invoked
+   */
+  static <T> T dispatchPrimitiveOrList(
+      List<?> data,
+      Closure<T> arrayHandler,
+      Closure<T> listHandler,
+      String label = 'element'
+  ) {
+    if (data == null || data.isEmpty() || data.every { Object item -> item instanceof double[] }) {
+      return arrayHandler(data)
+    }
+    if (data.every { Object item -> item instanceof List<?> }) {
+      return listHandler(data)
+    }
+    throw new IllegalArgumentException("Each ${label} must be a List<Number> or double[], got mixed input types")
+  }
+
   private static void validateMatrix(Matrix matrix) {
     if (matrix == null) {
       throw new IllegalArgumentException('Matrix cannot be null')

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/util/NumericConversion.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/util/NumericConversion.groovy
@@ -40,6 +40,38 @@ final class NumericConversion {
   }
 
   /**
+   * Convert a rectangular numeric row collection into a dense {@code double[][]} array.
+   *
+   * @param rows the numeric rows
+   * @param label the label used in validation messages
+   * @return the dense numeric matrix
+   */
+  static double[][] toDoubleMatrix(List<? extends List<? extends Number>> rows, String label) {
+    if (rows == null) {
+      throw new IllegalArgumentException("${label.capitalize()} cannot be null")
+    }
+    if (rows.isEmpty()) {
+      throw new IllegalArgumentException("${label.capitalize()} must contain at least one row")
+    }
+    if (rows[0] == null || rows[0].isEmpty()) {
+      throw new IllegalArgumentException("${label.capitalize()} must contain at least one column")
+    }
+
+    int columnCount = rows[0].size()
+    double[][] values = new double[rows.size()][columnCount]
+    for (int row = 0; row < rows.size(); row++) {
+      List<? extends Number> currentRow = rows[row]
+      if (currentRow == null || currentRow.size() != columnCount) {
+        throw new IllegalArgumentException("${label.capitalize()} rows must all have the same length")
+      }
+      for (int col = 0; col < columnCount; col++) {
+        values[row][col] = toFiniteDouble(currentRow[col], "${label} value at row ${row}, column ${col}")
+      }
+    }
+    values
+  }
+
+  /**
    * Convert a numeric Matrix column into a dense {@code double[]} array.
    *
    * @param matrix the source matrix
@@ -127,6 +159,49 @@ final class NumericConversion {
   }
 
   /**
+   * Convert a dense primitive vector into immutable {@code BigDecimal} values.
+   *
+   * @param values the primitive vector
+   * @param label the label used in validation messages
+   * @return the converted values
+   */
+  static List<BigDecimal> toBigDecimalList(double[] values, String label = 'values') {
+    if (values == null) {
+      throw new IllegalArgumentException("${label.capitalize()} cannot be null")
+    }
+    List<BigDecimal> converted = []
+    for (int i = 0; i < values.length; i++) {
+      if (!Double.isFinite(values[i])) {
+        throw new IllegalArgumentException("${label.capitalize()} must contain only finite values")
+      }
+      converted << BigDecimal.valueOf(values[i])
+    }
+    converted.asImmutable() as List<BigDecimal>
+  }
+
+  /**
+   * Convert a dense primitive matrix into immutable {@code BigDecimal} rows.
+   *
+   * @param values the primitive matrix
+   * @param label the label used in validation messages
+   * @return the converted rows
+   */
+  static List<List<BigDecimal>> toBigDecimalRows(double[][] values, String label = 'values') {
+    if (values == null) {
+      throw new IllegalArgumentException("${label.capitalize()} cannot be null")
+    }
+    List<List<BigDecimal>> rows = []
+    int columnCount = values.length == 0 ? 0 : values[0].length
+    for (int row = 0; row < values.length; row++) {
+      if (values[row] == null || values[row].length != columnCount) {
+        throw new IllegalArgumentException("${label.capitalize()} rows must all have the same length")
+      }
+      rows << toBigDecimalList(values[row], "${label} row ${row}")
+    }
+    rows.asImmutable() as List<List<BigDecimal>>
+  }
+
+  /**
    * Convert a significance level to {@code BigDecimal} and validate that it lies in {@code (0, 1)}.
    *
    * @param value the source significance level
@@ -140,6 +215,21 @@ final class NumericConversion {
       throw new IllegalArgumentException("${label.capitalize()} must be between 0 and 1, got ${alpha}")
     }
     alpha
+  }
+
+  /**
+   * Convert a unit-interval value to {@code BigDecimal} and validate that it lies in {@code [0, 1]}.
+   *
+   * @param value the source value
+   * @param label the label used in validation messages
+   * @return the validated value
+   */
+  static BigDecimal toUnitInterval(Object value, String label = 'value') {
+    BigDecimal normalized = toBigDecimal(value, label)
+    if (normalized < 0 || normalized > 1) {
+      throw new IllegalArgumentException("${label.capitalize()} must be between 0 and 1, got ${normalized}")
+    }
+    normalized
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/util/NumericConversion.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/util/NumericConversion.groovy
@@ -218,6 +218,23 @@ final class NumericConversion {
   }
 
   /**
+   * Convert an integral numeric value to {@code int} and reject non-integral inputs.
+   *
+   * @param value the source value
+   * @param label the label used in validation messages
+   * @return the validated integer value
+   * @since 2.4.0
+   */
+  static int toExactInt(Object value, String label) {
+    BigDecimal normalized = toBigDecimal(value, label)
+    try {
+      normalized.intValueExact()
+    } catch (ArithmeticException e) {
+      throw new IllegalArgumentException("${label.capitalize()} must be an integer, got ${normalized}", e)
+    }
+  }
+
+  /**
    * Convert a unit-interval value to {@code BigDecimal} and validate that it lies in {@code [0, 1]}.
    *
    * @param value the source value

--- a/matrix-stats/src/main/java/se/alipsa/matrix/stats/util/LeastSquaresKernel.java
+++ b/matrix-stats/src/main/java/se/alipsa/matrix/stats/util/LeastSquaresKernel.java
@@ -1,0 +1,343 @@
+package se.alipsa.matrix.stats.util;
+
+/**
+ * Internal primitive least-squares utilities for numerically dense regression paths.
+ *
+ * <p>The public Groovy-facing APIs in {@code matrix-stats} should continue to accept
+ * {@code Number}, {@code List}, {@code Matrix}, and {@code Grid} inputs. This utility keeps
+ * the hot floating-point linear algebra loops in Java so those Groovy APIs can remain
+ * idiomatic without paying repeated dynamic-loop overhead in solver-heavy call paths.</p>
+ */
+public final class LeastSquaresKernel {
+
+  private static final double SINGULARITY_THRESHOLD = 1e-14d;
+
+  private LeastSquaresKernel() {
+  }
+
+  /**
+   * Fit an ordinary least squares regression model and return the full computation result.
+   *
+   * @param response the response vector
+   * @param predictors the design matrix
+   * @return coefficients, standard errors, and residual metrics
+   * @throws IllegalArgumentException if the inputs are invalid or the model is not estimable
+   */
+  public static OlsComputation fitMultipleLinearRegression(double[] response, double[][] predictors) {
+    validateMultipleRegressionInputs(response, predictors);
+
+    int observationCount = response.length;
+    int predictorCount = predictors[0].length;
+
+    double[][] transpose = transpose(predictors);
+    double[][] xtx = multiply(transpose, predictors);
+    double[][] xtxInverse = invertSquareMatrix(xtx);
+    double[] xty = multiply(transpose, response);
+    double[] coefficients = multiply(xtxInverse, xty);
+    double residualSumOfSquares = calculateResidualSumOfSquaresUnchecked(response, predictors, coefficients);
+
+    int degreesOfFreedom = observationCount - predictorCount;
+    if (degreesOfFreedom <= 0) {
+      throw new IllegalArgumentException(
+          "Ordinary least squares requires more observations (" + observationCount + ") than predictors (" + predictorCount + ")"
+      );
+    }
+
+    double errorVariance = residualSumOfSquares / degreesOfFreedom;
+    double[] standardErrors = calculateStandardErrors(xtxInverse, errorVariance);
+    return new OlsComputation(coefficients, standardErrors, residualSumOfSquares, errorVariance);
+  }
+
+  /**
+   * Fit an ordinary least squares regression and return the coefficient vector.
+   *
+   * @param response the response vector
+   * @param predictors the design matrix
+   * @return the fitted coefficients
+   * @throws IllegalArgumentException if the inputs are invalid or the normal equations cannot be solved
+   */
+  public static double[] fitOls(double[] response, double[][] predictors) {
+    validateOlsInputs(response, predictors);
+
+    double[][] transpose = transpose(predictors);
+    double[][] xtx = multiply(transpose, predictors);
+    double[] xty = multiply(transpose, response);
+    return solveSquareSystem(xtx, xty);
+  }
+
+  /**
+   * Calculate the residual sum of squares for a fitted linear model.
+   *
+   * @param response the observed response vector
+   * @param predictors the design matrix
+   * @param coefficients the fitted coefficient vector
+   * @return the residual sum of squares
+   * @throws IllegalArgumentException if the inputs are invalid
+   */
+  public static double calculateResidualSumOfSquares(double[] response, double[][] predictors, double[] coefficients) {
+    validateResidualInputs(response, predictors, coefficients);
+    return calculateResidualSumOfSquaresUnchecked(response, predictors, coefficients);
+  }
+
+  /**
+   * Immutable OLS computation result.
+   *
+   * @param coefficients fitted coefficient vector
+   * @param standardErrors coefficient standard errors
+   * @param residualSumOfSquares residual sum of squares
+   * @param errorVariance residual variance estimate
+   */
+  public record OlsComputation(
+      double[] coefficients,
+      double[] standardErrors,
+      double residualSumOfSquares,
+      double errorVariance
+  ) {
+  }
+
+  private static void validateMultipleRegressionInputs(double[] response, double[][] predictors) {
+    if (response == null || predictors == null) {
+      throw new IllegalArgumentException("Response vector and design matrix cannot be null");
+    }
+    if (response.length == 0) {
+      throw new IllegalArgumentException("Response vector cannot be empty");
+    }
+    if (predictors.length != response.length) {
+      throw new IllegalArgumentException(
+          "Design matrix row count (" + predictors.length + ") must match response length (" + response.length + ")"
+      );
+    }
+    if (predictors.length == 0 || predictors[0].length == 0) {
+      throw new IllegalArgumentException("Design matrix must contain at least one predictor");
+    }
+
+    int columnCount = predictors[0].length;
+    if (response.length <= columnCount) {
+      throw new IllegalArgumentException(
+          "Ordinary least squares requires more observations (" + response.length + ") than predictors (" + columnCount + ")"
+      );
+    }
+    for (double[] row : predictors) {
+      if (row.length != columnCount) {
+        throw new IllegalArgumentException("Design matrix rows must all have the same length");
+      }
+    }
+  }
+
+  private static void validateOlsInputs(double[] response, double[][] predictors) {
+    if (response == null || predictors == null) {
+      throw new IllegalArgumentException("Response vector and design matrix cannot be null");
+    }
+    if (predictors.length == 0 || predictors[0].length == 0) {
+      throw new IllegalArgumentException("Design matrix must contain at least one row and one column");
+    }
+    if (predictors.length != response.length) {
+      throw new IllegalArgumentException(
+          "Design matrix row count (" + predictors.length + ") must match response length (" + response.length + ")"
+      );
+    }
+
+    int columnCount = predictors[0].length;
+    for (double[] row : predictors) {
+      if (row.length != columnCount) {
+        throw new IllegalArgumentException("Design matrix rows must all have the same length");
+      }
+    }
+  }
+
+  private static void validateResidualInputs(double[] response, double[][] predictors, double[] coefficients) {
+    if (response == null || predictors == null || coefficients == null) {
+      throw new IllegalArgumentException("Response vector, design matrix, and coefficients cannot be null");
+    }
+    if (predictors.length == 0) {
+      throw new IllegalArgumentException("Design matrix must contain at least one row");
+    }
+    if (predictors.length != response.length) {
+      throw new IllegalArgumentException(
+          "Design matrix row count (" + predictors.length + ") must match response length (" + response.length + ")"
+      );
+    }
+    if (predictors[0].length != coefficients.length) {
+      throw new IllegalArgumentException(
+          "Coefficient count (" + coefficients.length + ") must match design matrix column count (" + predictors[0].length + ")"
+      );
+    }
+    for (double[] row : predictors) {
+      if (row.length != coefficients.length) {
+        throw new IllegalArgumentException("Design matrix rows must all have the same length");
+      }
+    }
+  }
+
+  private static double[][] transpose(double[][] matrix) {
+    int rowCount = matrix.length;
+    int columnCount = matrix[0].length;
+    double[][] result = new double[columnCount][rowCount];
+    for (int row = 0; row < rowCount; row++) {
+      for (int column = 0; column < columnCount; column++) {
+        result[column][row] = matrix[row][column];
+      }
+    }
+    return result;
+  }
+
+  private static double[][] multiply(double[][] left, double[][] right) {
+    int rowCount = left.length;
+    int innerCount = left[0].length;
+    int columnCount = right[0].length;
+    double[][] result = new double[rowCount][columnCount];
+
+    for (int row = 0; row < rowCount; row++) {
+      for (int inner = 0; inner < innerCount; inner++) {
+        double value = left[row][inner];
+        if (value == 0.0d) {
+          continue;
+        }
+        for (int column = 0; column < columnCount; column++) {
+          result[row][column] += value * right[inner][column];
+        }
+      }
+    }
+    return result;
+  }
+
+  private static double[] multiply(double[][] matrix, double[] vector) {
+    double[] result = new double[matrix.length];
+    for (int row = 0; row < matrix.length; row++) {
+      double sum = 0.0d;
+      for (int column = 0; column < vector.length; column++) {
+        sum += matrix[row][column] * vector[column];
+      }
+      result[row] = sum;
+    }
+    return result;
+  }
+
+  private static double[][] invertSquareMatrix(double[][] matrix) {
+    int dimension = matrix.length;
+    double[][] augmented = new double[dimension][2 * dimension];
+    for (int row = 0; row < dimension; row++) {
+      for (int column = 0; column < dimension; column++) {
+        augmented[row][column] = matrix[row][column];
+        augmented[row][column + dimension] = row == column ? 1.0d : 0.0d;
+      }
+    }
+
+    for (int pivotColumn = 0; pivotColumn < dimension; pivotColumn++) {
+      int pivotRow = findPivotRow(augmented, pivotColumn, dimension);
+      if (pivotRow != pivotColumn) {
+        swapRows(augmented, pivotColumn, pivotRow);
+      }
+
+      double pivot = augmented[pivotColumn][pivotColumn];
+      if (Math.abs(pivot) <= SINGULARITY_THRESHOLD) {
+        throw new IllegalArgumentException("Singular matrix at column " + pivotColumn + " - cannot invert matrix");
+      }
+
+      for (int column = 0; column < 2 * dimension; column++) {
+        augmented[pivotColumn][column] /= pivot;
+      }
+      for (int row = 0; row < dimension; row++) {
+        if (row == pivotColumn) {
+          continue;
+        }
+        double factor = augmented[row][pivotColumn];
+        if (factor == 0.0d) {
+          continue;
+        }
+        for (int column = 0; column < 2 * dimension; column++) {
+          augmented[row][column] -= factor * augmented[pivotColumn][column];
+        }
+      }
+    }
+
+    double[][] inverse = new double[dimension][dimension];
+    for (int row = 0; row < dimension; row++) {
+      System.arraycopy(augmented[row], dimension, inverse[row], 0, dimension);
+    }
+    return inverse;
+  }
+
+  private static double[] solveSquareSystem(double[][] matrix, double[] vector) {
+    int dimension = vector.length;
+    double[][] augmented = new double[dimension][dimension + 1];
+    for (int row = 0; row < dimension; row++) {
+      System.arraycopy(matrix[row], 0, augmented[row], 0, dimension);
+      augmented[row][dimension] = vector[row];
+    }
+
+    for (int pivotColumn = 0; pivotColumn < dimension; pivotColumn++) {
+      int pivotRow = findPivotRow(augmented, pivotColumn, dimension);
+      if (pivotRow != pivotColumn) {
+        swapRows(augmented, pivotColumn, pivotRow);
+      }
+
+      double pivot = augmented[pivotColumn][pivotColumn];
+      if (Math.abs(pivot) <= SINGULARITY_THRESHOLD) {
+        throw new IllegalArgumentException("Singular matrix at column " + pivotColumn + " - cannot solve linear system");
+      }
+
+      for (int row = pivotColumn + 1; row < dimension; row++) {
+        double factor = augmented[row][pivotColumn] / pivot;
+        for (int column = pivotColumn; column <= dimension; column++) {
+          augmented[row][column] -= factor * augmented[pivotColumn][column];
+        }
+      }
+    }
+
+    double[] solution = new double[dimension];
+    for (int row = dimension - 1; row >= 0; row--) {
+      double sum = augmented[row][dimension];
+      for (int column = row + 1; column < dimension; column++) {
+        sum -= augmented[row][column] * solution[column];
+      }
+      double diagonal = augmented[row][row];
+      if (Math.abs(diagonal) <= SINGULARITY_THRESHOLD) {
+        throw new IllegalArgumentException("Singular matrix at column " + row + " - cannot solve linear system");
+      }
+      solution[row] = sum / diagonal;
+    }
+    return solution;
+  }
+
+  private static double calculateResidualSumOfSquaresUnchecked(double[] response, double[][] predictors, double[] coefficients) {
+    double rss = 0.0d;
+    for (int row = 0; row < response.length; row++) {
+      double fitted = 0.0d;
+      for (int column = 0; column < coefficients.length; column++) {
+        fitted += predictors[row][column] * coefficients[column];
+      }
+      double residual = response[row] - fitted;
+      rss += residual * residual;
+    }
+    return rss;
+  }
+
+  private static double[] calculateStandardErrors(double[][] xtxInverse, double variance) {
+    double[] standardErrors = new double[xtxInverse.length];
+    for (int index = 0; index < xtxInverse.length; index++) {
+      double diagonal = Math.max(0.0d, xtxInverse[index][index]);
+      standardErrors[index] = Math.sqrt(variance * diagonal);
+    }
+    return standardErrors;
+  }
+
+  private static int findPivotRow(double[][] matrix, int pivotColumn, int rowCount) {
+    int maxRow = pivotColumn;
+    double maxValue = Math.abs(matrix[pivotColumn][pivotColumn]);
+    for (int row = pivotColumn + 1; row < rowCount; row++) {
+      double value = Math.abs(matrix[row][pivotColumn]);
+      if (value > maxValue) {
+        maxValue = value;
+        maxRow = row;
+      }
+    }
+    return maxRow;
+  }
+
+  private static void swapRows(double[][] matrix, int firstRow, int secondRow) {
+    double[] temp = matrix[firstRow];
+    matrix[firstRow] = matrix[secondRow];
+    matrix[secondRow] = temp;
+  }
+}

--- a/matrix-stats/src/main/java/se/alipsa/matrix/stats/util/LeastSquaresKernel.java
+++ b/matrix-stats/src/main/java/se/alipsa/matrix/stats/util/LeastSquaresKernel.java
@@ -36,14 +36,7 @@ public final class LeastSquaresKernel {
     double[] coefficients = multiply(xtxInverse, xty);
     double residualSumOfSquares = calculateResidualSumOfSquaresUnchecked(response, predictors, coefficients);
 
-    int degreesOfFreedom = observationCount - predictorCount;
-    if (degreesOfFreedom <= 0) {
-      throw new IllegalArgumentException(
-          "Ordinary least squares requires more observations (" + observationCount + ") than predictors (" + predictorCount + ")"
-      );
-    }
-
-    double errorVariance = residualSumOfSquares / degreesOfFreedom;
+    double errorVariance = residualSumOfSquares / (observationCount - predictorCount);
     double[] standardErrors = calculateStandardErrors(xtxInverse, errorVariance);
     return new OlsComputation(coefficients, standardErrors, residualSumOfSquares, errorVariance);
   }

--- a/matrix-stats/src/main/java/se/alipsa/matrix/stats/util/LeastSquaresKernel.java
+++ b/matrix-stats/src/main/java/se/alipsa/matrix/stats/util/LeastSquaresKernel.java
@@ -7,6 +7,13 @@ package se.alipsa.matrix.stats.util;
  * {@code Number}, {@code List}, {@code Matrix}, and {@code Grid} inputs. This utility keeps
  * the hot floating-point linear algebra loops in Java so those Groovy APIs can remain
  * idiomatic without paying repeated dynamic-loop overhead in solver-heavy call paths.</p>
+ *
+ * <p><strong>Numerical limitations:</strong> Matrix inversion and linear system solving use
+ * Gauss-Jordan elimination with partial pivoting and a singularity threshold of {@code 1e-14}.
+ * This is suitable for the current low-dimensional use cases (unit root tests, simple OLS)
+ * but may produce inaccurate results for near-singular or ill-conditioned matrices. If this
+ * class is extended to higher-dimensional problems, consider switching to a QR- or SVD-based
+ * decomposition.</p>
  */
 public final class LeastSquaresKernel {
 

--- a/matrix-stats/src/test/groovy/AccuracyTest.groovy
+++ b/matrix-stats/src/test/groovy/AccuracyTest.groovy
@@ -1,6 +1,5 @@
 import static org.junit.jupiter.api.Assertions.*
 
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 import se.alipsa.matrix.stats.Accuracy

--- a/matrix-stats/src/test/groovy/AnovaTest.groovy
+++ b/matrix-stats/src/test/groovy/AnovaTest.groovy
@@ -165,6 +165,7 @@ class AnovaTest {
     assertTrue(result.evaluate(0.01), 'should reject null at alpha=0.01')
     assertTrue(result.evaluate(0.001), 'should reject null at alpha=0.001')
     assertTrue(result.evaluate(0.0001), 'should reject null at alpha=0.0001')
+    assertTrue(result.evaluate(0.05G), 'should reject null at alpha=0.05 as BigDecimal')
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/EllipseTest.groovy
+++ b/matrix-stats/src/test/groovy/EllipseTest.groovy
@@ -266,7 +266,7 @@ class EllipseTest {
         maxDist = dist
       }
     }
-    return maxDist
+    maxDist
   }
 
   private void assertAllFinite(List<BigDecimal> xVals, List<BigDecimal> yVals) {

--- a/matrix-stats/src/test/groovy/KMeansPlusPlusTest.groovy
+++ b/matrix-stats/src/test/groovy/KMeansPlusPlusTest.groovy
@@ -101,4 +101,20 @@ class KMeansPlusPlusTest {
     assertTrue(clustering.wcssValue > 0)
     assertTrue(clustering.executionTimeValue >= 0)
   }
+
+  @Test
+  void testBuilderAcceptsNumberEpsilon() {
+    List<List<BigDecimal>> points = gaussianClusters(20, 0.05).collectNested { Double value ->
+      BigDecimal.valueOf(value)
+    } as List<List<BigDecimal>>
+
+    KMeansPlusPlus clustering = new KMeansPlusPlus.Builder(4, points)
+        .iterations(5)
+        .epsilon(0.003G)
+        .useEpsilon(true)
+        .randomSeed(RANDOM_SEED)
+        .build()
+
+    assertEquals(points.size(), clustering.assignments.size())
+  }
 }

--- a/matrix-stats/src/test/groovy/KMeansPlusPlusTest.groovy
+++ b/matrix-stats/src/test/groovy/KMeansPlusPlusTest.groovy
@@ -81,4 +81,24 @@ class KMeansPlusPlusTest {
     assert clustering.getCentroids().length <= (int)Math.max(2, Math.sqrt(data.length / 2.0d))
     assert clustering.getCentroids().length >= Math.max(2, (int) Math.round(Math.cbrt(data.length)))
   }
+
+  @Test
+  void testGroovyFacingBuilderAndValueAccessors() {
+    List<List<BigDecimal>> points = gaussianClusters(25, 0.05).collectNested { Double value ->
+      BigDecimal.valueOf(value)
+    } as List<List<BigDecimal>>
+
+    KMeansPlusPlus clustering = new KMeansPlusPlus.Builder(4, points)
+        .iterations(10)
+        .pp(true)
+        .randomSeed(RANDOM_SEED)
+        .build()
+
+    assertEquals(points.size(), clustering.assignments.size())
+    assertEquals(4, clustering.centroidValues.size())
+    assertEquals(2, clustering.centroidValues[0].size())
+    assertEquals(2, clustering.assignments[0].pointValues.size())
+    assertTrue(clustering.wcssValue > 0)
+    assertTrue(clustering.executionTimeValue >= 0)
+  }
 }

--- a/matrix-stats/src/test/groovy/QuantileRegressionTest.groovy
+++ b/matrix-stats/src/test/groovy/QuantileRegressionTest.groovy
@@ -149,9 +149,9 @@ class QuantileRegressionTest {
     def x = [1, 2, 3, 4, 5]
     def y = [2, 4, 6, 8, 10]
 
-    Exception exception = assertThrows(IllegalArgumentException.class, {
+    Exception exception = assertThrows(IllegalArgumentException) {
       new QuantileRegression(x, y, 0.0)
-    })
+    }
 
     assertTrue(exception.message.contains("must be in the open interval (0, 1)"))
   }
@@ -161,9 +161,9 @@ class QuantileRegressionTest {
     def x = [1, 2, 3, 4, 5]
     def y = [2, 4, 6, 8, 10]
 
-    Exception exception = assertThrows(IllegalArgumentException.class, {
+    Exception exception = assertThrows(IllegalArgumentException) {
       new QuantileRegression(x, y, 1.0)
-    })
+    }
 
     assertTrue(exception.message.contains("must be in the open interval (0, 1)"))
   }
@@ -173,9 +173,9 @@ class QuantileRegressionTest {
     def x = [1, 2, 3, 4, 5]
     def y = [2, 4, 6, 8, 10]
 
-    Exception exception = assertThrows(IllegalArgumentException.class, {
+    Exception exception = assertThrows(IllegalArgumentException) {
       new QuantileRegression(x, y, -0.5)
-    })
+    }
 
     assertTrue(exception.message.contains("must be in the open interval (0, 1)"))
   }
@@ -185,9 +185,9 @@ class QuantileRegressionTest {
     def x = [1, 2, 3, 4, 5]
     def y = [2, 4, 6, 8, 10]
 
-    Exception exception = assertThrows(IllegalArgumentException.class, {
+    Exception exception = assertThrows(IllegalArgumentException) {
       new QuantileRegression(x, y, 1.5)
-    })
+    }
 
     assertTrue(exception.message.contains("must be in the open interval (0, 1)"))
   }
@@ -197,9 +197,9 @@ class QuantileRegressionTest {
     def x = [1]
     def y = [2]
 
-    Exception exception = assertThrows(IllegalArgumentException.class, {
+    Exception exception = assertThrows(IllegalArgumentException) {
       new QuantileRegression(x, y, 0.5)
-    })
+    }
 
     assertTrue(exception.message.contains("Need at least 2 data points"))
   }
@@ -209,9 +209,9 @@ class QuantileRegressionTest {
     def x = [1, 2, 3]
     def y = [2, 4]
 
-    Exception exception = assertThrows(IllegalArgumentException.class, {
+    Exception exception = assertThrows(IllegalArgumentException) {
       new QuantileRegression(x, y, 0.5)
-    })
+    }
 
     assertTrue(exception.message.contains("Must have equal number"))
   }

--- a/matrix-stats/src/test/groovy/StatUtilsTest.groovy
+++ b/matrix-stats/src/test/groovy/StatUtilsTest.groovy
@@ -1,0 +1,21 @@
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+import org.junit.jupiter.api.Test
+
+import se.alipsa.matrix.stats.StatUtils
+
+class StatUtilsTest {
+
+  @Test
+  void testMeanAcceptsListInput() {
+    assertEquals(2.5d, StatUtils.mean([1.0G, 2.0G, 3.0G, 4.0G]), 1e-10d)
+  }
+
+  @Test
+  void testVarianceAcceptsListAndNumberMean() {
+    List<BigDecimal> values = [1.0, 2.0, 3.0, 4.0]
+
+    assertEquals(1.6666666666666667d, StatUtils.variance(values), 1e-10d)
+    assertEquals(1.6666666666666667d, StatUtils.variance(values, 2.5G), 1e-10d)
+  }
+}

--- a/matrix-stats/src/test/groovy/StatUtilsTest.groovy
+++ b/matrix-stats/src/test/groovy/StatUtilsTest.groovy
@@ -1,4 +1,5 @@
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertThrows
 
 import org.junit.jupiter.api.Test
 
@@ -7,15 +8,27 @@ import se.alipsa.matrix.stats.StatUtils
 class StatUtilsTest {
 
   @Test
-  void testMeanAcceptsListInput() {
-    assertEquals(2.5d, StatUtils.mean([1.0G, 2.0G, 3.0G, 4.0G]), 1e-10d)
+  void testMean() {
+    double result = StatUtils.mean([1.0d, 2.0d, 3.0d, 4.0d] as double[])
+    assertEquals(2.5d, result, 1e-10d)
   }
 
   @Test
-  void testVarianceAcceptsListAndNumberMean() {
-    List<BigDecimal> values = [1.0, 2.0, 3.0, 4.0]
+  void testMeanEmptyThrows() {
+    assertThrows(IllegalArgumentException) {
+      StatUtils.mean([] as double[])
+    }
+  }
 
-    assertEquals(1.6666666666666667d, StatUtils.variance(values), 1e-10d)
-    assertEquals(1.6666666666666667d, StatUtils.variance(values, 2.5G), 1e-10d)
+  @Test
+  void testVariance() {
+    double result = StatUtils.variance([1.0d, 2.0d, 3.0d, 4.0d] as double[])
+    assertEquals(1.6666666666666667d, result, 1e-10d)
+  }
+
+  @Test
+  void testVarianceWithMean() {
+    double result = StatUtils.variance([1.0d, 2.0d, 3.0d, 4.0d] as double[], 2.5d)
+    assertEquals(1.6666666666666667d, result, 1e-10d)
   }
 }

--- a/matrix-stats/src/test/groovy/StudentTest.groovy
+++ b/matrix-stats/src/test/groovy/StudentTest.groovy
@@ -35,9 +35,9 @@ class StudentTest {
     }
     // R's t.test defaults to Welch's t-test, so we use Welch class
     TtestResult result = Welch.tTest(setosa['Petal Length'], virginica['Petal Length'])
-    //println(result)
+    // println(result)
     assertEquals(-49.98618626, result.getT(8), "t value")
-    //println("var1 = ${result.var1}, var2 = ${result.var2}")
+    // println("var1 = ${result.var1}, var2 = ${result.var2}")
     assertEquals(58.60939455, result.getDf(8), "Degrees of freedom")
     assertEquals(0.17366400, result.getSd1(8), "sd1")
     assertEquals(0.55189470, result.getSd2(8), "sd2")
@@ -67,7 +67,7 @@ class StudentTest {
   void testOneSample() {
     def plantHeights = [14, 14, 16, 13, 12, 17, 15, 14, 15, 13, 15, 14]
     def t = Student.tTest(plantHeights, 15)
-    //println(t)
+    // println(t)
     assertEquals(-1.68484708, t.getT(8))
     assertEquals(11, t.getDf())
     assertEquals(0.12014461, t.getP(8))
@@ -108,10 +108,10 @@ class StudentTest {
         group: ['pre'] * 20 + ['post'] * 20)
         .types(Integer, String)
         .build()
-    def pre = data.subset('group', { it == 'pre' })
-    def post = data.subset('group', { it == 'post' })
+    def pre = data.subset('group') { it == 'pre' }
+    def post = data.subset('group') { it == 'post' }
     def result = Student.pairedTTest(post['score'], pre['score'])
-    //println(result)
+    // println(result)
     assertEquals(1.58801321, result.getT(8), 't statistic')
     assertEquals(19, result.getDf() as Integer, 'Degrees of freedom')
     assertEquals(0.128785661, result.getP(9), 'P value')

--- a/matrix-stats/src/test/groovy/contingency/BarnardTest.groovy
+++ b/matrix-stats/src/test/groovy/contingency/BarnardTest.groovy
@@ -107,8 +107,6 @@ class BarnardTest {
 
   @Test
   void testValidation() {
-    int[][] validTable = [[10, 5], [5, 10]]
-
     // Null table
     assertThrows(IllegalArgumentException) {
       Barnard.test(null)

--- a/matrix-stats/src/test/groovy/contingency/BarnardTest.groovy
+++ b/matrix-stats/src/test/groovy/contingency/BarnardTest.groovy
@@ -214,10 +214,12 @@ class BarnardTest {
     String interp01 = result.interpret(0.01)
     String interp05 = result.interpret(0.05)
     String interp10 = result.interpret(0.10)
+    String interp05BigDecimal = result.interpret(0.05G)
 
     assertNotNull(interp01, 'Interpretation at α=0.01 should not be null')
     assertNotNull(interp05, 'Interpretation at α=0.05 should not be null')
     assertNotNull(interp10, 'Interpretation at α=0.10 should not be null')
+    assertEquals(interp05, interp05BigDecimal, 'BigDecimal alpha should produce the same interpretation')
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/contingency/BoschlooTest.groovy
+++ b/matrix-stats/src/test/groovy/contingency/BoschlooTest.groovy
@@ -226,10 +226,12 @@ class BoschlooTest {
     String interp01 = result.interpret(0.01)
     String interp05 = result.interpret(0.05)
     String interp10 = result.interpret(0.10)
+    String interp05BigDecimal = result.interpret(0.05G)
 
     assertNotNull(interp01, 'Interpretation at α=0.01 should not be null')
     assertNotNull(interp05, 'Interpretation at α=0.05 should not be null')
     assertNotNull(interp10, 'Interpretation at α=0.10 should not be null')
+    assertEquals(interp05, interp05BigDecimal, 'BigDecimal alpha should produce the same interpretation')
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/contingency/BoschlooTest.groovy
+++ b/matrix-stats/src/test/groovy/contingency/BoschlooTest.groovy
@@ -105,8 +105,6 @@ class BoschlooTest {
 
   @Test
   void testValidation() {
-    int[][] validTable = [[10, 5], [5, 10]]
-
     // Null table
     assertThrows(IllegalArgumentException) {
       Boschloo.test(null)

--- a/matrix-stats/src/test/groovy/contingency/ChiSquaredTest.groovy
+++ b/matrix-stats/src/test/groovy/contingency/ChiSquaredTest.groovy
@@ -243,6 +243,7 @@ class ChiSquaredTest {
 
     // Should reject null hypothesis at 0.05 level
     assertTrue(result.evaluate(0.05), 'Should reject H0 at 0.05 for strong dependence')
+    assertTrue(result.evaluate(0.05G), 'Should reject H0 at 0.05 for strong dependence with BigDecimal alpha')
     assertTrue(result.evaluate(0.01), 'Should reject H0 at 0.01 for strong dependence')
 
     // Test with independent data

--- a/matrix-stats/src/test/groovy/contingency/CochranMantelHaenszelTest.groovy
+++ b/matrix-stats/src/test/groovy/contingency/CochranMantelHaenszelTest.groovy
@@ -201,7 +201,9 @@ class CochranMantelHaenszelTest {
     def result = CochranMantelHaenszel.test(strata)
 
     String evaluation = result.evaluate()
+    String bigDecimalEvaluation = result.evaluate(0.05G)
     assertNotNull(evaluation, 'Evaluation should not be null')
+    assertEquals(evaluation, bigDecimalEvaluation, 'BigDecimal alpha should produce the same evaluation at the default level')
     assertTrue(evaluation.contains('χ² statistic'), 'Should contain statistic info')
     assertTrue(evaluation.contains('Common odds ratio'), 'Should contain odds ratio')
     assertTrue(evaluation.contains('Conclusion'), 'Should contain conclusion')

--- a/matrix-stats/src/test/groovy/contingency/CochranMantelHaenszelTest.groovy
+++ b/matrix-stats/src/test/groovy/contingency/CochranMantelHaenszelTest.groovy
@@ -115,8 +115,6 @@ class CochranMantelHaenszelTest {
 
   @Test
   void testValidation() {
-    int[][] validStratum = [[12, 8], [6, 14]]
-
     // Null strata list
     assertThrows(IllegalArgumentException) {
       CochranMantelHaenszel.test(null)

--- a/matrix-stats/src/test/groovy/contingency/FisherTest.groovy
+++ b/matrix-stats/src/test/groovy/contingency/FisherTest.groovy
@@ -194,10 +194,10 @@ class FisherTest {
     def result = Fisher.test(table)
 
     assertNotNull(result.confidenceInterval)
-    assertEquals(2, result.confidenceInterval.length)
+    assertEquals(2, result.confidenceInterval.size())
 
-    double lower = result.confidenceInterval[0]
-    double upper = result.confidenceInterval[1]
+    BigDecimal lower = result.confidenceInterval[0]
+    BigDecimal upper = result.confidenceInterval[1]
 
     // Lower bound should be less than odds ratio
     assertTrue(lower < result.oddsRatio, "Lower CI bound should be < odds ratio")

--- a/matrix-stats/src/test/groovy/contingency/FisherTest.groovy
+++ b/matrix-stats/src/test/groovy/contingency/FisherTest.groovy
@@ -179,6 +179,7 @@ class FisherTest {
     def table1 = [[18, 2], [4, 16]]
     def result1 = Fisher.test(table1)
     assertTrue(result1.evaluate(0.05), "Should reject null at 5% level")
+    assertTrue(result1.evaluate(0.05G), "Should reject null at 5% level with BigDecimal alpha")
     assertTrue(result1.evaluate(), "Should reject null with default alpha")
 
     // Non-significant result

--- a/matrix-stats/src/test/groovy/distribution/ChiSquaredDistributionTest.groovy
+++ b/matrix-stats/src/test/groovy/distribution/ChiSquaredDistributionTest.groovy
@@ -86,4 +86,15 @@ class ChiSquaredDistributionTest {
     assertEquals(0.0d, distribution.inverseCumulativeProbability(0.0d), TOLERANCE)
     assertTrue(Double.isInfinite(distribution.inverseCumulativeProbability(1.0d)))
   }
+
+  @Test
+  void testIdiomaticNumberOverloadsReturnBigDecimal() {
+    ChiSquaredDistribution distribution = new ChiSquaredDistribution(2)
+
+    BigDecimal cdf = distribution.cumulativeProbability(5.99)
+    BigDecimal quantile = distribution.inverseCumulativeProbability(0.95)
+
+    assertEquals(0.95d, cdf as double, 1e-2)
+    assertEquals(5.99d, quantile as double, 1e-1)
+  }
 }

--- a/matrix-stats/src/test/groovy/distribution/FDistributionApiTypingTest.groovy
+++ b/matrix-stats/src/test/groovy/distribution/FDistributionApiTypingTest.groovy
@@ -1,0 +1,42 @@
+package distribution
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+import groovy.transform.CompileStatic
+
+import org.junit.jupiter.api.Test
+
+import se.alipsa.matrix.stats.distribution.FDistribution
+
+@CompileStatic
+class FDistributionApiTypingTest {
+
+  @Test
+  void testPrimitiveGroupTypedOverloads() {
+    double[] group1 = [10, 12, 11, 13, 9] as double[]
+    double[] group2 = [14, 15, 13, 16, 14] as double[]
+    double[] group3 = [8, 9, 7, 10, 8] as double[]
+    List<double[]> groups = [group1, group2, group3]
+
+    BigDecimal fValue = FDistribution.oneWayAnovaFValueArrays(groups)
+    BigDecimal pValue = FDistribution.oneWayAnovaPValueArrays(groups)
+
+    assertEquals(26.63d, fValue as double, 0.01d)
+    assertEquals(3.867e-5d, pValue as double, 1e-6d)
+  }
+
+  @Test
+  void testNumericListTypedOverloads() {
+    Collection<List<BigDecimal>> groups = [
+      [10.0, 12.0, 11.0, 13.0, 9.0],
+      [14.0, 15.0, 13.0, 16.0, 14.0],
+      [8.0, 9.0, 7.0, 10.0, 8.0]
+    ]
+
+    BigDecimal fValue = FDistribution.oneWayAnovaFValueFromLists(groups)
+    BigDecimal pValue = FDistribution.oneWayAnovaPValueFromLists(groups)
+
+    assertEquals(26.63d, fValue as double, 0.01d)
+    assertEquals(3.867e-5d, pValue as double, 1e-6d)
+  }
+}

--- a/matrix-stats/src/test/groovy/distribution/FDistributionTest.groovy
+++ b/matrix-stats/src/test/groovy/distribution/FDistributionTest.groovy
@@ -74,6 +74,19 @@ class FDistributionTest {
   }
 
   @Test
+  void testIdiomaticNumberOverloadsReturnBigDecimal() {
+    def dist = new FDistribution(5, 10)
+
+    BigDecimal cdf = dist.cdf(2.5)
+    BigDecimal pValue = dist.pValue(2.5)
+    BigDecimal staticPValue = FDistribution.pValue(4.26, 3, 16)
+
+    assertEquals(0.8979977233557302, cdf as double, TOLERANCE)
+    assertEquals(0.1020022766442698, pValue as double, TOLERANCE)
+    assertEquals(0.021635907788579045, staticPValue as double, TOLERANCE)
+  }
+
+  @Test
   void testOneWayAnovaFValue() {
     // R> group1 <- c(10, 12, 11, 13, 9)
     // R> group2 <- c(14, 15, 13, 16, 14)
@@ -201,5 +214,20 @@ class FDistributionTest {
 
     double pValue = FDistribution.oneWayAnovaPValue([g1, g2, g3, g4])
     assertTrue(pValue < 0.0001, 'p-value should be very small for distinct groups')
+  }
+
+  @Test
+  void testOneWayAnovaIdiomaticListOverloads() {
+    List<List<Integer>> groups = [
+        [10, 12, 11, 13, 9],
+        [14, 15, 13, 16, 14],
+        [8, 9, 7, 10, 8]
+    ]
+
+    BigDecimal fValue = FDistribution.oneWayAnovaFValue(groups)
+    BigDecimal pValue = FDistribution.oneWayAnovaPValue(groups)
+
+    assertEquals(26.63, fValue as double, 0.01)
+    assertEquals(3.867e-5, pValue as double, 1e-6)
   }
 }

--- a/matrix-stats/src/test/groovy/distribution/HypergeometricDistributionTest.groovy
+++ b/matrix-stats/src/test/groovy/distribution/HypergeometricDistributionTest.groovy
@@ -70,4 +70,17 @@ class HypergeometricDistributionTest {
       )
     }
   }
+
+  @Test
+  void testIdiomaticNumberOverloadsReturnBigDecimal() {
+    HypergeometricDistribution distribution = new HypergeometricDistribution(37, 21, 17)
+
+    BigDecimal probability = distribution.probability(10)
+    BigDecimal lowerTail = distribution.cumulativeProbability(10)
+    BigDecimal upperTail = distribution.upperCumulativeProbability(10)
+
+    assertEquals(distribution.probability(10), probability as double, TOLERANCE)
+    assertEquals(distribution.cumulativeProbability(10), lowerTail as double, TOLERANCE)
+    assertEquals(distribution.upperCumulativeProbability(10), upperTail as double, TOLERANCE)
+  }
 }

--- a/matrix-stats/src/test/groovy/distribution/HypergeometricDistributionTest.groovy
+++ b/matrix-stats/src/test/groovy/distribution/HypergeometricDistributionTest.groovy
@@ -83,4 +83,19 @@ class HypergeometricDistributionTest {
     assertEquals(distribution.cumulativeProbability(10), lowerTail as double, TOLERANCE)
     assertEquals(distribution.upperCumulativeProbability(10), upperTail as double, TOLERANCE)
   }
+
+  @Test
+  void testIdiomaticNumberOverloadsRejectNonIntegralInput() {
+    HypergeometricDistribution distribution = new HypergeometricDistribution(37, 21, 17)
+
+    IllegalArgumentException probabilityException = assertThrows(IllegalArgumentException) {
+      distribution.probability(10.5G)
+    }
+    assertEquals('X must be an integer, got 10.5', probabilityException.message)
+
+    IllegalArgumentException cumulativeException = assertThrows(IllegalArgumentException) {
+      distribution.cumulativeProbability(10.5G)
+    }
+    assertEquals('X must be an integer, got 10.5', cumulativeException.message)
+  }
 }

--- a/matrix-stats/src/test/groovy/distribution/NormalDistributionTest.groovy
+++ b/matrix-stats/src/test/groovy/distribution/NormalDistributionTest.groovy
@@ -88,4 +88,15 @@ class NormalDistributionTest {
       assertEquals(p, distribution.cumulativeProbability(x), 1e-10, "Round-trip mismatch for p=$p")
     }
   }
+
+  @Test
+  void testIdiomaticNumberOverloadsReturnBigDecimal() {
+    NormalDistribution distribution = new NormalDistribution(2, 1.5)
+
+    BigDecimal cdf = distribution.cumulativeProbability(2)
+    BigDecimal quantile = distribution.inverseCumulativeProbability(0.5)
+
+    assertEquals(0.5d, cdf as double, TOLERANCE)
+    assertEquals(2.0d, quantile as double, TOLERANCE)
+  }
 }

--- a/matrix-stats/src/test/groovy/distribution/TDistributionTest.groovy
+++ b/matrix-stats/src/test/groovy/distribution/TDistributionTest.groovy
@@ -95,6 +95,21 @@ class TDistributionTest {
   }
 
   @Test
+  void testIdiomaticListAndNumberOverloadsReturnBigDecimal() {
+    def dist = new TDistribution(9)
+    List<Integer> sample1 = [10, 12, 11, 13, 9]
+    List<Integer> sample2 = [14, 15, 13, 16, 14]
+
+    BigDecimal cdf = dist.cdf(1.5)
+    BigDecimal twoTailed = dist.twoTailedPValue(2.262)
+    BigDecimal listPValue = TDistribution.twoSampleTTest(sample1, sample2)
+
+    assertEquals(dist.cdf(1.5d), cdf as double, TOLERANCE)
+    assertEquals(0.05001284550245466, twoTailed as double, TOLERANCE)
+    assertEquals(0.005470215157182601, listPValue as double, TOLERANCE)
+  }
+
+  @Test
   void testOneSampleTTest() {
     // Sample: mean=11.5, sd=1.58, n=10, t=(11.5-10)/(1.58/sqrt(10))=3.0
     // p-value from Apache Commons Math for t=3, df=9

--- a/matrix-stats/src/test/groovy/formula/FormulaDesignMatrixTest.groovy
+++ b/matrix-stats/src/test/groovy/formula/FormulaDesignMatrixTest.groovy
@@ -11,6 +11,7 @@ import groovy.transform.CompileStatic
 import org.junit.jupiter.api.Test
 
 import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.ext.NumberExtension
 import se.alipsa.matrix.stats.formula.ContrastType
 import se.alipsa.matrix.stats.formula.ModelFrame
 import se.alipsa.matrix.stats.formula.ModelFrameResult
@@ -28,15 +29,15 @@ class FormulaDesignMatrixTest {
   void testLogTransform() {
     Matrix data = Matrix.builder()
       .columnNames(['y', 'x'])
-      .rows([[1.0, 1.0], [2.0, Math.E]])
+      .rows([[1.0, 1.0], [2.0, NumberExtension.E]])
       .types([BigDecimal, BigDecimal])
       .build()
 
     ModelFrameResult result = ModelFrame.of('y ~ log(x)', data).evaluate()
 
     assertEquals(['log_x'], result.predictorNames)
-    assertTrue((result.data[0, 'log_x'] as BigDecimal) == 0.0)
-    assertTrue((result.data[1, 'log_x'] as BigDecimal) == 1.0)
+    assertEquals(0.0, result.data[0, 'log_x'] as BigDecimal)
+    assertEquals(NumberExtension.E.log(), result.data[1, 'log_x'] as BigDecimal)
   }
 
   @Test
@@ -65,8 +66,8 @@ class FormulaDesignMatrixTest {
     ModelFrameResult result = ModelFrame.of('y ~ exp(x)', data).evaluate()
 
     assertEquals(['exp_x'], result.predictorNames)
-    assertTrue((result.data[0, 'exp_x'] as BigDecimal) == 1.0)
-    assertTrue((result.data[1, 'exp_x'] as BigDecimal) == Math.E as BigDecimal)
+    assertEquals(1.0, result.data[0, 'exp_x'] as BigDecimal)
+    assertEquals(1.0.exp(), result.data[1, 'exp_x'] as BigDecimal)
   }
 
   @Test
@@ -346,7 +347,7 @@ class FormulaDesignMatrixTest {
     // Factors sorted alphabetically: group before log(x)
     assertEquals(['group_B:log_x'], result.predictorNames)
     assertTrue((result.data[0, 'group_B:log_x'] as BigDecimal) == 0.0)
-    assertTrue((result.data[1, 'group_B:log_x'] as BigDecimal) == Math.log(9.0) as BigDecimal)
+    assertTrue((result.data[1, 'group_B:log_x'] as BigDecimal) == 9.0.log())
   }
 
   @Test
@@ -515,7 +516,7 @@ class FormulaDesignMatrixTest {
     assertEquals(2, result.data.rowCount())
     assertEquals([1], result.droppedRows)
     assertTrue((result.data[0, 'log_x'] as BigDecimal) == 0.0)
-    assertTrue((result.data[1, 'log_x'] as BigDecimal) == Math.log(3.0) as BigDecimal)
+    assertTrue((result.data[1, 'log_x'] as BigDecimal) == 3.0.log())
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/formula/SplineBasisTest.groovy
+++ b/matrix-stats/src/test/groovy/formula/SplineBasisTest.groovy
@@ -36,6 +36,22 @@ class SplineBasisTest {
   }
 
   @Test
+  void testSplineBasisListOverload() {
+    List<BigDecimal> x = [1.0, 2.0, 3.0, 4.0]
+
+    double[][] fromList = SplineBasisExpander.naturalCubicSplineBasis(x, 2)
+    double[][] fromArray = SplineBasisExpander.naturalCubicSplineBasis([1.0d, 2.0d, 3.0d, 4.0d] as double[], 2)
+
+    assertEquals(fromArray.length, fromList.length)
+    assertEquals(fromArray[0].length, fromList[0].length)
+    for (int row = 0; row < fromArray.length; row++) {
+      for (int column = 0; column < fromArray[row].length; column++) {
+        assertEquals(fromArray[row][column], fromList[row][column], 1e-10d)
+      }
+    }
+  }
+
+  @Test
   void testSplineBasisDf1() {
     double[] x = [1.0, 2.0, 3.0] as double[]
     double[][] basis = SplineBasisExpander.naturalCubicSplineBasis(x, 1)

--- a/matrix-stats/src/test/groovy/regression/GamMethodTest.groovy
+++ b/matrix-stats/src/test/groovy/regression/GamMethodTest.groovy
@@ -148,4 +148,11 @@ class GamMethodTest {
     assertTrue(ex.message.contains('offsets'))
   }
 
+  @Test
+  void testGamOptionsAcceptNumberLambda() {
+    GamOptions options = new GamOptions(1.5G)
+
+    assertEquals(1.5d, options.lambda, 1e-10d)
+  }
+
 }

--- a/matrix-stats/src/test/groovy/regression/LoessMethodTest.groovy
+++ b/matrix-stats/src/test/groovy/regression/LoessMethodTest.groovy
@@ -165,4 +165,12 @@ class LoessMethodTest {
     assertTrue(ex.message.contains('offsets'))
   }
 
+  @Test
+  void testLoessOptionsAcceptNumberSpan() {
+    LoessOptions options = new LoessOptions(0.3G, 2)
+
+    assertEquals(0.3d, options.span, 1e-10d)
+    assertEquals(2, options.degree)
+  }
+
 }

--- a/matrix-stats/src/test/groovy/regression/MultipleLinearRegressionTest.groovy
+++ b/matrix-stats/src/test/groovy/regression/MultipleLinearRegressionTest.groovy
@@ -54,4 +54,26 @@ class MultipleLinearRegressionTest {
       new MultipleLinearRegression(response, predictors)
     }
   }
+
+  @Test
+  void testGroovyFacingConstructorAndValueAccessors() {
+    List<BigDecimal> response = [2.1, 3.9, 5.8, 8.2, 9.7, 11.9]
+    List<List<BigDecimal>> predictors = [
+      [1.0, 0.5, 1.2],
+      [1.0, 1.0, 1.8],
+      [1.0, 1.5, 2.1],
+      [1.0, 2.0, 2.9],
+      [1.0, 2.5, 3.2],
+      [1.0, 3.0, 3.8]
+    ]
+
+    MultipleLinearRegression model = new MultipleLinearRegression(response, predictors)
+
+    assertEquals(model.coefficients.length, model.coefficientValues.size())
+    assertEquals(model.standardErrors.length, model.standardErrorValues.size())
+    assertEquals(model.coefficients[0], model.coefficientValues[0] as double, 1e-12d)
+    assertEquals(model.standardErrors[0], model.standardErrorValues[0] as double, 1e-12d)
+    assertEquals(model.residualSumOfSquares, model.residualSumOfSquaresValue as double, 1e-12d)
+    assertEquals(model.errorVariance, model.errorVarianceValue as double, 1e-12d)
+  }
 }

--- a/matrix-stats/src/test/groovy/regression/MultipleLinearRegressionTest.groovy
+++ b/matrix-stats/src/test/groovy/regression/MultipleLinearRegressionTest.groovy
@@ -9,6 +9,7 @@ import org.apache.commons.math3.stat.regression.OLSMultipleLinearRegression
 import org.junit.jupiter.api.Test
 
 import se.alipsa.matrix.stats.regression.MultipleLinearRegression
+import se.alipsa.matrix.stats.util.LeastSquaresKernel
 
 /**
  * Tests for native ordinary least squares multiple linear regression.
@@ -75,5 +76,29 @@ class MultipleLinearRegressionTest {
     assertEquals(model.standardErrors[0], model.standardErrorValues[0] as double, 1e-12d)
     assertEquals(model.residualSumOfSquares, model.residualSumOfSquaresValue as double, 1e-12d)
     assertEquals(model.errorVariance, model.errorVarianceValue as double, 1e-12d)
+  }
+
+  @Test
+  void testGroovyFacingConstructorMatchesLeastSquaresKernel() {
+    List<BigDecimal> response = [2.1, 3.9, 5.8, 8.2, 9.7, 11.9]
+    List<List<BigDecimal>> predictors = [
+      [1.0, 0.5, 1.2],
+      [1.0, 1.0, 1.8],
+      [1.0, 1.5, 2.1],
+      [1.0, 2.0, 2.9],
+      [1.0, 2.5, 3.2],
+      [1.0, 3.0, 3.8]
+    ]
+
+    MultipleLinearRegression model = new MultipleLinearRegression(response, predictors)
+    LeastSquaresKernel.OlsComputation kernel = LeastSquaresKernel.fitMultipleLinearRegression(
+      response.collect { BigDecimal value -> value as double } as double[],
+      predictors.collect { List<BigDecimal> row -> row.collect { BigDecimal value -> value as double } as double[] } as double[][]
+    )
+
+    assertEquals(kernel.coefficients().toList(), model.coefficients.toList())
+    assertEquals(kernel.standardErrors().toList(), model.standardErrors.toList())
+    assertEquals(kernel.residualSumOfSquares(), model.residualSumOfSquares, 1e-12d)
+    assertEquals(kernel.errorVariance(), model.errorVariance, 1e-12d)
   }
 }

--- a/matrix-stats/src/test/groovy/se/alipsa/matrix/stats/timeseries/Section45BenchmarkTest.groovy
+++ b/matrix-stats/src/test/groovy/se/alipsa/matrix/stats/timeseries/Section45BenchmarkTest.groovy
@@ -1,0 +1,325 @@
+package se.alipsa.matrix.stats.timeseries
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+import org.ejml.simple.SimpleMatrix
+import org.ejml.simple.SimpleSVD
+import org.junit.jupiter.api.Test
+
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.core.util.Logger
+import se.alipsa.matrix.stats.linalg.Linalg
+import se.alipsa.matrix.stats.linalg.SvdResult
+import se.alipsa.matrix.stats.regression.MultipleLinearRegression
+import se.alipsa.matrix.stats.solver.BrentSolver
+import se.alipsa.matrix.stats.solver.LinearProgramSolver
+import se.alipsa.matrix.stats.solver.MultivariateObjective
+import se.alipsa.matrix.stats.solver.NelderMeadOptimizer
+import se.alipsa.matrix.stats.solver.UnivariateObjective
+
+/**
+ * Informational section 4.5 benchmarks for the initial hotspot areas identified in PR 1.
+ *
+ * These tests deliberately avoid strict timing assertions because CI environments vary.
+ * Instead they verify output equivalence and log warm benchmark timings for the idiomatic
+ * Groovy-facing path versus the retained primitive kernel or primitive overload.
+ */
+@SuppressWarnings(['DuplicateNumberLiteral', 'MethodName'])
+class Section45BenchmarkTest {
+
+  private static final Logger log = Logger.getLogger(Section45BenchmarkTest)
+  private static final int WARMUPS = 2
+  private static final int RUNS = 5
+
+  @Test
+  void benchmarkLinalgSvdFacadeAgainstPrimitiveKernel() {
+    double[][] values = createDenseMatrix(18)
+    Matrix matrix = toMatrix(values)
+
+    SvdResult groovyResult = Linalg.svd(matrix)
+    double[] primitiveValues = primitiveSingularValues(values)
+    assertEquals(primitiveValues.length, groovyResult.singularValues.size())
+    for (int i = 0; i < primitiveValues.length; i++) {
+      assertEquals(primitiveValues[i], groovyResult.singularValues[i] as double, 1e-10d)
+    }
+
+    List<Long> groovyTimings = benchmarkSamples {
+      for (int i = 0; i < 15; i++) {
+        Linalg.svd(matrix)
+      }
+    }
+    List<Long> primitiveTimings = benchmarkSamples {
+      for (int i = 0; i < 15; i++) {
+        primitiveSingularValues(values)
+      }
+    }
+
+    logBenchmark('linalg.svd(Matrix)', groovyTimings, 'primitive EJML SVD', primitiveTimings)
+  }
+
+  @Test
+  void benchmarkMultipleLinearRegressionListConstructorAgainstPrimitiveConstructor() {
+    RegressionData data = regressionData(160)
+
+    MultipleLinearRegression groovyModel = new MultipleLinearRegression(data.responseValues, data.predictorValues)
+    MultipleLinearRegression primitiveModel = new MultipleLinearRegression(data.response, data.predictors)
+    assertEquals(primitiveModel.coefficients.length, groovyModel.coefficients.length)
+    for (int i = 0; i < primitiveModel.coefficients.length; i++) {
+      assertEquals(primitiveModel.coefficients[i], groovyModel.coefficients[i], 1e-12d)
+    }
+
+    List<Long> groovyTimings = benchmarkSamples {
+      for (int i = 0; i < 40; i++) {
+        new MultipleLinearRegression(data.responseValues, data.predictorValues)
+      }
+    }
+    List<Long> primitiveTimings = benchmarkSamples {
+      for (int i = 0; i < 40; i++) {
+        new MultipleLinearRegression(data.response, data.predictors)
+      }
+    }
+
+    logBenchmark('MultipleLinearRegression(List, List)', groovyTimings, 'MultipleLinearRegression(double[], double[][])', primitiveTimings)
+  }
+
+  @Test
+  void benchmarkBrentSolverNumberOverloadAgainstPrimitiveOverload() {
+    UnivariateObjective scalarObjective = { double x -> x * x * x - x - 2.0d } as UnivariateObjective
+    BrentSolver.SolverResult groovyBrent = BrentSolver.solve(
+      scalarObjective,
+      1.0G,
+      2.0G,
+      0.000000000001G,
+      0.000000000001G,
+      100
+    )
+    BrentSolver.SolverResult primitiveBrent = BrentSolver.solve(
+      scalarObjective,
+      1.0d,
+      2.0d,
+      1e-12d,
+      1e-12d,
+      100
+    )
+    assertEquals(primitiveBrent.root, groovyBrent.root, 1e-12d)
+
+    List<Long> brentGroovyTimings = benchmarkSamples {
+      for (int i = 0; i < 120; i++) {
+        BrentSolver.solve(scalarObjective, 1.0G, 2.0G, 0.000000000001G, 0.000000000001G, 100)
+      }
+    }
+    List<Long> brentPrimitiveTimings = benchmarkSamples {
+      for (int i = 0; i < 120; i++) {
+        BrentSolver.solve(scalarObjective, 1.0d, 2.0d, 1e-12d, 1e-12d, 100)
+      }
+    }
+    logBenchmark('BrentSolver.solve(Number...)', brentGroovyTimings, 'BrentSolver.solve(double...)', brentPrimitiveTimings)
+  }
+
+  @Test
+  void benchmarkLinearProgramSolverListOverloadAgainstPrimitiveOverload() {
+    List<BigDecimal> objectiveValues = [2.0, 1.0, 3.0]
+    List<List<BigDecimal>> constraintValues = [
+      [1.0, 1.0, 0.0],
+      [0.0, 1.0, 1.0]
+    ]
+    List<BigDecimal> rhsValues = [4.0, 3.0]
+    double[] objective = [2.0d, 1.0d, 3.0d] as double[]
+    double[][] constraints = [
+      [1.0d, 1.0d, 0.0d],
+      [0.0d, 1.0d, 1.0d]
+    ] as double[][]
+    double[] rhs = [4.0d, 3.0d] as double[]
+
+    LinearProgramSolver.Solution groovyLp = LinearProgramSolver.minimize(objectiveValues, constraintValues, rhsValues)
+    LinearProgramSolver.Solution primitiveLp = LinearProgramSolver.minimize(objective, constraints, rhs)
+    assertEquals(primitiveLp.value, groovyLp.value, 1e-12d)
+    for (int i = 0; i < primitiveLp.point.length; i++) {
+      assertEquals(primitiveLp.point[i], groovyLp.point[i], 1e-12d)
+    }
+
+    List<Long> lpGroovyTimings = benchmarkSamples {
+      for (int i = 0; i < 90; i++) {
+        LinearProgramSolver.minimize(objectiveValues, constraintValues, rhsValues)
+      }
+    }
+    List<Long> lpPrimitiveTimings = benchmarkSamples {
+      for (int i = 0; i < 90; i++) {
+        LinearProgramSolver.minimize(objective, constraints, rhs)
+      }
+    }
+    logBenchmark('LinearProgramSolver.minimize(List, List, List)', lpGroovyTimings, 'LinearProgramSolver.minimize(double[], double[][], double[])', lpPrimitiveTimings)
+  }
+
+  @Test
+  void benchmarkNelderMeadListOverloadAgainstPrimitiveOverload() {
+    MultivariateObjective vectorObjective = { double[] point ->
+      double dx = point[0] - 1.0d
+      double dy = point[1] + 2.0d
+      dx * dx + dy * dy
+    } as MultivariateObjective
+
+    NelderMeadOptimizer.OptimizationResult groovyNelder = NelderMeadOptimizer.minimize(
+      vectorObjective,
+      [0.0, 0.0],
+      [0.5, 0.5],
+      500,
+      0.000001G,
+      0.000001G
+    )
+    NelderMeadOptimizer.OptimizationResult primitiveNelder = NelderMeadOptimizer.minimize(
+      vectorObjective,
+      [0.0d, 0.0d] as double[],
+      [0.5d, 0.5d] as double[],
+      500,
+      1e-6d,
+      1e-6d
+    )
+    assertEquals(primitiveNelder.value, groovyNelder.value, 1e-9d)
+    assertEquals(primitiveNelder.point[0], groovyNelder.point[0], 1e-6d)
+    assertEquals(primitiveNelder.point[1], groovyNelder.point[1], 1e-6d)
+
+    List<Long> nelderGroovyTimings = benchmarkSamples {
+      for (int i = 0; i < 80; i++) {
+        NelderMeadOptimizer.minimize(vectorObjective, [0.0, 0.0], [0.5, 0.5], 500, 0.000001G, 0.000001G)
+      }
+    }
+    List<Long> nelderPrimitiveTimings = benchmarkSamples {
+      for (int i = 0; i < 80; i++) {
+        NelderMeadOptimizer.minimize(vectorObjective, [0.0d, 0.0d] as double[], [0.5d, 0.5d] as double[], 500, 1e-6d, 1e-6d)
+      }
+    }
+    logBenchmark('NelderMeadOptimizer.minimize(List, List)', nelderGroovyTimings, 'NelderMeadOptimizer.minimize(double[], double[])', nelderPrimitiveTimings)
+  }
+
+  @Test
+  void benchmarkTimeseriesListNormalizationAgainstPrimitiveHelper() {
+    RegressionData data = regressionData(220)
+
+    double[] groovyCoefficients = fitOlsFromLists(data.responseValues, data.predictorValues)
+    double[] primitiveCoefficients = TimeSeriesUtils.fitOLS(data.response, data.predictors)
+    assertEquals(primitiveCoefficients.length, groovyCoefficients.length)
+    for (int i = 0; i < primitiveCoefficients.length; i++) {
+      assertEquals(primitiveCoefficients[i], groovyCoefficients[i], 1e-12d)
+    }
+
+    List<Long> groovyTimings = benchmarkSamples {
+      for (int i = 0; i < 60; i++) {
+        fitOlsFromLists(data.responseValues, data.predictorValues)
+      }
+    }
+    List<Long> primitiveTimings = benchmarkSamples {
+      for (int i = 0; i < 60; i++) {
+        TimeSeriesUtils.fitOLS(data.response, data.predictors)
+      }
+    }
+
+    logBenchmark('timeseries list normalization + fitOLS', groovyTimings, 'TimeSeriesUtils.fitOLS(double[], double[][])', primitiveTimings)
+  }
+
+  private static Matrix toMatrix(double[][] values) {
+    int columnCount = values[0].length
+    Matrix.builder()
+      .columnNames((0..<columnCount).collect { int idx -> "c${idx}" })
+      .rows(values.collect { double[] row -> row.toList() })
+      .types((0..<columnCount).collect { Double })
+      .build()
+  }
+
+  private static double[][] createDenseMatrix(int size) {
+    double[][] values = new double[size][size]
+    for (int row = 0; row < size; row++) {
+      for (int column = 0; column < size; column++) {
+        if (row == column) {
+          values[row][column] = size + row + 1.0d
+        } else {
+          values[row][column] = ((row + column) % 7 + 1) / 20.0d
+        }
+      }
+    }
+    values
+  }
+
+  private static double[] primitiveSingularValues(double[][] values) {
+    SimpleSVD<SimpleMatrix> decomposition = new SimpleMatrix(values).svd()
+    int singularValueCount = Math.min(decomposition.getW().numRows(), decomposition.getW().numCols())
+    double[] singularValues = new double[singularValueCount]
+    for (int i = 0; i < singularValueCount; i++) {
+      singularValues[i] = decomposition.getW().get(i, i)
+    }
+    singularValues
+  }
+
+  private static RegressionData regressionData(int rowCount) {
+    double[] response = new double[rowCount]
+    double[][] predictors = new double[rowCount][3]
+    List<BigDecimal> responseValues = []
+    List<List<BigDecimal>> predictorValues = []
+
+    for (int row = 0; row < rowCount; row++) {
+      double x1 = row / 10.0d
+      double x2 = Math.sin(row / 13.0d)
+      predictors[row][0] = 1.0d
+      predictors[row][1] = x1
+      predictors[row][2] = x2
+      response[row] = 2.5d + 0.75d * x1 - 0.5d * x2 + Math.cos(row / 17.0d) * 0.03d
+      responseValues << BigDecimal.valueOf(response[row])
+      predictorValues << predictors[row].collect { double value -> BigDecimal.valueOf(value) }
+    }
+
+    new RegressionData(
+      response: response,
+      predictors: predictors,
+      responseValues: responseValues,
+      predictorValues: predictorValues
+    )
+  }
+
+  private static double[] fitOlsFromLists(List<? extends Number> responseValues, List<? extends List<? extends Number>> predictorValues) {
+    double[] response = responseValues.collect { Number value -> value as double } as double[]
+    double[][] predictors = predictorValues.collect { List<? extends Number> row ->
+      row.collect { Number value -> value as double } as double[]
+    } as double[][]
+    TimeSeriesUtils.fitOLS(response, predictors)
+  }
+
+  private static List<Long> benchmarkSamples(Closure action) {
+    for (int i = 0; i < WARMUPS; i++) {
+      action.call()
+    }
+
+    List<Long> samples = []
+    for (int i = 0; i < RUNS; i++) {
+      long start = System.nanoTime()
+      action.call()
+      samples << (System.nanoTime() - start)
+    }
+    samples
+  }
+
+  private static void logBenchmark(String groovyLabel, List<Long> groovyTimings, String primitiveLabel, List<Long> primitiveTimings) {
+    log.info(
+      "${groovyLabel} avg=${avgMs(groovyTimings)}ms min=${minMs(groovyTimings)}ms max=${maxMs(groovyTimings)}ms; " +
+      "${primitiveLabel} avg=${avgMs(primitiveTimings)}ms min=${minMs(primitiveTimings)}ms max=${maxMs(primitiveTimings)}ms"
+    )
+  }
+
+  private static String avgMs(List<Long> values) {
+    String.format(Locale.US, '%.2f', ((values.sum() as long) / 1_000_000.0d) / values.size())
+  }
+
+  private static String minMs(List<Long> values) {
+    String.format(Locale.US, '%.2f', (values.min() as long) / 1_000_000.0d)
+  }
+
+  private static String maxMs(List<Long> values) {
+    String.format(Locale.US, '%.2f', (values.max() as long) / 1_000_000.0d)
+  }
+
+  private static class RegressionData {
+    double[] response
+    double[][] predictors
+    List<BigDecimal> responseValues
+    List<List<BigDecimal>> predictorValues
+  }
+}

--- a/matrix-stats/src/test/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtilsTest.groovy
+++ b/matrix-stats/src/test/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtilsTest.groovy
@@ -8,6 +8,8 @@ import groovy.transform.CompileStatic
 
 import org.junit.jupiter.api.Test
 
+import se.alipsa.matrix.stats.util.LeastSquaresKernel
+
 /**
  * Regression tests for shared linear algebra helpers used by the time-series package.
  */
@@ -120,6 +122,20 @@ class TimeSeriesUtilsTest {
   }
 
   @Test
+  void fitOLSMatchesLeastSquaresKernel() {
+    double[][] x = [
+      [1.0, 0.0] as double[],
+      [1.0, 1.0] as double[],
+      [1.0, 2.0] as double[],
+      [1.0, 3.0] as double[],
+      [1.0, 4.0] as double[]
+    ] as double[][]
+    double[] y = [1.2, 2.9, 5.1, 7.05, 9.2] as double[]
+
+    assertArrayEquals(LeastSquaresKernel.fitOls(y, x), TimeSeriesUtils.fitOLS(y, x), 1e-12d)
+  }
+
+  @Test
   void calculateRSSReturnsExpectedValue() {
     double[][] x = [
       [1.0, 0.0] as double[],
@@ -136,6 +152,21 @@ class TimeSeriesUtilsTest {
   }
 
   @Test
+  void calculateRSSMatchesLeastSquaresKernel() {
+    double[][] x = [
+      [1.0, 0.0] as double[],
+      [1.0, 1.0] as double[],
+      [1.0, 2.0] as double[],
+      [1.0, 3.0] as double[],
+      [1.0, 4.0] as double[]
+    ] as double[][]
+    double[] y = [1.2, 2.9, 5.1, 7.05, 9.2] as double[]
+    double[] beta = TimeSeriesUtils.fitOLS(y, x)
+
+    assertEquals(LeastSquaresKernel.calculateResidualSumOfSquares(y, x, beta), TimeSeriesUtils.calculateRSS(y, x, beta), 1e-12d)
+  }
+
+  @Test
   void calculateRSSThrowsOnRaggedMatrix() {
     double[][] x = [
       [1.0, 0.0] as double[],
@@ -146,7 +177,7 @@ class TimeSeriesUtilsTest {
 
     IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
       TimeSeriesUtils.calculateRSS(y, x, beta)
-  }
+    }
 
     assertEquals("Design matrix rows must all have the same length", exception.message)
   }

--- a/matrix-stats/src/test/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtilsTest.groovy
+++ b/matrix-stats/src/test/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtilsTest.groovy
@@ -16,21 +16,21 @@ class TimeSeriesUtilsTest {
 
   @Test
   void solveLinearSystemSolvesWellConditionedSquareSystem() {
-    double[][] A = [
+    double[][] a = [
       [2.0, 1.0, -1.0] as double[],
       [-3.0, -1.0, 2.0] as double[],
       [-2.0, 1.0, 2.0] as double[]
     ] as double[][]
     double[] b = [8.0, -11.0, -3.0] as double[]
 
-    double[] solution = TimeSeriesUtils.solveLinearSystem(A, b)
+    double[] solution = TimeSeriesUtils.solveLinearSystem(a, b)
 
     assertArrayEquals([2.0, 3.0, -1.0] as double[], solution, 1e-12)
   }
 
   @Test
   void solveLinearSystemSolvesWellConditionedOverdeterminedSystem() {
-    double[][] A = [
+    double[][] a = [
       [1.0, 0.0] as double[],
       [1.0, 1.0] as double[],
       [1.0, 2.0] as double[],
@@ -38,21 +38,21 @@ class TimeSeriesUtilsTest {
     ] as double[][]
     double[] b = [1.0, 3.0, 5.0, 7.0] as double[]
 
-    double[] solution = TimeSeriesUtils.solveLinearSystem(A, b)
+    double[] solution = TimeSeriesUtils.solveLinearSystem(a, b)
 
     assertArrayEquals([1.0, 2.0] as double[], solution, 1e-12)
   }
 
   @Test
   void solveLinearSystemThrowsOnSingularSquareMatrix() {
-    double[][] A = [
+    double[][] a = [
       [1.0, 2.0] as double[],
       [2.0, 4.0] as double[]
     ] as double[][]
     double[] b = [3.0, 6.0] as double[]
 
     IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
-      TimeSeriesUtils.solveLinearSystem(A, b)
+      TimeSeriesUtils.solveLinearSystem(a, b)
     }
 
     assertEquals("Singular matrix at column 1 - cannot solve linear system", exception.message)
@@ -60,7 +60,7 @@ class TimeSeriesUtilsTest {
 
   @Test
   void solveLinearSystemThrowsOnSingularOverdeterminedSystem() {
-    double[][] A = [
+    double[][] a = [
       [1.0, 1.0] as double[],
       [1.0, 1.0] as double[],
       [1.0, 1.0] as double[],
@@ -69,7 +69,7 @@ class TimeSeriesUtilsTest {
     double[] b = [2.0, 2.0, 2.0, 2.0] as double[]
 
     IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
-      TimeSeriesUtils.solveLinearSystem(A, b)
+      TimeSeriesUtils.solveLinearSystem(a, b)
     }
 
     assertEquals("Singular matrix at column 1 - cannot solve linear system", exception.message)
@@ -77,12 +77,12 @@ class TimeSeriesUtilsTest {
 
   @Test
   void invertMatrixUsesPartialPivoting() {
-    double[][] A = [
+    double[][] a = [
       [0.0, 1.0] as double[],
       [1.0, 0.0] as double[]
     ] as double[][]
 
-    double[][] inverse = TimeSeriesUtils.invertMatrix(A)
+    double[][] inverse = TimeSeriesUtils.invertMatrix(a)
 
     assertEquals(0.0, inverse[0][0], 1e-12)
     assertEquals(1.0, inverse[0][1], 1e-12)
@@ -92,13 +92,13 @@ class TimeSeriesUtilsTest {
 
   @Test
   void invertMatrixThrowsOnSingularMatrix() {
-    double[][] A = [
+    double[][] a = [
       [1.0, 2.0] as double[],
       [2.0, 4.0] as double[]
     ] as double[][]
 
     IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
-      TimeSeriesUtils.invertMatrix(A)
+      TimeSeriesUtils.invertMatrix(a)
     }
 
     assertEquals("Singular matrix at column 1 - cannot invert matrix", exception.message)
@@ -106,7 +106,7 @@ class TimeSeriesUtilsTest {
 
   @Test
   void fitOLSReturnsExpectedCoefficients() {
-    double[][] X = [
+    double[][] x = [
       [1.0, 0.0] as double[],
       [1.0, 1.0] as double[],
       [1.0, 2.0] as double[],
@@ -114,14 +114,14 @@ class TimeSeriesUtilsTest {
     ] as double[][]
     double[] y = [1.0, 3.0, 5.0, 7.0] as double[]
 
-    double[] beta = TimeSeriesUtils.fitOLS(y, X)
+    double[] beta = TimeSeriesUtils.fitOLS(y, x)
 
     assertArrayEquals([1.0, 2.0] as double[], beta, 1e-12)
   }
 
   @Test
   void calculateRSSReturnsExpectedValue() {
-    double[][] X = [
+    double[][] x = [
       [1.0, 0.0] as double[],
       [1.0, 1.0] as double[],
       [1.0, 2.0] as double[],
@@ -130,14 +130,14 @@ class TimeSeriesUtilsTest {
     double[] y = [1.0, 3.0, 5.0, 7.0] as double[]
     double[] beta = [1.0, 2.0] as double[]
 
-    double rss = TimeSeriesUtils.calculateRSS(y, X, beta)
+    double rss = TimeSeriesUtils.calculateRSS(y, x, beta)
 
     assertEquals(0.0, rss, 1e-12)
   }
 
   @Test
   void calculateRSSThrowsOnRaggedMatrix() {
-    double[][] X = [
+    double[][] x = [
       [1.0, 0.0] as double[],
       [1.0] as double[]
     ] as double[][]
@@ -145,8 +145,8 @@ class TimeSeriesUtilsTest {
     double[] beta = [1.0, 2.0] as double[]
 
     IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
-      TimeSeriesUtils.calculateRSS(y, X, beta)
-    }
+      TimeSeriesUtils.calculateRSS(y, x, beta)
+  }
 
     assertEquals("Design matrix rows must all have the same length", exception.message)
   }

--- a/matrix-stats/src/test/groovy/solver/SolverApiTest.groovy
+++ b/matrix-stats/src/test/groovy/solver/SolverApiTest.groovy
@@ -66,4 +66,13 @@ class SolverApiTest {
     assertEquals(-2.0d, result.pointValues[1] as double, 1e-3d)
     assertEquals(0.0d, result.objectiveValue as double, 1e-6d)
   }
+
+  @Test
+  void testObjectiveInterfacesAcceptGroovyFacingInputs() {
+    UnivariateObjective scalarObjective = { double x -> x * x } as UnivariateObjective
+    MultivariateObjective vectorObjective = { double[] point -> point[0] + point[1] } as MultivariateObjective
+
+    assertEquals(2.25d, scalarObjective.value(1.5G), 1e-10d)
+    assertEquals(3.0d, vectorObjective.value([1.0G, 2.0G]), 1e-10d)
+  }
 }

--- a/matrix-stats/src/test/groovy/solver/SolverApiTest.groovy
+++ b/matrix-stats/src/test/groovy/solver/SolverApiTest.groovy
@@ -1,0 +1,69 @@
+package solver
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+import groovy.transform.CompileStatic
+
+import org.junit.jupiter.api.Test
+
+import se.alipsa.matrix.stats.solver.BrentSolver
+import se.alipsa.matrix.stats.solver.LinearProgramSolver
+import se.alipsa.matrix.stats.solver.MultivariateObjective
+import se.alipsa.matrix.stats.solver.NelderMeadOptimizer
+import se.alipsa.matrix.stats.solver.UnivariateObjective
+
+@CompileStatic
+class SolverApiTest {
+
+  @Test
+  void testBrentSolverNumberOverloadAndValueAccessors() {
+    BrentSolver.SolverResult result = BrentSolver.solve(
+      { double x -> x * x - 2.0d } as UnivariateObjective,
+      0.0G,
+      2.0G,
+      0.000000000001G,
+      0.000000000001G,
+      100
+    )
+
+    assertEquals(Math.sqrt(2.0d), result.rootValue as double, 1e-10d)
+    assertTrue(result.lowerBoundValue <= result.rootValue)
+    assertTrue(result.upperBoundValue >= result.rootValue)
+  }
+
+  @Test
+  void testLinearProgramSolverListOverloadAndValueAccessors() {
+    LinearProgramSolver.Solution result = LinearProgramSolver.minimize(
+      [1.0, 2.0],
+      [[1.0, 1.0]],
+      [1.0]
+    )
+
+    assertEquals(2, result.pointValues.size())
+    assertEquals(1.0d, result.pointValues[0] as double, 1e-10d)
+    assertEquals(0.0d, result.pointValues[1] as double, 1e-10d)
+    assertEquals(1.0d, result.objectiveValue as double, 1e-10d)
+  }
+
+  @Test
+  void testNelderMeadListOverloadAndValueAccessors() {
+    NelderMeadOptimizer.OptimizationResult result = NelderMeadOptimizer.minimize(
+      { double[] point ->
+        double dx = point[0] - 1.0d
+        double dy = point[1] + 2.0d
+        dx * dx + dy * dy
+      } as MultivariateObjective,
+      [0.0, 0.0],
+      [0.5, 0.5],
+      500,
+      0.000001G,
+      0.000001G
+    )
+
+    assertEquals(2, result.pointValues.size())
+    assertEquals(1.0d, result.pointValues[0] as double, 1e-3d)
+    assertEquals(-2.0d, result.pointValues[1] as double, 1e-3d)
+    assertEquals(0.0d, result.objectiveValue as double, 1e-6d)
+  }
+}

--- a/matrix-stats/src/test/groovy/timeseries/AdfGlsTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/AdfGlsTest.groovy
@@ -365,4 +365,17 @@ class AdfGlsTest {
     // For trend-stationary series, should generally reject unit root
     assertTrue(result.statistic <= 0, 'Statistic should be negative')
   }
+
+  @Test
+  void testResultSupportsNumberAlpha() {
+    double[] data = [
+      100, 101, 99, 100, 102, 98, 100, 101, 99, 100,
+      101, 99, 100, 102, 98, 100, 101, 99, 100, 101
+    ] as double[]
+
+    def result = AdfGls.test(data, 0, "drift")
+
+    assertNotNull(result.interpret(0.10G))
+    assertNotNull(result.evaluate(0.10G))
+  }
 }

--- a/matrix-stats/src/test/groovy/timeseries/CcmTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/CcmTest.groovy
@@ -459,4 +459,18 @@ class CcmTest {
     assertEquals(2, result.embeddingDim)
     assertEquals(1, result.timeLag)
   }
+
+  @Test
+  void testGroovyFacingInputsAndValueAccessors() {
+    List<BigDecimal> x = (0..<120).collect { Math.sin(it * 0.1d) + 0.01d * it }
+    List<BigDecimal> y = (0..<120).collect { Math.cos(it * 0.08d) + 0.015d * it }
+
+    def result = Ccm.test(x, y, 3, 1, [20, 40, 60])
+
+    assertEquals([20, 40, 60], result.librarySizeValues)
+    assertEquals(3, result.xmapYValues.size())
+    assertEquals(3, result.ymapXValues.size())
+    assertNotNull(result.xCausesY(0.2G))
+    assertNotNull(result.yCausesX(0.2G))
+  }
 }

--- a/matrix-stats/src/test/groovy/timeseries/CcmTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/CcmTest.groovy
@@ -37,12 +37,12 @@ class CcmTest {
     assertEquals(3, result.embeddingDim)
     assertEquals(1, result.timeLag)
     assertEquals(200, result.seriesLength)
-    assertEquals(5, result.xmapY.length)
-    assertEquals(5, result.ymapX.length)
+    assertEquals(5, result.xmapY.size())
+    assertEquals(5, result.ymapX.size())
 
     // X drives Y, so Y|M(X) should show cross-map skill
     // Note: Due to randomness in library selection, exact causality detection may vary
-    assertTrue(result.ymapX.length > 0, "Should compute cross-map skills")
+    assertFalse(result.ymapX.isEmpty(), "Should compute cross-map skills")
   }
 
   @Test
@@ -148,7 +148,7 @@ class CcmTest {
 
     assertNotNull(result)
     assertNotNull(result.librarySizes)
-    assertTrue(result.librarySizes.length > 0)
+    assertFalse(result.librarySizes.isEmpty())
   }
 
   @Test
@@ -325,7 +325,7 @@ class CcmTest {
     def result = Ccm.test(x, y, 3, 1, [20, 40, 60, 80, 100])
 
     // Library sizes should be sorted
-    for (int i = 0; i < result.librarySizes.length - 1; i++) {
+    for (int i = 0; i < result.librarySizes.size() - 1; i++) {
       assertTrue(result.librarySizes[i] < result.librarySizes[i + 1],
                  "Library sizes should be increasing")
     }
@@ -379,7 +379,7 @@ class CcmTest {
     def result = Ccm.test(x, y, 3, 1, [40])
 
     assertNotNull(result)
-    assertEquals(1, result.librarySizes.length)
+    assertEquals(1, result.librarySizes.size())
     assertEquals(40, result.librarySizes[0])
   }
 
@@ -405,8 +405,8 @@ class CcmTest {
     assertEquals(100, result.seriesLength)
 
     // Arrays should match library sizes
-    assertEquals(result.librarySizes.length, result.xmapY.length)
-    assertEquals(result.librarySizes.length, result.ymapX.length)
+    assertEquals(result.librarySizes.size(), result.xmapY.size())
+    assertEquals(result.librarySizes.size(), result.ymapX.size())
   }
 
   @Test
@@ -428,8 +428,8 @@ class CcmTest {
 
     assertNotNull(result)
     // Chaotic systems should show measurable cross-map skill
-    assertTrue(result.xmapY.length == 4)
-    assertTrue(result.ymapX.length == 4)
+    assertEquals(4, result.xmapY.size())
+    assertEquals(4, result.ymapX.size())
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/timeseries/CcmTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/CcmTest.groovy
@@ -152,6 +152,18 @@ class CcmTest {
   }
 
   @Test
+  void testListOverloadRejectsNonIntegralLibrarySizes() {
+    List<BigDecimal> x = (1..30).collect { int i -> i * 0.1 }
+    List<BigDecimal> y = (1..30).collect { int i -> i * 0.2 }
+
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException) {
+      Ccm.test(x, y, 3, 1, [10.5G, 15])
+    }
+
+    assertEquals('Library size must be an integer, got 10.5', ex.message)
+  }
+
+  @Test
   void testValidation() {
     double[] x = new double[50]
     double[] y = new double[50]

--- a/matrix-stats/src/test/groovy/timeseries/ChowTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/ChowTest.groovy
@@ -380,4 +380,22 @@ class ChowTest {
     assertTrue(result.statistic >= 0)
     assertTrue(result.pValue >= 0 && result.pValue <= 1)
   }
+
+  @Test
+  void testResultSupportsNumberAlpha() {
+    double[] y = new double[20]
+    double[][] X = new double[20][2]
+    Random rnd = new Random(91)
+
+    for (int i = 0; i < 20; i++) {
+      X[i][0] = 1.0
+      X[i][1] = i + 1.0
+      y[i] = 2.0 + 3.0 * (i + 1.0) + (rnd.nextDouble() - 0.5) * 0.05
+    }
+
+    def result = Chow.test(y, X, 10)
+
+    assertNotNull(result.interpret(0.10G))
+    assertNotNull(result.evaluate(0.10G))
+  }
 }

--- a/matrix-stats/src/test/groovy/timeseries/DfTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/DfTest.groovy
@@ -300,4 +300,17 @@ class DfTest {
     assertTrue(result.standardError < 1.0,
                'Standard error should be reasonable')
   }
+
+  @Test
+  void testResultSupportsNumberAlpha() {
+    double[] data = [
+      100, 101, 99, 100, 102, 98, 100, 101, 99, 100,
+      101, 99, 100, 102, 98, 100, 101, 99, 100, 101
+    ] as double[]
+
+    def result = Df.test(data, "drift")
+
+    assertNotNull(result.interpret(0.10G))
+    assertNotNull(result.evaluate(0.10G))
+  }
 }

--- a/matrix-stats/src/test/groovy/timeseries/GrangerTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/GrangerTest.groovy
@@ -291,4 +291,15 @@ class GrangerTest {
     assertNotNull(interp05)
     assertNotNull(interp10)
   }
+
+  @Test
+  void testResultSupportsNumberAlphaEvaluate() {
+    double[] x = (1..30).collect { it + Math.random() * 0.5 } as double[]
+    double[] y = (1..30).collect { it * 1.5 + Math.random() * 0.5 } as double[]
+
+    def result = Granger.test(x, y, 2)
+
+    assertNotNull(result.interpret(0.10G))
+    assertNotNull(result.evaluate(0.10G))
+  }
 }

--- a/matrix-stats/src/test/groovy/timeseries/JohansenApiTypingTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/JohansenApiTypingTest.groovy
@@ -1,0 +1,51 @@
+package timeseries
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotNull
+
+import groovy.transform.CompileStatic
+
+import org.junit.jupiter.api.Test
+
+import se.alipsa.matrix.stats.timeseries.Johansen
+
+@CompileStatic
+class JohansenApiTypingTest {
+
+  @Test
+  void testPrimitiveSeriesTypedOverload() {
+    Random rnd = new Random(42)
+    int n = 80
+    double[] y1 = new double[n]
+    double[] y2 = new double[n]
+    for (int i = 1; i < n; i++) {
+      y1[i] = y1[i - 1] + rnd.nextGaussian() * 0.4d
+      y2[i] = y1[i] + rnd.nextGaussian() * 0.1d
+    }
+    List<double[]> data = [y1, y2]
+
+    Johansen.JohansenResult result = Johansen.testArrays(data, 1)
+
+    assertNotNull(result)
+    assertEquals(2, result.numVariables)
+  }
+
+  @Test
+  void testNumericListTypedOverload() {
+    Random rnd = new Random(84)
+    int n = 80
+    List<BigDecimal> y1 = [0.0]
+    List<BigDecimal> y2 = [0.0]
+    for (int i = 1; i < n; i++) {
+      BigDecimal nextY1 = y1[i - 1] + rnd.nextGaussian() * 0.4d
+      y1 << nextY1
+      y2 << nextY1 + rnd.nextGaussian() * 0.1d
+    }
+    Collection<List<BigDecimal>> data = [y1, y2]
+
+    Johansen.JohansenResult result = Johansen.testSeries(data, 1)
+
+    assertNotNull(result)
+    assertEquals(2, result.numVariables)
+  }
+}

--- a/matrix-stats/src/test/groovy/timeseries/JohansenTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/JohansenTest.groovy
@@ -41,16 +41,16 @@ class JohansenTest {
     assertEquals('const', result.type)
 
     // Should have 2 eigenvalues
-    assertEquals(2, result.eigenvalues.length)
-    assertEquals(2, result.traceStatistics.length)
+    assertEquals(2, result.eigenvalues.size())
+    assertEquals(2, result.traceStatistics.size())
 
     // Eigenvalues should be between 0 and 1
-    for (double eigen : result.eigenvalues) {
+    for (BigDecimal eigen : result.eigenvalues) {
       assertTrue(eigen >= 0 && eigen <= 1, "Eigenvalue should be in [0,1]: ${eigen}")
     }
 
     // Trace statistics should be positive
-    for (double trace : result.traceStatistics) {
+    for (BigDecimal trace : result.traceStatistics) {
       assertTrue(trace >= 0, "Trace statistic should be non-negative: ${trace}")
     }
   }
@@ -103,8 +103,8 @@ class JohansenTest {
 
     assertNotNull(result)
     assertEquals(3, result.numVariables)
-    assertEquals(3, result.eigenvalues.length)
-    assertEquals(3, result.traceStatistics.length)
+    assertEquals(3, result.eigenvalues.size())
+    assertEquals(3, result.traceStatistics.size())
   }
 
   @Test
@@ -268,7 +268,7 @@ class JohansenTest {
     def result = Johansen.test([y1, y2], 1)
 
     // Eigenvalues should be sorted in descending order
-    for (int i = 0; i < result.eigenvalues.length - 1; i++) {
+    for (int i = 0; i < result.eigenvalues.size() - 1; i++) {
       assertTrue(result.eigenvalues[i] >= result.eigenvalues[i+1],
                  "Eigenvalues should be in descending order")
     }
@@ -292,7 +292,7 @@ class JohansenTest {
     def result = Johansen.test([y1, y2], 1)
 
     // Trace statistics should decrease as r increases
-    for (int i = 0; i < result.traceStatistics.length - 1; i++) {
+    for (int i = 0; i < result.traceStatistics.size() - 1; i++) {
       assertTrue(result.traceStatistics[i] >= result.traceStatistics[i+1],
                  "Trace statistics should be non-increasing")
     }
@@ -317,7 +317,7 @@ class JohansenTest {
 
     // Critical values should be available
     assertNotNull(result.criticalValues5pct)
-    assertTrue(result.criticalValues5pct.length > 0)
+    assertFalse(result.criticalValues5pct.isEmpty())
   }
 
   @Test
@@ -346,8 +346,8 @@ class JohansenTest {
 
     assertNotNull(result)
     assertEquals(4, result.numVariables)
-    assertEquals(4, result.eigenvalues.length)
-    assertEquals(4, result.traceStatistics.length)
+    assertEquals(4, result.eigenvalues.size())
+    assertEquals(4, result.traceStatistics.size())
   }
 
   @Test
@@ -420,8 +420,8 @@ class JohansenTest {
     def actual = Johansen.test(data, 2, 'const')
     Map<String, Object> expected = apacheJohansenReference(data, 2, 'const')
 
-    assertArrayEquals(expected.eigenvalues as double[], actual.eigenvalues, 1e-10)
-    assertArrayEquals(expected.traceStatistics as double[], actual.traceStatistics, 1e-9)
+    assertArrayEquals(expected.eigenvalues as double[], actual.eigenvalues.collect { it as double } as double[], 1e-10)
+    assertArrayEquals(expected.traceStatistics as double[], actual.traceStatistics.collect { it as double } as double[], 1e-9)
   }
 
   @Test
@@ -431,8 +431,8 @@ class JohansenTest {
     def actual = Johansen.test(data, 1, 'trend')
     Map<String, Object> expected = apacheJohansenReference(data, 1, 'trend')
 
-    assertArrayEquals(expected.eigenvalues as double[], actual.eigenvalues, 1e-10)
-    assertArrayEquals(expected.traceStatistics as double[], actual.traceStatistics, 1e-9)
+    assertArrayEquals(expected.eigenvalues as double[], actual.eigenvalues.collect { it as double } as double[], 1e-10)
+    assertArrayEquals(expected.traceStatistics as double[], actual.traceStatistics.collect { it as double } as double[], 1e-9)
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/timeseries/JohansenTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/JohansenTest.groovy
@@ -435,6 +435,28 @@ class JohansenTest {
     assertArrayEquals(expected.traceStatistics as double[], actual.traceStatistics, 1e-9)
   }
 
+  @Test
+  void testGroovyFacingInputsAndValueAccessors() {
+    Random rnd = new Random(987)
+    int n = 80
+    List<BigDecimal> y1 = []
+    List<BigDecimal> y2 = []
+
+    BigDecimal current = 0
+    for (int i = 0; i < n; i++) {
+      current += rnd.nextGaussian() * 0.3d
+      y1 << current
+      y2 << current + rnd.nextGaussian() * 0.05d
+    }
+
+    def result = Johansen.test([y1, y2], 1)
+
+    assertEquals(2, result.eigenvalueValues.size())
+    assertEquals(2, result.traceStatisticValues.size())
+    assertFalse(result.criticalValueRows5pct.isEmpty())
+    assertFalse(result.criticalValueRows5pct[0].isEmpty())
+  }
+
   private static List<double[]> sampleCointegratedData(int seed, int n) {
     Random rnd = new Random(seed)
     double[] y1 = new double[n]

--- a/matrix-stats/src/test/groovy/timeseries/PortmanteauTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/PortmanteauTest.groovy
@@ -330,4 +330,18 @@ class PortmanteauTest {
     assertEquals(20, result.lags, 'Should test 20 lags')
     assertNotNull(result, 'Should handle long series')
   }
+
+  @Test
+  void testResultSupportsNumberAlphaEvaluate() {
+    List<Double> data = []
+    Random rnd = new Random(204)
+    for (int i = 0; i < 50; i++) {
+      data.add(rnd.nextGaussian())
+    }
+
+    def result = Portmanteau.ljungBox(data)
+
+    assertNotNull(result.interpret(0.10G))
+    assertNotNull(result.evaluate(0.10G))
+  }
 }

--- a/matrix-stats/src/test/groovy/timeseries/TurningPointTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/TurningPointTest.groovy
@@ -361,4 +361,14 @@ class TurningPointTest {
     def result2 = TurningPoint.test(monotonic)
     assertTrue(result2.statistic < 0, 'Fewer turning points should give negative statistic')
   }
+
+  @Test
+  void testResultSupportsNumberAlphaEvaluate() {
+    double[] data = (1..40).collect { it + Math.sin(it * 0.5d) } as double[]
+
+    def result = TurningPoint.test(data)
+
+    assertNotNull(result.interpret(0.10G))
+    assertNotNull(result.evaluate(0.10G))
+  }
 }

--- a/matrix-stats/src/test/groovy/timeseries/UnitRootTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/UnitRootTest.groovy
@@ -410,4 +410,20 @@ class UnitRootTest {
     assertNotNull(consensus)
     assertTrue(consensus.length() > 0)
   }
+
+  @Test
+  void testSummaryAndConsensusSupportNumberAlpha() {
+    Random rnd = new Random(888)
+    double[] data = new double[60]
+    for (int i = 0; i < 60; i++) {
+      data[i] = rnd.nextGaussian()
+    }
+
+    def result = UnitRoot.test(data)
+
+    assertNotNull(result.summary(0.10G))
+    assertNotNull(result.getConsensus(0.10G))
+    assertNotNull(result.isStationary(0.10G))
+    assertNotNull(result.hasUnitRoot(0.10G))
+  }
 }

--- a/matrix-stats/src/test/groovy/util/LeastSquaresKernelTest.groovy
+++ b/matrix-stats/src/test/groovy/util/LeastSquaresKernelTest.groovy
@@ -1,0 +1,92 @@
+package util
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertThrows
+
+import org.apache.commons.math3.stat.regression.OLSMultipleLinearRegression
+import org.junit.jupiter.api.Test
+
+import se.alipsa.matrix.stats.util.LeastSquaresKernel
+
+class LeastSquaresKernelTest {
+
+  @Test
+  void testFitMultipleLinearRegressionMatchesExpectedCoefficientsAndStandardErrors() {
+    double[] response = [2.1d, 3.9d, 5.8d, 8.2d, 9.7d, 11.9d] as double[]
+    double[][] predictors = [
+      [1.0d, 0.5d, 1.2d],
+      [1.0d, 1.0d, 1.8d],
+      [1.0d, 1.5d, 2.1d],
+      [1.0d, 2.0d, 2.9d],
+      [1.0d, 2.5d, 3.2d],
+      [1.0d, 3.0d, 3.8d]
+    ] as double[][]
+
+    LeastSquaresKernel.OlsComputation result = LeastSquaresKernel.fitMultipleLinearRegression(response, predictors)
+    OLSMultipleLinearRegression apacheModel = new OLSMultipleLinearRegression()
+    apacheModel.noIntercept = true
+    apacheModel.newSampleData(response, predictors)
+    double[] apacheCoefficients = apacheModel.estimateRegressionParameters()
+    double[] apacheResiduals = new double[response.length]
+    for (int row = 0; row < response.length; row++) {
+      double fitted = 0.0d
+      for (int column = 0; column < apacheCoefficients.length; column++) {
+        fitted += predictors[row][column] * apacheCoefficients[column]
+      }
+      apacheResiduals[row] = response[row] - fitted
+    }
+    double apacheResidualSumOfSquares = apacheResiduals.collect { double residual -> residual * residual }.sum() as double
+    double apacheErrorVariance = apacheResidualSumOfSquares / (response.length - predictors[0].length)
+
+    assertArrayEquals(apacheCoefficients, result.coefficients(), 1e-12d)
+    assertArrayEquals(apacheModel.estimateRegressionParametersStandardErrors(), result.standardErrors(), 1e-12d)
+    assertEquals(apacheResidualSumOfSquares, result.residualSumOfSquares(), 1e-12d)
+    assertEquals(apacheErrorVariance, result.errorVariance(), 1e-12d)
+  }
+
+  @Test
+  void testFitOlsMatchesExpectedCoefficients() {
+    double[][] predictors = [
+      [1.0d, 0.0d] as double[],
+      [1.0d, 1.0d] as double[],
+      [1.0d, 2.0d] as double[],
+      [1.0d, 3.0d] as double[]
+    ] as double[][]
+    double[] response = [1.0d, 3.0d, 5.0d, 7.0d] as double[]
+
+    double[] coefficients = LeastSquaresKernel.fitOls(response, predictors)
+
+    assertArrayEquals([1.0d, 2.0d] as double[], coefficients, 1e-12d)
+  }
+
+  @Test
+  void testCalculateResidualSumOfSquaresMatchesExpectedValue() {
+    double[][] predictors = [
+      [1.0d, 0.0d] as double[],
+      [1.0d, 1.0d] as double[],
+      [1.0d, 2.0d] as double[],
+      [1.0d, 3.0d] as double[]
+    ] as double[][]
+    double[] response = [1.0d, 3.0d, 5.0d, 7.0d] as double[]
+    double[] coefficients = [1.0d, 2.0d] as double[]
+
+    assertEquals(0.0d, LeastSquaresKernel.calculateResidualSumOfSquares(response, predictors, coefficients), 1e-12d)
+  }
+
+  @Test
+  void testCalculateResidualSumOfSquaresRejectsRaggedMatrix() {
+    double[][] predictors = [
+      [1.0d, 0.0d] as double[],
+      [1.0d] as double[]
+    ] as double[][]
+    double[] response = [1.0d, 3.0d] as double[]
+    double[] coefficients = [1.0d, 2.0d] as double[]
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      LeastSquaresKernel.calculateResidualSumOfSquares(response, predictors, coefficients)
+    }
+
+    assertEquals("Design matrix rows must all have the same length", exception.message)
+  }
+}


### PR DESCRIPTION
4.1 Clean up the higher-risk public API surfaces together so the migration pattern stays consistent across the numerically dense packages.
4.2 Replace public primitive parameters with idiomatic Groovy-facing inputs.
4.3 Replace public scalar return values with `BigDecimal`.
4.4 Replace public primitive vector/matrix outputs with idiomatic Groovy-facing containers.
4.5 For each hotspot identified in PR 1, benchmark the idiomatic Groovy-facing path against a Java primitive utility.
4.6 For each area benchmarked, decide explicitly whether to:
    - use only the idiomatic Groovy implementation
    - keep an idiomatic Groovy public wrapper over a Java primitive utility
    - defer deeper internal cleanup if the algorithmic risk is too high for the current PR
4.7 Add output-equivalence tests for every retained Java utility path.
4.7.1 Remove or simplify any remaining adapter classes whose primitive bridge methods have become pure delegation only.
4.8 Verification