### PR TITLE
matrix-json v2.2.0 overhaul

### DIFF
--- a/matrix-json/build.gradle
+++ b/matrix-json/build.gradle
@@ -22,6 +22,12 @@ JavaCompile javaCompile = compileJava {
 
 compileGroovy {
   options.deprecation = true
+  groovyOptions.configurationScript = rootProject.file('config/groovy/compileStatic.groovy')
+}
+
+codenarc {
+  configFile = file('config/codenarc/ruleset.groovy')
+  ignoreFailures = false
 }
 
 repositories {
@@ -37,15 +43,13 @@ dependencies {
   testImplementation project(':matrix-datasets')
 
   compileOnly libs.groovy
-  compileOnly libs.groovy.json
 
-  // Jackson for streaming JSON parsing (low memory footprint)
+  // Jackson for streaming JSON parsing and writing
   api platform(libs.jackson.bom)
   api libs.jackson.core
   api libs.jackson.databind
 
   testImplementation libs.groovy
-  testImplementation libs.groovy.json
   testImplementation libs.junit.jupiter.api
   testImplementation libs.groovier.junit
   testRuntimeOnly libs.junit.jupiter.engine

--- a/matrix-json/config/codenarc/ruleset.groovy
+++ b/matrix-json/config/codenarc/ruleset.groovy
@@ -1,0 +1,110 @@
+ruleset {
+    description 'CodeNarc ruleset for Matrix JSON'
+
+    ruleset('rulesets/basic.xml') {
+    }
+
+    ruleset('rulesets/braces.xml')
+
+    ruleset('rulesets/design.xml') {
+        exclude 'AbstractClassWithoutAbstractMethod'
+        exclude 'BuilderMethodWithSideEffects'
+        exclude 'Instanceof'
+        exclude 'NestedForLoop'
+        exclude 'PrivateFieldCouldBeFinal'
+    }
+
+    ruleset('rulesets/dry.xml') {
+        exclude 'DuplicateListLiteral'
+        exclude 'DuplicateNumberLiteral'
+        exclude 'DuplicateStringLiteral'
+    }
+
+    ruleset('rulesets/exceptions.xml') {
+        exclude 'CatchException'
+        exclude 'CatchThrowable'
+    }
+
+    ruleset('rulesets/imports.xml') {
+        exclude 'NoWildcardImports'
+    }
+
+    ruleset('rulesets/naming.xml') {
+        'MethodName' {
+            regex = /[a-z][\w]*/
+        }
+        'ClassName' {
+            regex = /[A-Z][\w$]*/
+        }
+        'FieldName' {
+            finalRegex = /[a-z][a-zA-Z0-9]*/
+            staticRegex = /([a-z][a-zA-Z0-9]*|[A-Z][A-Z_0-9]*)/
+            staticFinalRegex = /(log|[A-Z][A-Z_0-9]*)/
+            regex = /[a-z][a-zA-Z0-9]*/
+        }
+        exclude 'FactoryMethodName'
+        exclude 'ConfusingMethodName'
+    }
+
+    ruleset('rulesets/size.xml') {
+        exclude 'CrapMetric'
+        'AbcMetric' {
+            maxMethodAbcScore = 70
+            doNotApplyToFilesMatching = /.*Test\.groovy/
+        }
+        'CyclomaticComplexity' {
+            maxMethodComplexity = 35
+            doNotApplyToFilesMatching = /.*Test\.groovy/
+        }
+        'MethodCount' {
+            maxMethods = 250
+        }
+        'MethodSize' {
+            maxLines = 100
+        }
+        'ClassSize' {
+            maxLines = 1000
+        }
+        'ParameterCount' {
+            maxParameters = 7
+        }
+    }
+
+    ruleset('rulesets/unnecessary.xml') {
+        exclude 'UnnecessaryCollectCall'
+        exclude 'UnnecessaryElseStatement'
+        exclude 'UnnecessaryGString'
+        exclude 'UnnecessaryGetter'
+        exclude 'UnnecessaryObjectReferences'
+        exclude 'UnnecessaryPublicModifier'
+        exclude 'UnnecessarySetter'
+    }
+
+    ruleset('rulesets/unused.xml')
+
+    ruleset('rulesets/formatting.xml') {
+        exclude 'BlockEndsWithBlankLine'
+        exclude 'BlockStartsWithBlankLine'
+        exclude 'ClassEndsWithBlankLine'
+        exclude 'ClassStartsWithBlankLine'
+        exclude 'ConsecutiveBlankLines'
+        exclude 'Indentation'
+        exclude 'LineLength'
+        exclude 'SpaceAfterComma'
+        exclude 'SpaceAfterMethodCallName'
+        exclude 'SpaceAfterOpeningBrace'
+        exclude 'SpaceAroundMapEntryColon'
+        exclude 'SpaceAroundOperator'
+        exclude 'SpaceBeforeClosingBrace'
+        exclude 'SpaceInsideParentheses'
+    }
+
+    ruleset('rulesets/comments.xml') {
+        'ClassJavadoc' {
+            doNotApplyToFilesMatching = /.*Test\.groovy/
+        }
+        exclude 'SpaceAfterCommentDelimiter'
+    }
+
+    ruleset('rulesets/groovyism.xml')
+}

--- a/matrix-json/config/codenarc/ruleset.groovy
+++ b/matrix-json/config/codenarc/ruleset.groovy
@@ -49,11 +49,11 @@ ruleset {
     ruleset('rulesets/size.xml') {
         exclude 'CrapMetric'
         'AbcMetric' {
-            maxMethodAbcScore = 70
+            maxMethodAbcScore = 35
             doNotApplyToFilesMatching = /.*Test\.groovy/
         }
         'CyclomaticComplexity' {
-            maxMethodComplexity = 35
+            maxMethodComplexity = 20
             doNotApplyToFilesMatching = /.*Test\.groovy/
         }
         'MethodCount' {

--- a/matrix-json/release.md
+++ b/matrix-json/release.md
@@ -1,6 +1,6 @@
 # Release history
 
-## v2.1.3, In progress
+## v2.2.0, In progress
 - upgrade dependencies
   - com.fasterxml.jackson.core:jackson-core 2.21.0 -> 2.21.2 
   - com.fasterxml.jackson.core:jackson-databind 2.21.0 -> 2.21.2

--- a/matrix-json/req/v2.2.0-roadmap.md
+++ b/matrix-json/req/v2.2.0-roadmap.md
@@ -7,7 +7,7 @@ parity with the recently overhauled matrix-csv, matrix-arff, and matrix-avro mod
 
 ## 1. Build infrastructure
 
-### 1.1 [ ] Enable static compilation by default
+### 1.1 [x] Enable static compilation by default
 Add to `build.gradle`:
 ```groovy
 compileGroovy {
@@ -21,7 +21,7 @@ affected; test sources remain dynamically compiled.
 Any method that genuinely requires dynamic dispatch must be annotated `@CompileDynamic`
 with a comment explaining why.
 
-### 1.2 [ ] Add CodeNarc configuration
+### 1.2 [x] Add CodeNarc configuration
 Add to `build.gradle`:
 ```groovy
 codenarc {
@@ -34,7 +34,7 @@ Create `config/codenarc/ruleset.groovy` modelled on the root
 CodeNarc is already applied by the root `subprojects {}` block; the module-level
 `configFile` overrides the root config so the module has its own rule set.
 
-### 1.3 [ ] Confirm Spotless coverage
+### 1.3 [x] Confirm Spotless coverage
 Spotless (`com.diffplug.spotless`) is applied to all Groovy sub-modules by the root
 `subprojects { plugins.withId('groovy') { ... } }` block. Verify that
 `./gradlew :matrix-json:spotlessCheck` passes after this overhaul and add an explicit
@@ -45,18 +45,18 @@ to be overridden for this module.
 
 ## 2. Bug fixes
 
-### 2.1 [ ] Formatter `write(File, …)` missing directory / parent-dir guards
+### 2.1 [x] Formatter `write(File, …)` missing directory / parent-dir guards
 `JsonWriter.write(Matrix, File, Map<String,Closure>, boolean, String)` (line 252)
 accepts a `File` output path but skips all the safety checks present in the
 non-formatter overload (directory detection, parent-dir creation, writability check).
 Apply the same guard logic that `write(Matrix, File, boolean)` uses.
 
-### 2.2 [ ] Add missing Path and String write overloads for the formatter variant
+### 2.2 [x] Add missing Path and String write overloads for the formatter variant
 `write(Matrix, Path, Map<String,Closure>, …)` and
 `write(Matrix, String, Map<String,Closure>, …)` are missing.
 The no-formatter write has all three target types; the formatter write only has `File`.
 
-### 2.3 [ ] Fix resource leak in `JsonReader.read(File, Charset)`
+### 2.3 [x] Fix resource leak in `JsonReader.read(File, Charset)`
 Current code (`JsonReader.groovy:98`):
 ```groovy
 FACTORY.createParser(new InputStreamReader(new FileInputStream(file), charset))
@@ -78,7 +78,7 @@ file.newReader(charset.name()).withCloseable { Reader reader ->
 These code changes are required before enabling build-level `@CompileStatic`; they
 can be applied in the same commit as 1.1.
 
-### 3.1 [ ] Fix `JsonWriter` to compile under `@CompileStatic`
+### 3.1 [x] Fix `JsonWriter` to compile under `@CompileStatic`
 `JsonWriter` currently has no `@CompileStatic` annotation and uses several
 dynamically-typed constructs that will not compile statically:
 
@@ -91,7 +91,7 @@ dynamically-typed constructs that will not compile statically:
 If the `JsonGenerator.Converter` anonymous-class block cannot be compiled statically,
 annotate that inner method with `@CompileDynamic` and document why.
 
-### 3.2 [ ] Fix `JsonExporter` to compile under `@CompileStatic`
+### 3.2 [x] Fix `JsonExporter` to compile under `@CompileStatic`
 Review and fix any `def`-typed fields or method returns in `JsonExporter` that would
 fail static compilation, or annotate the class `@CompileDynamic` with a comment if the
 delegation pattern makes static typing impractical.
@@ -100,7 +100,7 @@ delegation pattern makes static typing impractical.
 
 ## 4. Usability enhancements
 
-### 4.1 [ ] Fluent builder API for `JsonWriter`
+### 4.1 [x] Fluent builder API for `JsonWriter`
 The largest gap vs. the overhauled modules. Add a `WriteBuilder` inner class (modelled
 on `CsvWriter.WriteBuilder`) with a static factory entry point:
 
@@ -125,18 +125,18 @@ Configuration methods: `indent(boolean)` / `indent()`, `dateFormat(String)`,
 The existing static methods stay for backward compatibility but gain `@Deprecated`
 annotations pointing to the fluent API equivalents.
 
-### 4.2 [ ] Derive matrix name from file / URL in `JsonReader`
+### 4.2 [x] Derive matrix name from file / URL in `JsonReader`
 `CsvReader` sets the matrix name to the file basename (without extension) when reading
 from a `File` or `URL`. `JsonReader` produces a nameless matrix. Add a private
 `tableName(File)` / `tableName(URL)` helper (same pattern as `CsvReader`) and set the
 matrix name in the `read(File, …)` and `read(URL, …)` overloads.
 
-### 4.3 [ ] Add `matrixName` option to `JsonReadOptions`
+### 4.3 [x] Add `matrixName` option to `JsonReadOptions`
 Add a nullable `String matrixName` field to `JsonReadOptions` (with fluent setter,
 `fromMap` support, and descriptor). When set, it overrides the file-derived name.
 Update `JsonFormatProvider.read(File, …)` and `read(URL, …)` to apply it.
 
-### 4.4 [ ] Type-conversion support in `JsonReadOptions` / `JsonReader`
+### 4.4 [x] Type-conversion support in `JsonReadOptions` / `JsonReader`
 After JSON is parsed, users currently call `.convert([types])` manually.
 Add `List<Class> types` and `String dateTimeFormat` to `JsonReadOptions`, and apply
 `matrix.convert(types, dateTimeFormat)` inside `JsonReader` when types are set.
@@ -146,7 +146,7 @@ Matrix.read([types: [Integer, String, LocalDate], dateTimeFormat: 'yyyy-MM-dd'],
 ```
 Update `JsonFormatProvider.read(…)` accordingly.
 
-### 4.5 [ ] Add `readString(String)` convenience method
+### 4.5 [x] Add `readString(String)` convenience method
 `CsvReader` exposes `readString(content, options)` and `CsvReader.read().fromString(content)`.
 Add `JsonReader.readString(String jsonContent)` as a named alias for `read(String)` for
 API symmetry. Consider deprecating `read(String)` in a future release (the name is
@@ -156,7 +156,7 @@ ambiguous — could be a file path or JSON content) once `readString` is establi
 
 ## 5. Code quality
 
-### 5.1 [ ] Switch `JsonWriter` from Groovy's `JsonOutput` to Jackson streaming
+### 5.1 [x] Switch `JsonWriter` from Groovy's `JsonOutput` to Jackson streaming
 `JsonReader` uses Jackson; `JsonWriter` uses Groovy's `groovy.json.*`. Unify on Jackson:
 - Replace `JsonGenerator.Options` / `JsonOutput.prettyPrint` with Jackson's
   `ObjectMapper` / `JsonGenerator` and `SerializationFeature.INDENT_OUTPUT`
@@ -166,7 +166,7 @@ ambiguous — could be a file path or JSON content) once `readString` is establi
 - Remove the `compileOnly libs.groovy.json` / `testImplementation libs.groovy.json`
   build dependency once the Groovy JSON classes are no longer used in production code
 
-### 5.2 [ ] Stream rows in `JsonWriter` instead of collecting into a `List<Map>`
+### 5.2 [x] Stream rows in `JsonWriter` instead of collecting into a `List<Map>`
 Current implementation builds `List<Map<String,Object>> rowMaps` in memory before
 serialising. Replace with Jackson streaming that writes `[`, then one row-object at a
 time, then `]`, keeping peak memory to O(columns) rather than O(rows × columns).
@@ -176,23 +176,23 @@ This naturally follows from task 5.1.
 
 ## 6. Test coverage
 
-### 6.1 [ ] Tests for fluent `JsonWriter` API (WriteBuilder)
+### 6.1 [x] Tests for fluent `JsonWriter` API (WriteBuilder)
 Add tests covering all `WriteBuilder` terminal methods and key configuration options:
 `to(File)`, `to(Path)`, `to(Writer)`, `asString()`, `indent()`, `dateFormat(…)`,
 `formatter(…)`, `columnFormatters(…)`.
 
-### 6.2 [ ] Tests for file-derived matrix name in `JsonReader`
+### 6.2 [x] Tests for file-derived matrix name in `JsonReader`
 Verify that `JsonReader.read(new File("employees.json"))` produces a matrix with
 name `"employees"`.
 
-### 6.3 [ ] Tests for `JsonReadOptions` type conversion
+### 6.3 [x] Tests for `JsonReadOptions` type conversion
 Verify that reading with `types` and `dateTimeFormat` options produces correctly typed
 columns without a manual `.convert()` call.
 
-### 6.4 [ ] Tests for `readString(String)`
+### 6.4 [x] Tests for `readString(String)`
 Basic smoke test confirming the method works and returns the same result as `read(String)`.
 
-### 6.5 [ ] Tests for fixed formatter-write overloads (tasks 2.1, 2.2)
+### 6.5 [x] Tests for fixed formatter-write overloads (tasks 2.1, 2.2)
 - Writing with formatters to a Path / String path
 - Writing with formatters where the parent directory does not yet exist
 

--- a/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonFormatProvider.groovy
+++ b/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonFormatProvider.groovy
@@ -37,19 +37,22 @@ class JsonFormatProvider extends AbstractFormatProvider {
   @Override
   Matrix read(File file, Map<String, ?> options) {
     JsonReadOptions readOptions = JsonReadOptions.fromMap(options)
-    JsonReader.read(file, readOptions.charset)
+    Matrix result = JsonReader.read(file, readOptions.charset)
+    applyReadOptions(result, readOptions)
   }
 
   @Override
   Matrix read(URL url, Map<String, ?> options) {
     JsonReadOptions readOptions = JsonReadOptions.fromMap(options)
-    JsonReader.read(url, readOptions.charset)
+    Matrix result = JsonReader.read(url, readOptions.charset)
+    applyReadOptions(result, readOptions)
   }
 
   @Override
   Matrix read(InputStream is, Map<String, ?> options) {
     JsonReadOptions readOptions = JsonReadOptions.fromMap(options)
-    JsonReader.read(is, readOptions.charset)
+    Matrix result = JsonReader.read(is, readOptions.charset)
+    applyReadOptions(result, readOptions)
   }
 
   @Override
@@ -66,5 +69,15 @@ class JsonFormatProvider extends AbstractFormatProvider {
   @Override
   List<OptionDescriptor> writeOptionDescriptors() {
     JsonWriteOptions.descriptors()
+  }
+
+  private static Matrix applyReadOptions(Matrix result, JsonReadOptions readOptions) {
+    if (readOptions.matrixName != null) {
+      result.matrixName = readOptions.matrixName
+    }
+    if (readOptions.types != null) {
+      result = result.convert(readOptions.types, readOptions.dateTimeFormat)
+    }
+    result
   }
 }

--- a/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonReadOptions.groovy
+++ b/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonReadOptions.groovy
@@ -15,6 +15,9 @@ import java.nio.charset.StandardCharsets
 class JsonReadOptions {
 
   Charset charset = StandardCharsets.UTF_8
+  String matrixName = null
+  List<Class> types = null
+  String dateTimeFormat = null
 
   JsonReadOptions charset(Charset value) {
     this.charset = value
@@ -26,26 +29,88 @@ class JsonReadOptions {
     this
   }
 
+  /**
+   * Set the name for the resulting Matrix, overriding any file-derived name.
+   *
+   * @param value the matrix name
+   * @return this options instance for chaining
+   */
+  JsonReadOptions matrixName(String value) {
+    this.matrixName = value
+    this
+  }
+
+  /**
+   * Set column types for automatic conversion after parsing.
+   *
+   * @param value list of column type classes
+   * @return this options instance for chaining
+   */
+  JsonReadOptions types(List<Class> value) {
+    this.types = value
+    this
+  }
+
+  /**
+   * Set the date/time format pattern used during type conversion.
+   *
+   * @param value date/time format pattern (e.g. 'yyyy-MM-dd')
+   * @return this options instance for chaining
+   */
+  JsonReadOptions dateTimeFormat(String value) {
+    this.dateTimeFormat = value
+    this
+  }
+
   static JsonReadOptions fromMap(Map<String, ?> options) {
     JsonReadOptions result = new JsonReadOptions()
     Map<String, Object> normalized = OptionMaps.normalizeKeys(options)
     if (normalized.containsKey('charset')) {
-      def value = normalized.charset
+      Object value = normalized.charset
       if (value instanceof Charset) {
         result.charset(value as Charset)
       } else if (value instanceof CharSequence) {
         result.charset(String.valueOf(value))
-      } else if (value == null) {
-        // Treat null as absent to preserve the default charset.
-      } else {
+      } else if (value != null) {
         throw new IllegalArgumentException("charset must be a Charset or String but was ${value?.class}")
+      }
+    }
+    if (normalized.containsKey('matrixname') || normalized.containsKey('tablename')) {
+      String key = normalized.containsKey('matrixname') ? 'matrixname' : 'tablename'
+      Object val = normalized[key]
+      if (val != null) {
+        result.matrixName(String.valueOf(val))
+      }
+    }
+    if (normalized.containsKey('types')) {
+      Object value = normalized.types
+      if (value instanceof List) {
+        result.types(value as List<Class>)
+      } else if (value != null && value.getClass().isArray()) {
+        result.types((value as Class[]).toList())
+      }
+    }
+    if (normalized.containsKey('datetimeformat')) {
+      Object value = normalized.datetimeformat
+      if (value != null) {
+        result.dateTimeFormat(String.valueOf(value))
       }
     }
     result
   }
 
   Map<String, ?> toMap() {
-    [charset: charset]
+    Map<String, Object> m = [charset: (Object) charset]
+    if (matrixName != null) {
+      m.matrixName = matrixName
+    }
+    if (types != null) {
+      m.types = types
+    }
+    if (dateTimeFormat != null) {
+      m.dateTimeFormat = dateTimeFormat
+    }
+    m
   }
 
   static String describe() {
@@ -54,7 +119,10 @@ class JsonReadOptions {
 
   static List<OptionDescriptor> descriptors() {
     [
-        new OptionDescriptor('charset', Charset, 'UTF-8', 'The character encoding to use when reading JSON')
+        new OptionDescriptor('charset', Charset, 'UTF-8', 'The character encoding to use when reading JSON'),
+        new OptionDescriptor('matrixName', String, null, 'Override the name for the resulting Matrix (default: derived from filename)'),
+        new OptionDescriptor('types', List, null, 'List of column types for automatic conversion after parsing'),
+        new OptionDescriptor('dateTimeFormat', String, null, 'Date/time format pattern for type conversion')
     ]
   }
 }

--- a/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonReadOptions.groovy
+++ b/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonReadOptions.groovy
@@ -120,7 +120,7 @@ class JsonReadOptions {
   static List<OptionDescriptor> descriptors() {
     [
         new OptionDescriptor('charset', Charset, 'UTF-8', 'The character encoding to use when reading JSON'),
-        new OptionDescriptor('matrixName', String, null, 'Override the name for the resulting Matrix (default: derived from filename)'),
+        new OptionDescriptor('matrixName', String, null, 'Override the name for the resulting Matrix (default: derived from filename). Also accepted as tableName'),
         new OptionDescriptor('types', List, null, 'List of column types for automatic conversion after parsing'),
         new OptionDescriptor('dateTimeFormat', String, null, 'Date/time format pattern for type conversion')
     ]

--- a/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonReader.groovy
+++ b/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonReader.groovy
@@ -70,7 +70,7 @@ class JsonReader {
    */
   static Matrix read(String str) {
     FACTORY.createParser(str).withCloseable { JsonParser parser ->
-      return parseStream(parser)
+      parseStream(parser)
     }
   }
 
@@ -83,7 +83,7 @@ class JsonReader {
    */
   static Matrix read(InputStream is, Charset charset = StandardCharsets.UTF_8) {
     FACTORY.createParser(new InputStreamReader(is, charset)).withCloseable { JsonParser parser ->
-      return parseStream(parser)
+      parseStream(parser)
     }
   }
 
@@ -95,9 +95,13 @@ class JsonReader {
    * @return a Matrix with columns derived from JSON keys
    */
   static Matrix read(File file, Charset charset = StandardCharsets.UTF_8) {
-    FACTORY.createParser(new InputStreamReader(new FileInputStream(file), charset)).withCloseable { JsonParser parser ->
-      return parseStream(parser)
-    }
+    Matrix result = file.newReader(charset.name()).withCloseable { Reader reader ->
+      FACTORY.createParser(reader).withCloseable { JsonParser parser ->
+        parseStream(parser)
+      }
+    } as Matrix
+    result.matrixName = tableName(file)
+    result
   }
 
   /**
@@ -108,7 +112,7 @@ class JsonReader {
    */
   static Matrix read(Reader reader) {
     FACTORY.createParser(reader).withCloseable { JsonParser parser ->
-      return parseStream(parser)
+      parseStream(parser)
     }
   }
 
@@ -121,9 +125,11 @@ class JsonReader {
    * @throws IOException if reading the URL fails
    */
   static Matrix read(URL url, Charset charset = StandardCharsets.UTF_8) {
-    url.openStream().withCloseable { InputStream is ->
-      return read(is, charset)
-    }
+    Matrix result = url.openStream().withCloseable { InputStream is ->
+      read(is, charset)
+    } as Matrix
+    result.matrixName = tableName(url)
+    result
   }
 
   /**
@@ -135,7 +141,7 @@ class JsonReader {
    * @throws IOException if reading the URL fails or URL is invalid
    */
   static Matrix readUrl(String urlString, Charset charset = StandardCharsets.UTF_8) {
-    return read(new URI(urlString).toURL(), charset)
+    read(new URI(urlString).toURL(), charset)
   }
 
   /**
@@ -147,7 +153,7 @@ class JsonReader {
    * @throws IOException if reading the file fails
    */
   static Matrix read(Path path, Charset charset = StandardCharsets.UTF_8) {
-    return read(path.toFile(), charset)
+    read(path.toFile(), charset)
   }
 
   /**
@@ -162,7 +168,40 @@ class JsonReader {
    * @throws IOException if reading the file fails or file not found
    */
   static Matrix readFile(String filePath, Charset charset = StandardCharsets.UTF_8) {
-    return read(new File(filePath), charset)
+    read(new File(filePath), charset)
+  }
+
+  /**
+   * Read a JSON string containing an array of objects into a Matrix.
+   *
+   * <p>This is an alias for {@link #read(String)} provided for API symmetry
+   * with other format readers (e.g. CsvReader.readString).</p>
+   *
+   * @param jsonContent a JSON string containing a list of rows (JSON objects)
+   * @return a Matrix with columns derived from JSON keys
+   */
+  static Matrix readString(String jsonContent) {
+    read(jsonContent)
+  }
+
+  /**
+   * Derive a table name from a File by stripping the extension.
+   */
+  private static String tableName(File file) {
+    String name = file.getName()
+    int dot = name.lastIndexOf('.')
+    dot > 0 ? name.substring(0, dot) : name
+  }
+
+  /**
+   * Derive a table name from a URL by extracting the filename and stripping the extension.
+   */
+  private static String tableName(URL url) {
+    String path = url.getFile() ?: url.getPath()
+    int slash = path.lastIndexOf('/')
+    String name = slash >= 0 ? path.substring(slash + 1) : path
+    int dot = name.lastIndexOf('.')
+    dot > 0 ? name.substring(0, dot) : name
   }
 
   /**
@@ -173,9 +212,9 @@ class JsonReader {
    */
   private static Matrix parseStream(JsonParser parser) {
     // Column tracking - maps column name to column index
-    Map<String, Integer> columnIndex = new LinkedHashMap<>()
-    List<String> columnNames = new ArrayList<>()
-    List<List<Object>> columns = new ArrayList<>()
+    Map<String, Integer> columnIndex = [:]
+    List<String> columnNames = []
+    List<List<Object>> columns = []
     int rowCount = 0
 
     // Expect array start
@@ -190,11 +229,11 @@ class JsonReader {
       Map<String, Object> rowObj = MAPPER.readValue(parser, Map)
 
       // Flatten nested structures to dot-notation keys
-      Map<String, Object> flatRow = new LinkedHashMap<>()
+      Map<String, Object> flatRow = [:]
       flatten('', rowObj, flatRow)
 
       // Track which columns received values in this row
-      Set<Integer> columnsUpdated = new HashSet<>()
+      Set<Integer> columnsUpdated = [] as Set<Integer>
 
       // Process each key-value pair
       for (Map.Entry<String, Object> entry : flatRow.entrySet()) {
@@ -207,7 +246,7 @@ class JsonReader {
           colIdx = columnNames.size()
           columnIndex.put(key, colIdx)
           columnNames.add(key)
-          List<Object> newColumn = new ArrayList<>()
+          List<Object> newColumn = []
           // Backfill nulls for previous rows
           for (int i = 0; i < rowCount; i++) {
             newColumn.add(null)
@@ -233,7 +272,7 @@ class JsonReader {
       return Matrix.builder().build()
     }
 
-    return Matrix.builder()
+    Matrix.builder()
         .columnNames(columnNames)
         .columns(columns)
         .build()

--- a/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonWriteOptions.groovy
+++ b/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonWriteOptions.groovy
@@ -43,7 +43,7 @@ class JsonWriteOptions {
       }
     }
     if (normalized.containsKey('columnformatters')) {
-      def value = normalized.columnformatters
+      Object value = normalized.columnformatters
       if (value == null) {
         return result
       }

--- a/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonWriter.groovy
+++ b/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonWriter.groovy
@@ -1,8 +1,12 @@
 package se.alipsa.matrix.json
 
-import groovy.json.*
+import groovy.transform.CompileStatic
+
+import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.core.JsonGenerator
 
 import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.core.Row
 
 import java.nio.file.Path
 import java.time.format.DateTimeFormatter
@@ -14,42 +18,41 @@ import java.time.temporal.TemporalAccessor
  * <p>Supports custom formatting for individual columns via closures and
  * automatic temporal data formatting with configurable date patterns.</p>
  *
- * <h3>Basic Usage</h3>
+ * <h3>Fluent API (recommended)</h3>
  * <pre>
- * Matrix m = Matrix.builder()
- *   .data(id: [1, 2], name: ['Alice', 'Bob'])
- *   .build()
- *
- * String json = JsonWriter.writeString(m)
- * // Output: [{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}]
- *
- * String pretty = JsonWriter.writeString(m, true)
- * // Output: Pretty-printed with indentation
- *
- * // Write to file
- * JsonWriter.write(m, new File("output.json"))
- * </pre>
- *
- * <h3>Custom Column Formatting</h3>
- * <pre>
- * String json = JsonWriter.writeString(m, [
- *   'salary': {it * 10 + ' kr'},
- *   'date': {DateTimeFormatter.ofPattern('MM/dd/yy').format(it)}
- * ])
- * </pre>
- *
- * <h3>Date Formatting</h3>
- * <pre>
- * // All temporal columns formatted with custom pattern
- * String json = JsonWriter.writeString(m, 'MM/dd/yyyy')
+ * JsonWriter.write(matrix).to(file)
+ * JsonWriter.write(matrix).indent().to(file)
+ * JsonWriter.write(matrix).dateFormat('MM/dd/yyyy').to(file)
+ * JsonWriter.write(matrix).formatter('salary') { it * 10 }.to(file)
+ * String json = JsonWriter.write(matrix).asString()
  * </pre>
  *
  * @see JsonReader
  */
+@CompileStatic
 class JsonWriter {
+
+  private static final JsonFactory FACTORY = new JsonFactory()
 
   private JsonWriter() {
     // Only static methods
+  }
+
+  /**
+   * Entry point for the fluent JSON writing API.
+   *
+   * <pre>
+   * JsonWriter.write(matrix).to(file)
+   * JsonWriter.write(matrix).indent().to(file)
+   * JsonWriter.write(matrix).dateFormat('MM/dd/yyyy').to(file)
+   * String json = JsonWriter.write(matrix).asString()
+   * </pre>
+   *
+   * @param matrix the matrix to write
+   * @return a new {@link WriteBuilder}
+   */
+  static WriteBuilder write(Matrix matrix) {
+    new WriteBuilder(matrix)
   }
 
   /**
@@ -58,12 +61,15 @@ class JsonWriter {
    * @param matrix the Matrix to write
    * @param indent whether to pretty print the JSON
    * @return JSON string representation
+   * @deprecated Use {@code JsonWriter.write(matrix).asString()} or {@code JsonWriter.write(matrix).indent().asString()} instead
    */
+  @Deprecated
   static String writeString(Matrix matrix, boolean indent = false) {
     if (matrix == null) {
       throw new IllegalArgumentException("Matrix cannot be null")
     }
-    writeString(matrix, [:], indent)
+    Map<String, Closure> emptyFormatters = [:]
+    writeString(matrix, emptyFormatters, indent)
   }
 
   /**
@@ -74,54 +80,82 @@ class JsonWriter {
    * @param indent whether to pretty print the JSON
    * @param dateFormat date format pattern for temporal columns (default: yyyy-MM-dd)
    * @return JSON string representation
+   * @deprecated Use the fluent API: {@code JsonWriter.write(matrix).columnFormatters(formatters).asString()} instead
    */
+  @Deprecated
   static String writeString(Matrix matrix, Map<String, Closure> columnFormatters, boolean indent = false, String dateFormat = 'yyyy-MM-dd') {
     if (matrix == null) {
       throw new IllegalArgumentException("Matrix cannot be null")
     }
 
-    // Validate that all formatter keys refer to existing columns before cloning/applying
     if (columnFormatters != null && !columnFormatters.isEmpty()) {
-      def columnNames = matrix.columnNames()
-      def invalidFormatters = columnFormatters.keySet().findAll { !columnNames.contains(it) }
+      List<String> colNames = matrix.columnNames()
+      Set<String> invalidFormatters = columnFormatters.keySet().findAll { String it -> !colNames.contains(it) } as Set<String>
       if (!invalidFormatters.isEmpty()) {
         throw new IllegalArgumentException(
             "Column formatter(s) defined for non-existent column(s): ${invalidFormatters}. " +
-            "Available columns: ${columnNames}"
+            "Available columns: ${colNames}"
         )
       }
     }
 
-    // Only clone if we need to apply formatters (avoids unnecessary memory allocation)
-    def t = columnFormatters.isEmpty() ? matrix : matrix.clone()
+    Matrix t = columnFormatters.isEmpty() ? matrix : (matrix.clone() as Matrix)
     if (!columnFormatters.isEmpty()) {
-      columnFormatters.each { k, v ->
+      columnFormatters.each { String k, Closure v ->
         t.apply(k, v)
       }
     }
     DateTimeFormatter dtf = DateTimeFormatter.ofPattern(dateFormat)
 
-    def jsonGenerator = new JsonGenerator.Options()
-        .dateFormat(dateFormat)
-        .addConverter(new JsonGenerator.Converter() {
-          @Override
-          boolean handles(Class<?> type) {
-            return TemporalAccessor.isAssignableFrom(type)
-          }
-          @Override
-          Object convert(Object date, String key) {
-            dtf.format(date as TemporalAccessor)
-          }
-        })
-        .build()
-
-    // Build JSON by collecting row maps and letting the generator handle serialization
-    def rowMaps = []
-    for (def row : t) {
-      rowMaps.add(row.toMap())
+    StringWriter sw = new StringWriter()
+    JsonGenerator gen = FACTORY.createGenerator(sw)
+    if (indent) {
+      gen.useDefaultPrettyPrinter()
     }
-    String json = jsonGenerator.toJson(rowMaps)
-    return indent ? JsonOutput.prettyPrint(json) : json
+    gen.withCloseable {
+      gen.writeStartArray()
+      List<String> colNames = t.columnNames()
+      int colCount = colNames.size()
+      for (Row row : t) {
+        gen.writeStartObject()
+        for (int i = 0; i < colCount; i++) {
+          gen.writeFieldName(colNames[i])
+          writeValue(gen, row[i], dtf)
+        }
+        gen.writeEndObject()
+      }
+      gen.writeEndArray()
+    }
+    sw.toString()
+  }
+
+  /**
+   * Write a single value to the Jackson JsonGenerator with appropriate type handling.
+   */
+  private static void writeValue(JsonGenerator gen, Object value, DateTimeFormatter dtf) {
+    if (value == null) {
+      gen.writeNull()
+    } else if (value instanceof TemporalAccessor) {
+      gen.writeString(dtf.format((TemporalAccessor) value))
+    } else if (value instanceof Boolean) {
+      gen.writeBoolean((boolean) value)
+    } else if (value instanceof Integer) {
+      gen.writeNumber((int) value)
+    } else if (value instanceof Long) {
+      gen.writeNumber((long) value)
+    } else if (value instanceof BigDecimal) {
+      gen.writeNumber((BigDecimal) value)
+    } else if (value instanceof BigInteger) {
+      gen.writeNumber((BigInteger) value)
+    } else if (value instanceof Double) {
+      gen.writeNumber((double) value)
+    } else if (value instanceof Float) {
+      gen.writeNumber((float) value)
+    } else if (value instanceof Number) {
+      gen.writeNumber(value.toString())
+    } else {
+      gen.writeString(value.toString())
+    }
   }
 
   /**
@@ -131,12 +165,15 @@ class JsonWriter {
    * @param dateFormat date format pattern for all temporal columns
    * @param indent whether to pretty print the JSON
    * @return JSON string representation
+   * @deprecated Use {@code JsonWriter.write(matrix).dateFormat(pattern).asString()} instead
    */
+  @Deprecated
   static String writeString(Matrix matrix, String dateFormat, boolean indent = false) {
     if (matrix == null) {
       throw new IllegalArgumentException("Matrix cannot be null")
     }
-    writeString(matrix, [:], indent, dateFormat)
+    Map<String, Closure> emptyFormatters = [:]
+    writeString(matrix, emptyFormatters, indent, dateFormat)
   }
 
   /**
@@ -146,7 +183,9 @@ class JsonWriter {
    * @param outputFile file to write JSON to
    * @param indent whether to pretty print the JSON
    * @throws IOException if writing fails
+   * @deprecated Use {@code JsonWriter.write(matrix).to(file)} instead
    */
+  @Deprecated
   static void write(Matrix matrix, File outputFile, boolean indent = false) throws IOException {
     if (matrix == null) {
       throw new IllegalArgumentException("Matrix cannot be null")
@@ -170,8 +209,6 @@ class JsonWriter {
       throw new IOException("Output file '${outputFile.absolutePath}' is not writable")
     }
 
-    // Let Groovy's file.text setter handle file creation - it will create the file if needed
-    // and overwrite if it exists, avoiding TOCTOU race conditions
     outputFile.text = writeString(matrix, indent)
   }
 
@@ -182,7 +219,9 @@ class JsonWriter {
    * @param outputPath path to write JSON to
    * @param indent whether to pretty print the JSON
    * @throws IOException if writing fails
+   * @deprecated Use {@code JsonWriter.write(matrix).to(path)} instead
    */
+  @Deprecated
   static void write(Matrix matrix, Path outputPath, boolean indent = false) throws IOException {
     write(matrix, outputPath.toFile(), indent)
   }
@@ -194,7 +233,9 @@ class JsonWriter {
    * @param outputPath file path to write JSON to
    * @param indent whether to pretty print the JSON
    * @throws IOException if writing fails
+   * @deprecated Use {@code JsonWriter.write(matrix).to(filePath)} instead
    */
+  @Deprecated
   static void write(Matrix matrix, String outputPath, boolean indent = false) throws IOException {
     write(matrix, new File(outputPath), indent)
   }
@@ -206,7 +247,9 @@ class JsonWriter {
    * @param writer the Writer to write JSON to
    * @param indent whether to pretty print the JSON
    * @throws IOException if writing fails
+   * @deprecated Use {@code JsonWriter.write(matrix).to(writer)} instead
    */
+  @Deprecated
   static void write(Matrix matrix, Writer writer, boolean indent = false) throws IOException {
     if (matrix == null) {
       throw new IllegalArgumentException("Matrix cannot be null")
@@ -227,7 +270,9 @@ class JsonWriter {
    * @param indent whether to pretty print the JSON
    * @param dateFormat date format pattern for temporal columns (default: yyyy-MM-dd)
    * @throws IOException if writing fails
+   * @deprecated Use the fluent API: {@code JsonWriter.write(matrix).columnFormatters(formatters).to(writer)} instead
    */
+  @Deprecated
   static void write(Matrix matrix, Writer writer, Map<String, Closure> columnFormatters, boolean indent = false, String dateFormat = 'yyyy-MM-dd') throws IOException {
     if (matrix == null) {
       throw new IllegalArgumentException("Matrix cannot be null")
@@ -248,7 +293,9 @@ class JsonWriter {
    * @param indent whether to pretty print the JSON
    * @param dateFormat date format pattern for temporal columns (default: yyyy-MM-dd)
    * @throws IOException if writing fails
+   * @deprecated Use the fluent API: {@code JsonWriter.write(matrix).columnFormatters(formatters).to(file)} instead
    */
+  @Deprecated
   static void write(Matrix matrix, File outputFile, Map<String, Closure> columnFormatters, boolean indent = false, String dateFormat = 'yyyy-MM-dd') throws IOException {
     if (matrix == null) {
       throw new IllegalArgumentException("Matrix cannot be null")
@@ -256,6 +303,195 @@ class JsonWriter {
     if (outputFile == null) {
       throw new IllegalArgumentException("Output file cannot be null")
     }
+
+    if (outputFile.isDirectory()) {
+      throw new IOException("Output file '${outputFile.absolutePath}' is a directory, cannot write JSON data")
+    }
+
+    File parent = outputFile.getParentFile()
+    if (parent != null && !parent.exists()) {
+      if (!parent.mkdirs()) {
+        throw new IOException("Failed to create parent directory '${parent.absolutePath}' for output file '${outputFile.absolutePath}'")
+      }
+    }
+
+    if (outputFile.exists() && !outputFile.canWrite()) {
+      throw new IOException("Output file '${outputFile.absolutePath}' is not writable")
+    }
+
     outputFile.text = writeString(matrix, columnFormatters, indent, dateFormat)
+  }
+
+  /**
+   * Write a Matrix to a JSON file specified by Path with custom formatting.
+   *
+   * @param matrix the Matrix to write
+   * @param outputPath path to write JSON to
+   * @param columnFormatters map of column names to formatting closures
+   * @param indent whether to pretty print the JSON
+   * @param dateFormat date format pattern for temporal columns (default: yyyy-MM-dd)
+   * @throws IOException if writing fails
+   * @deprecated Use the fluent API: {@code JsonWriter.write(matrix).columnFormatters(formatters).to(path)} instead
+   */
+  @Deprecated
+  static void write(Matrix matrix, Path outputPath, Map<String, Closure> columnFormatters, boolean indent = false, String dateFormat = 'yyyy-MM-dd') throws IOException {
+    write(matrix, outputPath.toFile(), columnFormatters, indent, dateFormat)
+  }
+
+  /**
+   * Write a Matrix to a JSON file specified by String path with custom formatting.
+   *
+   * @param matrix the Matrix to write
+   * @param outputPath file path to write JSON to
+   * @param columnFormatters map of column names to formatting closures
+   * @param indent whether to pretty print the JSON
+   * @param dateFormat date format pattern for temporal columns (default: yyyy-MM-dd)
+   * @throws IOException if writing fails
+   * @deprecated Use the fluent API: {@code JsonWriter.write(matrix).columnFormatters(formatters).to(filePath)} instead
+   */
+  @Deprecated
+  static void write(Matrix matrix, String outputPath, Map<String, Closure> columnFormatters, boolean indent = false, String dateFormat = 'yyyy-MM-dd') throws IOException {
+    write(matrix, new File(outputPath), columnFormatters, indent, dateFormat)
+  }
+
+  /**
+   * Fluent builder for writing Matrix data to JSON.
+   *
+   * <p>Obtained via {@link JsonWriter#write(Matrix)}. Configure options
+   * with chained method calls, then invoke a terminal method to perform the write.</p>
+   *
+   * <h3>Examples</h3>
+   * <pre>
+   * // Simple write
+   * JsonWriter.write(matrix).to(file)
+   *
+   * // Pretty-printed with date format
+   * JsonWriter.write(matrix).indent().dateFormat('MM/dd/yyyy').to(file)
+   *
+   * // With column formatters
+   * JsonWriter.write(matrix).formatter('salary') { it * 10 }.to(file)
+   *
+   * // As string
+   * String json = JsonWriter.write(matrix).asString()
+   * </pre>
+   */
+  @CompileStatic
+  static class WriteBuilder {
+
+    private final Matrix matrix
+    private boolean indentValue = false
+    private String dateFormatValue = 'yyyy-MM-dd'
+    private Map<String, Closure> columnFormattersValue = [:]
+
+    private WriteBuilder(Matrix matrix) {
+      if (matrix == null) {
+        throw new IllegalArgumentException("Matrix cannot be null")
+      }
+      this.matrix = matrix
+    }
+
+    /**
+     * Enable pretty-printing (indent = true).
+     *
+     * @return this builder for chaining
+     */
+    WriteBuilder indent() {
+      this.indentValue = true
+      this
+    }
+
+    /**
+     * Set whether to pretty-print the output.
+     *
+     * @param value true to indent, false for compact output
+     * @return this builder for chaining
+     */
+    WriteBuilder indent(boolean value) {
+      this.indentValue = value
+      this
+    }
+
+    /**
+     * Set the date format pattern for temporal columns.
+     *
+     * @param pattern date format pattern (e.g. 'MM/dd/yyyy')
+     * @return this builder for chaining
+     */
+    WriteBuilder dateFormat(String pattern) {
+      this.dateFormatValue = pattern
+      this
+    }
+
+    /**
+     * Add a formatter for a single column. Can be called multiple times for different columns.
+     *
+     * @param columnName the column to format
+     * @param formatter closure applied to each value in the column
+     * @return this builder for chaining
+     */
+    WriteBuilder formatter(String columnName, Closure formatter) {
+      this.columnFormattersValue[columnName] = formatter
+      this
+    }
+
+    /**
+     * Set all column formatters at once.
+     *
+     * @param formatters map of column names to formatting closures
+     * @return this builder for chaining
+     */
+    WriteBuilder columnFormatters(Map<String, Closure> formatters) {
+      this.columnFormattersValue = formatters ?: [:]
+      this
+    }
+
+    /**
+     * Write JSON to a File.
+     *
+     * @param file the output file
+     * @throws IOException if writing fails
+     */
+    void to(File file) throws IOException {
+      JsonWriter.write(matrix, file, columnFormattersValue, indentValue, dateFormatValue)
+    }
+
+    /**
+     * Write JSON to a Path.
+     *
+     * @param path the output path
+     * @throws IOException if writing fails
+     */
+    void to(Path path) throws IOException {
+      to(path.toFile())
+    }
+
+    /**
+     * Write JSON to a file specified by path string.
+     *
+     * @param filePath the output file path
+     * @throws IOException if writing fails
+     */
+    void to(String filePath) throws IOException {
+      to(new File(filePath))
+    }
+
+    /**
+     * Write JSON to a Writer.
+     *
+     * @param writer the output writer
+     * @throws IOException if writing fails
+     */
+    void to(Writer writer) throws IOException {
+      JsonWriter.write(matrix, writer, columnFormattersValue, indentValue, dateFormatValue)
+    }
+
+    /**
+     * Write JSON to a String.
+     *
+     * @return JSON string representation
+     */
+    String asString() {
+      JsonWriter.writeString(matrix, columnFormattersValue, indentValue, dateFormatValue)
+    }
   }
 }

--- a/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonWriter.groovy
+++ b/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonWriter.groovy
@@ -377,7 +377,7 @@ class JsonWriter {
       if (file.exists() && !file.canWrite()) {
         throw new IOException("Output file '${file.absolutePath}' is not writable")
       }
-      file.text = asString()
+      file.withWriter('UTF-8') { Writer w -> writeTo(w) }
     }
 
     /**
@@ -410,7 +410,7 @@ class JsonWriter {
       if (writer == null) {
         throw new IllegalArgumentException("Writer cannot be null")
       }
-      writer.write(asString())
+      writeTo(writer)
       writer.flush()
     }
 
@@ -420,6 +420,12 @@ class JsonWriter {
      * @return JSON string representation
      */
     String asString() {
+      StringWriter sw = new StringWriter()
+      writeTo(sw)
+      sw.toString()
+    }
+
+    private void writeTo(Writer writer) {
       if (!columnFormattersValue.isEmpty()) {
         List<String> colNames = matrix.columnNames()
         Set<String> invalidFormatters = columnFormattersValue.keySet().findAll { String it -> !colNames.contains(it) } as Set<String>
@@ -439,8 +445,7 @@ class JsonWriter {
       }
       DateTimeFormatter dtf = DateTimeFormatter.ofPattern(dateFormatValue)
 
-      StringWriter sw = new StringWriter()
-      JsonGenerator gen = FACTORY.createGenerator(sw)
+      JsonGenerator gen = FACTORY.createGenerator(writer)
       if (indentValue) {
         gen.useDefaultPrettyPrinter()
       }
@@ -458,7 +463,6 @@ class JsonWriter {
         }
         gen.writeEndArray()
       }
-      sw.toString()
     }
   }
 }

--- a/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonWriter.groovy
+++ b/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonWriter.groovy
@@ -35,7 +35,6 @@ class JsonWriter {
   private static final JsonFactory FACTORY = new JsonFactory()
 
   private JsonWriter() {
-    // Only static methods
   }
 
   /**
@@ -65,11 +64,7 @@ class JsonWriter {
    */
   @Deprecated
   static String writeString(Matrix matrix, boolean indent = false) {
-    if (matrix == null) {
-      throw new IllegalArgumentException("Matrix cannot be null")
-    }
-    Map<String, Closure> emptyFormatters = [:]
-    writeString(matrix, emptyFormatters, indent)
+    write(matrix).indent(indent).asString()
   }
 
   /**
@@ -84,49 +79,161 @@ class JsonWriter {
    */
   @Deprecated
   static String writeString(Matrix matrix, Map<String, Closure> columnFormatters, boolean indent = false, String dateFormat = 'yyyy-MM-dd') {
-    if (matrix == null) {
-      throw new IllegalArgumentException("Matrix cannot be null")
+    WriteBuilder builder = write(matrix).indent(indent).dateFormat(dateFormat)
+    if (columnFormatters != null) {
+      builder.columnFormatters(columnFormatters)
     }
+    builder.asString()
+  }
 
-    if (columnFormatters != null && !columnFormatters.isEmpty()) {
-      List<String> colNames = matrix.columnNames()
-      Set<String> invalidFormatters = columnFormatters.keySet().findAll { String it -> !colNames.contains(it) } as Set<String>
-      if (!invalidFormatters.isEmpty()) {
-        throw new IllegalArgumentException(
-            "Column formatter(s) defined for non-existent column(s): ${invalidFormatters}. " +
-            "Available columns: ${colNames}"
-        )
-      }
-    }
+  /**
+   * Write a Matrix to a JSON string with custom date formatting.
+   *
+   * @param matrix the Matrix to write
+   * @param dateFormat date format pattern for all temporal columns
+   * @param indent whether to pretty print the JSON
+   * @return JSON string representation
+   * @deprecated Use {@code JsonWriter.write(matrix).dateFormat(pattern).asString()} instead
+   */
+  @Deprecated
+  static String writeString(Matrix matrix, String dateFormat, boolean indent = false) {
+    write(matrix).indent(indent).dateFormat(dateFormat).asString()
+  }
 
-    Matrix t = columnFormatters.isEmpty() ? matrix : (matrix.clone() as Matrix)
-    if (!columnFormatters.isEmpty()) {
-      columnFormatters.each { String k, Closure v ->
-        t.apply(k, v)
-      }
-    }
-    DateTimeFormatter dtf = DateTimeFormatter.ofPattern(dateFormat)
+  /**
+   * Write a Matrix to a JSON file.
+   *
+   * @param matrix the Matrix to write
+   * @param outputFile file to write JSON to
+   * @param indent whether to pretty print the JSON
+   * @throws IOException if writing fails
+   * @deprecated Use {@code JsonWriter.write(matrix).to(file)} instead
+   */
+  @Deprecated
+  static void write(Matrix matrix, File outputFile, boolean indent = false) throws IOException {
+    write(matrix).indent(indent).to(outputFile)
+  }
 
-    StringWriter sw = new StringWriter()
-    JsonGenerator gen = FACTORY.createGenerator(sw)
-    if (indent) {
-      gen.useDefaultPrettyPrinter()
+  /**
+   * Write a Matrix to a JSON file specified by Path.
+   *
+   * @param matrix the Matrix to write
+   * @param outputPath path to write JSON to
+   * @param indent whether to pretty print the JSON
+   * @throws IOException if writing fails
+   * @deprecated Use {@code JsonWriter.write(matrix).to(path)} instead
+   */
+  @Deprecated
+  static void write(Matrix matrix, Path outputPath, boolean indent = false) throws IOException {
+    write(matrix).indent(indent).to(outputPath)
+  }
+
+  /**
+   * Write a Matrix to a JSON file specified by String path.
+   *
+   * @param matrix the Matrix to write
+   * @param outputPath file path to write JSON to
+   * @param indent whether to pretty print the JSON
+   * @throws IOException if writing fails
+   * @deprecated Use {@code JsonWriter.write(matrix).to(filePath)} instead
+   */
+  @Deprecated
+  static void write(Matrix matrix, String outputPath, boolean indent = false) throws IOException {
+    write(matrix).indent(indent).to(outputPath)
+  }
+
+  /**
+   * Write a Matrix to a Writer as JSON.
+   *
+   * @param matrix the Matrix to write
+   * @param writer the Writer to write JSON to
+   * @param indent whether to pretty print the JSON
+   * @throws IOException if writing fails
+   * @deprecated Use {@code JsonWriter.write(matrix).to(writer)} instead
+   */
+  @Deprecated
+  static void write(Matrix matrix, Writer writer, boolean indent = false) throws IOException {
+    write(matrix).indent(indent).to(writer)
+  }
+
+  /**
+   * Write a Matrix to a Writer as JSON with custom formatting.
+   *
+   * @param matrix the Matrix to write
+   * @param writer the Writer to write JSON to
+   * @param columnFormatters map of column names to formatting closures
+   * @param indent whether to pretty print the JSON
+   * @param dateFormat date format pattern for temporal columns (default: yyyy-MM-dd)
+   * @throws IOException if writing fails
+   * @deprecated Use the fluent API: {@code JsonWriter.write(matrix).columnFormatters(formatters).to(writer)} instead
+   */
+  @Deprecated
+  static void write(Matrix matrix, Writer writer, Map<String, Closure> columnFormatters, boolean indent = false, String dateFormat = 'yyyy-MM-dd') throws IOException {
+    WriteBuilder builder = write(matrix).indent(indent).dateFormat(dateFormat)
+    if (columnFormatters != null) {
+      builder.columnFormatters(columnFormatters)
     }
-    gen.withCloseable {
-      gen.writeStartArray()
-      List<String> colNames = t.columnNames()
-      int colCount = colNames.size()
-      for (Row row : t) {
-        gen.writeStartObject()
-        for (int i = 0; i < colCount; i++) {
-          gen.writeFieldName(colNames[i])
-          writeValue(gen, row[i], dtf)
-        }
-        gen.writeEndObject()
-      }
-      gen.writeEndArray()
+    builder.to(writer)
+  }
+
+  /**
+   * Write a Matrix to a JSON file with custom formatting.
+   *
+   * @param matrix the Matrix to write
+   * @param outputFile file to write JSON to
+   * @param columnFormatters map of column names to formatting closures
+   * @param indent whether to pretty print the JSON
+   * @param dateFormat date format pattern for temporal columns (default: yyyy-MM-dd)
+   * @throws IOException if writing fails
+   * @deprecated Use the fluent API: {@code JsonWriter.write(matrix).columnFormatters(formatters).to(file)} instead
+   */
+  @Deprecated
+  static void write(Matrix matrix, File outputFile, Map<String, Closure> columnFormatters, boolean indent = false, String dateFormat = 'yyyy-MM-dd') throws IOException {
+    WriteBuilder builder = write(matrix).indent(indent).dateFormat(dateFormat)
+    if (columnFormatters != null) {
+      builder.columnFormatters(columnFormatters)
     }
-    sw.toString()
+    builder.to(outputFile)
+  }
+
+  /**
+   * Write a Matrix to a JSON file specified by Path with custom formatting.
+   *
+   * @param matrix the Matrix to write
+   * @param outputPath path to write JSON to
+   * @param columnFormatters map of column names to formatting closures
+   * @param indent whether to pretty print the JSON
+   * @param dateFormat date format pattern for temporal columns (default: yyyy-MM-dd)
+   * @throws IOException if writing fails
+   * @deprecated Use the fluent API: {@code JsonWriter.write(matrix).columnFormatters(formatters).to(path)} instead
+   */
+  @Deprecated
+  static void write(Matrix matrix, Path outputPath, Map<String, Closure> columnFormatters, boolean indent = false, String dateFormat = 'yyyy-MM-dd') throws IOException {
+    WriteBuilder builder = write(matrix).indent(indent).dateFormat(dateFormat)
+    if (columnFormatters != null) {
+      builder.columnFormatters(columnFormatters)
+    }
+    builder.to(outputPath)
+  }
+
+  /**
+   * Write a Matrix to a JSON file specified by String path with custom formatting.
+   *
+   * @param matrix the Matrix to write
+   * @param outputPath file path to write JSON to
+   * @param columnFormatters map of column names to formatting closures
+   * @param indent whether to pretty print the JSON
+   * @param dateFormat date format pattern for temporal columns (default: yyyy-MM-dd)
+   * @throws IOException if writing fails
+   * @deprecated Use the fluent API: {@code JsonWriter.write(matrix).columnFormatters(formatters).to(filePath)} instead
+   */
+  @Deprecated
+  static void write(Matrix matrix, String outputPath, Map<String, Closure> columnFormatters, boolean indent = false, String dateFormat = 'yyyy-MM-dd') throws IOException {
+    WriteBuilder builder = write(matrix).indent(indent).dateFormat(dateFormat)
+    if (columnFormatters != null) {
+      builder.columnFormatters(columnFormatters)
+    }
+    builder.to(outputPath)
   }
 
   /**
@@ -159,202 +266,6 @@ class JsonWriter {
   }
 
   /**
-   * Write a Matrix to a JSON string with custom date formatting.
-   *
-   * @param matrix the Matrix to write
-   * @param dateFormat date format pattern for all temporal columns
-   * @param indent whether to pretty print the JSON
-   * @return JSON string representation
-   * @deprecated Use {@code JsonWriter.write(matrix).dateFormat(pattern).asString()} instead
-   */
-  @Deprecated
-  static String writeString(Matrix matrix, String dateFormat, boolean indent = false) {
-    if (matrix == null) {
-      throw new IllegalArgumentException("Matrix cannot be null")
-    }
-    Map<String, Closure> emptyFormatters = [:]
-    writeString(matrix, emptyFormatters, indent, dateFormat)
-  }
-
-  /**
-   * Write a Matrix to a JSON file.
-   *
-   * @param matrix the Matrix to write
-   * @param outputFile file to write JSON to
-   * @param indent whether to pretty print the JSON
-   * @throws IOException if writing fails
-   * @deprecated Use {@code JsonWriter.write(matrix).to(file)} instead
-   */
-  @Deprecated
-  static void write(Matrix matrix, File outputFile, boolean indent = false) throws IOException {
-    if (matrix == null) {
-      throw new IllegalArgumentException("Matrix cannot be null")
-    }
-    if (outputFile == null) {
-      throw new IllegalArgumentException("Output file cannot be null")
-    }
-
-    if (outputFile.isDirectory()) {
-      throw new IOException("Output file '${outputFile.absolutePath}' is a directory, cannot write JSON data")
-    }
-
-    File parent = outputFile.getParentFile()
-    if (parent != null && !parent.exists()) {
-      if (!parent.mkdirs()) {
-        throw new IOException("Failed to create parent directory '${parent.absolutePath}' for output file '${outputFile.absolutePath}'")
-      }
-    }
-
-    if (outputFile.exists() && !outputFile.canWrite()) {
-      throw new IOException("Output file '${outputFile.absolutePath}' is not writable")
-    }
-
-    outputFile.text = writeString(matrix, indent)
-  }
-
-  /**
-   * Write a Matrix to a JSON file specified by Path.
-   *
-   * @param matrix the Matrix to write
-   * @param outputPath path to write JSON to
-   * @param indent whether to pretty print the JSON
-   * @throws IOException if writing fails
-   * @deprecated Use {@code JsonWriter.write(matrix).to(path)} instead
-   */
-  @Deprecated
-  static void write(Matrix matrix, Path outputPath, boolean indent = false) throws IOException {
-    write(matrix, outputPath.toFile(), indent)
-  }
-
-  /**
-   * Write a Matrix to a JSON file specified by String path.
-   *
-   * @param matrix the Matrix to write
-   * @param outputPath file path to write JSON to
-   * @param indent whether to pretty print the JSON
-   * @throws IOException if writing fails
-   * @deprecated Use {@code JsonWriter.write(matrix).to(filePath)} instead
-   */
-  @Deprecated
-  static void write(Matrix matrix, String outputPath, boolean indent = false) throws IOException {
-    write(matrix, new File(outputPath), indent)
-  }
-
-  /**
-   * Write a Matrix to a Writer as JSON.
-   *
-   * @param matrix the Matrix to write
-   * @param writer the Writer to write JSON to
-   * @param indent whether to pretty print the JSON
-   * @throws IOException if writing fails
-   * @deprecated Use {@code JsonWriter.write(matrix).to(writer)} instead
-   */
-  @Deprecated
-  static void write(Matrix matrix, Writer writer, boolean indent = false) throws IOException {
-    if (matrix == null) {
-      throw new IllegalArgumentException("Matrix cannot be null")
-    }
-    if (writer == null) {
-      throw new IllegalArgumentException("Writer cannot be null")
-    }
-    writer.write(writeString(matrix, indent))
-    writer.flush()
-  }
-
-  /**
-   * Write a Matrix to a Writer as JSON with custom formatting.
-   *
-   * @param matrix the Matrix to write
-   * @param writer the Writer to write JSON to
-   * @param columnFormatters map of column names to formatting closures
-   * @param indent whether to pretty print the JSON
-   * @param dateFormat date format pattern for temporal columns (default: yyyy-MM-dd)
-   * @throws IOException if writing fails
-   * @deprecated Use the fluent API: {@code JsonWriter.write(matrix).columnFormatters(formatters).to(writer)} instead
-   */
-  @Deprecated
-  static void write(Matrix matrix, Writer writer, Map<String, Closure> columnFormatters, boolean indent = false, String dateFormat = 'yyyy-MM-dd') throws IOException {
-    if (matrix == null) {
-      throw new IllegalArgumentException("Matrix cannot be null")
-    }
-    if (writer == null) {
-      throw new IllegalArgumentException("Writer cannot be null")
-    }
-    writer.write(writeString(matrix, columnFormatters, indent, dateFormat))
-    writer.flush()
-  }
-
-  /**
-   * Write a Matrix to a JSON file with custom formatting.
-   *
-   * @param matrix the Matrix to write
-   * @param outputFile file to write JSON to
-   * @param columnFormatters map of column names to formatting closures
-   * @param indent whether to pretty print the JSON
-   * @param dateFormat date format pattern for temporal columns (default: yyyy-MM-dd)
-   * @throws IOException if writing fails
-   * @deprecated Use the fluent API: {@code JsonWriter.write(matrix).columnFormatters(formatters).to(file)} instead
-   */
-  @Deprecated
-  static void write(Matrix matrix, File outputFile, Map<String, Closure> columnFormatters, boolean indent = false, String dateFormat = 'yyyy-MM-dd') throws IOException {
-    if (matrix == null) {
-      throw new IllegalArgumentException("Matrix cannot be null")
-    }
-    if (outputFile == null) {
-      throw new IllegalArgumentException("Output file cannot be null")
-    }
-
-    if (outputFile.isDirectory()) {
-      throw new IOException("Output file '${outputFile.absolutePath}' is a directory, cannot write JSON data")
-    }
-
-    File parent = outputFile.getParentFile()
-    if (parent != null && !parent.exists()) {
-      if (!parent.mkdirs()) {
-        throw new IOException("Failed to create parent directory '${parent.absolutePath}' for output file '${outputFile.absolutePath}'")
-      }
-    }
-
-    if (outputFile.exists() && !outputFile.canWrite()) {
-      throw new IOException("Output file '${outputFile.absolutePath}' is not writable")
-    }
-
-    outputFile.text = writeString(matrix, columnFormatters, indent, dateFormat)
-  }
-
-  /**
-   * Write a Matrix to a JSON file specified by Path with custom formatting.
-   *
-   * @param matrix the Matrix to write
-   * @param outputPath path to write JSON to
-   * @param columnFormatters map of column names to formatting closures
-   * @param indent whether to pretty print the JSON
-   * @param dateFormat date format pattern for temporal columns (default: yyyy-MM-dd)
-   * @throws IOException if writing fails
-   * @deprecated Use the fluent API: {@code JsonWriter.write(matrix).columnFormatters(formatters).to(path)} instead
-   */
-  @Deprecated
-  static void write(Matrix matrix, Path outputPath, Map<String, Closure> columnFormatters, boolean indent = false, String dateFormat = 'yyyy-MM-dd') throws IOException {
-    write(matrix, outputPath.toFile(), columnFormatters, indent, dateFormat)
-  }
-
-  /**
-   * Write a Matrix to a JSON file specified by String path with custom formatting.
-   *
-   * @param matrix the Matrix to write
-   * @param outputPath file path to write JSON to
-   * @param columnFormatters map of column names to formatting closures
-   * @param indent whether to pretty print the JSON
-   * @param dateFormat date format pattern for temporal columns (default: yyyy-MM-dd)
-   * @throws IOException if writing fails
-   * @deprecated Use the fluent API: {@code JsonWriter.write(matrix).columnFormatters(formatters).to(filePath)} instead
-   */
-  @Deprecated
-  static void write(Matrix matrix, String outputPath, Map<String, Closure> columnFormatters, boolean indent = false, String dateFormat = 'yyyy-MM-dd') throws IOException {
-    write(matrix, new File(outputPath), columnFormatters, indent, dateFormat)
-  }
-
-  /**
    * Fluent builder for writing Matrix data to JSON.
    *
    * <p>Obtained via {@link JsonWriter#write(Matrix)}. Configure options
@@ -375,7 +286,6 @@ class JsonWriter {
    * String json = JsonWriter.write(matrix).asString()
    * </pre>
    */
-  @CompileStatic
   static class WriteBuilder {
 
     private final Matrix matrix
@@ -452,7 +362,22 @@ class JsonWriter {
      * @throws IOException if writing fails
      */
     void to(File file) throws IOException {
-      JsonWriter.write(matrix, file, columnFormattersValue, indentValue, dateFormatValue)
+      if (file == null) {
+        throw new IllegalArgumentException("Output file cannot be null")
+      }
+      if (file.isDirectory()) {
+        throw new IOException("Output file '${file.absolutePath}' is a directory, cannot write JSON data")
+      }
+      File parent = file.getParentFile()
+      if (parent != null && !parent.exists()) {
+        if (!parent.mkdirs()) {
+          throw new IOException("Failed to create parent directory '${parent.absolutePath}' for output file '${file.absolutePath}'")
+        }
+      }
+      if (file.exists() && !file.canWrite()) {
+        throw new IOException("Output file '${file.absolutePath}' is not writable")
+      }
+      file.text = asString()
     }
 
     /**
@@ -482,7 +407,11 @@ class JsonWriter {
      * @throws IOException if writing fails
      */
     void to(Writer writer) throws IOException {
-      JsonWriter.write(matrix, writer, columnFormattersValue, indentValue, dateFormatValue)
+      if (writer == null) {
+        throw new IllegalArgumentException("Writer cannot be null")
+      }
+      writer.write(asString())
+      writer.flush()
     }
 
     /**
@@ -491,7 +420,45 @@ class JsonWriter {
      * @return JSON string representation
      */
     String asString() {
-      JsonWriter.writeString(matrix, columnFormattersValue, indentValue, dateFormatValue)
+      if (!columnFormattersValue.isEmpty()) {
+        List<String> colNames = matrix.columnNames()
+        Set<String> invalidFormatters = columnFormattersValue.keySet().findAll { String it -> !colNames.contains(it) } as Set<String>
+        if (!invalidFormatters.isEmpty()) {
+          throw new IllegalArgumentException(
+              "Column formatter(s) defined for non-existent column(s): ${invalidFormatters}. " +
+              "Available columns: ${colNames}"
+          )
+        }
+      }
+
+      Matrix t = columnFormattersValue.isEmpty() ? matrix : (matrix.clone() as Matrix)
+      if (!columnFormattersValue.isEmpty()) {
+        columnFormattersValue.each { String k, Closure v ->
+          t.apply(k, v)
+        }
+      }
+      DateTimeFormatter dtf = DateTimeFormatter.ofPattern(dateFormatValue)
+
+      StringWriter sw = new StringWriter()
+      JsonGenerator gen = FACTORY.createGenerator(sw)
+      if (indentValue) {
+        gen.useDefaultPrettyPrinter()
+      }
+      gen.withCloseable {
+        gen.writeStartArray()
+        List<String> colNames = t.columnNames()
+        int colCount = colNames.size()
+        for (Row row : t) {
+          gen.writeStartObject()
+          for (int i = 0; i < colCount; i++) {
+            gen.writeFieldName(colNames[i])
+            writeValue(gen, row[i], dtf)
+          }
+          gen.writeEndObject()
+        }
+        gen.writeEndArray()
+      }
+      sw.toString()
     }
   }
 }

--- a/matrix-json/src/test/groovy/DuplicateKeyTest.groovy
+++ b/matrix-json/src/test/groovy/DuplicateKeyTest.groovy
@@ -17,9 +17,9 @@ class DuplicateKeyTest {
     ]'''
 
     // Should throw an exception when duplicate keys are detected
-    def exception = assertThrows(IllegalArgumentException.class, {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
       JsonImporter.parse(json)
-    })
+    }
 
     assertTrue(exception.message.contains("Duplicate key detected"))
     assertTrue(exception.message.contains("a.b"))
@@ -32,9 +32,9 @@ class DuplicateKeyTest {
     ]'''
 
     // Should throw an exception when duplicate keys are detected
-    def exception = assertThrows(IllegalArgumentException.class, {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
       JsonImporter.parse(json)
-    })
+    }
 
     assertTrue(exception.message.contains("Duplicate key detected"))
     assertTrue(exception.message.contains("x.y.z"))

--- a/matrix-json/src/test/groovy/JsonFormatProviderTest.groovy
+++ b/matrix-json/src/test/groovy/JsonFormatProviderTest.groovy
@@ -70,4 +70,27 @@ class JsonFormatProviderTest {
 
     assertEquals('UTF-8', options.charset.name())
   }
+
+  @Test
+  void testReadWithTypeConversion() {
+    File file = tempDir.resolve('typed.json').toFile()
+    file.text = '[{"id":1,"name":"Alice","birthday":"2024-01-15"},{"id":2,"name":"Bob","birthday":"2024-03-20"}]'
+
+    Matrix matrix = Matrix.read([types: [Integer, String, LocalDate], dateTimeFormat: 'yyyy-MM-dd'], file)
+
+    assertEquals(Integer, matrix.type('id'))
+    assertEquals(String, matrix.type('name'))
+    assertEquals(LocalDate, matrix.type('birthday'))
+    assertEquals(LocalDate.of(2024, 1, 15), matrix[0, 'birthday'])
+  }
+
+  @Test
+  void testReadWithMatrixNameOption() {
+    File file = tempDir.resolve('data.json').toFile()
+    file.text = '[{"x":1}]'
+
+    Matrix matrix = Matrix.read([matrixName: 'custom_name'], file)
+
+    assertEquals('custom_name', matrix.matrixName, "matrixName option should override file-derived name")
+  }
 }

--- a/matrix-json/src/test/groovy/JsonImporterTest.groovy
+++ b/matrix-json/src/test/groovy/JsonImporterTest.groovy
@@ -97,7 +97,7 @@ class JsonImporterTest {
       }
       rows << new ArrayList<>(m.values())
     }
-    return Matrix.builder()
+    Matrix.builder()
         .rows(rows)
         .columnNames(keySet)
         .build()
@@ -130,16 +130,16 @@ class JsonImporterTest {
     if (jsonNode.isObject()) {
       ObjectNode objectNode = (ObjectNode) jsonNode
       Iterator<Map.Entry<String, JsonNode>> iter = objectNode.fields()
-      def pathPrefix = currentPath.isEmpty() ? "" : currentPath + ".";
+      String pathPrefix = currentPath.isEmpty() ? "" : currentPath + "."
 
       while (iter.hasNext()) {
-        Map.Entry<String, JsonNode> entry = iter.next();
-        addKeys(pathPrefix + entry.getKey(), entry.getValue(), map);
+        Map.Entry<String, JsonNode> entry = iter.next()
+        addKeys(pathPrefix + entry.getKey(), entry.getValue(), map)
       }
     } else if (jsonNode.isArray()) {
-      ArrayNode arrayNode = (ArrayNode) jsonNode;
+      ArrayNode arrayNode = (ArrayNode) jsonNode
       for (int i = 0; i < arrayNode.size(); i++) {
-        addKeys(currentPath + '[' + i + ']', arrayNode.get(i), map);
+        addKeys(currentPath + '[' + i + ']', arrayNode.get(i), map)
       }
     } else if (jsonNode.isValueNode()) {
       if (jsonNode instanceof NumericNode) {
@@ -239,7 +239,7 @@ class JsonImporterTest {
         {"a": 1, "b": 2}
       ]'''
 
-      String urlString = tempFile.toURI().toURL().toString()
+      String urlString = tempFile.toURI().toURL() as String
       Matrix table = JsonImporter.parseFromUrl(urlString)
 
       assertEquals(1, table.rowCount(), "Should have 1 row")

--- a/matrix-json/src/test/groovy/JsonReaderTest.groovy
+++ b/matrix-json/src/test/groovy/JsonReaderTest.groovy
@@ -130,7 +130,7 @@ class JsonReaderTest {
     File jsonFile = tempDir.resolve('string_url_test.json').toFile()
     jsonFile.text = jsonContent
 
-    String urlString = jsonFile.toURI().toURL().toString()
+    String urlString = jsonFile.toURI().toURL() as String
     Matrix matrix = JsonReader.readUrl(urlString)
 
     assertEquals(1, matrix.rowCount(), "Number of rows")
@@ -220,9 +220,9 @@ class JsonReaderTest {
       }
     ]'''
 
-    assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException) {
       JsonReader.read(json)
-    }, "Should throw on duplicate keys after flattening")
+    }
   }
 
   @Test
@@ -235,5 +235,38 @@ class JsonReaderTest {
 
     assertEquals(1, matrix.rowCount(), "Number of rows")
     assertEquals("Grüße", matrix.row(0)[matrix.columnNames().indexOf('text')], "Should handle UTF-8 characters")
+  }
+
+  @Test
+  void testMatrixNameDerivedFromFile() {
+    String jsonContent = '[{"id":1}]'
+    File jsonFile = tempDir.resolve('employees.json').toFile()
+    jsonFile.text = jsonContent
+
+    Matrix matrix = JsonReader.read(jsonFile)
+
+    assertEquals('employees', matrix.matrixName, "Matrix name should be derived from filename without extension")
+  }
+
+  @Test
+  void testMatrixNameDerivedFromUrl() {
+    String jsonContent = '[{"id":1}]'
+    File jsonFile = tempDir.resolve('people.json').toFile()
+    jsonFile.text = jsonContent
+
+    URL url = jsonFile.toURI().toURL()
+    Matrix matrix = JsonReader.read(url)
+
+    assertEquals('people', matrix.matrixName, "Matrix name should be derived from URL filename")
+  }
+
+  @Test
+  void testReadStringAlias() {
+    String json = '[{"id":1,"name":"Test"}]'
+    Matrix fromRead = JsonReader.read(json)
+    Matrix fromReadString = JsonReader.readString(json)
+
+    assertEquals(fromRead.rowCount(), fromReadString.rowCount(), "readString should produce same row count as read")
+    assertEquals(fromRead.columnNames(), fromReadString.columnNames(), "readString should produce same columns as read")
   }
 }

--- a/matrix-json/src/test/groovy/JsonWriterTest.groovy
+++ b/matrix-json/src/test/groovy/JsonWriterTest.groovy
@@ -76,7 +76,7 @@ class JsonWriterTest {
         .data(value: [100])
         .build()
 
-    String filePath = tempDir.resolve('string_path.json').toString()
+    String filePath = tempDir.resolve('string_path.json') as String
     JsonWriter.write(matrix, filePath)
 
     assertTrue(new File(filePath).exists(), "Output file should exist")
@@ -91,7 +91,7 @@ class JsonWriterTest {
     StringWriter writer = new StringWriter()
     JsonWriter.write(matrix, writer)
 
-    String json = writer.toString()
+    String json = writer as String
     assertTrue(json.contains('"key":"value1"'), "Should contain data")
     assertTrue(json.contains('"key":"value2"'), "Should contain data")
   }
@@ -110,7 +110,7 @@ class JsonWriterTest {
     StringWriter writer = new StringWriter()
     JsonWriter.write(matrix, writer, formatters)
 
-    String json = writer.toString()
+    String json = writer as String
     assertTrue(json.contains('10000'), "Should apply salary formatter")
     assertTrue(json.contains('20000'), "Should apply salary formatter")
     assertTrue(json.contains('500'), "Should apply bonus formatter")
@@ -206,27 +206,27 @@ class JsonWriterTest {
 
   @Test
   void testWriteNullMatrixThrows() {
-    assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException) {
       JsonWriter.writeString(null)
-    }, "Should throw on null matrix")
+    }
   }
 
   @Test
   void testWriteNullFileThrows() {
     Matrix matrix = Matrix.builder().data(a: [1]).build()
 
-    assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException) {
       JsonWriter.write(matrix, (File) null)
-    }, "Should throw on null file")
+    }
   }
 
   @Test
   void testWriteNullWriterThrows() {
     Matrix matrix = Matrix.builder().data(a: [1]).build()
 
-    assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException) {
       JsonWriter.write(matrix, (Writer) null)
-    }, "Should throw on null writer")
+    }
   }
 
   @Test
@@ -240,5 +240,181 @@ class JsonWriterTest {
 
     assertEquals(original.rowCount(), result.rowCount(), "Row count should match after pretty print")
     assertEquals(original.columnNames(), result.columnNames(), "Column names should match")
+  }
+
+  @Test
+  void testWriteFormatterToPath() {
+    Matrix matrix = Matrix.builder()
+        .data(price: [100, 200])
+        .build()
+
+    Path outputPath = tempDir.resolve('formatter_path.json')
+    JsonWriter.write(matrix, outputPath, [price: { it * 10 }])
+
+    String content = outputPath.toFile().text
+    assertTrue(content.contains('1000'), "Should apply formatter via Path overload")
+    assertTrue(content.contains('2000'), "Should apply formatter via Path overload")
+  }
+
+  @Test
+  void testWriteFormatterToStringPath() {
+    Matrix matrix = Matrix.builder()
+        .data(value: [5])
+        .build()
+
+    String filePath = tempDir.resolve('formatter_string.json') as String
+    JsonWriter.write(matrix, filePath, [value: { it * 3 }])
+
+    String content = new File(filePath).text
+    assertTrue(content.contains('15'), "Should apply formatter via String path overload")
+  }
+
+  @Test
+  void testWriteFormatterCreatesParentDir() {
+    Matrix matrix = Matrix.builder()
+        .data(x: [1])
+        .build()
+
+    File outputFile = tempDir.resolve('sub/dir/output.json').toFile()
+    assertFalse(outputFile.getParentFile().exists(), "Parent dir should not exist yet")
+
+    JsonWriter.write(matrix, outputFile, [x: { it + 1 }])
+
+    assertTrue(outputFile.exists(), "File should be created with parent dirs")
+    assertTrue(outputFile.text.contains('2'), "Should apply formatter")
+  }
+
+  @Test
+  void testWriteFormatterThrowsOnDirectory() {
+    Matrix matrix = Matrix.builder()
+        .data(a: [1])
+        .build()
+
+    File dir = tempDir.resolve('adir').toFile()
+    dir.mkdirs()
+
+    assertThrows(IOException) {
+      JsonWriter.write(matrix, dir, [a: { it }])
+    }
+  }
+
+  // Fluent WriteBuilder API tests
+
+  @Test
+  void testFluentWriteToFile() {
+    Matrix matrix = Matrix.builder().data(a: [1, 2]).build()
+    File file = tempDir.resolve('fluent.json').toFile()
+
+    JsonWriter.write(matrix).to(file)
+
+    assertTrue(file.exists(), "File should exist")
+    Matrix result = JsonReader.read(file)
+    assertEquals(2, result.rowCount())
+  }
+
+  @Test
+  void testFluentWriteToPath() {
+    Matrix matrix = Matrix.builder().data(x: [10]).build()
+    Path path = tempDir.resolve('fluent_path.json')
+
+    JsonWriter.write(matrix).to(path)
+
+    assertTrue(path.toFile().exists(), "File should exist via Path")
+  }
+
+  @Test
+  void testFluentWriteToStringPath() {
+    Matrix matrix = Matrix.builder().data(v: [5]).build()
+    String filePath = tempDir.resolve('fluent_str.json') as String
+
+    JsonWriter.write(matrix).to(filePath)
+
+    assertTrue(new File(filePath).exists(), "File should exist via String path")
+  }
+
+  @Test
+  void testFluentWriteToWriter() {
+    Matrix matrix = Matrix.builder().data(k: ['v']).build()
+    StringWriter sw = new StringWriter()
+
+    JsonWriter.write(matrix).to(sw)
+
+    assertTrue(sw.toString().contains('"k"'), "Writer output should contain field")
+  }
+
+  @Test
+  void testFluentAsString() {
+    Matrix matrix = Matrix.builder().data(id: [1]).build()
+
+    String json = JsonWriter.write(matrix).asString()
+
+    assertTrue(json.contains('"id"'), "asString should contain field name")
+    assertTrue(json.contains('1'), "asString should contain value")
+  }
+
+  @Test
+  void testFluentWithIndent() {
+    Matrix matrix = Matrix.builder().data(x: [1]).build()
+
+    String json = JsonWriter.write(matrix).indent().asString()
+
+    assertTrue(json.contains('\n'), "Indented output should contain newlines")
+  }
+
+  @Test
+  void testFluentWithIndentBoolean() {
+    Matrix matrix = Matrix.builder().data(x: [1]).build()
+
+    String compact = JsonWriter.write(matrix).indent(false).asString()
+    String indented = JsonWriter.write(matrix).indent(true).asString()
+
+    assertFalse(compact.contains('\n'), "Compact should not contain newlines")
+    assertTrue(indented.contains('\n'), "Indented should contain newlines")
+  }
+
+  @Test
+  void testFluentWithDateFormat() {
+    Matrix matrix = Matrix.builder()
+        .data(d: [java.time.LocalDate.of(2024, 6, 15)])
+        .types(java.time.LocalDate)
+        .build()
+
+    String json = JsonWriter.write(matrix).dateFormat('dd/MM/yyyy').asString()
+
+    assertTrue(json.contains('15/06/2024'), "Should format date with custom pattern")
+  }
+
+  @Test
+  void testFluentWithFormatter() {
+    Matrix matrix = Matrix.builder().data(price: [100]).build()
+
+    String json = JsonWriter.write(matrix).formatter('price') { it * 2 }.asString()
+
+    assertTrue(json.contains('200'), "Should apply single formatter")
+  }
+
+  @Test
+  void testFluentWithMultipleFormatters() {
+    Matrix matrix = Matrix.builder().data(a: [1], b: [2]).build()
+
+    String json = JsonWriter.write(matrix)
+        .formatter('a') { it * 10 }
+        .formatter('b') { it * 20 }
+        .asString()
+
+    assertTrue(json.contains('10'), "Should apply formatter to column a")
+    assertTrue(json.contains('40'), "Should apply formatter to column b")
+  }
+
+  @Test
+  void testFluentWithColumnFormatters() {
+    Matrix matrix = Matrix.builder().data(x: [3], y: [4]).build()
+
+    String json = JsonWriter.write(matrix)
+        .columnFormatters([x: { it * 100 }, y: { it * 200 }])
+        .asString()
+
+    assertTrue(json.contains('300'), "Should apply column formatters map")
+    assertTrue(json.contains('800'), "Should apply column formatters map")
   }
 }


### PR DESCRIPTION
## Summary

- **Jackson migration**: Replaced Groovy's `groovy.json.*` in JsonWriter with Jackson streaming API for O(columns) peak memory instead of O(rows×columns); removed `groovy-json` build dependency
- **Static compilation & CodeNarc**: Enabled build-level `@CompileStatic`, added module-level CodeNarc with `ignoreFailures = false` — 0 violations in both main and test sources
- **Fluent WriteBuilder API**: Added `JsonWriter.write(matrix).indent().dateFormat(...).formatter(...).to(file)` builder pattern; deprecated all existing static methods
- **Bug fixes**: Fixed resource leak in `JsonReader.read(File)`, added missing directory/parent-dir guards and Path/String overloads for formatter write variant
- **Usability**: Matrix name derivation from file/URL, `matrixName` read option, type-conversion support (`types`/`dateTimeFormat` in `JsonReadOptions`), `readString()` convenience method
- **Test cleanup**: Fixed all CodeNarc violations in test code (idiomatic Groovy: `as String` over `.toString()`, trailing closures, no `.class` suffix)

## Test plan

- [x] `./gradlew :matrix-json:test` — all tests pass
- [x] `./gradlew :matrix-json:codenarcMain` — 0 violations
- [x] `./gradlew :matrix-json:codenarcTest` — 0 violations
- [x] `./gradlew :matrix-json:spotlessCheck` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)