### PR TITLE
[codex] Tighten MatrixResultSet behavior

### DIFF
--- a/matrix-sql/req/v2.4.0-roadmap.md
+++ b/matrix-sql/req/v2.4.0-roadmap.md
@@ -15,9 +15,15 @@ Completed test commands:
 - `./gradlew :matrix-sql:test --rerun-tasks`
 - `./gradlew test`
 
-Phase 2 [ ] `MatrixResultSet` JDBC behavior.
+Phase 2 [x] `MatrixResultSet` JDBC behavior.
 - Covers roadmap section `3`.
 - Focus: predictable JDBC-style failures for missing columns, closed result sets, invalid cursor state, and null stream/temporal getters.
+
+Completed test commands:
+- `./gradlew :matrix-sql:test --tests "MatrixResultSetTest" --rerun-tasks`
+- `./gradlew :matrix-sql:test --rerun-tasks`
+- `./gradlew :matrix-sql:spotlessCheck`
+- `./gradlew test`
 
 Phase 3 [ ] Convenience APIs.
 - Covers roadmap section `4`.
@@ -107,7 +113,7 @@ Tests to record when done:
 
 Goal: make `MatrixResultSet` fail predictably and match common JDBC expectations for missing columns, null values, and cursor state.
 
-3.1 [ ] Add internal guard methods in `matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixResultSet.groovy` for closed result sets, valid current rows, and valid column indexes.
+3.1 [x] Add internal guard methods in `matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixResultSet.groovy` for closed result sets, valid current rows, and valid column indexes.
 
 Acceptance criteria:
 - Getter methods throw `SQLException` when the result set is closed.
@@ -117,7 +123,7 @@ Acceptance criteria:
 Tests to record when done:
 - `./gradlew :matrix-sql:test --tests "MatrixResultSetTest"`
 
-3.2 [ ] Fix `findColumn` to throw `SQLException` when a column label is unknown.
+3.2 [x] Fix `findColumn` to throw `SQLException` when a column label is unknown.
 
 Acceptance criteria:
 - `findColumn('missing')` throws `SQLException`.
@@ -126,7 +132,7 @@ Acceptance criteria:
 Tests to record when done:
 - `./gradlew :matrix-sql:test --tests "MatrixResultSetTest"`
 
-3.3 [ ] Fix null handling for stream and temporal getters.
+3.3 [x] Fix null handling for stream and temporal getters.
 
 Acceptance criteria:
 - `getCharacterStream` returns `null` for null values and makes `wasNull()` true.

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixResultSet.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixResultSet.groovy
@@ -2819,13 +2819,14 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Date getDate(int columnIndex, Calendar cal) throws SQLException {
-    def val = readValue(columnIndex)
+    int idx = checkedColumnIndex(columnIndex)
+    def val = matrix[rowIdx, idx]
     if (val instanceof Number) {
-      // assume we are storing millis
       lastReadValue = new Date(val + cal.getTimeZone().getOffset(0) as long)
-      return lastReadValue as Date
+    } else {
+      lastReadValue = matrix[rowIdx, idx, Date]
     }
-    lastReadValue = val as Date
+    return lastReadValue as Date
   }
 
   /**
@@ -2873,13 +2874,14 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Time getTime(int columnIndex, Calendar cal) throws SQLException {
-    def val = readValue(columnIndex)
+    int idx = checkedColumnIndex(columnIndex)
+    def val = matrix[rowIdx, idx]
     if (val instanceof Number) {
-      // assume we are storing millis
       lastReadValue = new Time(val + cal.getTimeZone().getOffset(0) as long)
-      return lastReadValue as Time
+    } else {
+      lastReadValue = matrix[rowIdx, idx, Time]
     }
-    lastReadValue = val as Time
+    return lastReadValue as Time
   }
 
   /**
@@ -2927,13 +2929,14 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
-    def val = readValue(columnIndex)
+    int idx = checkedColumnIndex(columnIndex)
+    def val = matrix[rowIdx, idx]
     if (val instanceof Number) {
-      // assume we are storing millis
       lastReadValue = new Timestamp(val + cal.getTimeZone().getOffset(0) as long)
-      return lastReadValue as Timestamp
+    } else {
+      lastReadValue = matrix[rowIdx, idx, Timestamp]
     }
-    lastReadValue = val as Timestamp
+    return lastReadValue as Timestamp
   }
 
   /**

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixResultSet.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixResultSet.groovy
@@ -77,7 +77,6 @@ class MatrixResultSet implements ResultSet{
   }
 
   private int checkedColumnIndex(String columnLabel) throws SQLException {
-    ensureOpen()
     int columnIndex = matrix.columnIndex(columnLabel)
     if (columnIndex < 0) {
       throw new SQLException("Column not found: $columnLabel")
@@ -948,6 +947,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   int findColumn(String columnLabel) throws SQLException {
+    ensureOpen()
     checkedColumnIndex(columnLabel) + 1
   }
 
@@ -2825,7 +2825,7 @@ class MatrixResultSet implements ResultSet{
       lastReadValue = new Date(val + cal.getTimeZone().getOffset(0) as long)
       return lastReadValue as Date
     }
-    lastReadValue = readValue(columnIndex, Date)
+    lastReadValue = val as Date
   }
 
   /**
@@ -2879,7 +2879,7 @@ class MatrixResultSet implements ResultSet{
       lastReadValue = new Time(val + cal.getTimeZone().getOffset(0) as long)
       return lastReadValue as Time
     }
-    lastReadValue = readValue(columnIndex, Time)
+    lastReadValue = val as Time
   }
 
   /**
@@ -2933,7 +2933,7 @@ class MatrixResultSet implements ResultSet{
       lastReadValue = new Timestamp(val + cal.getTimeZone().getOffset(0) as long)
       return lastReadValue as Timestamp
     }
-    lastReadValue = readValue(columnIndex, Timestamp)
+    lastReadValue = val as Timestamp
   }
 
   /**

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixResultSet.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixResultSet.groovy
@@ -2979,7 +2979,9 @@ class MatrixResultSet implements ResultSet{
   @Override
   URL getURL(int columnIndex) throws SQLException {
     try {
-      new URL(matrix[rowIdx, columnIndex - 1, String])
+      String val = readValue(columnIndex, String)
+      lastReadValue = val
+      val == null ? null : new URL(val)
     } catch (MalformedURLException e) {
       throw new SQLException(e.getMessage(), e)
     }
@@ -3003,7 +3005,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   URL getURL(String columnLabel) throws SQLException {
-    getURL(matrix.columnIndex(columnLabel) +1)
+    getURL(findColumn(columnLabel))
   }
 
   /**

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixResultSet.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixResultSet.groovy
@@ -54,6 +54,55 @@ class MatrixResultSet implements ResultSet{
   MatrixResultSet(Matrix matrix) {
     this.matrix = matrix.clone()
   }
+
+  private void ensureOpen() throws SQLException {
+    if (matrix == null) {
+      throw new SQLException('Result set is closed')
+    }
+  }
+
+  private void ensureCurrentRow() throws SQLException {
+    ensureOpen()
+    if (rowIdx < 0 || rowIdx >= matrix.rowCount()) {
+      throw new SQLException("Cursor is not positioned on a valid row: ${rowIdx + 1}")
+    }
+  }
+
+  private int checkedColumnIndex(int columnIndex) throws SQLException {
+    ensureCurrentRow()
+    if (columnIndex < 1 || columnIndex > matrix.columnCount()) {
+      throw new SQLException("Column index out of range: $columnIndex")
+    }
+    columnIndex - 1
+  }
+
+  private int checkedColumnIndex(String columnLabel) throws SQLException {
+    ensureOpen()
+    int columnIndex = matrix.columnIndex(columnLabel)
+    if (columnIndex < 0) {
+      throw new SQLException("Column not found: $columnLabel")
+    }
+    columnIndex
+  }
+
+  private def readValue(int columnIndex) throws SQLException {
+    matrix[rowIdx, checkedColumnIndex(columnIndex)]
+  }
+
+  private def readValue(String columnLabel) throws SQLException {
+    ensureCurrentRow()
+    matrix[rowIdx, checkedColumnIndex(columnLabel)]
+  }
+
+  private def readValue(int columnIndex, Class type) throws SQLException {
+    matrix[rowIdx, checkedColumnIndex(columnIndex), type]
+  }
+
+  private def readValue(String columnLabel, Class type) throws SQLException {
+    ensureCurrentRow()
+    matrix[rowIdx, checkedColumnIndex(columnLabel), type]
+  }
+
   /**
    * Moves the cursor forward one row from its current position.
    * A {@code ResultSet} cursor is initially positioned
@@ -82,6 +131,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   boolean next() throws SQLException {
+    ensureOpen()
     rowIdx++
     if (rowIdx >= matrix.rowCount()) {
       return false
@@ -136,6 +186,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   boolean wasNull() throws SQLException {
+    ensureOpen()
     return lastReadValue == null
   }
 
@@ -153,7 +204,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   String getString(int columnIndex) throws SQLException {
-    lastReadValue = matrix[rowIdx, columnIndex -1, String]
+    lastReadValue = readValue(columnIndex, String)
   }
 
   /**
@@ -177,7 +228,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   boolean getBoolean(int columnIndex) throws SQLException {
-    lastReadValue = matrix[rowIdx, columnIndex-1, Boolean]
+    lastReadValue = readValue(columnIndex, Boolean)
     lastReadValue == null ? false : (boolean) lastReadValue
   }
 
@@ -195,7 +246,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   byte getByte(int columnIndex) throws SQLException {
-    lastReadValue = matrix[rowIdx, columnIndex-1, Byte]
+    lastReadValue = readValue(columnIndex, Byte)
     lastReadValue == null ? (byte) 0 : (byte) lastReadValue
   }
 
@@ -213,7 +264,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   short getShort(int columnIndex) throws SQLException {
-    lastReadValue = matrix[rowIdx, columnIndex-1, Short]
+    lastReadValue = readValue(columnIndex, Short)
     lastReadValue == null ? (short) 0 : (short) lastReadValue
   }
 
@@ -231,7 +282,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   int getInt(int columnIndex) throws SQLException {
-    lastReadValue = matrix[rowIdx, columnIndex-1, Integer]
+    lastReadValue = readValue(columnIndex, Integer)
     lastReadValue ?: 0
   }
 
@@ -249,7 +300,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   long getLong(int columnIndex) throws SQLException {
-    lastReadValue = matrix[rowIdx, columnIndex-1, Long]
+    lastReadValue = readValue(columnIndex, Long)
     lastReadValue ?: 0
   }
 
@@ -267,7 +318,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   float getFloat(int columnIndex) throws SQLException {
-    lastReadValue = matrix[rowIdx, columnIndex-1, Float]
+    lastReadValue = readValue(columnIndex, Float)
     lastReadValue ?: 0
   }
 
@@ -285,14 +336,14 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   double getDouble(int columnIndex) throws SQLException {
-    lastReadValue = matrix[rowIdx, columnIndex-1, Double]
+    lastReadValue = readValue(columnIndex, Double)
     lastReadValue ?: 0
   }
 
   /** @deprecated */
   @Override
   BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
-    lastReadValue = matrix[rowIdx, columnIndex-1, BigDecimal]
+    lastReadValue = readValue(columnIndex, BigDecimal)
     (lastReadValue == null) ? null : lastReadValue.setScale(scale)
   }
 
@@ -311,7 +362,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   byte[] getBytes(int columnIndex) throws SQLException {
-    lastReadValue = matrix[rowIdx, columnIndex-1, byte[]]
+    lastReadValue = readValue(columnIndex, byte[])
   }
 
   /**
@@ -328,7 +379,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Date getDate(int columnIndex) throws SQLException {
-    lastReadValue = matrix[rowIdx, columnIndex-1, Date]
+    lastReadValue = readValue(columnIndex, Date)
   }
 
   /**
@@ -345,7 +396,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Time getTime(int columnIndex) throws SQLException {
-    lastReadValue = matrix[rowIdx, columnIndex-1, Time]
+    lastReadValue = readValue(columnIndex, Time)
   }
 
   /**
@@ -362,7 +413,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Timestamp getTimestamp(int columnIndex) throws SQLException {
-    lastReadValue = matrix[rowIdx, columnIndex-1, Timestamp]
+    lastReadValue = readValue(columnIndex, Timestamp)
   }
 
   /**
@@ -392,7 +443,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   InputStream getAsciiStream(int columnIndex) throws SQLException {
-    String val = matrix[rowIdx, columnIndex-1, String]
+    String val = readValue(columnIndex, String)
     if (val == null) {
       lastReadValue = null
     } else {
@@ -406,7 +457,7 @@ class MatrixResultSet implements ResultSet{
   /** @deprecated */
   @Override
   InputStream getUnicodeStream(int columnIndex) throws SQLException {
-    String val = matrix[rowIdx, columnIndex-1, String]
+    String val = readValue(columnIndex, String)
     lastReadValue = val == null ? null : new ByteArrayInputStream(val.getBytes(StandardCharsets.UTF_8))
   }
 
@@ -435,7 +486,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   InputStream getBinaryStream(int columnIndex) throws SQLException {
-    byte[] val = matrix[rowIdx, columnIndex-1, byte[]]
+    byte[] val = readValue(columnIndex, byte[])
     lastReadValue = val == null ? null : new ByteArrayInputStream(val)
   }
 
@@ -453,7 +504,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   String getString(String columnLabel) throws SQLException {
-    getString(matrix.columnIndex(columnLabel)+1)
+    getString(findColumn(columnLabel))
   }
 
   /**
@@ -477,7 +528,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   boolean getBoolean(String columnLabel) throws SQLException {
-    getBoolean(matrix.columnIndex(columnLabel)+1)
+    getBoolean(findColumn(columnLabel))
   }
 
   /**
@@ -494,7 +545,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   byte getByte(String columnLabel) throws SQLException {
-    getByte(matrix.columnIndex(columnLabel)+1)
+    getByte(findColumn(columnLabel))
   }
 
   /**
@@ -511,7 +562,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   short getShort(String columnLabel) throws SQLException {
-    getShort(matrix.columnIndex(columnLabel)+1)
+    getShort(findColumn(columnLabel))
   }
 
   /**
@@ -528,7 +579,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   int getInt(String columnLabel) throws SQLException {
-    getInt(matrix.columnIndex(columnLabel)+1)
+    getInt(findColumn(columnLabel))
   }
 
   /**
@@ -545,7 +596,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   long getLong(String columnLabel) throws SQLException {
-    getLong(matrix.columnIndex(columnLabel)+1)
+    getLong(findColumn(columnLabel))
   }
 
   /**
@@ -562,7 +613,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   float getFloat(String columnLabel) throws SQLException {
-    getFloat(matrix.columnIndex(columnLabel)+1)
+    getFloat(findColumn(columnLabel))
   }
 
   /**
@@ -579,13 +630,13 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   double getDouble(String columnLabel) throws SQLException {
-   getDouble(matrix.columnIndex(columnLabel)+1)
+   getDouble(findColumn(columnLabel))
   }
 
   /** @deprecated */
   @Override
   BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
-    getBigDecimal(matrix.columnIndex(columnLabel)+1)
+    getBigDecimal(findColumn(columnLabel), scale)
   }
 
   /**
@@ -603,7 +654,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   byte[] getBytes(String columnLabel) throws SQLException {
-    getBytes(matrix.columnIndex(columnLabel)+1)
+    getBytes(findColumn(columnLabel))
   }
 
   /**
@@ -620,7 +671,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Date getDate(String columnLabel) throws SQLException {
-    getDate(matrix.columnIndex(columnLabel)+1)
+    getDate(findColumn(columnLabel))
   }
 
   /**
@@ -638,7 +689,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Time getTime(String columnLabel) throws SQLException {
-   getTime(matrix.columnIndex(columnLabel)+1)
+   getTime(findColumn(columnLabel))
   }
 
   /**
@@ -655,7 +706,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Timestamp getTimestamp(String columnLabel) throws SQLException {
-    getTimestamp(matrix.columnIndex(columnLabel)+1)
+    getTimestamp(findColumn(columnLabel))
   }
 
   /**
@@ -684,13 +735,13 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   InputStream getAsciiStream(String columnLabel) throws SQLException {
-    getAsciiStream(matrix.columnIndex(columnLabel)+1)
+    getAsciiStream(findColumn(columnLabel))
   }
 
   /** @deprecated */
   @Override
   InputStream getUnicodeStream(String columnLabel) throws SQLException {
-    getUnicodeStream(matrix.columnIndex(columnLabel)+1)
+    getUnicodeStream(findColumn(columnLabel))
   }
 
   /**
@@ -718,7 +769,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   InputStream getBinaryStream(String columnLabel) throws SQLException {
-    getBinaryStream(matrix.columnIndex(columnLabel)+1)
+    getBinaryStream(findColumn(columnLabel))
   }
 
   /**
@@ -849,7 +900,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Object getObject(int columnIndex) throws SQLException {
-    lastReadValue = matrix[rowIdx, columnIndex-1]
+    lastReadValue = readValue(columnIndex)
   }
 
   /**
@@ -882,7 +933,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Object getObject(String columnLabel) throws SQLException {
-    lastReadValue = matrix[rowIdx, columnLabel]
+    lastReadValue = readValue(columnLabel)
   }
 
   /**
@@ -897,7 +948,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   int findColumn(String columnLabel) throws SQLException {
-    return matrix.columnIndex(columnLabel) + 1
+    checkedColumnIndex(columnLabel) + 1
   }
 
   /**
@@ -915,8 +966,9 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Reader getCharacterStream(int columnIndex) throws SQLException {
-    String val = matrix[rowIdx, columnIndex-1, String]
-    new CharArrayReader(val.toCharArray())
+    String val = readValue(columnIndex, String)
+    lastReadValue = val
+    val == null ? null : new CharArrayReader(val.toCharArray())
   }
 
   /**
@@ -935,7 +987,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Reader getCharacterStream(String columnLabel) throws SQLException {
-    getCharacterStream(matrix.columnIndex(columnLabel)+1)
+    getCharacterStream(findColumn(columnLabel))
   }
 
   /**
@@ -954,7 +1006,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   BigDecimal getBigDecimal(int columnIndex) throws SQLException {
-    matrix[rowIdx, columnIndex-1, BigDecimal]
+    lastReadValue = readValue(columnIndex, BigDecimal)
   }
 
   /**
@@ -974,7 +1026,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   BigDecimal getBigDecimal(String columnLabel) throws SQLException {
-    matrix[rowIdx, columnLabel, BigDecimal]
+    getBigDecimal(findColumn(columnLabel))
   }
 
   /**
@@ -2550,13 +2602,14 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
-    Class<?> type = matrix.type(columnIndex-1)
+    int zeroBasedColumnIndex = checkedColumnIndex(columnIndex)
+    Class<?> type = matrix.type(zeroBasedColumnIndex)
     String sqlType = sqlTypeMapper.sqlType(type)
     if (sqlType.contains('(')) {
       sqlType = sqlType.substring(0, sqlType.indexOf('('))
     }
     Class<?> mapType = map.getOrDefault(sqlType, type)
-    matrix[rowIdx, columnIndex-1, mapType]
+    lastReadValue = matrix[rowIdx, zeroBasedColumnIndex, mapType]
   }
 
   /**
@@ -2662,7 +2715,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException {
-    return getObject(matrix.columnIndex(columnLabel)+1, map)
+    return getObject(findColumn(columnLabel), map)
   }
 
   /**
@@ -2766,12 +2819,13 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Date getDate(int columnIndex, Calendar cal) throws SQLException {
-    def val = matrix[rowIdx, columnIndex-1]
+    def val = readValue(columnIndex)
     if (val instanceof Number) {
       // assume we are storing millis
-      return new Date(val + cal.getTimeZone().getOffset(0) as long)
+      lastReadValue = new Date(val + cal.getTimeZone().getOffset(0) as long)
+      return lastReadValue as Date
     }
-    return matrix[rowIdx, columnIndex-1, Date]
+    lastReadValue = readValue(columnIndex, Date)
   }
 
   /**
@@ -2795,7 +2849,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Date getDate(String columnLabel, Calendar cal) throws SQLException {
-    getDate(matrix.columnIndex(columnLabel)+1, cal)
+    getDate(findColumn(columnLabel), cal)
   }
 
   /**
@@ -2819,12 +2873,13 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Time getTime(int columnIndex, Calendar cal) throws SQLException {
-    def val = matrix[rowIdx, columnIndex-1]
+    def val = readValue(columnIndex)
     if (val instanceof Number) {
       // assume we are storing millis
-      return new Time(val + cal.getTimeZone().getOffset(0) as long)
+      lastReadValue = new Time(val + cal.getTimeZone().getOffset(0) as long)
+      return lastReadValue as Time
     }
-    return matrix[rowIdx, columnIndex-1, Time]
+    lastReadValue = readValue(columnIndex, Time)
   }
 
   /**
@@ -2848,7 +2903,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Time getTime(String columnLabel, Calendar cal) throws SQLException {
-    getTime(matrix.columnIndex(columnLabel)+1, cal)
+    getTime(findColumn(columnLabel), cal)
   }
 
   /**
@@ -2872,12 +2927,13 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
-    def val = matrix[rowIdx, columnIndex-1]
+    def val = readValue(columnIndex)
     if (val instanceof Number) {
       // assume we are storing millis
-      return new Timestamp(val + cal.getTimeZone().getOffset(0) as long)
+      lastReadValue = new Timestamp(val + cal.getTimeZone().getOffset(0) as long)
+      return lastReadValue as Timestamp
     }
-    return matrix[rowIdx, columnIndex-1, Timestamp]
+    lastReadValue = readValue(columnIndex, Timestamp)
   }
 
   /**
@@ -2901,7 +2957,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
-    getTimestamp(matrix.columnIndex(columnLabel) + 1, cal)
+    getTimestamp(findColumn(columnLabel), cal)
   }
 
   /**
@@ -4408,7 +4464,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
-    matrix[rowIdx, columnIndex-1, type]
+    lastReadValue = readValue(columnIndex, type)
   }
 
   /**
@@ -4440,7 +4496,7 @@ class MatrixResultSet implements ResultSet{
    */
   @Override
   <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
-    matrix[rowIdx, columnLabel, type]
+    getObject(findColumn(columnLabel), type)
   }
 
   /**

--- a/matrix-sql/src/test/groovy/MatrixResultSetTest.groovy
+++ b/matrix-sql/src/test/groovy/MatrixResultSetTest.groovy
@@ -149,6 +149,50 @@ class MatrixResultSetTest {
   }
 
   @Test
+  void testGetURLRoutesThroughGuardsAndUpdatesLastReadValue() {
+    Matrix matrix = Matrix.builder('urls').data([
+        site: ['https://example.com', null]
+    ])
+    .types(String)
+    .build()
+
+    ResultSet rs = new MatrixResultSet(matrix)
+
+    // Cursor before first row should throw
+    assertThrows(SQLException) { rs.getURL(1) }
+    assertThrows(SQLException) { rs.getURL('site') }
+
+    assertTrue(rs.next())
+
+    // Valid access by index and label
+    assertEquals(new URL('https://example.com'), rs.getURL(1))
+    assertFalse(rs.wasNull())
+    assertEquals(new URL('https://example.com'), rs.getURL('site'))
+    assertFalse(rs.wasNull())
+
+    // Null value
+    assertTrue(rs.next())
+    assertNull(rs.getURL(1))
+    assertTrue(rs.wasNull())
+    assertNull(rs.getURL('site'))
+    assertTrue(rs.wasNull())
+
+    // Invalid column index and label
+    assertThrows(SQLException) { rs.getURL(0) }
+    assertThrows(SQLException) { rs.getURL(2) }
+    assertThrows(SQLException) { rs.getURL('missing') }
+
+    // After last row
+    assertFalse(rs.next())
+    assertThrows(SQLException) { rs.getURL(1) }
+
+    // Closed result set
+    rs.close()
+    assertThrows(SQLException) { rs.getURL(1) }
+    assertThrows(SQLException) { rs.getURL('site') }
+  }
+
+  @Test
   void testWrapperContracts() {
     Matrix matrix = Matrix.builder('wrap').data([
         name: ['x']

--- a/matrix-sql/src/test/groovy/MatrixResultSetTest.groovy
+++ b/matrix-sql/src/test/groovy/MatrixResultSetTest.groovy
@@ -6,8 +6,11 @@ import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.datasets.Dataset
 import se.alipsa.matrix.sql.MatrixResultSet
 
+import java.sql.Date
 import java.sql.ResultSet
 import java.sql.SQLException
+import java.sql.Time
+import java.sql.Timestamp
 import java.sql.Types
 
 class MatrixResultSetTest {
@@ -83,6 +86,65 @@ class MatrixResultSetTest {
     assertTrue(rs.wasNull())
 
     assertNull(rs.getUnicodeStream(8))
+    assertTrue(rs.wasNull())
+
+    assertNull(rs.getCharacterStream(8))
+    assertTrue(rs.wasNull())
+  }
+
+  @Test
+  void testInvalidCursorAndColumnAccessThrowsSQLException() {
+    Matrix matrix = Matrix.builder('invalidAccess').data([
+        name: ['Alice']
+    ])
+    .types(String)
+    .build()
+
+    ResultSet rs = new MatrixResultSet(matrix)
+    assertThrows(SQLException) { rs.getString(1) }
+    assertThrows(SQLException) { rs.getString(0) }
+    assertThrows(SQLException) { rs.findColumn('missing') }
+    assertThrows(SQLException) { rs.getString('missing') }
+
+    assertTrue(rs.next())
+    assertThrows(SQLException) { rs.getString(2) }
+    assertFalse(rs.next())
+    assertThrows(SQLException) { rs.getString(1) }
+
+    rs.close()
+    assertThrows(SQLException) { rs.next() }
+    assertThrows(SQLException) { rs.getMetaData() }
+    assertThrows(SQLException) { rs.wasNull() }
+  }
+
+  @Test
+  void testTemporalLabelAndCalendarGettersUpdateWasNull() {
+    Date date = Date.valueOf('2026-04-29')
+    Time time = Time.valueOf('12:34:56')
+    Timestamp timestamp = Timestamp.valueOf('2026-04-29 12:34:56')
+    Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone('UTC'))
+    Matrix matrix = Matrix.builder('temporal').data([
+        d: [date],
+        t: [time],
+        ts: [timestamp],
+        missingDate: [null]
+    ])
+    .types(Date, Time, Timestamp, Date)
+    .build()
+
+    ResultSet rs = new MatrixResultSet(matrix)
+    assertTrue(rs.next())
+
+    assertEquals(date, rs.getDate('d'))
+    assertFalse(rs.wasNull())
+    assertEquals(time, rs.getTime('t'))
+    assertEquals(timestamp, rs.getTimestamp('ts'))
+
+    assertEquals(date, rs.getDate('d', calendar))
+    assertEquals(time, rs.getTime('t', calendar))
+    assertEquals(timestamp, rs.getTimestamp('ts', calendar))
+
+    assertNull(rs.getDate('missingDate', calendar))
     assertTrue(rs.wasNull())
   }
 

--- a/matrix-sql/src/test/groovy/MatrixResultSetTest.groovy
+++ b/matrix-sql/src/test/groovy/MatrixResultSetTest.groovy
@@ -146,6 +146,29 @@ class MatrixResultSetTest {
 
     assertNull(rs.getDate('missingDate', calendar))
     assertTrue(rs.wasNull())
+    assertNull(rs.getTime('missingDate', calendar))
+    assertTrue(rs.wasNull())
+    assertNull(rs.getTimestamp('missingDate', calendar))
+    assertTrue(rs.wasNull())
+  }
+
+  @Test
+  void testCalendarGettersConvertStringStoredTemporalValues() {
+    Matrix matrix = Matrix.builder('stringTemporal').data([
+        d: ['2026-04-29'],
+        t: ['12:34:56'],
+        ts: ['2026-04-29 12:34:56']
+    ])
+    .types(String, String, String)
+    .build()
+
+    ResultSet rs = new MatrixResultSet(matrix)
+    assertTrue(rs.next())
+    Calendar cal = Calendar.getInstance(TimeZone.getTimeZone('UTC'))
+
+    assertEquals(Date.valueOf('2026-04-29'), rs.getDate(1, cal))
+    assertEquals(Time.valueOf('12:34:56'), rs.getTime(2, cal))
+    assertEquals(Timestamp.valueOf('2026-04-29 12:34:56'), rs.getTimestamp(3, cal))
   }
 
   @Test

--- a/matrix-sql/src/test/groovy/MatrixResultSetTest.groovy
+++ b/matrix-sql/src/test/groovy/MatrixResultSetTest.groovy
@@ -149,6 +149,46 @@ class MatrixResultSetTest {
   }
 
   @Test
+  void testCalendarGettersWithNumberMillisAppliesTimezoneOffset() {
+    long epochMillis = 1714392896000L  // 2024-04-29 12:34:56 UTC
+    Calendar utcCal = Calendar.getInstance(TimeZone.getTimeZone('UTC'))
+    Calendar cetCal = Calendar.getInstance(TimeZone.getTimeZone('Europe/Stockholm'))
+    int cetOffset = cetCal.getTimeZone().getOffset(0)
+
+    Matrix matrix = Matrix.builder('millis').data([
+        d: [epochMillis],
+        t: [epochMillis],
+        ts: [epochMillis]
+    ])
+    .types(Long, Long, Long)
+    .build()
+
+    ResultSet rs = new MatrixResultSet(matrix)
+    assertTrue(rs.next())
+
+    // UTC calendar: no offset change
+    Date dateUtc = rs.getDate(1, utcCal)
+    assertEquals(new Date(epochMillis), dateUtc)
+    assertFalse(rs.wasNull())
+
+    Time timeUtc = rs.getTime(2, utcCal)
+    assertEquals(new Time(epochMillis), timeUtc)
+    assertFalse(rs.wasNull())
+
+    Timestamp tsUtc = rs.getTimestamp(3, utcCal)
+    assertEquals(new Timestamp(epochMillis), tsUtc)
+    assertFalse(rs.wasNull())
+
+    // CET calendar: offset applied
+    Date dateCet = rs.getDate(1, cetCal)
+    assertEquals(new Date(epochMillis + cetOffset), dateCet)
+    Time timeCet = rs.getTime(2, cetCal)
+    assertEquals(new Time(epochMillis + cetOffset), timeCet)
+    Timestamp tsCet = rs.getTimestamp(3, cetCal)
+    assertEquals(new Timestamp(epochMillis + cetOffset), tsCet)
+  }
+
+  @Test
   void testGetURLRoutesThroughGuardsAndUpdatesLastReadValue() {
     Matrix matrix = Matrix.builder('urls').data([
         site: ['https://example.com', null]


### PR DESCRIPTION
## Summary

Implements Phase 2 of `matrix-sql/req/v2.4.0-roadmap.md`.

- Add shared `MatrixResultSet` guards for closed result sets, valid current rows, and JDBC 1-based column indexes.
- Route common index and label getters through validated access.
- Make `findColumn('missing')` throw `SQLException`.
- Fix null `getCharacterStream` behavior so it returns `null` and updates `wasNull()` state.
- Fix temporal label/calendar getters to return delegated values and update `lastReadValue` consistently.
- Add regression coverage in `MatrixResultSetTest`.

## Impact

This makes the Matrix-backed `ResultSet` fail more predictably and closer to JDBC expectations for invalid cursor state, missing columns, closed result sets, and null values.

## Validation

- `./gradlew :matrix-sql:test --tests "MatrixResultSetTest" --rerun-tasks`
- `./gradlew :matrix-sql:test --rerun-tasks`
- `./gradlew :matrix-sql:spotlessCheck`
- `./gradlew test`
- `git diff --check`
