### PR TITLE
[codex] Harden matrix-sql identifiers

### DIFF
--- a/matrix-sql/req/v2.4.0-roadmap.md
+++ b/matrix-sql/req/v2.4.0-roadmap.md
@@ -1,0 +1,254 @@
+# Matrix SQL 2.4.0 Roadmap
+
+This roadmap covers usability and correctness improvements for `matrix-sql` discovered during the module review.
+
+## PR Phases
+
+Use these phases when splitting implementation work into reviewable pull requests.
+
+Phase 1 [x] Identifier handling and type sizing.
+- Covers roadmap sections `1` and `2`.
+- Focus: generated SQL correctness, DDL robustness, insert/update consistency, and regression tests for unusual identifiers and null-only sampled data.
+
+Completed test commands:
+- `./gradlew :matrix-sql:test --tests "MatrixDbUtilTest" --tests "MatrixSqlTest" --rerun-tasks`
+- `./gradlew :matrix-sql:test --rerun-tasks`
+- `./gradlew test`
+
+Phase 2 [ ] `MatrixResultSet` JDBC behavior.
+- Covers roadmap section `3`.
+- Focus: predictable JDBC-style failures for missing columns, closed result sets, invalid cursor state, and null stream/temporal getters.
+
+Phase 3 [ ] Convenience APIs.
+- Covers roadmap section `4`.
+- Focus: source-compatible API additions for prepared-parameter operations, explicit table-name matrix inserts, and managed JDBC connections.
+
+Phase 4 [ ] Factory offline behavior.
+- Covers roadmap section `5`.
+- Focus: predictable generic factory creation when Maven Central version lookup is unavailable.
+
+Phase 5 [ ] Documentation and test hygiene.
+- Covers roadmap section `6`.
+- Focus: README examples, removal of test console output, and final cleanup.
+
+## 1. Harden SQL Identifier Handling
+
+Goal: make generated SQL work consistently for table and column names containing spaces, mixed case, reserved words, punctuation, and embedded quote characters.
+
+1.1 [x] Add a shared identifier helper in `matrix-sql/src/main/groovy/se/alipsa/matrix/sql` for validating, normalizing, and quoting SQL identifiers.
+
+Acceptance criteria:
+- Handles table names, column names, and constraint names through one API.
+- Escapes embedded double quotes by doubling them.
+- Supports unquoted generation only when explicitly requested.
+- Includes GroovyDoc for the public class and public methods.
+
+Tests to record when done:
+- `./gradlew :matrix-sql:test --tests "MatrixDbUtilTest"`
+- `./gradlew :matrix-sql:test --tests "MatrixSqlTest"`
+
+1.2 [x] Update `MatrixDbUtil.createTableDdl` in `matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixDbUtil.groovy` to use the identifier helper for table names, column names, and primary key constraints.
+
+Acceptance criteria:
+- `createDdl` produces valid SQL for column names with spaces, mixed case, SQL keywords, and embedded quotes.
+- Primary key constraints no longer use raw `table.getMatrixName()` as an identifier.
+- Existing `addQuotes = false` behavior remains available for callers that need unquoted identifiers.
+
+Tests to record when done:
+- `./gradlew :matrix-sql:test --tests "MatrixDbUtilTest"`
+- `./gradlew :matrix-sql:test --tests "MatrixSqlTest.testPrimaryKey"`
+
+1.3 [x] Update `SqlGenerator` in `matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlGenerator.groovy` so prepared insert and update SQL use the same identifier rules.
+
+Acceptance criteria:
+- `insert(Matrix)`, `insert(String, Row)`, `update(String, Row, ...)`, and `update(Matrix, ...)` all quote column identifiers consistently.
+- Updating a table with a column such as `first name` or `select` succeeds.
+- Table names passed explicitly are treated consistently with generated table names.
+
+Tests to record when done:
+- `./gradlew :matrix-sql:test --tests "MatrixSqlTest"`
+
+1.4 [x] Add regression tests for unusual identifiers.
+
+Acceptance criteria:
+- Tests cover table names with spaces or punctuation.
+- Tests cover column names with spaces, SQL keywords, mixed case, and embedded quotes.
+- Tests cover create, insert, select, update, and drop paths.
+
+Tests to record when done:
+- `./gradlew :matrix-sql:test --rerun-tasks`
+
+## 2. Improve Type Sizing Defaults
+
+Goal: avoid invalid or overly narrow DDL when sampled values are null, blank, or absent.
+
+2.1 [x] Update `MatrixDbUtil.createMappings` in `matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixDbUtil.groovy` to provide safe minimum sizes for String and BigDecimal columns.
+
+Acceptance criteria:
+- All-null String columns receive a valid `VARCHAR` size.
+- All-null BigDecimal columns receive a valid precision and scale.
+- Empty matrices still generate usable DDL when column types are known.
+- Defaults are centralized as named constants.
+
+Tests to record when done:
+- `./gradlew :matrix-sql:test --tests "MatrixDbUtilTest"`
+
+2.2 [x] Add tests for null-only and empty sampled data.
+
+Acceptance criteria:
+- Tests assert non-zero `VARCHAR_SIZE`.
+- Tests assert positive `DECIMAL_PRECISION`.
+- Tests cover `scanNumRows = 0` and `scanNumRows` greater than row count.
+
+Tests to record when done:
+- `./gradlew :matrix-sql:test --tests "MatrixDbUtilTest"`
+
+## 3. Tighten MatrixResultSet JDBC Behavior
+
+Goal: make `MatrixResultSet` fail predictably and match common JDBC expectations for missing columns, null values, and cursor state.
+
+3.1 [ ] Add internal guard methods in `matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixResultSet.groovy` for closed result sets, valid current rows, and valid column indexes.
+
+Acceptance criteria:
+- Getter methods throw `SQLException` when the result set is closed.
+- Getter methods throw `SQLException` when the cursor is before the first row or after the last row.
+- Column index validation uses JDBC 1-based indexing in error messages.
+
+Tests to record when done:
+- `./gradlew :matrix-sql:test --tests "MatrixResultSetTest"`
+
+3.2 [ ] Fix `findColumn` to throw `SQLException` when a column label is unknown.
+
+Acceptance criteria:
+- `findColumn('missing')` throws `SQLException`.
+- Label-based getters use the same validation path.
+
+Tests to record when done:
+- `./gradlew :matrix-sql:test --tests "MatrixResultSetTest"`
+
+3.3 [ ] Fix null handling for stream and temporal getters.
+
+Acceptance criteria:
+- `getCharacterStream` returns `null` for null values and makes `wasNull()` true.
+- `getDate(String)`, `getTime(String)`, `getTimestamp(String)`, and Calendar overloads return the delegated value.
+- `lastReadValue` is updated consistently by `getBigDecimal` and temporal getters.
+
+Tests to record when done:
+- `./gradlew :matrix-sql:test --tests "MatrixResultSetTest"`
+
+## 4. Add Safer Query Convenience APIs
+
+Goal: make common database operations easy without requiring users to hand-build unsafe SQL strings.
+
+4.1 [ ] Add prepared parameter overloads to `MatrixSql` for select, execute, update, and delete operations.
+
+Proposed API:
+```groovy
+Matrix select(String sqlQuery, List params, String matrixName = 'myMatrix')
+int update(String sqlQuery, List params)
+int delete(String sqlQuery, List params)
+Map<Integer, Object> execute(String sqlQuery, List params)
+```
+
+Acceptance criteria:
+- Parameters are bound with `PreparedStatement#setObject`.
+- Select overload returns a `Matrix` with the requested matrix name.
+- Update/delete overloads return update counts.
+- Execute overload clearly documents limitations if multiple result sets are not supported with prepared statements.
+
+Tests to record when done:
+- `./gradlew :matrix-sql:test --tests "MatrixSqlTest"`
+
+4.2 [ ] Add `insert(String tableName, Matrix table)` to `MatrixSql`.
+
+Acceptance criteria:
+- Delegates to `MatrixDbUtil.insert(Connection, String, Matrix)`.
+- Complements existing `insert(Matrix)` and `insert(String, Row)`.
+- Handles generated SQL with the shared identifier helper.
+
+Tests to record when done:
+- `./gradlew :matrix-sql:test --tests "MatrixSqlTest"`
+
+4.3 [ ] Add a managed connection facade constructor.
+
+Proposed API:
+```groovy
+MatrixSql(Connection connection, DataBaseProvider dbProvider)
+MatrixSql(Connection connection, SqlTypeMapper mapper)
+```
+
+Acceptance criteria:
+- Callers who manage JDBC connections can use the high-level `MatrixSql` API without dropping down to `MatrixDbUtil`.
+- `close()` behavior is documented clearly. Prefer not closing externally-owned connections unless explicitly configured.
+- Existing `ConnectionInfo` constructors are unchanged.
+
+Tests to record when done:
+- `./gradlew :matrix-sql:test --tests "MatrixSqlTest"`
+
+## 5. Improve Factory Offline Behavior
+
+Goal: make `MatrixSqlFactory.create(...)` predictable in offline or restricted-network environments.
+
+5.1 [ ] Add provider fallback versions for generic factory creation in `matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSqlFactory.groovy`.
+
+Acceptance criteria:
+- Known providers can be created without Maven Central version lookup success.
+- Fallback versions are centralized and easy to update.
+- Lookup failures log a warning and use fallback when available.
+- Unsupported providers still fail with a clear message.
+
+Tests to record when done:
+- `./gradlew :matrix-sql:test --tests "MatrixSqlTest.testFactorySetsDriverWhenMissing"`
+
+5.2 [ ] Add tests for factory fallback behavior.
+
+Acceptance criteria:
+- Tests stub or replace `artifactLookup` to simulate network failure.
+- H2 generic factory creation uses the fallback version.
+- Error messages include provider dependency coordinates when no fallback exists.
+
+Tests to record when done:
+- `./gradlew :matrix-sql:test --tests "MatrixSqlTest"`
+
+## 6. Refresh Documentation and Test Hygiene
+
+Goal: make the module easier to adopt and keep the test output consistent with repository conventions.
+
+6.1 [ ] Expand `matrix-sql/readme.md` examples for insert, select, update, delete, prepared-parameter operations, and managed-connection usage.
+
+Acceptance criteria:
+- README includes complete examples for each public workflow.
+- Examples use try-with-resources where appropriate.
+- Examples avoid `println` in favor of assertions or returned values.
+- Version snippets are updated to current module versions.
+
+Tests to record when done:
+- Documentation-only, no test command required.
+
+6.2 [ ] Replace `println` and `System.err.println` usage in matrix-sql tests with assertions or the matrix-core `Logger`.
+
+Acceptance criteria:
+- No active `println`, `System.out`, or `System.err` usages remain under `matrix-sql/src/test/groovy`.
+- Derby test asserts selected data instead of printing it.
+
+Tests to record when done:
+- `./gradlew :matrix-sql:test --rerun-tasks`
+
+## 7. Final Verification
+
+7.1 [ ] Run focused module verification after implementation.
+
+Tests to record when done:
+- `./gradlew :matrix-sql:test --rerun-tasks`
+
+7.2 [ ] Run full repository verification before merge.
+
+Tests to record when done:
+- `./gradlew test`
+
+7.3 [ ] Update the release notes or PR description with the modules touched and all test commands run.
+
+Acceptance criteria:
+- Notes distinguish bug fixes from usability enhancements.
+- Notes call out any source-compatible API additions.
+- Notes call out any behavior changes around identifier quoting or externally-managed connections.

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixDbUtil.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixDbUtil.groovy
@@ -102,7 +102,7 @@ class MatrixDbUtil {
   String createTableDdl(String tableName, Matrix table, Map<String, Map<String, Integer>> props, boolean addQuotes, String... primaryKey) {
     String sql = "create table ${SqlIdentifier.renderTable(tableName, addQuotes)} (\n"
 
-    List<String> columns = new ArrayList<>()
+    List<String> columns = []
     int i = 0
     List<Class> types = table.types()
     for (String name : table.columnNames()) {
@@ -198,7 +198,7 @@ class MatrixDbUtil {
             maxLength = val.length()
           }
         }
-        props.put(VARCHAR_SIZE, Math.max(DEFAULT_VARCHAR_SIZE, maxLength))
+        props.put(VARCHAR_SIZE, DEFAULT_VARCHAR_SIZE.max(maxLength))
       }
       mappings.put(name, props)
     }

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixDbUtil.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixDbUtil.groovy
@@ -26,6 +26,10 @@ import java.util.stream.IntStream
 // @CompileStatic
 class MatrixDbUtil {
 
+  static final int DEFAULT_VARCHAR_SIZE = 255
+  static final int DEFAULT_DECIMAL_PRECISION = 38
+  static final int DEFAULT_DECIMAL_SCALE = 10
+
   private static final Logger log = Logger.getLogger(MatrixDbUtil)
 
   SqlTypeMapper mapper
@@ -77,7 +81,7 @@ class MatrixDbUtil {
       throw e
     }
     try {
-      result.inserted = insert(con, tableName, table)
+      result.inserted = insert(con, tableName, table, addQuotes)
     } catch (SQLException e) {
       log.error("Failed to insert data to table $tableName: ${e.message}", e)
       throw e
@@ -96,22 +100,20 @@ class MatrixDbUtil {
    * @return the create table ddl statement
    */
   String createTableDdl(String tableName, Matrix table, Map<String, Map<String, Integer>> props, boolean addQuotes, String... primaryKey) {
-    String sql = "create table $tableName (\n"
+    String sql = "create table ${SqlIdentifier.renderTable(tableName, addQuotes)} (\n"
 
     List<String> columns = new ArrayList<>()
     int i = 0
     List<Class> types = table.types()
     for (String name : table.columnNames()) {
       Class type = types.get(i++)
-      if (addQuotes) {
-        columns.add("\"" + name + "\" " + mapper.sqlType(type, props[name]))
-      } else {
-        columns.add(name + " " + mapper.sqlType(type, props[name]))
-      }
+      columns.add("${SqlIdentifier.render(name, addQuotes)} ${mapper.sqlType(type, props[name])}")
     }
     sql += String.join(",\n", columns)
     if (primaryKey.length > 0) {
-      sql += "\n , CONSTRAINT pk_" + table.getMatrixName() + " PRIMARY KEY (\"" + String.join("\", \"", primaryKey) + "\")"
+      sql += "\n , CONSTRAINT ${SqlIdentifier.constraintName('pk', tableName, addQuotes)} PRIMARY KEY ("
+      sql += SqlIdentifier.renderAll(primaryKey.toList(), addQuotes).join(', ')
+      sql += ")"
     }
     sql += "\n)"
     sql
@@ -182,8 +184,9 @@ class MatrixDbUtil {
             right = val.scale()
           }
         }
-        props.put(DECIMAL_PRECISION, left + right)
-        props.put(DECIMAL_SCALE, right)
+        Integer precision = left + right
+        props.put(DECIMAL_PRECISION, precision > 0 ? precision : DEFAULT_DECIMAL_PRECISION)
+        props.put(DECIMAL_SCALE, precision > 0 ? right : DEFAULT_DECIMAL_SCALE)
       } else if (type == String) {
         Integer maxLength = 0
         for (int r = 0; r < rowsToScan; r++) {
@@ -195,7 +198,7 @@ class MatrixDbUtil {
             maxLength = val.length()
           }
         }
-        props.put(VARCHAR_SIZE, maxLength)
+        props.put(VARCHAR_SIZE, Math.max(DEFAULT_VARCHAR_SIZE, maxLength))
       }
       mappings.put(name, props)
     }
@@ -222,7 +225,7 @@ class MatrixDbUtil {
    * @return the result of the drop operation
    */
   Object dropTable(Connection con, String tableName) {
-    dbExecuteSql(con, "drop table $tableName")
+    dbExecuteSql(con, "drop table ${SqlIdentifier.renderTable(tableName)}")
   }
 
   /**
@@ -322,7 +325,21 @@ class MatrixDbUtil {
    * @throws SQLException if any sql error occurs
    */
   int insert(Connection con, String tableName, Matrix table) throws SQLException {
-    String insertSql = SqlGenerator.createPreparedInsertSql(tableName, table)
+    insert(con, tableName, table, true)
+  }
+
+  /**
+   * Insert the data from the given table into the given table in the database.
+   *
+   * @param con the db connection
+   * @param tableName the name of the table to insert into
+   * @param table the table containing the data to insert
+   * @param addQuotes whether to quote identifiers
+   * @return the number of inserted rows
+   * @throws SQLException if any sql error occurs
+   */
+  int insert(Connection con, String tableName, Matrix table, boolean addQuotes) throws SQLException {
+    String insertSql = SqlGenerator.createPreparedInsertSql(tableName, table, addQuotes)
     try(PreparedStatement stm = con.prepareStatement(insertSql)) {
       for (Row row : table) {
         int i = 1

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixDbUtil.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixDbUtil.groovy
@@ -365,9 +365,9 @@ class MatrixDbUtil {
     if (name == null || name.isBlank()) {
       throw new IllegalArgumentException("Matrix name is required but was '$name'")
     }
-    name.replace(".", "_")
-        .replace("-", "_")
-        .replace("*", "")
+    name.replaceAll(/[^A-Za-z0-9_ ]/, '_')
+        .replaceAll(/_+/, '_')
+        .replaceAll(/^_+|_+$/, '')
   }
 
   /**

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSql.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSql.groovy
@@ -218,7 +218,7 @@ class MatrixSql implements Closeable {
   }
 
   Object dropTable(String tableName) {
-    dbExecuteSql("drop table $tableName")
+    dbExecuteSql("drop table ${SqlIdentifier.renderTable(tableName)}")
   }
 
   Object dropTable(Matrix table) {
@@ -299,7 +299,7 @@ class MatrixSql implements Closeable {
     if (updateColumns.isEmpty()) {
       throw new IllegalArgumentException("No columns left to update after excluding match columns")
     }
-    String sql = SqlGenerator.createPreparedUpdateSql(table.getMatrixName(), updateColumns, matchColumns)
+    String sql = SqlGenerator.createPreparedUpdateSql(tableName(table), updateColumns, matchColumns)
     try(PreparedStatement stm = connect().prepareStatement(sql)) {
       for (Row row : table) {
         List<Object> values = SqlGenerator.updateValues(row, updateColumns, matchColumns)

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlGenerator.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlGenerator.groovy
@@ -121,14 +121,11 @@ class SqlGenerator {
   static String createPreparedInsertSql(String tableName, Matrix table, boolean addQuotes) {
     StringBuilder sql = new StringBuilder("insert into ${SqlIdentifier.renderTable(tableName, addQuotes)} ( ")
     List<String> columnNames = table.columnNames()
+    String placeholders = (['?'] * columnNames.size()).join(', ')
 
     sql.append(SqlIdentifier.renderAll(columnNames, addQuotes).join(', '))
     sql.append(' ) values ( ')
-    List<String> values = []
-    columnNames.forEach(n -> {
-      values.add('?')
-    })
-    sql.append(String.join(", ", values))
+    sql.append(placeholders)
     sql.append(' ) ')
     sql.toString()
   }
@@ -140,15 +137,11 @@ class SqlGenerator {
   static String createPreparedInsertSql(String tableName, Row row, boolean addQuotes) {
     String sql = "insert into ${SqlIdentifier.renderTable(tableName, addQuotes)} ( "
     List<String> columnNames = row.columnNames()
+    String placeholders = (['?'] * columnNames.size()).join(', ')
 
     sql += SqlIdentifier.renderAll(columnNames, addQuotes).join(', ')
     sql += " ) values ( "
-
-    List<String> values = []
-    columnNames.forEach(n -> {
-      values.add('?')
-    })
-    sql += String.join(", ", values)
+    sql += placeholders
     sql += " ) "
     sql
   }

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlGenerator.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlGenerator.groovy
@@ -74,7 +74,7 @@ class SqlGenerator {
     sql += updateColumns.collect { String column -> "${SqlIdentifier.render(column, addQuotes)} = ?" }.join(", ")
     sql += " where "
     sql += matchColumns.collect { String column -> "${SqlIdentifier.render(column, addQuotes)} = ?" }.join(" and ")
-    return sql
+    sql
   }
 
   /**
@@ -85,9 +85,9 @@ class SqlGenerator {
    * @return update column names
    */
   static List<String> updateColumnNames(List<String> columnNames, List<String> matchColumns) {
-    List<String> updateColumns = new ArrayList<>(columnNames)
+    List<String> updateColumns = [] + columnNames
     updateColumns.removeAll(matchColumns)
-    return updateColumns
+    updateColumns
   }
 
   /**
@@ -99,10 +99,10 @@ class SqlGenerator {
    * @return ordered list of parameter values
    */
   static List<Object> updateValues(Row row, List<String> updateColumns, List<String> matchColumns) {
-    List<Object> values = new ArrayList<>(updateColumns.size() + matchColumns.size())
+    List<Object> values = []
     updateColumns.each { values.add(row[it]) }
     matchColumns.each { values.add(row[it]) }
-    return values
+    values
   }
 
   /**
@@ -111,7 +111,7 @@ class SqlGenerator {
    * @deprecated use {@link #createPreparedUpdate(String, Row, String[])}
    */
   static String createUpdateSql(String tableName, Row row, String[] matchColumnName) {
-    return createPreparedUpdate(tableName, row, matchColumnName).sql
+    createPreparedUpdate(tableName, row, matchColumnName).sql
   }
 
   static String createPreparedInsertSql(String tableName, Matrix table) {
@@ -124,13 +124,13 @@ class SqlGenerator {
 
     sql.append(SqlIdentifier.renderAll(columnNames, addQuotes).join(', '))
     sql.append(' ) values ( ')
-    List<String> values = new ArrayList<>()
+    List<String> values = []
     columnNames.forEach(n -> {
       values.add('?')
     })
     sql.append(String.join(", ", values))
     sql.append(' ) ')
-    return sql.toString()
+    sql.toString()
   }
 
   static String createPreparedInsertSql(String tableName, Row row) {
@@ -144,13 +144,13 @@ class SqlGenerator {
     sql += SqlIdentifier.renderAll(columnNames, addQuotes).join(', ')
     sql += " ) values ( "
 
-    List<String> values = new ArrayList<>()
+    List<String> values = []
     columnNames.forEach(n -> {
       values.add('?')
     })
     sql += String.join(", ", values)
-    sql += " ); "
-    return sql
+    sql += " ) "
+    sql
   }
 
 }

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlGenerator.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlGenerator.groovy
@@ -52,10 +52,28 @@ class SqlGenerator {
    * @return the SQL update statement with placeholders
    */
   static String createPreparedUpdateSql(String tableName, List<String> updateColumns, List<String> matchColumns) {
-    String sql = "update " + tableName + " set "
-    sql += updateColumns.collect { "${it} = ?" }.join(", ")
+    createPreparedUpdateSql(tableName, updateColumns, matchColumns, true)
+  }
+
+  /**
+   * Create a prepared update statement (with placeholders).
+   *
+   * @param tableName the table name
+   * @param updateColumns columns to update in the SET clause
+   * @param matchColumns columns to match in the WHERE clause
+   * @param addQuotes whether to quote identifiers
+   * @return the SQL update statement with placeholders
+   */
+  static String createPreparedUpdateSql(
+      String tableName,
+      List<String> updateColumns,
+      List<String> matchColumns,
+      boolean addQuotes
+  ) {
+    String sql = "update ${SqlIdentifier.renderTable(tableName, addQuotes)} set "
+    sql += updateColumns.collect { String column -> "${SqlIdentifier.render(column, addQuotes)} = ?" }.join(", ")
     sql += " where "
-    sql += matchColumns.collect { "${it} = ?" }.join(" and ")
+    sql += matchColumns.collect { String column -> "${SqlIdentifier.render(column, addQuotes)} = ?" }.join(" and ")
     return sql
   }
 
@@ -97,10 +115,14 @@ class SqlGenerator {
   }
 
   static String createPreparedInsertSql(String tableName, Matrix table) {
-    StringBuilder sql = new StringBuilder("insert into " + tableName + " ( ")
+    createPreparedInsertSql(tableName, table, true)
+  }
+
+  static String createPreparedInsertSql(String tableName, Matrix table, boolean addQuotes) {
+    StringBuilder sql = new StringBuilder("insert into ${SqlIdentifier.renderTable(tableName, addQuotes)} ( ")
     List<String> columnNames = table.columnNames()
 
-    sql.append('"').append(String.join('", "', columnNames)).append('"')
+    sql.append(SqlIdentifier.renderAll(columnNames, addQuotes).join(', '))
     sql.append(' ) values ( ')
     List<String> values = new ArrayList<>()
     columnNames.forEach(n -> {
@@ -112,10 +134,14 @@ class SqlGenerator {
   }
 
   static String createPreparedInsertSql(String tableName, Row row) {
-    String sql = "insert into " + tableName + " ( "
+    createPreparedInsertSql(tableName, row, true)
+  }
+
+  static String createPreparedInsertSql(String tableName, Row row, boolean addQuotes) {
+    String sql = "insert into ${SqlIdentifier.renderTable(tableName, addQuotes)} ( "
     List<String> columnNames = row.columnNames()
 
-    sql += "\"" + String.join("\", \"", columnNames) + "\""
+    sql += SqlIdentifier.renderAll(columnNames, addQuotes).join(', ')
     sql += " ) values ( "
 
     List<String> values = new ArrayList<>()

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlIdentifier.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlIdentifier.groovy
@@ -32,8 +32,9 @@ class SqlIdentifier {
   }
 
   /**
-   * Render a table identifier. Simple table names are left unquoted for source compatibility;
-   * names containing spaces, punctuation, reserved words, or embedded quotes are quoted.
+   * Render a table identifier. Simple table names are intentionally left unquoted for source compatibility
+   * with existing callers that create a table and later query it with raw SQL such as {@code select * from myTable}.
+   * Table names containing spaces, punctuation, reserved words, or embedded quotes are quoted.
    *
    * @param tableName the table name to render
    * @param addQuotes true to quote when needed, false to always render unquoted
@@ -83,27 +84,77 @@ class SqlIdentifier {
   }
 
   private static final Set<String> SQL_KEYWORDS = [
+      'ADD',
       'ALL',
+      'ALTER',
       'AND',
       'AS',
+      'ASC',
+      'BETWEEN',
+      'BY',
+      'CASCADE',
+      'CASE',
+      'CHECK',
+      'COLUMN',
+      'CONSTRAINT',
       'CREATE',
+      'CROSS',
+      'CURRENT_DATE',
+      'CURRENT_TIME',
+      'CURRENT_TIMESTAMP',
+      'DATABASE',
+      'DATE',
+      'DEFAULT',
       'DELETE',
+      'DESC',
+      'DISTINCT',
       'DROP',
+      'ELSE',
+      'END',
+      'EXISTS',
+      'FALSE',
+      'FOREIGN',
       'FROM',
+      'FULL',
       'GROUP',
+      'HAVING',
+      'IN',
+      'INDEX',
+      'INNER',
       'INSERT',
       'INTO',
+      'IS',
       'JOIN',
+      'KEY',
+      'LEFT',
+      'LIKE',
+      'LIMIT',
       'NOT',
       'NULL',
+      'OFFSET',
+      'ON',
       'OR',
       'ORDER',
+      'OUTER',
       'PRIMARY',
+      'REFERENCES',
+      'RIGHT',
+      'SCHEMA',
       'SELECT',
       'SET',
       'TABLE',
+      'THEN',
+      'TIME',
+      'TIMESTAMP',
+      'TRUE',
+      'TYPE',
+      'UNION',
       'UPDATE',
+      'USER',
+      'VALUE',
       'VALUES',
+      'VIEW',
+      'WHEN',
       'WHERE'
   ] as Set<String>
 }

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlIdentifier.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlIdentifier.groovy
@@ -1,0 +1,109 @@
+package se.alipsa.matrix.sql
+
+import groovy.transform.CompileStatic
+
+/**
+ * Utility methods for rendering SQL identifiers in generated statements.
+ */
+@CompileStatic
+class SqlIdentifier {
+
+  /**
+   * Quote an identifier with standard SQL double quotes.
+   *
+   * @param identifier the identifier to quote
+   * @return the quoted identifier
+   */
+  static String quote(String identifier) {
+    String value = requireIdentifier(identifier)
+    "\"${value.replace('"', '""')}\""
+  }
+
+  /**
+   * Render an identifier, optionally quoted.
+   *
+   * @param identifier the identifier to render
+   * @param addQuotes true to quote the identifier, false to render it unquoted
+   * @return a rendered SQL identifier
+   */
+  static String render(String identifier, boolean addQuotes = true) {
+    String value = requireIdentifier(identifier)
+    addQuotes ? quote(value) : value
+  }
+
+  /**
+   * Render a table identifier. Simple table names are left unquoted for source compatibility;
+   * names containing spaces, punctuation, reserved words, or embedded quotes are quoted.
+   *
+   * @param tableName the table name to render
+   * @param addQuotes true to quote when needed, false to always render unquoted
+   * @return a rendered table identifier
+   */
+  static String renderTable(String tableName, boolean addQuotes = true) {
+    String value = requireIdentifier(tableName)
+    addQuotes && requiresQuoting(value) ? quote(value) : value
+  }
+
+  /**
+   * Render multiple identifiers.
+   *
+   * @param identifiers the identifiers to render
+   * @param addQuotes true to quote identifiers, false to render them unquoted
+   * @return a list of rendered SQL identifiers
+   */
+  static List<String> renderAll(Collection<String> identifiers, boolean addQuotes = true) {
+    identifiers.collect { String identifier -> render(identifier, addQuotes) }
+  }
+
+  /**
+   * Create a constraint identifier from a prefix and table name.
+   *
+   * @param prefix the constraint prefix
+   * @param tableName the table name
+   * @param addQuotes true to quote the generated constraint name
+   * @return a rendered constraint identifier
+   */
+  static String constraintName(String prefix, String tableName, boolean addQuotes = true) {
+    String normalized = "${requireIdentifier(prefix)}_${requireIdentifier(tableName)}"
+        .replaceAll(/[^A-Za-z0-9_]/, '_')
+        .replaceAll(/_+/, '_')
+        .replaceAll(/^_+|_+$/, '')
+    render(normalized, addQuotes)
+  }
+
+  private static String requireIdentifier(String identifier) {
+    if (identifier == null || identifier.isBlank()) {
+      throw new IllegalArgumentException("SQL identifier is required but was '$identifier'")
+    }
+    identifier
+  }
+
+  private static boolean requiresQuoting(String identifier) {
+    !(identifier ==~ /[A-Za-z_][A-Za-z0-9_]*/) || SQL_KEYWORDS.contains(identifier.toUpperCase())
+  }
+
+  private static final Set<String> SQL_KEYWORDS = [
+      'ALL',
+      'AND',
+      'AS',
+      'CREATE',
+      'DELETE',
+      'DROP',
+      'FROM',
+      'GROUP',
+      'INSERT',
+      'INTO',
+      'JOIN',
+      'NOT',
+      'NULL',
+      'OR',
+      'ORDER',
+      'PRIMARY',
+      'SELECT',
+      'SET',
+      'TABLE',
+      'UPDATE',
+      'VALUES',
+      'WHERE'
+  ] as Set<String>
+}

--- a/matrix-sql/src/test/groovy/MatrixDbUtilTest.groovy
+++ b/matrix-sql/src/test/groovy/MatrixDbUtilTest.groovy
@@ -1,4 +1,7 @@
 import static org.junit.jupiter.api.Assertions.*
+import static se.alipsa.groovy.datautil.sqltypes.SqlTypeMapper.getDECIMAL_PRECISION
+import static se.alipsa.groovy.datautil.sqltypes.SqlTypeMapper.getDECIMAL_SCALE
+import static se.alipsa.groovy.datautil.sqltypes.SqlTypeMapper.getVARCHAR_SIZE
 
 import it.AbstractDbTest
 import org.junit.jupiter.api.Test
@@ -8,6 +11,7 @@ import se.alipsa.groovy.datautil.DataBaseProvider
 import se.alipsa.groovy.datautil.sqltypes.SqlTypeMapper
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.sql.MatrixDbUtil
+import se.alipsa.matrix.sql.SqlIdentifier
 
 class MatrixDbUtilTest {
 
@@ -30,6 +34,49 @@ class MatrixDbUtilTest {
   }
 
   @Test
+  void testDdlQuotesUnusualIdentifiers() {
+    Matrix m = Matrix.builder('odd table-name*').data([
+        'id': [1],
+        'first name': ['Alice'],
+        'select': ['reserved'],
+        'quote " col': ['quoted']
+    ])
+    .types(int, String, String, String)
+    .build()
+
+    def util = new MatrixDbUtil(SqlTypeMapper.create(DataBaseProvider.UNKNOWN))
+    Map mappings = util.createMappings(m, m.rowCount())
+    String tableName = MatrixDbUtil.tableName(m)
+    String ddl = util.createTableDdl(tableName, m, mappings, true, 'id')
+
+    assertTrue(ddl.startsWith("create table ${SqlIdentifier.quote(tableName)}"))
+    assertTrue(ddl.contains('"first name"'))
+    assertTrue(ddl.contains('"select"'))
+    assertTrue(ddl.contains('"quote "" col"'))
+    assertTrue(ddl.contains("CONSTRAINT ${SqlIdentifier.quote('pk_odd_table_name')} PRIMARY KEY (\"id\")"))
+  }
+
+  @Test
+  void testDdlCanRenderUnquotedIdentifiers() {
+    Matrix m = Matrix.builder('plain_table').data([
+        id: [1],
+        name: ['Alice']
+    ])
+    .types(int, String)
+    .build()
+
+    def util = new MatrixDbUtil(SqlTypeMapper.create(DataBaseProvider.UNKNOWN))
+    Map mappings = util.createMappings(m, m.rowCount())
+    String ddl = util.createTableDdl(MatrixDbUtil.tableName(m), m, mappings, false, 'id')
+
+    assertTrue(ddl.startsWith('create table plain_table'))
+    assertTrue(ddl.contains('id '))
+    assertTrue(ddl.contains('name '))
+    assertTrue(ddl.contains('CONSTRAINT pk_plain_table PRIMARY KEY (id)'))
+    assertFalse(ddl.contains('"id"'))
+  }
+
+  @Test
   void testCreateMappingsClampsScanRows() {
     Matrix m = Matrix.builder('small').data([
         name: ['abc'],
@@ -43,5 +90,56 @@ class MatrixDbUtilTest {
     assertEquals(2, mappings.size())
     assertEquals(1, mappings['name'].size())
     assertEquals(2, mappings['amount'].size())
+  }
+
+  @Test
+  void testCreateMappingsUsesDefaultsForNullOnlyColumns() {
+    Matrix m = Matrix.builder('nulls').data([
+        name: [null, null],
+        amount: [null, null]
+    ])
+    .types(String, BigDecimal)
+    .build()
+
+    def util = new MatrixDbUtil(SqlTypeMapper.create(DataBaseProvider.UNKNOWN))
+    Map mappings = util.createMappings(m, 2)
+
+    assertEquals(MatrixDbUtil.DEFAULT_VARCHAR_SIZE, mappings['name'][VARCHAR_SIZE])
+    assertEquals(MatrixDbUtil.DEFAULT_DECIMAL_PRECISION, mappings['amount'][DECIMAL_PRECISION])
+    assertEquals(MatrixDbUtil.DEFAULT_DECIMAL_SCALE, mappings['amount'][DECIMAL_SCALE])
+  }
+
+  @Test
+  void testCreateMappingsUsesDefaultsForZeroScanRows() {
+    Matrix m = Matrix.builder('zeroScan').data([
+        name: ['abc'],
+        amount: [12.34]
+    ])
+    .types(String, BigDecimal)
+    .build()
+
+    def util = new MatrixDbUtil(SqlTypeMapper.create(DataBaseProvider.UNKNOWN))
+    Map mappings = util.createMappings(m, 0)
+
+    assertEquals(MatrixDbUtil.DEFAULT_VARCHAR_SIZE, mappings['name'][VARCHAR_SIZE])
+    assertEquals(MatrixDbUtil.DEFAULT_DECIMAL_PRECISION, mappings['amount'][DECIMAL_PRECISION])
+    assertEquals(MatrixDbUtil.DEFAULT_DECIMAL_SCALE, mappings['amount'][DECIMAL_SCALE])
+  }
+
+  @Test
+  void testCreateMappingsUsesDefaultsForEmptyMatrices() {
+    Matrix m = Matrix.builder('empty').data([
+        name: [],
+        amount: []
+    ])
+    .types(String, BigDecimal)
+    .build()
+
+    def util = new MatrixDbUtil(SqlTypeMapper.create(DataBaseProvider.UNKNOWN))
+    Map mappings = util.createMappings(m, 10)
+
+    assertEquals(MatrixDbUtil.DEFAULT_VARCHAR_SIZE, mappings['name'][VARCHAR_SIZE])
+    assertEquals(MatrixDbUtil.DEFAULT_DECIMAL_PRECISION, mappings['amount'][DECIMAL_PRECISION])
+    assertEquals(MatrixDbUtil.DEFAULT_DECIMAL_SCALE, mappings['amount'][DECIMAL_SCALE])
   }
 }

--- a/matrix-sql/src/test/groovy/MatrixDbUtilTest.groovy
+++ b/matrix-sql/src/test/groovy/MatrixDbUtilTest.groovy
@@ -77,6 +77,17 @@ class MatrixDbUtilTest {
   }
 
   @Test
+  void testTableNameSanitizesUnsafeCharacters() {
+    Matrix m = Matrix.builder('fun(data) with \'quotes\' and *stuff*').data([
+        id: [1]
+    ])
+    .types(int)
+    .build()
+
+    assertEquals('fun_data_ with _quotes_ and _stuff', MatrixDbUtil.tableName(m))
+  }
+
+  @Test
   void testCreateMappingsClampsScanRows() {
     Matrix m = Matrix.builder('small').data([
         name: ['abc'],

--- a/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
+++ b/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
@@ -13,6 +13,7 @@ import se.alipsa.matrix.core.Row
 import se.alipsa.matrix.datasets.Dataset
 import se.alipsa.matrix.sql.MatrixSql
 import se.alipsa.matrix.sql.MatrixSqlFactory
+import se.alipsa.matrix.sql.SqlIdentifier
 
 import java.sql.Connection
 import java.sql.ResultSet
@@ -255,5 +256,62 @@ class MatrixSqlTest {
       assertEquals(ci.url, h2.connectionInfo.url, "Urls does not match")
     }
     assertEquals(ddl1, ddl2)
+  }
+
+  @Test
+  void testGeneratedSqlHandlesQuotedIdentifiers() {
+    Matrix data = Matrix.builder('odd table-name*').data([
+        'id': [1],
+        'first name': ['Alice'],
+        'select': ['reserved'],
+        'MiXeD': ['Case'],
+        'quote " col': ['quoted']
+    ])
+    .types(int, String, String, String, String)
+    .build()
+
+    String url = h2MemUrl('quoted_identifiers', 'DATABASE_TO_UPPER=FALSE')
+    try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+      String tableName = matrixSql.tableName(data)
+      matrixSql.create(data, 'id')
+      assertTrue(matrixSql.tableExists(tableName))
+
+      Matrix extra = Matrix.builder('extra').data([
+          'id': [2],
+          'first name': ['Beatrice'],
+          'select': ['second'],
+          'MiXeD': ['Camel'],
+          'quote " col': ['embedded']
+      ])
+      .types(int, String, String, String, String)
+      .build()
+      assertEquals(1, matrixSql.insert(tableName, extra.row(0)))
+
+      Row changed = extra.row(0)
+      changed['first name'] = 'Bob'
+      changed['select'] = 'updated'
+      changed['MiXeD'] = 'StillMixed'
+      changed['quote " col'] = 'still " quoted'
+      assertEquals(1, matrixSql.update(tableName, changed, 'id'))
+
+      Matrix stored = matrixSql.select("""
+        select ${SqlIdentifier.quote('id')},
+               ${SqlIdentifier.quote('first name')},
+               ${SqlIdentifier.quote('select')},
+               ${SqlIdentifier.quote('MiXeD')},
+               ${SqlIdentifier.quote('quote " col')}
+        from ${SqlIdentifier.quote(tableName)}
+        order by ${SqlIdentifier.quote('id')}
+      """)
+      assertEquals(2, stored.rowCount())
+      assertEquals('Alice', stored[0, 'first name'])
+      assertEquals('Bob', stored[1, 'first name'])
+      assertEquals('updated', stored[1, 'select'])
+      assertEquals('StillMixed', stored[1, 'MiXeD'])
+      assertEquals('still " quoted', stored[1, 'quote " col'])
+
+      matrixSql.dropTable(tableName)
+      assertFalse(matrixSql.tableExists(tableName))
+    }
   }
 }

--- a/matrix-sql/src/test/groovy/SqlIdentifierTest.groovy
+++ b/matrix-sql/src/test/groovy/SqlIdentifierTest.groovy
@@ -1,0 +1,61 @@
+import static org.junit.jupiter.api.Assertions.*
+
+import org.junit.jupiter.api.Test
+
+import se.alipsa.matrix.sql.SqlIdentifier
+
+class SqlIdentifierTest {
+
+  @Test
+  void testQuoteEscapesEmbeddedQuotes() {
+    assertEquals('"quote "" col"', SqlIdentifier.quote('quote " col'))
+  }
+
+  @Test
+  void testQuoteRequiresIdentifier() {
+    assertThrows(IllegalArgumentException) {
+      SqlIdentifier.quote(null)
+    }
+    assertThrows(IllegalArgumentException) {
+      SqlIdentifier.quote('')
+    }
+    assertThrows(IllegalArgumentException) {
+      SqlIdentifier.quote('  ')
+    }
+  }
+
+  @Test
+  void testConstraintNameNormalizesSpecialCharacters() {
+    assertEquals('"pk_odd_table_name"', SqlIdentifier.constraintName('pk', 'odd table-name*'))
+  }
+
+  @Test
+  void testRenderTableQuotesReservedWords() {
+    [
+        'SELECT',
+        'user',
+        'key',
+        'constraint',
+        'timestamp',
+        'value'
+    ].each { String keyword ->
+      assertEquals("\"$keyword\"", SqlIdentifier.renderTable(keyword))
+    }
+  }
+
+  @Test
+  void testRenderTableKeepsSimpleNamesUnquotedForCompatibility() {
+    assertEquals('plain_table', SqlIdentifier.renderTable('plain_table'))
+  }
+
+  @Test
+  void testRenderTableQuotesNamesThatNeedQuoting() {
+    assertEquals('"my table"', SqlIdentifier.renderTable('my table'))
+    assertEquals('"quote "" table"', SqlIdentifier.renderTable('quote " table'))
+  }
+
+  @Test
+  void testRenderTableCanBeForcedUnquoted() {
+    assertEquals('select', SqlIdentifier.renderTable('select', false))
+  }
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of `matrix-sql/req/v2.4.0-roadmap.md`.

- Add a shared `SqlIdentifier` helper for generated SQL identifier rendering and escaping.
- Use consistent identifier handling in matrix-sql DDL, insert, update, and drop paths.
- Preserve existing simple unquoted table-name workflows while quoting unusual table names when needed.
- Add safe default sizing for null-only or empty sampled `String` and `BigDecimal` columns.
- Add regression coverage for unusual identifiers, embedded quotes, reserved words, explicit unquoted DDL, direct identifier helper behavior, and null/empty mapping defaults.

## Impact

This fixes generated SQL fragility around spaces, reserved words, mixed-case columns, and embedded quote characters, while keeping source-compatible behavior for common simple table names.

Behavior change to note: `MatrixDbUtil.tableName()` now replaces unsafe non-alphanumeric characters with underscores instead of only stripping `*` and replacing `.`/`-`. For example, `my*table` now becomes `my_table`; previously it became `mytable`.

## Validation

- `./gradlew :matrix-sql:test --tests "MatrixDbUtilTest" --tests "MatrixSqlTest" --rerun-tasks`
- `./gradlew :matrix-sql:test --tests "SqlIdentifierTest" --tests "MatrixDbUtilTest" --tests "MatrixSqlTest" --rerun-tasks`
- `./gradlew :matrix-sql:test --rerun-tasks`
- `./gradlew test`
- `./gradlew :matrix-sql:spotlessCheck`
- `git diff --check`
