### PR TITLE
Implemented section 3 in matrix-stats.

### DIFF
--- a/matrix-stats/req/v2.4.0-groovyFormulas.md
+++ b/matrix-stats/req/v2.4.0-groovyFormulas.md
@@ -553,13 +553,15 @@ Cover:
 3.10 [x] Run focused section 3 tests and record the exact passing command.
 
 ```bash
-GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'formula.*' --tests 'regression.GamMethodTest' --tests 'regression.LoessMethodTest' --tests 'regression.LmMethodTest'
+GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'formula.*'
+GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:codenarcMain :matrix-stats:codenarcTest
 ```
 
-Passing verification command:
+Passing verification commands:
 
 ```bash
-GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'formula.*' --tests 'regression.GamMethodTest' --tests 'regression.LoessMethodTest' --tests 'regression.LmMethodTest'
+GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'formula.*'
+GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:codenarcMain :matrix-stats:codenarcTest
 ```
 
 ## 4. Fit Convenience Methods

--- a/matrix-stats/req/v2.4.0-groovyFormulas.md
+++ b/matrix-stats/req/v2.4.0-groovyFormulas.md
@@ -427,7 +427,7 @@ GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:codenarcMain :matrix-
 
 Section 3 adds parity with the existing supported string formula subset for transformed terms, polynomial terms, smooth terms, and arithmetic expression terms. This section should land after sections 1 and 2.
 
-3.1 [ ] Implement transform helper methods.
+3.1 [x] Implement transform helper methods.
 
 Required helpers:
 
@@ -444,7 +444,7 @@ s(x, 6)
 
 `smooth(x)` uses the same default smooth-term behavior as the existing string formula `s(x)`. If the current fit method chooses the effective basis size later, document that the default is fit-time/model-frame behavior rather than a DSL-level numeric constant.
 
-3.2 [ ] Implement expression-term support for `I { ... }`.
+3.2 [x] Implement expression-term support for `I { ... }`.
 
 `I { ... }` must match the existing supported string `I(...)` subset. It should allow arithmetic expression terms without making ordinary formula `+` ambiguous.
 
@@ -464,7 +464,7 @@ is evaluated with an `ExpressionDsl` delegate where `x` is an expression variabl
 
 The DSL may optionally support `I(expr)` for already-built expression objects, but the closure form is the required API because it solves the operator ambiguity.
 
-3.3 [ ] Define and test the `ExpressionDsl` operator scope before implementation.
+3.3 [x] Define and test the `ExpressionDsl` operator scope before implementation.
 
 The `ExpressionDsl` used inside `I { ... }` must match the currently supported string `I(...)` arithmetic subset. At minimum, audit the existing parser and then either support or explicitly reject:
 
@@ -480,7 +480,7 @@ The `ExpressionDsl` used inside `I { ... }` must match the currently supported s
 
 Do not over-promise arithmetic operators that the string parser does not already support. If the parser supports less than the minimum arithmetic set above, document the narrower scope in README/tutorial examples and add negative tests for unsupported operators.
 
-3.4 [ ] Reject transformed responses explicitly.
+3.4 [x] Reject transformed responses explicitly.
 
 These should fail with the same effective limitation as string formulas:
 
@@ -496,7 +496,7 @@ Transformed responses are not supported: log(y) | x. Move transforms to the pred
 
 Use `FormulaParseException` for transformed responses.
 
-3.5 [ ] Ensure unsupported smooth interactions fail consistently.
+3.5 [x] Ensure unsupported smooth interactions fail consistently.
 
 These should fail like the string formula equivalents:
 
@@ -511,7 +511,7 @@ Required error example:
 Smooth terms cannot be used inside interactions: smooth(x) % z
 ```
 
-3.6 [ ] Ensure parity with the existing string formula subset.
+3.6 [x] Ensure parity with the existing string formula subset.
 
 At minimum, support the Groovy equivalents for:
 
@@ -522,7 +522,7 @@ At minimum, support the Groovy equivalents for:
 
 Any supported string formula subset feature missing from the DSL is a blocker for completing section 3.
 
-3.7 [ ] Add section 3 syntax tests.
+3.7 [x] Add section 3 syntax tests.
 
 Cover:
 
@@ -532,7 +532,7 @@ Cover:
 - `y | smooth(time, 6)`
 - `y | s(time, 6)`
 
-3.8 [ ] Add section 3 ModelFrame parity tests.
+3.8 [x] Add section 3 ModelFrame parity tests.
 
 Compare DSL results with equivalent string formulas for:
 
@@ -541,7 +541,7 @@ Compare DSL results with equivalent string formulas for:
 - polynomial terms
 - smooth terms
 
-3.9 [ ] Add section 3 negative tests.
+3.9 [x] Add section 3 negative tests.
 
 Cover:
 
@@ -550,7 +550,13 @@ Cover:
 - malformed arithmetic expression inside `I { ... }`
 - unsupported arithmetic operators inside `I { ... }`, if any are outside the supported string parser subset
 
-3.10 [ ] Run focused section 3 tests and record the exact passing command.
+3.10 [x] Run focused section 3 tests and record the exact passing command.
+
+```bash
+GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'formula.*' --tests 'regression.GamMethodTest' --tests 'regression.LoessMethodTest' --tests 'regression.LmMethodTest'
+```
+
+Passing verification command:
 
 ```bash
 GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'formula.*' --tests 'regression.GamMethodTest' --tests 'regression.LoessMethodTest' --tests 'regression.LmMethodTest'

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ModelFrame.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ModelFrame.groovy
@@ -270,7 +270,10 @@ final class ModelFrame {
     }
 
     // Stage 4: Validate response
-    String responseName = extractResponseName(normalized.response)
+    String responseName = extractResponseName(
+      normalized.response,
+      parsedFormula?.source ?: normalized.asFormulaString()
+    )
     validateResponseColumn(responseName)
 
     // Stage 4: Validate all predictor variables
@@ -492,7 +495,7 @@ final class ModelFrame {
     }
   }
 
-  private static String extractResponseName(FormulaExpression response) {
+  private static String extractResponseName(FormulaExpression response, String formulaSource) {
     FormulaExpression unwrapped = response
     while (unwrapped instanceof FormulaExpression.Grouping) {
       unwrapped = (unwrapped as FormulaExpression.Grouping).expression
@@ -500,8 +503,9 @@ final class ModelFrame {
     if (unwrapped instanceof FormulaExpression.Variable) {
       return (unwrapped as FormulaExpression.Variable).name
     }
-    throw new IllegalArgumentException(
-      "Transformed responses are not yet supported; use a raw variable on the left-hand side, got: ${response.asFormulaString()}"
+    throw new FormulaParseException(
+      "Transformed responses are not supported: ${formulaSource}. Move transforms to the predictor side.",
+      unwrapped.start
     )
   }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/BinaryTermExpr.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/BinaryTermExpr.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.formula.dsl
 
+import groovy.transform.CompileDynamic
+
 /**
  * Binary additive or subtractive formula term expression.
  */
@@ -20,6 +22,17 @@ class BinaryTermExpr extends TermExpr {
     this.left = requireTerm(left, 'left')
     this.operator = requireOperator(operator)
     this.right = requireTerm(right, 'right')
+  }
+
+  /**
+   * Builds a full formula expression using this term as the response.
+   *
+   * @param predictors the predictor-side term expression
+   * @return the full formula specification
+   */
+  @CompileDynamic
+  GroovyFormulaSpec or(TermExpr predictors) {
+    new GroovyFormulaSpec(this, requireTerm(predictors, 'predictors'))
   }
 
   @Override

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/ExpressionDsl.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/ExpressionDsl.groovy
@@ -1,0 +1,272 @@
+package se.alipsa.matrix.stats.formula.dsl
+
+import groovy.transform.CompileDynamic
+import groovy.transform.PackageScope
+
+/**
+ * Internal arithmetic-expression DSL used inside {@code I { ... }} closures.
+ */
+@PackageScope
+final class ExpressionDsl {
+
+  private static final String INVALID_EXPRESSION_MESSAGE =
+    'I { ... } must return an arithmetic expression such as x + 1'
+
+  @CompileDynamic
+  static ExpressionExpr evaluate(
+    @DelegatesTo(value = ExpressionDsl, strategy = Closure.DELEGATE_FIRST)
+    Closure<?> closure
+  ) {
+    if (closure == null) {
+      throw new IllegalArgumentException('I { ... } cannot be null')
+    }
+    ExpressionDsl dsl = new ExpressionDsl()
+    Closure cloned = closure.rehydrate(dsl, closure.owner, closure.thisObject)
+    cloned.resolveStrategy = Closure.DELEGATE_FIRST
+    def result
+    use(ExpressionNumberOperators) {
+      result = cloned.call()
+    }
+    if (result instanceof ExpressionExpr) {
+      return result as ExpressionExpr
+    }
+    if (result instanceof Number) {
+      return new ExpressionNumberExpr(result as Number)
+    }
+    throw new IllegalArgumentException(INVALID_EXPRESSION_MESSAGE)
+  }
+
+  ExpressionVariableExpr propertyMissing(String name) {
+    new ExpressionVariableExpr(name)
+  }
+
+  ExpressionVariableExpr col(String name) {
+    new ExpressionVariableExpr(name, true)
+  }
+
+  ExpressionFunctionExpr log(Object expression) {
+    new ExpressionFunctionExpr('log', [ExpressionExpr.coerce(expression, 'expression')])
+  }
+
+  ExpressionFunctionExpr sqrt(Object expression) {
+    new ExpressionFunctionExpr('sqrt', [ExpressionExpr.coerce(expression, 'expression')])
+  }
+
+  ExpressionFunctionExpr exp(Object expression) {
+    new ExpressionFunctionExpr('exp', [ExpressionExpr.coerce(expression, 'expression')])
+  }
+}
+
+@PackageScope
+abstract class ExpressionExpr {
+
+  ExpressionExpr plus(Object other) {
+    new ExpressionBinaryExpr(this, '+', coerce(other, 'other'))
+  }
+
+  ExpressionExpr minus(Object other) {
+    new ExpressionBinaryExpr(this, '-', coerce(other, 'other'))
+  }
+
+  ExpressionExpr multiply(Object other) {
+    new ExpressionBinaryExpr(this, '*', coerce(other, 'other'))
+  }
+
+  ExpressionExpr div(Object other) {
+    new ExpressionBinaryExpr(this, '/', coerce(other, 'other'))
+  }
+
+  ExpressionExpr power(Object other) {
+    new ExpressionBinaryExpr(this, '^', coerce(other, 'other'))
+  }
+
+  ExpressionExpr negative() {
+    new ExpressionUnaryExpr('-', this)
+  }
+
+  ExpressionExpr positive() {
+    this
+  }
+
+  Object remainder(Object other) {
+    throw new IllegalArgumentException("Unsupported arithmetic operator '%' in I { ... }")
+  }
+
+  abstract String render()
+
+  static ExpressionExpr coerce(Object value, String label) {
+    if (value instanceof ExpressionExpr) {
+      return value as ExpressionExpr
+    }
+    if (value instanceof Number) {
+      return new ExpressionNumberExpr(value as Number)
+    }
+    throw new IllegalArgumentException("${label} must be a number or arithmetic expression")
+  }
+
+  static String renderNumber(Number value) {
+    BigDecimal decimal = value as BigDecimal
+    BigDecimal normalized = decimal.stripTrailingZeros()
+    normalized.scale() <= 0 ? normalized.toPlainString() : normalized.toPlainString()
+  }
+
+  static int precedence(String operator) {
+    switch (operator) {
+      case '^' -> 3
+      case '*', '/' -> 2
+      case '+', '-' -> 1
+      default -> 0
+    }
+  }
+}
+
+@PackageScope
+final class ExpressionVariableExpr extends ExpressionExpr {
+
+  final String name
+  final boolean quoted
+
+  ExpressionVariableExpr(String name, boolean quoted = false) {
+    this.name = IdentifierRenderingSupport.requireNonBlank(name, 'name')
+    this.quoted = quoted
+  }
+
+  @Override
+  String render() {
+    IdentifierRenderingSupport.renderIdentifier(name, quoted)
+  }
+}
+
+@PackageScope
+final class ExpressionNumberExpr extends ExpressionExpr {
+
+  final Number value
+
+  ExpressionNumberExpr(Number value) {
+    if (value == null) {
+      throw new IllegalArgumentException('value cannot be null')
+    }
+    this.value = value
+  }
+
+  @Override
+  String render() {
+    renderNumber(value)
+  }
+}
+
+@PackageScope
+final class ExpressionUnaryExpr extends ExpressionExpr {
+
+  final String operator
+  final ExpressionExpr expression
+
+  ExpressionUnaryExpr(String operator, ExpressionExpr expression) {
+    this.operator = IdentifierRenderingSupport.requireNonBlank(operator, 'operator')
+    this.expression = ExpressionExpr.coerce(expression, 'expression')
+  }
+
+  @Override
+  String render() {
+    String inner = expression instanceof ExpressionBinaryExpr ? "(${expression.render()})" : expression.render()
+    "${operator}${inner}"
+  }
+}
+
+@PackageScope
+final class ExpressionBinaryExpr extends ExpressionExpr {
+
+  final ExpressionExpr left
+  final String operator
+  final ExpressionExpr right
+
+  ExpressionBinaryExpr(ExpressionExpr left, String operator, ExpressionExpr right) {
+    this.left = ExpressionExpr.coerce(left, 'left')
+    this.operator = requireOperator(operator)
+    this.right = ExpressionExpr.coerce(right, 'right')
+  }
+
+  @Override
+  String render() {
+    "${formatOperand(left, true)} ${operator} ${formatOperand(right, false)}"
+  }
+
+  private String formatOperand(ExpressionExpr expression, boolean leftSide) {
+    if (expression instanceof ExpressionBinaryExpr) {
+      ExpressionBinaryExpr binary = expression as ExpressionBinaryExpr
+      int currentPrecedence = precedence(operator)
+      int childPrecedence = precedence(binary.operator)
+      boolean needsParentheses = childPrecedence < currentPrecedence ||
+        (!leftSide && operator == '^' && childPrecedence == currentPrecedence)
+      if (needsParentheses) {
+        return "(${binary.render()})"
+      }
+    }
+    expression.render()
+  }
+
+  private static String requireOperator(String operator) {
+    if (!(operator in ['+', '-', '*', '/', '^'])) {
+      throw new IllegalArgumentException("Unsupported arithmetic operator: ${operator}")
+    }
+    operator
+  }
+}
+
+@PackageScope
+final class ExpressionFunctionExpr extends ExpressionExpr {
+
+  final String name
+  final List<ExpressionExpr> arguments
+
+  ExpressionFunctionExpr(String name, List<ExpressionExpr> arguments) {
+    this.name = IdentifierRenderingSupport.requireNonBlank(name, 'name')
+    this.arguments = copyArguments(arguments)
+  }
+
+  @Override
+  String render() {
+    "${name}(${arguments.collect { ExpressionExpr argument -> argument.render() }.join(', ')})"
+  }
+
+  private static List<ExpressionExpr> copyArguments(List<ExpressionExpr> arguments) {
+    if (arguments == null || arguments.isEmpty()) {
+      throw new IllegalArgumentException('arguments cannot be null or empty')
+    }
+    if (arguments.any { ExpressionExpr argument -> argument == null }) {
+      throw new IllegalArgumentException('arguments cannot contain null values')
+    }
+    List.copyOf(arguments)
+  }
+}
+
+@PackageScope
+final class ExpressionNumberOperators {
+
+  private ExpressionNumberOperators() {
+  }
+
+  static ExpressionExpr plus(Number self, ExpressionExpr other) {
+    new ExpressionBinaryExpr(new ExpressionNumberExpr(self), '+', other)
+  }
+
+  static ExpressionExpr minus(Number self, ExpressionExpr other) {
+    new ExpressionBinaryExpr(new ExpressionNumberExpr(self), '-', other)
+  }
+
+  static ExpressionExpr multiply(Number self, ExpressionExpr other) {
+    new ExpressionBinaryExpr(new ExpressionNumberExpr(self), '*', other)
+  }
+
+  static ExpressionExpr div(Number self, ExpressionExpr other) {
+    new ExpressionBinaryExpr(new ExpressionNumberExpr(self), '/', other)
+  }
+
+  static ExpressionExpr power(Number self, ExpressionExpr other) {
+    new ExpressionBinaryExpr(new ExpressionNumberExpr(self), '^', other)
+  }
+
+  static Object remainder(Number self, ExpressionExpr other) {
+    throw new IllegalArgumentException("Unsupported arithmetic operator '%' in I { ... }")
+  }
+}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/ExpressionDsl.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/ExpressionDsl.groovy
@@ -107,7 +107,7 @@ abstract class ExpressionExpr {
   static String renderNumber(Number value) {
     BigDecimal decimal = value as BigDecimal
     BigDecimal normalized = decimal.stripTrailingZeros()
-    normalized.scale() <= 0 ? normalized.toPlainString() : normalized.toPlainString()
+    normalized.toPlainString()
   }
 
   static int precedence(String operator) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/FunctionTermExpr.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/FunctionTermExpr.groovy
@@ -1,0 +1,46 @@
+package se.alipsa.matrix.stats.formula.dsl
+
+import groovy.transform.PackageScope
+
+/**
+ * Internal function-style term such as {@code log(x)} or {@code s(x, 6)}.
+ */
+@PackageScope
+final class FunctionTermExpr extends TermExpr {
+
+  final String name
+  final List<Object> arguments
+
+  FunctionTermExpr(String name, List<Object> arguments) {
+    this.name = IdentifierRenderingSupport.requireNonBlank(name, 'name')
+    this.arguments = copyArguments(arguments)
+  }
+
+  @Override
+  String render() {
+    "${name}(${arguments.collect { Object argument -> renderArgument(argument) }.join(', ')})"
+  }
+
+  private static List<Object> copyArguments(List<Object> arguments) {
+    if (arguments == null || arguments.isEmpty()) {
+      throw new IllegalArgumentException('arguments cannot be null or empty')
+    }
+    if (arguments.any { Object argument -> argument == null }) {
+      throw new IllegalArgumentException('arguments cannot contain null values')
+    }
+    List.copyOf(arguments)
+  }
+
+  private static String renderArgument(Object argument) {
+    if (argument instanceof TermExpr) {
+      return (argument as TermExpr).render()
+    }
+    if (argument instanceof ExpressionExpr) {
+      return (argument as ExpressionExpr).render()
+    }
+    if (argument instanceof Number) {
+      return ExpressionExpr.renderNumber(argument as Number)
+    }
+    throw new IllegalArgumentException("Unsupported function argument type: ${argument.class.simpleName}")
+  }
+}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/FunctionTermExpr.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/FunctionTermExpr.groovy
@@ -1,9 +1,13 @@
 package se.alipsa.matrix.stats.formula.dsl
 
+import groovy.transform.CompileDynamic
 import groovy.transform.PackageScope
 
 /**
  * Internal function-style term such as {@code log(x)} or {@code s(x, 6)}.
+ *
+ * <p>The heterogeneous {@code arguments} list is internal storage for already-validated
+ * DSL nodes: {@link TermExpr}, {@link ExpressionExpr}, and numeric literals.</p>
  */
 @PackageScope
 final class FunctionTermExpr extends TermExpr {
@@ -14,6 +18,17 @@ final class FunctionTermExpr extends TermExpr {
   FunctionTermExpr(String name, List<Object> arguments) {
     this.name = IdentifierRenderingSupport.requireNonBlank(name, 'name')
     this.arguments = copyArguments(arguments)
+  }
+
+  /**
+   * Builds a full formula expression using this term as the response.
+   *
+   * @param predictors the predictor-side term expression
+   * @return the full formula specification
+   */
+  @CompileDynamic
+  GroovyFormulaSpec or(TermExpr predictors) {
+    new GroovyFormulaSpec(this, requireTerm(predictors, 'predictors'))
   }
 
   @Override

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaDsl.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaDsl.groovy
@@ -165,10 +165,15 @@ class GroovyFormulaDsl {
   /**
    * Creates an identity expression term from an arithmetic-expression closure.
    *
+   * <p>The closure is evaluated against {@link ExpressionDsl}, not the outer formula DSL, so
+   * operators such as {@code +} and {@code *} build arithmetic expressions instead of formula
+   * terms. For example: {@code y | I { (x + 1) * z }}.</p>
+   *
    * @param expression the arithmetic-expression closure
    * @return the identity term
    */
   @CompileDynamic
+  @SuppressWarnings('MethodName')
   TermExpr I(
     @DelegatesTo(value = ExpressionDsl, strategy = Closure.DELEGATE_FIRST)
     Closure<?> expression

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaDsl.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaDsl.groovy
@@ -74,6 +74,109 @@ class GroovyFormulaDsl {
   }
 
   /**
+   * Creates a logarithm transform term.
+   *
+   * @param expression the transformed input
+   * @return the transform term
+   */
+  TermExpr log(TermExpr expression) {
+    new FunctionTermExpr('log', [expression])
+  }
+
+  /**
+   * Creates a square-root transform term.
+   *
+   * @param expression the transformed input
+   * @return the transform term
+   */
+  TermExpr sqrt(TermExpr expression) {
+    new FunctionTermExpr('sqrt', [expression])
+  }
+
+  /**
+   * Creates an exponential transform term.
+   *
+   * @param expression the transformed input
+   * @return the transform term
+   */
+  TermExpr exp(TermExpr expression) {
+    new FunctionTermExpr('exp', [expression])
+  }
+
+  /**
+   * Creates a polynomial expansion term.
+   *
+   * @param expression the base term
+   * @param degree the polynomial degree
+   * @return the polynomial term
+   */
+  TermExpr poly(TermExpr expression, Number degree) {
+    if (degree == null) {
+      throw new IllegalArgumentException('degree cannot be null')
+    }
+    new FunctionTermExpr('poly', [expression, degree])
+  }
+
+  /**
+   * Creates a smooth term using the default basis size.
+   *
+   * @param expression the smooth input
+   * @return the smooth term
+   */
+  TermExpr smooth(TermExpr expression) {
+    new FunctionTermExpr('s', [expression])
+  }
+
+  /**
+   * Creates a smooth term with an explicit basis size.
+   *
+   * @param expression the smooth input
+   * @param df the requested degrees of freedom
+   * @return the smooth term
+   */
+  TermExpr smooth(TermExpr expression, Number df) {
+    if (df == null) {
+      throw new IllegalArgumentException('df cannot be null')
+    }
+    new FunctionTermExpr('s', [expression, df])
+  }
+
+  /**
+   * Alias for {@link #smooth(TermExpr)}.
+   *
+   * @param expression the smooth input
+   * @return the smooth term
+   */
+  TermExpr s(TermExpr expression) {
+    smooth(expression)
+  }
+
+  /**
+   * Alias for {@link #smooth(TermExpr, Number)}.
+   *
+   * @param expression the smooth input
+   * @param df the requested degrees of freedom
+   * @return the smooth term
+   */
+  TermExpr s(TermExpr expression, Number df) {
+    smooth(expression, df)
+  }
+
+  /**
+   * Creates an identity expression term from an arithmetic-expression closure.
+   *
+   * @param expression the arithmetic-expression closure
+   * @return the identity term
+   */
+  @CompileDynamic
+  TermExpr I(
+    @DelegatesTo(value = ExpressionDsl, strategy = Closure.DELEGATE_FIRST)
+    Closure<?> expression
+  ) {
+    new FunctionTermExpr('I', [ExpressionDsl.evaluate(expression)])
+  }
+
+  /**
    * Creates an interaction expression from two or more terms.
    *
    * @param first the first term

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaSpec.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaSpec.groovy
@@ -1,10 +1,12 @@
 package se.alipsa.matrix.stats.formula.dsl
 
+import groovy.transform.CompileDynamic
 import se.alipsa.matrix.stats.formula.FormulaParseException
 
 /**
  * Full Groovy formula DSL expression containing response and predictor sides.
  */
+@CompileDynamic
 class GroovyFormulaSpec {
 
   final TermExpr response
@@ -27,9 +29,16 @@ class GroovyFormulaSpec {
    * @return the rendered formula source
    */
   String render() {
-    if (response instanceof FunctionTermExpr) {
+    if (!(response instanceof TermRef)) {
+      String renderedDsl = "${response.render()} | ${predictors.render()}"
+      if (response instanceof FunctionTermExpr) {
+        throw new FormulaParseException(
+          "Transformed responses are not supported: ${renderedDsl}. Move transforms to the predictor side.",
+          0
+        )
+      }
       throw new FormulaParseException(
-        "Transformed responses are not supported: ${response.render()} | ${predictors.render()}. Move transforms to the predictor side.",
+        "Response must be a single variable in the Groovy formula DSL: ${renderedDsl}",
         0
       )
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaSpec.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaSpec.groovy
@@ -7,7 +7,7 @@ import se.alipsa.matrix.stats.formula.FormulaParseException
  */
 class GroovyFormulaSpec {
 
-  final TermRef response
+  final TermExpr response
   final TermExpr predictors
 
   /**
@@ -16,7 +16,7 @@ class GroovyFormulaSpec {
    * @param response the response term
    * @param predictors the predictor terms
    */
-  GroovyFormulaSpec(TermRef response, TermExpr predictors) {
+  GroovyFormulaSpec(TermExpr response, TermExpr predictors) {
     this.response = requireResponse(response)
     this.predictors = requirePredictors(predictors)
   }
@@ -27,6 +27,12 @@ class GroovyFormulaSpec {
    * @return the rendered formula source
    */
   String render() {
+    if (response instanceof FunctionTermExpr) {
+      throw new FormulaParseException(
+        "Transformed responses are not supported: ${response.render()} | ${predictors.render()}. Move transforms to the predictor side.",
+        0
+      )
+    }
     "${response.render()} ~ ${predictors.render()}"
   }
 
@@ -35,7 +41,7 @@ class GroovyFormulaSpec {
     render()
   }
 
-  private static TermRef requireResponse(TermRef response) {
+  private static TermExpr requireResponse(TermExpr response) {
     if (response == null) {
       throw new FormulaParseException('Formula expression must define a response term such as y | x + group', 0)
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaSpec.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaSpec.groovy
@@ -1,6 +1,7 @@
 package se.alipsa.matrix.stats.formula.dsl
 
 import groovy.transform.CompileDynamic
+
 import se.alipsa.matrix.stats.formula.FormulaParseException
 
 /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/IdentifierRenderingSupport.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/IdentifierRenderingSupport.groovy
@@ -1,0 +1,47 @@
+package se.alipsa.matrix.stats.formula.dsl
+
+import groovy.transform.PackageScope
+
+/**
+ * Shared identifier validation and rendering for formula DSL names.
+ */
+@PackageScope
+final class IdentifierRenderingSupport {
+
+  private IdentifierRenderingSupport() {
+  }
+
+  static String requireNonBlank(String value, String label) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("${label} cannot be null or blank")
+    }
+    value
+  }
+
+  static String renderIdentifier(String name, boolean quoted) {
+    if (quoted || !simpleIdentifier(name)) {
+      return "`${name.replace('`', '``')}`"
+    }
+    name
+  }
+
+  private static boolean simpleIdentifier(String value) {
+    if (value == '.') {
+      return false
+    }
+    char first = value.charAt(0)
+    if (!(Character.isLetter(first) || first == '_' || first == '.')) {
+      return false
+    }
+    if (first == '.' && value.length() > 1 && Character.isDigit(value.charAt(1))) {
+      return false
+    }
+    for (int i = 1; i < value.length(); i++) {
+      char current = value.charAt(i)
+      if (!(Character.isLetterOrDigit(current) || current == '_' || current == '.')) {
+        return false
+      }
+    }
+    true
+  }
+}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/TermExpr.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/TermExpr.groovy
@@ -6,6 +6,16 @@ package se.alipsa.matrix.stats.formula.dsl
 abstract class TermExpr {
 
   /**
+   * Builds a full formula expression using this term as the response.
+   *
+   * @param predictors the predictor-side term expression
+   * @return the full formula specification
+   */
+  GroovyFormulaSpec or(TermExpr predictors) {
+    new GroovyFormulaSpec(this, requireTerm(predictors, 'predictors'))
+  }
+
+  /**
    * Adds a term to this expression.
    *
    * @param other the term to add

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/TermExpr.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/TermExpr.groovy
@@ -6,16 +6,6 @@ package se.alipsa.matrix.stats.formula.dsl
 abstract class TermExpr {
 
   /**
-   * Builds a full formula expression using this term as the response.
-   *
-   * @param predictors the predictor-side term expression
-   * @return the full formula specification
-   */
-  GroovyFormulaSpec or(TermExpr predictors) {
-    new GroovyFormulaSpec(this, requireTerm(predictors, 'predictors'))
-  }
-
-  /**
    * Adds a term to this expression.
    *
    * @param other the term to add

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/TermRef.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/TermRef.groovy
@@ -15,52 +15,12 @@ class TermRef extends TermExpr {
    * @param quoted whether the name must be rendered with backticks
    */
   TermRef(String name, boolean quoted = false) {
-    this.name = requireNonBlank(name, 'name')
+    this.name = IdentifierRenderingSupport.requireNonBlank(name, 'name')
     this.quoted = quoted
-  }
-
-  /**
-   * Builds a full formula expression using this term as the response.
-   *
-   * @param predictors the predictor-side term expression
-   * @return the full formula specification
-   */
-  GroovyFormulaSpec or(TermExpr predictors) {
-    new GroovyFormulaSpec(this, requireTerm(predictors, 'predictors'))
   }
 
   @Override
   String render() {
-    if (quoted || !simpleIdentifier(name)) {
-      return "`${name.replace('`', '``')}`"
-    }
-    name
-  }
-
-  private static String requireNonBlank(String value, String label) {
-    if (value == null || value.isBlank()) {
-      throw new IllegalArgumentException("${label} cannot be null or blank")
-    }
-    value
-  }
-
-  private static boolean simpleIdentifier(String value) {
-    if (value == '.') {
-      return false
-    }
-    char first = value.charAt(0)
-    if (!(Character.isLetter(first) || first == '_' || first == '.')) {
-      return false
-    }
-    if (first == '.' && value.length() > 1 && Character.isDigit(value.charAt(1))) {
-      return false
-    }
-    for (int i = 1; i < value.length(); i++) {
-      char current = value.charAt(i)
-      if (!(Character.isLetterOrDigit(current) || current == '_' || current == '.')) {
-        return false
-      }
-    }
-    true
+    IdentifierRenderingSupport.renderIdentifier(name, quoted)
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/TermRef.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/TermRef.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.formula.dsl
 
+import groovy.transform.CompileDynamic
+
 /**
  * Reference to a formula variable or backtick-quoted column name.
  */
@@ -17,6 +19,17 @@ class TermRef extends TermExpr {
   TermRef(String name, boolean quoted = false) {
     this.name = IdentifierRenderingSupport.requireNonBlank(name, 'name')
     this.quoted = quoted
+  }
+
+  /**
+   * Builds a full formula expression using this term as the response.
+   *
+   * @param predictors the predictor-side term expression
+   * @return the full formula specification
+   */
+  @CompileDynamic
+  GroovyFormulaSpec or(TermExpr predictors) {
+    new GroovyFormulaSpec(this, requireTerm(predictors, 'predictors'))
   }
 
   @Override

--- a/matrix-stats/src/test/groovy/formula/FormulaDesignMatrixTest.groovy
+++ b/matrix-stats/src/test/groovy/formula/FormulaDesignMatrixTest.groovy
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.ext.NumberExtension
 import se.alipsa.matrix.stats.formula.ContrastType
+import se.alipsa.matrix.stats.formula.FormulaParseException
 import se.alipsa.matrix.stats.formula.ModelFrame
 import se.alipsa.matrix.stats.formula.ModelFrameResult
 import se.alipsa.matrix.stats.formula.NaAction
@@ -631,11 +632,10 @@ class FormulaDesignMatrixTest {
       .types([BigDecimal, BigDecimal])
       .build()
 
-    IllegalArgumentException ex = assertThrows(IllegalArgumentException) {
+    FormulaParseException ex = assertThrows(FormulaParseException) {
       ModelFrame.of('log(y) ~ x', data).evaluate()
     }
-    assertTrue(ex.message.contains('Transformed responses are not yet supported'))
-    assertTrue(ex.message.contains('log(y)'))
+    assertEquals('Transformed responses are not supported: log(y) ~ x. Move transforms to the predictor side.', ex.message)
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/formula/FormulaModelFrameTest.groovy
+++ b/matrix-stats/src/test/groovy/formula/FormulaModelFrameTest.groovy
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Row
+import se.alipsa.matrix.ext.NumberExtension
 import se.alipsa.matrix.stats.formula.Formula
 import se.alipsa.matrix.stats.formula.FormulaParseException
 import se.alipsa.matrix.stats.formula.ModelFrame
@@ -1132,6 +1133,90 @@ class FormulaModelFrameTest {
 
   @Test
   @CompileDynamic
+  void testDslModelFrameMatchesStringFormulaForTransforms() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x', 'z', 'w'])
+      .rows([
+        [10.0, 1.0, 4.0, 0.0],
+        [20.0, 2.0, 9.0, 1.0],
+        [30.0, NumberExtension.E, 16.0, 2.0],
+      ])
+      .types([BigDecimal, BigDecimal, BigDecimal, BigDecimal])
+      .build()
+
+    ModelFrameResult expected = ModelFrame.of('y ~ log(x) + sqrt(z) + exp(w)', data).evaluate()
+    ModelFrameResult actual = ModelFrame.of(data) {
+      y | log(x) + sqrt(z) + exp(w)
+    }.evaluate()
+
+    assertModelFrameParity(expected, actual)
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFrameMatchesStringFormulaForIExpression() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x', 'z'])
+      .rows([
+        [10.0, 1.0, 2.0],
+        [20.0, 2.0, 3.0],
+        [30.0, 3.0, 4.0],
+      ])
+      .types([BigDecimal, BigDecimal, BigDecimal])
+      .build()
+
+    ModelFrameResult expected = ModelFrame.of('y ~ I((x + 1) * z)', data).evaluate()
+    ModelFrameResult actual = ModelFrame.of(data) {
+      y | I { (x + 1) * z }
+    }.evaluate()
+
+    assertModelFrameParity(expected, actual)
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFrameMatchesStringFormulaForPolynomialTerms() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x'])
+      .rows([
+        [10.0, 1.0],
+        [20.0, 2.0],
+        [30.0, 3.0],
+      ])
+      .types([BigDecimal, BigDecimal])
+      .build()
+
+    ModelFrameResult expected = ModelFrame.of('y ~ poly(x, 3)', data).evaluate()
+    ModelFrameResult actual = ModelFrame.of(data) {
+      y | poly(x, 3)
+    }.evaluate()
+
+    assertModelFrameParity(expected, actual)
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFrameMatchesStringFormulaForSmoothTerms() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'time'])
+      .rows((1..12).collect { int value -> [value * 2.0, value as BigDecimal] })
+      .types([BigDecimal, BigDecimal])
+      .build()
+
+    ModelFrameResult expected = ModelFrame.of('y ~ s(time, 6)', data).evaluate()
+    ModelFrameResult smoothActual = ModelFrame.of(data) {
+      y | smooth(time, 6)
+    }.evaluate()
+    ModelFrameResult aliasActual = ModelFrame.of(data) {
+      y | s(time, 6)
+    }.evaluate()
+
+    assertModelFrameParity(expected, smoothActual)
+    assertModelFrameParity(expected, aliasActual)
+  }
+
+  @Test
+  @CompileDynamic
   void testDslModelFramePreservesBuilderMethodsAndMatchesStringFormula() {
     Matrix data = Matrix.builder()
       .columnNames(['y', 'x', 'group', 'w', 'off', 'active', 'id'])
@@ -1307,6 +1392,74 @@ class FormulaModelFrameTest {
     }
 
     assertEquals('interaction(...) requires at least two terms', exception.message)
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFrameRejectsTransformedResponseExplicitly() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x'])
+      .rows([[1.0, 2.0]])
+      .types([BigDecimal, BigDecimal])
+      .build()
+
+    FormulaParseException exception = assertThrows(FormulaParseException) {
+      ModelFrame.of(data) {
+        log(y) | x
+      }
+    }
+
+    assertEquals('Transformed responses are not supported: log(y) | x. Move transforms to the predictor side.', exception.message)
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFrameRejectsSmoothInteraction() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x', 'z'])
+      .rows([
+        [3.0, 1.0, 2.0],
+        [5.0, 2.0, 3.0],
+        [7.0, 3.0, 4.0],
+        [9.0, 4.0, 5.0],
+        [11.0, 5.0, 6.0],
+      ])
+      .types([BigDecimal, BigDecimal, BigDecimal])
+      .build()
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      ModelFrame.of(data) {
+        y | smooth(x) % z
+      }.evaluate()
+    }
+
+    assertTrue(exception.message.contains('Smooth terms cannot be used in interactions'))
+    assertTrue(exception.message.contains('s(x):z'))
+  }
+
+  @Test
+  @CompileDynamic
+  void testDslModelFrameRejectsExpandedSmoothInteraction() {
+    Matrix data = Matrix.builder()
+      .columnNames(['y', 'x', 'z'])
+      .rows([
+        [3.0, 1.0, 2.0],
+        [5.0, 2.0, 3.0],
+        [7.0, 3.0, 4.0],
+        [9.0, 4.0, 5.0],
+        [11.0, 5.0, 6.0],
+      ])
+      .types([BigDecimal, BigDecimal, BigDecimal])
+      .build()
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      ModelFrame.of(data) {
+        y | (smooth(x) + z) ** 2
+      }.evaluate()
+    }
+
+    assertTrue(exception.message.contains('Smooth terms cannot be used in interactions'))
+    assertTrue(exception.message.contains('s(x):z'))
   }
 
   private static void assertModelFrameParity(ModelFrameResult expected, ModelFrameResult actual) {

--- a/matrix-stats/src/test/groovy/formula/GroovyFormulaDslTest.groovy
+++ b/matrix-stats/src/test/groovy/formula/GroovyFormulaDslTest.groovy
@@ -212,6 +212,17 @@ class GroovyFormulaDslTest {
   }
 
   @Test
+  void testRejectsNonVariableResponseInDslUsingPipeSyntax() {
+    FormulaParseException exception = assertThrows(FormulaParseException) {
+      Formula.build {
+        (x + y) | z
+      }
+    }
+
+    assertEquals('Response must be a single variable in the Groovy formula DSL: x + y | z', exception.message)
+  }
+
+  @Test
   void testRejectsMalformedIExpressionClosure() {
     IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
       Formula.build {

--- a/matrix-stats/src/test/groovy/formula/GroovyFormulaDslTest.groovy
+++ b/matrix-stats/src/test/groovy/formula/GroovyFormulaDslTest.groovy
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 import se.alipsa.matrix.stats.formula.Formula
+import se.alipsa.matrix.stats.formula.FormulaParseException
 import se.alipsa.matrix.stats.formula.dsl.GroovyFormulaDsl
 import se.alipsa.matrix.stats.formula.dsl.TermRef
 
@@ -89,6 +90,48 @@ class GroovyFormulaDslTest {
   }
 
   @Test
+  void testBuildsTransformHelpers() {
+    assertDslEquals('y ~ log(x) + sqrt(z) + exp(w)') {
+      y | log(x) + sqrt(z) + exp(w)
+    }
+  }
+
+  @Test
+  void testBuildsIExpressionTerm() {
+    assertDslEquals('y ~ I(x + 1)') {
+      y | I { x + 1 }
+    }
+  }
+
+  @Test
+  void testBuildsIExpressionWithLeftNumericLiteral() {
+    assertDslEquals('y ~ I(1 + x)') {
+      y | I { 1 + x }
+    }
+  }
+
+  @Test
+  void testBuildsPolynomialHelper() {
+    assertDslEquals('y ~ poly(x, 3)') {
+      y | poly(x, 3)
+    }
+  }
+
+  @Test
+  void testBuildsSmoothHelper() {
+    assertDslEquals('y ~ s(time, 6)') {
+      y | smooth(time, 6)
+    }
+  }
+
+  @Test
+  void testBuildsSmoothAlias() {
+    assertDslEquals('y ~ s(time, 6)') {
+      y | s(time, 6)
+    }
+  }
+
+  @Test
   void testOperatorPrecedenceGroupsRightHandSideAdditionBeforeFormulaSeparator() {
     assertDslEquals('y ~ x + group') {
       y | x + group
@@ -155,6 +198,39 @@ class GroovyFormulaDslTest {
     assertEquals('plus', exception.method)
     assertEquals(Integer, exception.type)
     assertEquals(TermRef, exception.arguments[0].class)
+  }
+
+  @Test
+  void testRejectsTransformedResponseInDsl() {
+    FormulaParseException exception = assertThrows(FormulaParseException) {
+      Formula.build {
+        log(y) | x
+      }
+    }
+
+    assertEquals('Transformed responses are not supported: log(y) | x. Move transforms to the predictor side.', exception.message)
+  }
+
+  @Test
+  void testRejectsMalformedIExpressionClosure() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      Formula.build {
+        y | I { null }
+      }
+    }
+
+    assertEquals('I { ... } must return an arithmetic expression such as x + 1', exception.message)
+  }
+
+  @Test
+  void testRejectsUnsupportedArithmeticOperatorInIExpression() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      Formula.build {
+        y | I { x % 2 }
+      }
+    }
+
+    assertEquals("Unsupported arithmetic operator '%' in I { ... }", exception.message)
   }
 
   @Test


### PR DESCRIPTION
  The DSL now supports transform helpers and expression parity: matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaDsl.groovy:76 adds log, sqrt, exp,
  poly, smooth, s, and I { ... }. matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/ExpressionDsl.groovy:15 provides the dedicated arithmetic context for I
  { ... }, including numeric literals, unary minus, +, -, *, /, **, transform calls inside expressions, and explicit rejection of unsupported %.

  Transformed responses now fail explicitly with FormulaParseException instead of falling through to the old generic runtime path. That check happens for DSL responses in
  matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaSpec.groovy:29 and for string-formula model-frame evaluation in matrix-stats/src/main/groovy/se/
  alipsa/matrix/stats/formula/ModelFrame.groovy:273. I also updated the section 3 checklist and recorded the passing focused command in matrix-stats/req/v2.4.0-
  groovyFormulas.md:430.

  Tests were expanded in matrix-stats/src/test/groovy/formula/GroovyFormulaDslTest.groovy:92, matrix-stats/src/test/groovy/formula/FormulaModelFrameTest.groovy:1134, and
  matrix-stats/src/test/groovy/formula/FormulaDesignMatrixTest.groovy:628. Verified with:

  - GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'formula.*' --tests 'regression.GamMethodTest' --tests 'regression.LoessMethodTest' --tests 'regression.LmMethodTest'
  - GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew test

  Both passed.