### PR TITLE
[codex] Add Groovy formula DSL docs and verification close-out

### DIFF
--- a/docs/cookbook/matrix-stats.md
+++ b/docs/cookbook/matrix-stats.md
@@ -122,6 +122,50 @@ println(fit.predictorNames)
 println(fit.rSquared)
 ```
 
+## Groovy Formula DSL Recipes
+
+Compare the string and Groovy operator forms side by side when building the same model frame:
+
+```groovy
+import se.alipsa.matrix.stats.formula.ModelFrame
+
+def stringFrame = ModelFrame.of('y ~ x + group + x:group', data).evaluate()
+
+def dslFrame = ModelFrame.of(data) {
+  y | x + group + (x % group)
+}.evaluate()
+```
+
+Use the fit convenience helpers when you want to go straight from data plus DSL formula to a fitted
+model:
+
+```groovy
+import static se.alipsa.matrix.stats.regression.FitDsl.lm
+
+def model = lm(data) {
+  y | x + group + interaction(x, group)
+}
+```
+
+For three-way interactions, prefer the explicit helper:
+
+```groovy
+def interactionFrame = ModelFrame.of(data) {
+  y | interaction(x, group, z)
+}.evaluate()
+```
+
+Remember the Groovy DSL uses deferred syntax and dynamic lookup:
+
+- `|` instead of `~`
+- `noIntercept` instead of `0 +`
+- bare column names are resolved through `propertyMissing`, so keep the DSL out of `@CompileStatic`
+  callers unless you wrap it in a `@CompileDynamic` helper
+
+Inside `I { ... }`, stick to the arithmetic supported by the string formula subset: numeric
+literals, unary minus, `+`, `-`, `*`, `/`, `**`, and supported transform helpers such as `log`,
+`sqrt`, and `exp`.
+
 ## T-tests
 
 Use Welch for unequal variances and Student for pooled-variance or paired designs.

--- a/docs/tutorial/3-matrix-stats.md
+++ b/docs/tutorial/3-matrix-stats.md
@@ -234,6 +234,40 @@ Current limitations:
 - `lm`, `loess`, and `gam` reject unsupported frame metadata rather than silently ignoring it
 - smooth terms cannot be used inside interactions such as `s(x):z` or `s(x) * z`
 
+The same supported formula subset is available through the Groovy operator DSL:
+
+```groovy
+def stringFrame = ModelFrame.of('y ~ x + group + x:group', data).evaluate()
+
+def dslFrame = ModelFrame.of(data) {
+    y | x + group + (x % group)
+}.evaluate()
+```
+
+The first Groovy DSL version uses deferred syntax:
+
+- `|` instead of `~`
+- `noIntercept` instead of `0 +`
+
+The DSL is intentionally dynamic because bare column names are resolved via `propertyMissing` and
+the formula syntax relies on Groovy operator dispatch. Use string formulas or a `@CompileDynamic`
+helper if you are calling it from `@CompileStatic` code.
+
+`I { ... }` is limited to the arithmetic already supported by the string parser subset: numeric
+literals, unary minus, `+`, `-`, `*`, `/`, `**`, and supported transform helpers such as `log`,
+`sqrt`, and `exp`.
+
+For fitting, you can either dispatch through `FitRegistry` or use the convenience helpers in
+`FitDsl`:
+
+```groovy
+import static se.alipsa.matrix.stats.regression.FitDsl.lm
+
+def fit = lm(data) {
+    y | x + group + interaction(x, group)
+}
+```
+
 ## Linear Regression
 
 `LinearRegression` fits a simple least-squares model with one predictor.

--- a/matrix-stats/README.md
+++ b/matrix-stats/README.md
@@ -265,6 +265,72 @@ Current limitations:
   `lm` rejects weights and offsets, `loess` rejects offsets, and `gam` rejects weights and offsets
 - smooth terms cannot be used inside interactions such as `s(x):z` or `s(x) * z`
 
+## Groovy Formula DSL
+
+The string formula parser and the Groovy operator DSL cover the same supported model-frame subset.
+Use string formulas when you want explicit R-style source text, or the Groovy DSL when you want
+direct column references and operator syntax.
+
+```groovy
+def stringFrame = ModelFrame.of('y ~ x + group + x:group', data).evaluate()
+
+def dslFrame = ModelFrame.of(data) {
+    y | x + group + (x % group)
+}.evaluate()
+```
+
+The Groovy DSL uses deferred syntax in two places:
+
+- `|` instead of `~`
+- `noIntercept` instead of `0 +`
+
+```groovy
+def frame = ModelFrame.of(data) {
+    y | noIntercept + x + group
+}
+```
+
+The operator DSL is intentionally dynamic. Bare names such as `y`, `x`, and `group` are resolved
+through `propertyMissing`, and the infix formula syntax relies on Groovy operator dispatch. That is
+what keeps the DSL compact, but it also means it should live in dynamic Groovy code. In
+`@CompileStatic` callers, prefer string formulas or isolate the DSL inside a `@CompileDynamic`
+helper.
+
+`I { ... }` has a deliberately narrow arithmetic scope that matches the existing supported string
+formula subset. Inside `I { ... }`, use only:
+
+- numeric literals
+- unary minus
+- `+`, `-`, `*`, `/`, and `**`
+- transform helpers already supported by the formula parser, such as `log(x)`, `sqrt(x)`, and `exp(x)`
+
+```groovy
+def transformedFrame = ModelFrame.of(data) {
+    y | x + I { (x + 1) * z }
+}.evaluate()
+```
+
+For model fitting, you can either go through `FitRegistry` or use the Groovy convenience entry
+points in `FitDsl`:
+
+```groovy
+import static se.alipsa.matrix.stats.regression.FitDsl.gam
+import static se.alipsa.matrix.stats.regression.FitDsl.lm
+import static se.alipsa.matrix.stats.regression.FitDsl.loess
+
+def lmFit = lm(data) {
+    y | x + group + interaction(x, group)
+}
+
+def loessFit = loess(data) {
+    y | x
+}
+
+def gamFit = gam(data) {
+    y | smooth(time, 6) + group
+}
+```
+
 ## T-tests
 
 Use `Welch` for the default unequal-variance two-sample test, and `Student` when you explicitly want

--- a/matrix-stats/release.md
+++ b/matrix-stats/release.md
@@ -28,6 +28,7 @@
 #### Formula and Model-Frame Pipeline
 - Add R-style formula parsing and normalization support, including additive terms, intercept control, interactions, shorthand expansion, quoted identifiers, numeric transformations, `poly(...)`, and `s(...)` smooth terms.
 - Add `ModelFrame` and `ModelFrameResult` for design-matrix construction from Matrix data.
+- Add a Groovy-native operator DSL for formulas using `|`, `noIntercept`, `interaction(...)`, `smooth(...)`, and `I { ... }`.
 - Add categorical treatment encoding, dot expansion, subset support, NA handling, weights, offsets, and external environment variable resolution.
 - Add `NaAction` and formula metadata classes to make downstream model fitting explicit.
 - Reject unsupported response forms, smooth-term interactions, and unsupported frame metadata instead of silently ignoring them.
@@ -35,6 +36,7 @@
 #### Fit Registry and Formula-Based Regression
 - Add `FitRegistry`, `FitMethod`, `FitOptions`, and `FitResult` for named fit-method dispatch.
 - Add built-in `lm`, `loess`, and `gam` fit methods.
+- Add `FitDsl` convenience entry points so Groovy callers can write `lm(data) { y | x + group }`, `loess(data) { y | x }`, and `gam(data) { y | smooth(time, 6) + group }`.
 - Add `MultipleLinearRegression`, `LmMethod`, `LoessMethod`, and `GamMethod`.
 - Add `LoessOptions` and `GamOptions` with Groovy-facing numeric option surfaces.
 
@@ -76,7 +78,7 @@
 ### Documentation
 - Refresh `matrix-stats` README, tutorial, and cookbook docs for the 2.4.0 API surface.
 - Document the Commons Math runtime removal and EJML implementation detail.
-- Add examples for `Linalg`, `Interpolation`, formula/model-frame fitting, native distributions, and native solvers.
+- Add examples for `Linalg`, `Interpolation`, formula/model-frame fitting, the Groovy formula DSL, fit convenience helpers, native distributions, and native solvers.
 - Refresh broader tutorial setup snippets to use the current BOM and Groovy versions.
 
 ## v2.3.0, 2026-01-30

--- a/matrix-stats/req/v2.4.0-groovyFormulas.md
+++ b/matrix-stats/req/v2.4.0-groovyFormulas.md
@@ -632,15 +632,15 @@ GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'regress
 
 Section 5 updates documentation only after sections 1 through 4 have landed and the API is stable.
 
-5.1 [ ] Update `matrix-stats/README.md`.
+5.1 [x] Update `matrix-stats/README.md`.
 
 Add a Groovy formula DSL section after the existing formula model section.
 
-5.2 [ ] Update `docs/tutorial/3-matrix-stats.md`.
+5.2 [x] Update `docs/tutorial/3-matrix-stats.md`.
 
 Show both string and Groovy operator formula examples.
 
-5.3 [ ] Update `docs/cookbook/matrix-stats.md`.
+5.3 [x] Update `docs/cookbook/matrix-stats.md`.
 
 Add a short recipe comparing:
 
@@ -666,25 +666,25 @@ lm(data) {
 
 Document `interaction(x, group, z)` for three-way interactions.
 
-5.4 [ ] Document deferred syntax.
+5.4 [x] Document deferred syntax.
 
 Call out that the first Groovy DSL version uses `|` instead of `~` and `noIntercept` instead of `0 +`.
 
 Do not document `I { ... }` as deferred; it is required for parity with the supported string formula subset.
 
-5.5 [ ] Document dynamic DSL behavior.
+5.5 [x] Document dynamic DSL behavior.
 
 State that the operator DSL is intentionally dynamic because it relies on `propertyMissing` and operator dispatch for concise column references.
 
-5.6 [ ] Document `ExpressionDsl` arithmetic scope.
+5.6 [x] Document `ExpressionDsl` arithmetic scope.
 
 Document only the operators supported by the existing string parser subset. Do not over-promise arithmetic support in `I { ... }`.
 
-5.7 [ ] Update `matrix-stats/release.md`.
+5.7 [x] Update `matrix-stats/release.md`.
 
 Add the Groovy formula DSL to the v2.4.0 release notes if this lands before release.
 
-5.8 [ ] Run markdown/whitespace verification and record the exact passing command.
+5.8 [x] Run markdown/whitespace verification and record the exact passing command.
 
 ```bash
 git diff --check -- matrix-stats/README.md docs/tutorial/3-matrix-stats.md docs/cookbook/matrix-stats.md matrix-stats/release.md

--- a/matrix-stats/req/v2.4.0-groovyFormulas.md
+++ b/matrix-stats/req/v2.4.0-groovyFormulas.md
@@ -694,28 +694,28 @@ git diff --check -- matrix-stats/README.md docs/tutorial/3-matrix-stats.md docs/
 
 Section 6 is the final verification section after all implementation and docs PRs have landed.
 
-6.1 [ ] Run focused formula DSL tests and record the exact passing command.
+6.1 [x] Run focused formula DSL tests and record the exact passing command.
 
 ```bash
 GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'formula.GroovyFormulaDslTest'
 ```
 
-6.2 [ ] Run formula/model-frame regression tests and record the exact passing command.
+6.2 [x] Run formula/model-frame regression tests and record the exact passing command.
 
 ```bash
 GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'formula.*' --tests 'regression.*'
 ```
 
-6.3 [ ] Run full module verification and record the exact passing command.
+6.3 [x] Run full module verification and record the exact passing command.
 
 ```bash
 GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:spotlessApply :matrix-stats:test :matrix-stats:codenarcMain :matrix-stats:codenarcTest
 ```
 
-6.4 [ ] Run the full repo test suite before marking the feature complete and record the exact passing command.
+6.4 [x] Run the full repo test suite before marking the feature complete and record the exact passing command.
 
 ```bash
 GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew test
 ```
 
-6.5 [ ] Record all exact passing commands in this file or the final PR description before marking section 6 complete.
+6.5 [x] Record all exact passing commands in this file or the final PR description before marking section 6 complete.


### PR DESCRIPTION
## Summary
Finish the Groovy formula DSL work for `matrix-stats` by landing the section 4 fit helpers, the DSL follow-up fixes, the section 5 documentation updates, and the final section 6 verification record.

## What Changed
- Added `FitDsl` convenience entry points for `lm`, `loess`, and `gam`
- Added regression tests for `FitDsl` parity against `FitRegistry.instance().get(...).fit(ModelFrame.of(...).evaluate())`
- Centralized invalid-response `|` handling in `TermExpr` so non-variable response shapes report the formula-specific error instead of Groovy's generic missing-method error
- Removed redundant `or(...)` overrides from formula DSL subclasses once the base implementation was in place
- Documented the Groovy formula DSL in `matrix-stats/README.md`, `docs/tutorial/3-matrix-stats.md`, and `docs/cookbook/matrix-stats.md`
- Added the Groovy formula DSL and fit helper entries to `matrix-stats/release.md`
- Updated `matrix-stats/req/v2.4.0-groovyFormulas.md` through section 6 with the recorded validation commands

## Why
The Groovy formula work needed three things to be complete:
1. Direct fit helpers so callers can write `lm(data) { ... }` without manually building a `ModelFrame`
2. Consistent DSL failure messages for invalid response-side expressions
3. Documentation and recorded verification so the 2.4.0 feature scope is complete and reviewable

## User Impact
Callers can now write:

```groovy
lm(data) { y | x + group }
loess(data) { y | x }
gam(data) { y | smooth(time, 6) + group }
```

The docs now also describe:
- string-vs-Groovy formula parity
- deferred syntax (`|` and `noIntercept`)
- dynamic `propertyMissing` / operator-dispatch behavior
- the supported arithmetic scope inside `I { ... }`
- `interaction(x, group, z)` for three-way interactions

## Validation
- `GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'formula.GroovyFormulaDslTest'`
- `GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:test --tests 'formula.*' --tests 'regression.*'`
- `GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew :matrix-stats:spotlessApply :matrix-stats:test :matrix-stats:codenarcMain :matrix-stats:codenarcTest`
- `git diff --check -- matrix-stats/README.md docs/tutorial/3-matrix-stats.md docs/cookbook/matrix-stats.md matrix-stats/release.md`
- `GRADLE_USER_HOME=$PWD/.gradle-user ./gradlew test`

All of the above passed. The final full-repo run completed with:

```text
BUILD SUCCESSFUL in 17m 6s
530 actionable tasks: 529 executed, 1 up-to-date
Configuration cache entry stored.
```