### PR TITLE
[codex] Add Groovy formula fit DSL helpers

### DIFF
--- a/matrix-stats/req/v2.4.0-groovyFormulas.md
+++ b/matrix-stats/req/v2.4.0-groovyFormulas.md
@@ -568,7 +568,7 @@ GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:codenarcMain :matrix-
 
 Section 4 adds `lm(data) { ... }`, `loess(data) { ... }`, and `gam(data) { ... }`. It should land after sections 1 through 3 so fit methods can rely on the complete DSL formula subset.
 
-4.1 [ ] Add model-fit convenience APIs for the built-in fit methods.
+4.1 [x] Add model-fit convenience APIs for the built-in fit methods.
 
 Required API:
 
@@ -596,7 +596,7 @@ def smooth = gam(data) {
 }
 ```
 
-4.2 [ ] Implement `se.alipsa.matrix.stats.regression.FitDsl`.
+4.2 [x] Implement `se.alipsa.matrix.stats.regression.FitDsl`.
 
 Rationale: `FitRegistry` should remain focused on registration and lookup. `FitDsl` can provide static convenience methods that create a `ModelFrame` from the DSL formula and then delegate to `FitRegistry.instance().get(...)`.
 
@@ -608,11 +608,11 @@ Required behavior:
 - fit options are either supported with typed overloads or explicitly deferred in docs
 - public static methods live in `se.alipsa.matrix.stats.regression.FitDsl`
 
-4.3 [ ] Do not add convenience methods to `FitRegistry`.
+4.3 [x] Do not add convenience methods to `FitRegistry`.
 
 `FitRegistry` stays focused on registration and lookup.
 
-4.4 [ ] Add convenience fit-method tests.
+4.4 [x] Add convenience fit-method tests.
 
 Cover:
 
@@ -622,7 +622,7 @@ Cover:
 - parity with `FitRegistry.instance().get(...).fit(ModelFrame.of(...).evaluate())`
 - static import style for `FitDsl.lm`, `FitDsl.loess`, and `FitDsl.gam`
 
-4.5 [ ] Run focused section 4 tests and record the exact passing command.
+4.5 [x] Run focused section 4 tests and record the exact passing command.
 
 ```bash
 GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'regression.*' --tests 'formula.*'

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/BinaryTermExpr.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/BinaryTermExpr.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.formula.dsl
 
-import groovy.transform.CompileDynamic
-
 /**
  * Binary additive or subtractive formula term expression.
  */
@@ -22,17 +20,6 @@ class BinaryTermExpr extends TermExpr {
     this.left = requireTerm(left, 'left')
     this.operator = requireOperator(operator)
     this.right = requireTerm(right, 'right')
-  }
-
-  /**
-   * Builds a full formula expression using this term as the response.
-   *
-   * @param predictors the predictor-side term expression
-   * @return the full formula specification
-   */
-  @CompileDynamic
-  GroovyFormulaSpec or(TermExpr predictors) {
-    GroovyFormulaSpec.from(this, requireTerm(predictors, 'predictors'))
   }
 
   @Override

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/BinaryTermExpr.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/BinaryTermExpr.groovy
@@ -32,7 +32,7 @@ class BinaryTermExpr extends TermExpr {
    */
   @CompileDynamic
   GroovyFormulaSpec or(TermExpr predictors) {
-    new GroovyFormulaSpec(this, requireTerm(predictors, 'predictors'))
+    GroovyFormulaSpec.from(this, requireTerm(predictors, 'predictors'))
   }
 
   @Override

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/FunctionTermExpr.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/FunctionTermExpr.groovy
@@ -1,6 +1,5 @@
 package se.alipsa.matrix.stats.formula.dsl
 
-import groovy.transform.CompileDynamic
 import groovy.transform.PackageScope
 
 /**
@@ -18,17 +17,6 @@ final class FunctionTermExpr extends TermExpr {
   FunctionTermExpr(String name, List<Object> arguments) {
     this.name = IdentifierRenderingSupport.requireNonBlank(name, 'name')
     this.arguments = copyArguments(arguments)
-  }
-
-  /**
-   * Builds a full formula expression using this term as the response.
-   *
-   * @param predictors the predictor-side term expression
-   * @return the full formula specification
-   */
-  @CompileDynamic
-  GroovyFormulaSpec or(TermExpr predictors) {
-    GroovyFormulaSpec.from(this, requireTerm(predictors, 'predictors'))
   }
 
   @Override

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/FunctionTermExpr.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/FunctionTermExpr.groovy
@@ -28,7 +28,7 @@ final class FunctionTermExpr extends TermExpr {
    */
   @CompileDynamic
   GroovyFormulaSpec or(TermExpr predictors) {
-    new GroovyFormulaSpec(this, requireTerm(predictors, 'predictors'))
+    GroovyFormulaSpec.from(this, requireTerm(predictors, 'predictors'))
   }
 
   @Override

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaSpec.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaSpec.groovy
@@ -25,6 +25,17 @@ class GroovyFormulaSpec {
   }
 
   /**
+   * Creates a formula specification from response and predictor terms.
+   *
+   * @param response the response term
+   * @param predictors the predictor terms
+   * @return the formula specification
+   */
+  static GroovyFormulaSpec from(TermExpr response, TermExpr predictors) {
+    new GroovyFormulaSpec(response, predictors)
+  }
+
+  /**
    * Renders this specification to R-style formula syntax.
    *
    * @return the rendered formula source

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/TermExpr.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/TermExpr.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.formula.dsl
 
+import groovy.transform.CompileDynamic
+
 /**
  * Base type for Groovy-native formula DSL term expressions.
  */
@@ -44,6 +46,21 @@ abstract class TermExpr {
    */
   TermExpr power(Number degree) {
     new ExpansionExpr(this, degree)
+  }
+
+  /**
+   * Builds a full formula expression using this term as the response.
+   *
+   * <p>Most term shapes are invalid as responses, but routing them through
+   * {@link GroovyFormulaSpec} ensures users get a formula-specific error
+   * instead of Groovy's generic missing-method message.</p>
+   *
+   * @param predictors the predictor-side term expression
+   * @return the full formula specification
+   */
+  @CompileDynamic
+  GroovyFormulaSpec or(TermExpr predictors) {
+    GroovyFormulaSpec.from(this, requireTerm(predictors, 'predictors'))
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/TermRef.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/TermRef.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.stats.formula.dsl
 
-import groovy.transform.CompileDynamic
-
 /**
  * Reference to a formula variable or backtick-quoted column name.
  */
@@ -19,17 +17,6 @@ class TermRef extends TermExpr {
   TermRef(String name, boolean quoted = false) {
     this.name = IdentifierRenderingSupport.requireNonBlank(name, 'name')
     this.quoted = quoted
-  }
-
-  /**
-   * Builds a full formula expression using this term as the response.
-   *
-   * @param predictors the predictor-side term expression
-   * @return the full formula specification
-   */
-  @CompileDynamic
-  GroovyFormulaSpec or(TermExpr predictors) {
-    GroovyFormulaSpec.from(this, requireTerm(predictors, 'predictors'))
   }
 
   @Override

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/TermRef.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/TermRef.groovy
@@ -29,7 +29,7 @@ class TermRef extends TermExpr {
    */
   @CompileDynamic
   GroovyFormulaSpec or(TermExpr predictors) {
-    new GroovyFormulaSpec(this, requireTerm(predictors, 'predictors'))
+    GroovyFormulaSpec.from(this, requireTerm(predictors, 'predictors'))
   }
 
   @Override

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitDsl.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitDsl.groovy
@@ -1,0 +1,120 @@
+package se.alipsa.matrix.stats.regression
+
+import groovy.transform.CompileDynamic
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.stats.formula.ModelFrame
+import se.alipsa.matrix.stats.formula.dsl.GroovyFormulaDsl
+import se.alipsa.matrix.stats.formula.dsl.GroovyFormulaSpec
+
+/**
+ * Groovy-native convenience entry points for fitting built-in regression models.
+ *
+ * <p>These helpers evaluate a {@link ModelFrame} from the formula DSL and then delegate
+ * to the registered fit method in {@link FitRegistry}. They are intended for static-import
+ * usage such as {@code lm(data) { y | x + group }}.</p>
+ */
+final class FitDsl {
+
+  private FitDsl() {
+  }
+
+  /**
+   * Fits a linear model using the Groovy formula DSL.
+   *
+   * @param data the input dataset
+   * @param formula the Groovy formula closure
+   * @return the fitted result
+   */
+  static FitResult lm(
+    Matrix data,
+    @DelegatesTo(value = GroovyFormulaDsl, strategy = Closure.DELEGATE_FIRST)
+    Closure<GroovyFormulaSpec> formula
+  ) {
+    fit('lm', data, formula)
+  }
+
+  /**
+   * Fits a loess model using the Groovy formula DSL and default options.
+   *
+   * @param data the input dataset
+   * @param formula the Groovy formula closure
+   * @return the fitted result
+   */
+  static FitResult loess(
+    Matrix data,
+    @DelegatesTo(value = GroovyFormulaDsl, strategy = Closure.DELEGATE_FIRST)
+    Closure<GroovyFormulaSpec> formula
+  ) {
+    fit('loess', data, formula)
+  }
+
+  /**
+   * Fits a loess model using explicit loess options.
+   *
+   * @param data the input dataset
+   * @param options the loess options
+   * @param formula the Groovy formula closure
+   * @return the fitted result
+   */
+  static FitResult loess(
+    Matrix data,
+    LoessOptions options,
+    @DelegatesTo(value = GroovyFormulaDsl, strategy = Closure.DELEGATE_FIRST)
+    Closure<GroovyFormulaSpec> formula
+  ) {
+    fit('loess', data, formula, options)
+  }
+
+  /**
+   * Fits a generalized additive model using the Groovy formula DSL and default options.
+   *
+   * @param data the input dataset
+   * @param formula the Groovy formula closure
+   * @return the fitted result
+   */
+  static FitResult gam(
+    Matrix data,
+    @DelegatesTo(value = GroovyFormulaDsl, strategy = Closure.DELEGATE_FIRST)
+    Closure<GroovyFormulaSpec> formula
+  ) {
+    fit('gam', data, formula)
+  }
+
+  /**
+   * Fits a generalized additive model using explicit GAM options.
+   *
+   * @param data the input dataset
+   * @param options the GAM options
+   * @param formula the Groovy formula closure
+   * @return the fitted result
+   */
+  static FitResult gam(
+    Matrix data,
+    GamOptions options,
+    @DelegatesTo(value = GroovyFormulaDsl, strategy = Closure.DELEGATE_FIRST)
+    Closure<GroovyFormulaSpec> formula
+  ) {
+    fit('gam', data, formula, options)
+  }
+
+  @CompileDynamic
+  private static FitResult fit(
+    String methodName,
+    Matrix data,
+    @DelegatesTo(value = GroovyFormulaDsl, strategy = Closure.DELEGATE_FIRST)
+    Closure<GroovyFormulaSpec> formula
+  ) {
+    FitRegistry.instance().get(methodName).fit(ModelFrame.of(data, formula).evaluate())
+  }
+
+  @CompileDynamic
+  private static FitResult fit(
+    String methodName,
+    Matrix data,
+    @DelegatesTo(value = GroovyFormulaDsl, strategy = Closure.DELEGATE_FIRST)
+    Closure<GroovyFormulaSpec> formula,
+    FitOptions options
+  ) {
+    FitRegistry.instance().get(methodName).fit(ModelFrame.of(data, formula).evaluate(), options)
+  }
+}

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitDsl.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitDsl.groovy
@@ -1,6 +1,5 @@
 package se.alipsa.matrix.stats.regression
 
-import groovy.transform.CompileDynamic
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.formula.ModelFrame
 import se.alipsa.matrix.stats.formula.dsl.GroovyFormulaDsl
@@ -97,7 +96,6 @@ final class FitDsl {
     fit('gam', data, formula, options)
   }
 
-  @CompileDynamic
   private static FitResult fit(
     String methodName,
     Matrix data,
@@ -107,7 +105,6 @@ final class FitDsl {
     FitRegistry.instance().get(methodName).fit(ModelFrame.of(data, formula).evaluate())
   }
 
-  @CompileDynamic
   private static FitResult fit(
     String methodName,
     Matrix data,

--- a/matrix-stats/src/test/groovy/formula/GroovyFormulaDslTest.groovy
+++ b/matrix-stats/src/test/groovy/formula/GroovyFormulaDslTest.groovy
@@ -223,6 +223,22 @@ class GroovyFormulaDslTest {
   }
 
   @Test
+  void testRejectsOtherInvalidResponseShapesInDslUsingPipeSyntax() {
+    assertInvalidResponseShape('. | z') {
+      all | z
+    }
+    assertInvalidResponseShape('x^2 | z') {
+      (x ** 2) | z
+    }
+    assertInvalidResponseShape('x:y | z') {
+      (x % y) | z
+    }
+    assertInvalidResponseShape('0 | z') {
+      noIntercept | z
+    }
+  }
+
+  @Test
   void testRejectsMalformedIExpressionClosure() {
     IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
       Formula.build {
@@ -255,5 +271,13 @@ class GroovyFormulaDslTest {
 
   private static void assertDslEquals(String equivalentFormula, Closure<?> dsl) {
     assertEquals(Formula.normalize(equivalentFormula).asFormulaString(), Formula.build(dsl).asFormulaString())
+  }
+
+  private static void assertInvalidResponseShape(String renderedDsl, Closure<?> dsl) {
+    FormulaParseException exception = assertThrows(FormulaParseException) {
+      Formula.build(dsl)
+    }
+
+    assertEquals("Response must be a single variable in the Groovy formula DSL: ${renderedDsl}", exception.message)
   }
 }

--- a/matrix-stats/src/test/groovy/regression/FitDslTest.groovy
+++ b/matrix-stats/src/test/groovy/regression/FitDslTest.groovy
@@ -1,0 +1,143 @@
+package regression
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static se.alipsa.matrix.stats.regression.FitDsl.gam
+import static se.alipsa.matrix.stats.regression.FitDsl.lm
+import static se.alipsa.matrix.stats.regression.FitDsl.loess
+
+import groovy.transform.CompileDynamic
+
+import org.junit.jupiter.api.Test
+
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.stats.formula.ModelFrame
+import se.alipsa.matrix.stats.regression.FitRegistry
+import se.alipsa.matrix.stats.regression.FitResult
+import se.alipsa.matrix.stats.regression.GamOptions
+import se.alipsa.matrix.stats.regression.LoessOptions
+
+/**
+ * Tests for the Groovy formula fit convenience DSL.
+ */
+@CompileDynamic
+@SuppressWarnings('DuplicateNumberLiteral')
+class FitDslTest {
+
+  @Test
+  void testLmDslMatchesRegistryFit() {
+    Matrix data = Matrix.builder()
+      .columnNames(['x', 'group', 'y'])
+      .rows([
+        [1.0, 'A', 3.0],
+        [2.0, 'B', 6.0],
+        [3.0, 'A', 7.0],
+        [4.0, 'B', 10.0],
+        [5.0, 'A', 11.0],
+      ])
+      .types([BigDecimal, String, BigDecimal])
+      .build()
+
+    FitResult expected = FitRegistry.instance().get('lm').fit(ModelFrame.of('y ~ x + group', data).evaluate())
+    FitResult actual = lm(data) {
+      y | x + group
+    }
+
+    assertFitResultEquals(expected, actual)
+  }
+
+  @Test
+  void testLoessDslMatchesRegistryFit() {
+    Matrix data = Matrix.builder()
+      .columnNames(['x', 'y'])
+      .rows((0..<30).collect { int i ->
+        BigDecimal x = i * 0.2
+        BigDecimal y = (Math.sin(x as double) as BigDecimal) + (i % 4 == 0 ? 0.1 : -0.05)
+        [x, y]
+      })
+      .types([BigDecimal, BigDecimal])
+      .build()
+
+    LoessOptions options = new LoessOptions(0.35d)
+    FitResult expected = FitRegistry.instance().get('loess').fit(ModelFrame.of('y ~ x', data).evaluate(), options)
+    FitResult actual = loess(data, options) {
+      y | x
+    }
+
+    assertFitResultEquals(expected, actual)
+  }
+
+  @Test
+  void testGamDslMatchesRegistryFit() {
+    Matrix data = Matrix.builder()
+      .columnNames(['time', 'group', 'y'])
+      .rows((0..<24).collect { int i ->
+        BigDecimal time = i * 0.3
+        String group = i % 2 == 0 ? 'A' : 'B'
+        BigDecimal y = (Math.sin(time as double) as BigDecimal) + (group == 'B' ? 1.0 : 0.0)
+        [time, group, y]
+      })
+      .types([BigDecimal, String, BigDecimal])
+      .build()
+
+    GamOptions options = new GamOptions(0.5d)
+    FitResult expected = FitRegistry.instance().get('gam').fit(ModelFrame.of('y ~ s(time, 6) + group', data).evaluate(), options)
+    FitResult actual = gam(data, options) {
+      y | smooth(time, 6) + group
+    }
+
+    assertFitResultEquals(expected, actual)
+  }
+
+  @Test
+  void testStaticImportStyleWorksForAllFitDslMethods() {
+    Matrix linear = Matrix.builder()
+      .columnNames(['x', 'y'])
+      .rows([[1.0, 3.0], [2.0, 5.0], [3.0, 7.0]])
+      .types([BigDecimal, BigDecimal])
+      .build()
+
+    Matrix local = Matrix.builder()
+      .columnNames(['x', 'y'])
+      .rows((0..<12).collect { int i ->
+        BigDecimal x = i * 0.2
+        [x, Math.sin(x as double) as BigDecimal]
+      })
+      .types([BigDecimal, BigDecimal])
+      .build()
+
+    Matrix gamData = Matrix.builder()
+      .columnNames(['time', 'group', 'y'])
+      .rows((0..<12).collect { int i ->
+        BigDecimal time = i * 0.4
+        String group = i % 2 == 0 ? 'A' : 'B'
+        BigDecimal y = (Math.sin(time as double) as BigDecimal) + (group == 'B' ? 0.5 : 0.0)
+        [time, group, y]
+      })
+      .types([BigDecimal, String, BigDecimal])
+      .build()
+
+    FitResult lmResult = lm(linear) {
+      y | x
+    }
+    FitResult loessResult = loess(local) {
+      y | x
+    }
+    FitResult gamResult = gam(gamData) {
+      y | smooth(time, 6) + group
+    }
+
+    assertEquals(2, lmResult.coefficients.length)
+    assertEquals(local.rowCount(), loessResult.fittedValues.length)
+    assertEquals(gamData.rowCount(), gamResult.fittedValues.length)
+  }
+
+  private static void assertFitResultEquals(FitResult expected, FitResult actual) {
+    assertArrayEquals(expected.coefficients, actual.coefficients, 1e-12d)
+    assertArrayEquals(expected.standardErrors, actual.standardErrors, 1e-12d)
+    assertArrayEquals(expected.fittedValues, actual.fittedValues, 1e-12d)
+    assertArrayEquals(expected.residuals, actual.residuals, 1e-12d)
+    assertEquals(expected.rSquared, actual.rSquared, 1e-12d)
+    assertEquals(expected.predictorNames, actual.predictorNames)
+  }
+}


### PR DESCRIPTION
## Summary
Add Groovy-native fit convenience entry points for `lm`, `loess`, and `gam` in `matrix-stats`, backed by the new `FitDsl` helper.

## What Changed
- Added `se.alipsa.matrix.stats.regression.FitDsl` with static DSL entry points for `lm(data) { ... }`, `loess(data) { ... }`, and `gam(data) { ... }`
- Added typed overloads for `LoessOptions` and `GamOptions`
- Added regression tests covering parity with `FitRegistry.instance().get(...).fit(ModelFrame.of(...).evaluate())`
- Updated the section 4 checklist in `matrix-stats/req/v2.4.0-groovyFormulas.md`
- Tightened DSL error handling so invalid response shapes like `all | z`, `(x ** 2) | z`, `(x % y) | z`, and `noIntercept | z` report the formula-specific "Response must be a single variable" message instead of Groovy's generic missing-method error

## Why
Section 4 of the Groovy formulas work requires direct fit helpers that let callers use the Groovy DSL without manually building a `ModelFrame` and looking up methods in `FitRegistry`. The response-shape follow-up keeps DSL failures consistent across all invalid response term variants.

## Impact
Users can now write:

```groovy
lm(data) { y | x + group }
loess(data) { y | x }
gam(data) { y | smooth(time, 6) + group }
```

The API stays out of `FitRegistry`, so registration and lookup remain separate from Groovy convenience entry points.

## Validation
- `GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'regression.*' --tests 'formula.*'`
- `GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'formula.GroovyFormulaDslTest'`
- `GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
- `GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew test`

Note: the full `./gradlew test` run reported passing module test summaries including `matrix-stats`, `matrix-charts`, and `matrix-ggplot`, but the Gradle process did not return a final `BUILD SUCCESSFUL` line before hanging.