### PR TITLE
[codex] Implement formula DSL ModelFrame integration

### DIFF
--- a/matrix-stats/req/v2.4.0-groovyFormulas.md
+++ b/matrix-stats/req/v2.4.0-groovyFormulas.md
@@ -320,7 +320,7 @@ GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test
 
 Section 2 adds `ModelFrame` integration for the core DSL from section 1, but does not add transform helpers, `I { ... }`, or fit-method convenience functions.
 
-2.1 [ ] Add a public entry point for Groovy formula model frames.
+2.1 [x] Add a public entry point for Groovy formula model frames.
 
 Proposed API:
 
@@ -330,11 +330,11 @@ static ModelFrame of(Matrix data, @DelegatesTo(value = GroovyFormulaDsl, strateg
 
 This mirrors the existing string API but keeps the data first so the closure can resolve column names against a known Matrix when needed.
 
-2.2 [ ] Preserve the existing string API unchanged.
+2.2 [x] Preserve the existing string API unchanged.
 
 No existing `ModelFrame.of(String, Matrix)` or `ModelFrame.of(NormalizedFormula, Matrix)` behavior should change.
 
-2.3 [ ] Preserve existing `ModelFrame` builder methods.
+2.3 [x] Preserve existing `ModelFrame` builder methods.
 
 The following should work the same after a DSL formula is used:
 
@@ -349,7 +349,7 @@ ModelFrame.of(data) {
   .evaluate()
 ```
 
-2.4 [ ] Validate null inputs.
+2.4 [x] Validate null inputs.
 
 Required failures:
 
@@ -359,7 +359,7 @@ Required failures:
 - closure that returns a spec without response
 - closure that returns a spec without predictors when the existing string path would reject it
 
-2.5 [ ] Define clear error messages for common core DSL misuse.
+2.5 [x] Define clear error messages for common core DSL misuse.
 
 Required examples:
 
@@ -371,15 +371,15 @@ Required examples:
 
 Use `FormulaParseException` for formula-shape violations and `IllegalArgumentException` for API misuse such as null closures or malformed DSL helper calls.
 
-2.6 [ ] Ensure closure delegation does not leak into caller scope unexpectedly.
+2.6 [x] Ensure closure delegation does not leak into caller scope unexpectedly.
 
 Use `DELEGATE_FIRST` deliberately and document the behavior.
 
-2.7 [ ] Decide conflict behavior when a caller variable and a column name have the same identifier.
+2.7 [x] Decide conflict behavior when a caller variable and a column name have the same identifier.
 
 Preferred rule: DSL column lookup wins inside the formula closure; external values must be passed through explicit helpers or environment support.
 
-2.8 [ ] Add core ModelFrame parity tests.
+2.8 [x] Add core ModelFrame parity tests.
 
 Create or extend:
 
@@ -400,7 +400,7 @@ Compare DSL results with equivalent string formulas for:
 - weights and offsets
 - subset handling
 
-2.9 [ ] Add section 2 negative tests.
+2.9 [x] Add section 2 negative tests.
 
 Cover:
 
@@ -410,10 +410,17 @@ Cover:
 - unknown column
 - zero-argument and one-argument `interaction(...)`
 
-2.10 [ ] Run focused section 2 tests and record the exact passing command.
+2.10 [x] Run focused section 2 tests and record the exact passing command.
 
 ```bash
 GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'formula.GroovyFormulaDslTest' --tests 'formula.FormulaModelFrameTest'
+```
+
+Passed:
+
+```bash
+GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'formula.GroovyFormulaDslTest' --tests 'formula.FormulaModelFrameTest'
+GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:codenarcMain :matrix-stats:codenarcTest
 ```
 
 ## 3. Transform and Expression Parity

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ModelFrame.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ModelFrame.groovy
@@ -2,6 +2,8 @@ package se.alipsa.matrix.stats.formula
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Row
+import se.alipsa.matrix.stats.formula.dsl.GroovyFormulaDsl
+import se.alipsa.matrix.stats.formula.dsl.GroovyFormulaSpec
 
 /**
  * Evaluates a formula against a Matrix dataset to produce an expanded design matrix.
@@ -80,6 +82,31 @@ final class ModelFrame {
   static ModelFrame of(NormalizedFormula formula, Matrix data) {
     requireNonNull(formula, 'formula')
     new ModelFrame(null, formula, data)
+  }
+
+  /**
+   * Creates a model frame builder from the Groovy-native formula DSL and data.
+   *
+   * <p>The closure is rehydrated with a {@link GroovyFormulaDsl} delegate and uses
+   * {@link Closure#DELEGATE_FIRST}, so formula names inside the closure resolve against
+   * the DSL before owner properties.</p>
+   *
+   * @param data the input dataset
+   * @param formula the formula DSL closure, for example {@code { y | x + group }}
+   * @return a new builder
+   * @throws IllegalArgumentException if data or the closure is null
+   * @throws FormulaParseException if the closure produces a malformed formula specification
+   */
+  static ModelFrame of(
+    Matrix data,
+    @DelegatesTo(value = GroovyFormulaDsl, strategy = Closure.DELEGATE_FIRST)
+    Closure<GroovyFormulaSpec> formula
+  ) {
+    if (data == null) {
+      throw new IllegalArgumentException('Data cannot be null')
+    }
+    ParsedFormula parsed = Formula.parse(GroovyFormulaDsl.evaluate(formula).render())
+    new ModelFrame(parsed, null, data)
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ModelFrame.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ModelFrame.groovy
@@ -94,7 +94,8 @@ final class ModelFrame {
    * @param data the input dataset
    * @param formula the formula DSL closure, for example {@code { y | x + group }}
    * @return a new builder
-   * @throws IllegalArgumentException if data or the closure is null
+   * @throws IllegalArgumentException if data is null, the closure is null, or the closure
+   *   does not return a {@link GroovyFormulaSpec}
    * @throws FormulaParseException if the closure produces a malformed formula specification
    */
   static ModelFrame of(
@@ -102,9 +103,7 @@ final class ModelFrame {
     @DelegatesTo(value = GroovyFormulaDsl, strategy = Closure.DELEGATE_FIRST)
     Closure<GroovyFormulaSpec> formula
   ) {
-    if (data == null) {
-      throw new IllegalArgumentException('Data cannot be null')
-    }
+    requireNonNull(data, 'data')
     ParsedFormula parsed = Formula.parse(GroovyFormulaDsl.evaluate(formula).render())
     new ModelFrame(parsed, null, data)
   }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaSpec.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaSpec.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.formula.dsl
 
+import se.alipsa.matrix.stats.formula.FormulaParseException
+
 /**
  * Full Groovy formula DSL expression containing response and predictor sides.
  */
@@ -15,8 +17,8 @@ class GroovyFormulaSpec {
    * @param predictors the predictor terms
    */
   GroovyFormulaSpec(TermRef response, TermExpr predictors) {
-    this.response = response
-    this.predictors = TermExpr.requireTerm(predictors, 'predictors')
+    this.response = requireResponse(response)
+    this.predictors = requirePredictors(predictors)
   }
 
   /**
@@ -31,5 +33,19 @@ class GroovyFormulaSpec {
   @Override
   String toString() {
     render()
+  }
+
+  private static TermRef requireResponse(TermRef response) {
+    if (response == null) {
+      throw new FormulaParseException('Formula expression must define a response term such as y | x + group', 0)
+    }
+    response
+  }
+
+  private static TermExpr requirePredictors(TermExpr predictors) {
+    if (predictors == null) {
+      throw new FormulaParseException('Formula expression must define predictor terms such as y | x + group', 0)
+    }
+    predictors
   }
 }

--- a/matrix-stats/src/test/groovy/formula/FormulaModelFrameTest.groovy
+++ b/matrix-stats/src/test/groovy/formula/FormulaModelFrameTest.groovy
@@ -1184,7 +1184,7 @@ class FormulaModelFrameTest {
       ModelFrame.of((Matrix) null, { null } as Closure<GroovyFormulaSpec>)
     }
 
-    assertEquals('Data cannot be null', exception.message)
+    assertEquals('data cannot be null', exception.message)
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/formula/FormulaModelFrameTest.groovy
+++ b/matrix-stats/src/test/groovy/formula/FormulaModelFrameTest.groovy
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull
 import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.junit.jupiter.api.Assertions.assertTrue
 
+import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 
 import org.junit.jupiter.api.Test
@@ -12,17 +13,20 @@ import org.junit.jupiter.api.Test
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Row
 import se.alipsa.matrix.stats.formula.Formula
+import se.alipsa.matrix.stats.formula.FormulaParseException
 import se.alipsa.matrix.stats.formula.ModelFrame
 import se.alipsa.matrix.stats.formula.ModelFrameResult
 import se.alipsa.matrix.stats.formula.NaAction
 import se.alipsa.matrix.stats.formula.NormalizedFormula
 import se.alipsa.matrix.stats.formula.Terms
+import se.alipsa.matrix.stats.formula.dsl.GroovyFormulaSpec
+import se.alipsa.matrix.stats.formula.dsl.TermRef
 
 /**
  * Tests for ModelFrame evaluation pipeline.
  */
 @CompileStatic
-@SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral'])
+@SuppressWarnings(['ClassSize', 'DuplicateNumberLiteral', 'DuplicateStringLiteral'])
 class FormulaModelFrameTest {
 
   @Test
@@ -994,6 +998,355 @@ class FormulaModelFrameTest {
 
     assertEquals(['x'], result.predictorNames)
     assertEquals([10.0, 20.0], result.response)
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFrameMatchesStringFormulaForNumericPredictors() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x', 'z'])
+      .rows([
+        [10.0, 1.0, 2.0],
+        [20.0, 3.0, 4.0],
+        [30.0, 5.0, 6.0],
+      ])
+      .types([BigDecimal, BigDecimal, BigDecimal])
+      .build()
+
+    ModelFrameResult expected = ModelFrame.of('y ~ x + z', data).evaluate()
+    ModelFrameResult actual = ModelFrame.of(data) {
+      y | x + z
+    }.evaluate()
+
+    assertModelFrameParity(expected, actual)
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFrameMatchesStringFormulaForCategoricalEncoding() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x', 'species'])
+      .rows([
+        [1.0, 10.0, 'setosa'],
+        [2.0, 20.0, 'versicolor'],
+        [3.0, 30.0, 'virginica'],
+        [4.0, 40.0, 'setosa'],
+      ])
+      .types([BigDecimal, BigDecimal, String])
+      .build()
+
+    ModelFrameResult expected = ModelFrame.of('y ~ x + species', data).evaluate()
+    ModelFrameResult actual = ModelFrame.of(data) {
+      y | x + species
+    }.evaluate()
+
+    assertModelFrameParity(expected, actual)
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFrameMatchesStringFormulaForInteractions() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x', 'group'])
+      .rows([
+        [1.0, 2.0, 'A'],
+        [2.0, 3.0, 'B'],
+        [3.0, 4.0, 'A'],
+      ])
+      .types([BigDecimal, BigDecimal, String])
+      .build()
+
+    ModelFrameResult expected = ModelFrame.of('y ~ x + group + x:group', data).evaluate()
+    ModelFrameResult actual = ModelFrame.of(data) {
+      y | x + group + (x % group)
+    }.evaluate()
+
+    assertModelFrameParity(expected, actual)
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFrameMatchesStringFormulaForInteractionFunctionAlias() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x', 'group'])
+      .rows([
+        [1.0, 2.0, 'A'],
+        [2.0, 3.0, 'B'],
+        [3.0, 4.0, 'A'],
+      ])
+      .types([BigDecimal, BigDecimal, String])
+      .build()
+
+    ModelFrameResult expected = ModelFrame.of('y ~ x + group + x:group', data).evaluate()
+    ModelFrameResult actual = ModelFrame.of(data) {
+      y | x + group + interaction(x, group)
+    }.evaluate()
+
+    assertModelFrameParity(expected, actual)
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFrameMatchesStringFormulaForAllExpansionAndNoIntercept() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x', 'z', 'id'])
+      .rows([
+        [10.0, 1.0, 2.0, 100.0],
+        [20.0, 3.0, 4.0, 200.0],
+      ])
+      .types([BigDecimal, BigDecimal, BigDecimal, BigDecimal])
+      .build()
+
+    ModelFrameResult allExpected = ModelFrame.of('y ~ . - id', data).evaluate()
+    ModelFrameResult allActual = ModelFrame.of(data) {
+      y | all - id
+    }.evaluate()
+    assertModelFrameParity(allExpected, allActual)
+
+    ModelFrameResult noInterceptExpected = ModelFrame.of('y ~ 0 + x + z', data).evaluate()
+    ModelFrameResult noInterceptActual = ModelFrame.of(data) {
+      y | noIntercept + x + z
+    }.evaluate()
+    assertModelFrameParity(noInterceptExpected, noInterceptActual)
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFrameMatchesStringFormulaForQuotedIdentifiers() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y value', 'gross margin', 'unit price'])
+      .rows([
+        [10.0, 1.5, 3.0],
+        [20.0, 2.5, 4.0],
+      ])
+      .types([BigDecimal, BigDecimal, BigDecimal])
+      .build()
+
+    ModelFrameResult expected = ModelFrame.of('`y value` ~ `gross margin` + `unit price`', data).evaluate()
+    ModelFrameResult actual = ModelFrame.of(data) {
+      col('y value') | col('gross margin') + col('unit price')
+    }.evaluate()
+
+    assertModelFrameParity(expected, actual)
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFramePreservesBuilderMethodsAndMatchesStringFormula() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x', 'group', 'w', 'off', 'active', 'id'])
+      .rows([
+        [10.0, 1.0, 'A', 0.5, 0.1, true, 101.0],
+        [20.0, null, 'B', 1.0, 0.2, true, 102.0],
+        [30.0, 3.0, 'A', 1.5, 0.3, false, 103.0],
+        [40.0, 4.0, 'B', 2.0, 0.4, true, 104.0],
+      ])
+      .types([BigDecimal, BigDecimal, String, BigDecimal, BigDecimal, Boolean, BigDecimal])
+      .build()
+
+    ModelFrame expected = ModelFrame.of('y ~ . - id', data)
+      .weights('w')
+      .offset('off')
+      .subset { Row row -> row['active'] }
+      .naAction(NaAction.OMIT)
+
+    ModelFrame actual = ModelFrame.of(data) {
+      y | all - id
+    }
+      .weights('w')
+      .offset('off')
+      .subset { Row row -> row['active'] }
+      .naAction(NaAction.OMIT)
+
+    assertModelFrameParity(expected.evaluate(), actual.evaluate())
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslOwnerPropertyDoesNotOverrideFormulaColumnReference() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x'])
+      .rows([[10.0, 1.0], [20.0, 2.0]])
+      .types([BigDecimal, BigDecimal])
+      .build()
+    Expando owner = new Expando(x: 'owner-value')
+    Closure<GroovyFormulaSpec> formula = ({ col('y') | x } as Closure<GroovyFormulaSpec>).rehydrate(owner, owner, owner)
+
+    ModelFrameResult expected = ModelFrame.of('`y` ~ x', data).evaluate()
+    ModelFrameResult actual = ModelFrame.of(data, formula).evaluate()
+
+    assertModelFrameParity(expected, actual)
+  }
+
+  @Test
+  void testDslModelFrameNullDataThrowsClearMessage() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      ModelFrame.of((Matrix) null, { null } as Closure<GroovyFormulaSpec>)
+    }
+
+    assertEquals('Data cannot be null', exception.message)
+  }
+
+  @Test
+  void testDslModelFrameNullClosureThrowsClearMessage() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x'])
+      .rows([[1.0, 2.0]])
+      .types([BigDecimal, BigDecimal])
+      .build()
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      ModelFrame.of(data, (Closure<GroovyFormulaSpec>) null)
+    }
+
+    assertEquals('Formula closure cannot be null', exception.message)
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFrameClosureReturningNonFormulaValueThrowsClearMessage() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x', 'z'])
+      .rows([[1.0, 2.0, 3.0]])
+      .types([BigDecimal, BigDecimal, BigDecimal])
+      .build()
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      ModelFrame.of(data) {
+        x + z
+      }
+    }
+
+    assertEquals('Formula closure must return a Groovy formula expression such as y | x + group', exception.message)
+  }
+
+  @Test
+  void testDslModelFrameRejectsMissingResponseSpec() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x'])
+      .rows([[1.0, 2.0]])
+      .types([BigDecimal, BigDecimal])
+      .build()
+
+    FormulaParseException exception = assertThrows(FormulaParseException) {
+      ModelFrame.of(data) {
+        new GroovyFormulaSpec(null, new TermRef('x'))
+      }
+    }
+
+    assertEquals('Formula expression must define a response term such as y | x + group', exception.message)
+  }
+
+  @Test
+  void testDslModelFrameRejectsMissingPredictorsSpec() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x'])
+      .rows([[1.0, 2.0]])
+      .types([BigDecimal, BigDecimal])
+      .build()
+
+    FormulaParseException exception = assertThrows(FormulaParseException) {
+      ModelFrame.of(data) {
+        new GroovyFormulaSpec(new TermRef('y'), null)
+      }
+    }
+
+    assertEquals('Formula expression must define predictor terms such as y | x + group', exception.message)
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFrameUnknownColumnMatchesStringPathError() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x'])
+      .rows([[1.0, 2.0]])
+      .types([BigDecimal, BigDecimal])
+      .build()
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      ModelFrame.of(data) {
+        y | x + z
+      }.evaluate()
+    }
+
+    assertTrue(exception.message.contains('Unknown variable(s) in formula'))
+    assertTrue(exception.message.contains('z'))
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFrameRejectsZeroArgumentInteraction() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x'])
+      .rows([[1.0, 2.0]])
+      .types([BigDecimal, BigDecimal])
+      .build()
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      ModelFrame.of(data) {
+        y | interaction()
+      }
+    }
+
+    assertEquals('interaction(...) requires at least two terms', exception.message)
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFrameRejectsOneArgumentInteraction() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x'])
+      .rows([[1.0, 2.0]])
+      .types([BigDecimal, BigDecimal])
+      .build()
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      ModelFrame.of(data) {
+        y | interaction(x)
+      }
+    }
+
+    assertEquals('interaction(...) requires at least two terms', exception.message)
+  }
+
+  private static void assertModelFrameParity(ModelFrameResult expected, ModelFrameResult actual) {
+    assertEquals(expected.responseName, actual.responseName)
+    assertEquals(expected.response, actual.response)
+    assertEquals(expected.includeIntercept, actual.includeIntercept)
+    assertEquals(expected.predictorNames, actual.predictorNames)
+    assertEquals(expected.weights, actual.weights)
+    assertEquals(expected.offset, actual.offset)
+    assertEquals(expected.droppedRows, actual.droppedRows)
+    assertEquals(expected.formula.asFormulaString(), actual.formula.asFormulaString())
+    assertEquals(expected.data.rowCount(), actual.data.rowCount())
+    assertEquals(expected.data.columnCount(), actual.data.columnCount())
+
+    expected.predictorNames.each { String columnName ->
+      for (int row = 0; row < expected.data.rowCount(); row++) {
+        assertTrue(expected.data[row, columnName] == actual.data[row, columnName])
+      }
+    }
+
+    assertTermsParity(expected.terms, actual.terms)
+  }
+
+  private static void assertTermsParity(Terms expected, Terms actual) {
+    assertEquals(expected.response.asFormulaString(), actual.response.asFormulaString())
+    assertEquals(expected.includeIntercept, actual.includeIntercept)
+    assertEquals(expected.terms.size(), actual.terms.size())
+
+    for (int i = 0; i < expected.terms.size(); i++) {
+      Terms.TermInfo expectedTerm = expected.terms[i]
+      Terms.TermInfo actualTerm = actual.terms[i]
+      assertEquals(expectedTerm.sourceTerm.asFormulaString(), actualTerm.sourceTerm.asFormulaString())
+      assertEquals(expectedTerm.label, actualTerm.label)
+      assertEquals(expectedTerm.columns, actualTerm.columns)
+      assertEquals(expectedTerm.isCategorical, actualTerm.isCategorical)
+      assertEquals(expectedTerm.factorLevels, actualTerm.factorLevels)
+      assertEquals(expectedTerm.isSmooth, actualTerm.isSmooth)
+      assertEquals(expectedTerm.isDropped, actualTerm.isDropped)
+      assertEquals(expectedTerm.droppedReason, actualTerm.droppedReason)
+    }
   }
 
 }


### PR DESCRIPTION
## Summary
- add a data-first `ModelFrame.of(Matrix, Closure<GroovyFormulaSpec>)` entry point for the formula DSL
- preserve string-path semantics for dot expansion and removals by parsing the rendered DSL formula before model-frame evaluation
- add formula-shape validation for missing response and missing predictors
- extend `FormulaModelFrameTest` with parity and negative coverage for section 2 and record completion in the req doc

## Why
Section 2 of `matrix-stats/req/v2.4.0-groovyFormulas.md` requires `ModelFrame` integration for the Groovy formula DSL without changing the existing string APIs. The main behavioral risk was making the DSL path normalize too early, which breaks `all - id` parity because `ModelFrame` needs the parsed form for correct dot expansion.

## Impact
Users can now build model frames directly from the Groovy DSL and keep the existing builder chain for NA handling, weights, offsets, and subsets. Validation failures now report clearer messages for malformed DSL formula shapes.

## Validation
- `GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'formula.GroovyFormulaDslTest' --tests 'formula.FormulaModelFrameTest'`
- `GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
- `git diff --check`