### PR TITLE
[codex] Phase 3: Convenience APIs

### DIFF
--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSql.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSql.groovy
@@ -36,6 +36,12 @@ class MatrixSql implements Closeable {
   private Connection con
   private boolean closeConnectionOnClose = true
 
+  /**
+   * Create a MatrixSql instance using the given ConnectionInfo. A new connection will be
+   * created on first use and closed when {@link #close()} is called.
+   *
+   * @param ci the connection info describing the database driver, URL, and credentials
+   */
   MatrixSql(ConnectionInfo ci) {
     check(ci)
     this.ci = ci
@@ -43,6 +49,13 @@ class MatrixSql implements Closeable {
     matrixDbUtil = new MatrixDbUtil(mapper)
   }
 
+  /**
+   * Create a MatrixSql instance using the given ConnectionInfo and explicit database provider.
+   * A new connection will be created on first use and closed when {@link #close()} is called.
+   *
+   * @param ci the connection info describing the database driver, URL, and credentials
+   * @param dbProvider the database provider used for SQL type mapping
+   */
   MatrixSql(ConnectionInfo ci, DataBaseProvider dbProvider) {
     check(ci)
     this.ci = ci
@@ -78,14 +91,29 @@ class MatrixSql implements Closeable {
     this.closeConnectionOnClose = false
   }
 
+  /**
+   * Close this MatrixSql instance. If the underlying connection is managed internally
+   * (i.e. created from a {@link ConnectionInfo}), the connection is closed. If the connection
+   * was supplied externally, this is a no-op for the connection.
+   *
+   * @throws SQLException if a database access error occurs while closing the connection
+   */
   @Override
   void close() throws SQLException {
     if (closeConnectionOnClose && con != null) {
       con.close()
+      con = null
     }
-    con = null
   }
 
+  /**
+   * Execute a select query and return the result as a Matrix.
+   *
+   * @param sqlQuery the sql query to execute
+   * @param matrixName the name of the resulting Matrix
+   * @return a Matrix containing the query results
+   * @throws SQLException if a database access error occurs
+   */
   Matrix select(String sqlQuery, String matrixName = 'myMatrix') throws SQLException {
     matrixDbUtil.select(connect(), sqlQuery).withMatrixName(matrixName)
   }
@@ -94,23 +122,27 @@ class MatrixSql implements Closeable {
    * Execute a prepared select query and return the result as a Matrix.
    *
    * @param sqlQuery the sql query to execute, with '?' placeholders for parameters
-   * @param params the parameters to bind to the prepared statement
+   * @param params the parameters to bind to the prepared statement (raw List for Groovy generic compatibility)
    * @param matrixName the name of the resulting Matrix
    * @return a Matrix containing the query results
    * @throws SQLException if a database access error occurs
    */
   Matrix select(String sqlQuery, List params, String matrixName = 'myMatrix') throws SQLException {
     try(PreparedStatement stm = connect().prepareStatement(sqlQuery)) {
-      int i = 1
-      params.each {
-        stm.setObject(i++, it)
-      }
+      bindParams(stm, params)
       try (ResultSet rs = stm.executeQuery()) {
-        return Matrix.builder().data(rs).build().withMatrixName(matrixName)
+        Matrix.builder().data(rs).build().withMatrixName(matrixName)
       }
     }
   }
 
+  /**
+   * Execute an update query (UPDATE, INSERT, DELETE, or DDL).
+   *
+   * @param sqlQuery the sql query to execute
+   * @return the number of rows affected, or 0 for DDL statements
+   * @throws SQLException if a database access error occurs
+   */
   int update(String sqlQuery) {
     dbUpdate(sqlQuery)
   }
@@ -119,17 +151,14 @@ class MatrixSql implements Closeable {
    * Execute a prepared update query.
    *
    * @param sqlQuery the sql query to execute, with '?' placeholders for parameters
-   * @param params the parameters to bind to the prepared statement
+   * @param params the parameters to bind to the prepared statement (raw List for Groovy generic compatibility)
    * @return the number of rows affected
    * @throws SQLException if a database access error occurs
    */
   int update(String sqlQuery, List params) throws SQLException {
     try(PreparedStatement stm = connect().prepareStatement(sqlQuery)) {
-      int i = 1
-      params.each {
-        stm.setObject(i++, it)
-      }
-      return stm.executeUpdate()
+      bindParams(stm, params)
+      stm.executeUpdate()
     }
   }
 
@@ -153,17 +182,34 @@ class MatrixSql implements Closeable {
     update(tableName, row, new String[0])
   }
 
+  /**
+   * Update a single row in the given table, matching by the specified columns.
+   *
+   * @param tableName the name of the table to update
+   * @param row the row data containing both update values and match values
+   * @param matchColumnName the column(s) to match in the WHERE clause (required)
+   * @return the number of rows affected
+   * @throws SQLException if a database access error occurs
+   * @throws IllegalArgumentException if matchColumnName is empty
+   */
   int update(String tableName, Row row, String... matchColumnName) throws SQLException {
     SqlGenerator.PreparedUpdate prepared = SqlGenerator.createPreparedUpdate(tableName, row, matchColumnName)
     try(PreparedStatement stm = connect().prepareStatement(prepared.sql)) {
-      int i = 1
-      prepared.values.each {
-        stm.setObject(i++, it)
-      }
-      return stm.executeUpdate()
+      bindParams(stm, prepared.values)
+      stm.executeUpdate()
     }
   }
 
+  /**
+   * Update all rows in the database table corresponding to the Matrix, matching each row
+   * by the given columns.
+   *
+   * @param table the Matrix containing the rows to update; the table name is derived from the Matrix name
+   * @param matchColumnName the column(s) to match in the WHERE clause (required)
+   * @return the total number of rows affected
+   * @throws SQLException if a database access error occurs
+   * @throws IllegalArgumentException if matchColumnName is empty
+   */
   int update(Matrix table, String... matchColumnName) throws SQLException {
     dbExecuteBatchUpdate(table, matchColumnName)
   }
@@ -191,32 +237,59 @@ class MatrixSql implements Closeable {
    * will yield an update count of -1.
    *
    * @param sqlQuery the sql query to execute, with '?' placeholders for parameters
-   * @param params the parameters to bind to the prepared statement
+   * @param params the parameters to bind to the prepared statement (raw List for Groovy generic compatibility)
    * @return A Map with the result index as key and either a Matrix or an Integer as value
    * @throws SQLException if a database access error occurs
    */
   Map<Integer, Object> execute(String sqlQuery, List params) throws SQLException {
     try(PreparedStatement stm = connect().prepareStatement(sqlQuery)) {
-      int i = 1
-      params.each {
-        stm.setObject(i++, it)
-      }
-      return dbExecute(stm)
+      bindParams(stm, params)
+      dbExecute(stm)
     }
   }
 
+  /**
+   * Check whether a table with the given name exists in the database.
+   *
+   * @param tableName the name of the table to check
+   * @return true if the table exists, false otherwise
+   * @throws SQLException if a database access error occurs
+   */
   boolean tableExists(String tableName) throws SQLException {
     return matrixDbUtil.tableExists(connect(), tableName)
   }
 
+  /**
+   * Check whether the database table corresponding to the Matrix exists.
+   * The table name is derived from the Matrix name.
+   *
+   * @param table the Matrix whose name is used to look up the table
+   * @return true if the table exists, false otherwise
+   * @throws SQLException if a database access error occurs
+   */
   boolean tableExists(Matrix table) throws SQLException {
     tableExists(tableName(table))
   }
 
+  /**
+   * Return the names of all tables visible in the current database connection.
+   *
+   * @return a Set of table names
+   * @throws SQLException if a database access error occurs
+   */
   Set<String> getTableNames() throws SQLException {
     matrixDbUtil.getTableNames(connect())
   }
 
+  /**
+   * Execute an arbitrary SQL statement and return the raw result.
+   * Prefer {@link #select(String)}, {@link #update(String)}, or {@link #execute(String)}
+   * for typed results.
+   *
+   * @param sql the SQL statement to execute
+   * @return the result as returned by the underlying database utility
+   * @throws SQLException if a database access error occurs
+   */
   Object executeQuery(String sql) throws SQLException {
     matrixDbUtil.dbExecuteSql(connect(), sql)
   }
@@ -262,7 +335,6 @@ class MatrixSql implements Closeable {
   /**
    * create a table corresponding to the Matrix and insert the matrix data.
    *
-   * @param connectionInfo the connection info defined in the Connections tab
    * @param table the table to copy to the db
    * @param primaryKey name(s) of the primary key columns
    * @return A Map with the following keys:
@@ -311,19 +383,48 @@ class MatrixSql implements Closeable {
     matrixDbUtil.create(connect(), table, props, primaryKey)
   }
 
+  /**
+   * Generate the CREATE TABLE DDL for the given Matrix without executing it.
+   *
+   * @param table the Matrix to generate DDL for
+   * @param addQuotes whether to quote identifiers in the DDL
+   * @param scanNumrows optional number of rows to scan for type inference; defaults to max(100, rowCount)
+   * @return the DDL string
+   */
   String createDdl(Matrix table, boolean addQuotes = true, int... scanNumrows) {
     Map mappings = matrixDbUtil.createMappings(table, scanNumrows.length > 0 ? scanNumrows[0] : Math.max(100, table.rowCount()))
     matrixDbUtil.createTableDdl(tableName(table), table, mappings, addQuotes)
   }
 
+  /**
+   * Derive the database table name from the Matrix name.
+   *
+   * @param table the Matrix
+   * @return the table name
+   */
   static String tableName(Matrix table) {
     MatrixDbUtil.tableName(table)
   }
 
+  /**
+   * Drop the named table from the database.
+   *
+   * @param tableName the name of the table to drop
+   * @return the result of the DDL execution
+   * @throws SQLException if a database access error occurs
+   */
   Object dropTable(String tableName) {
     dbExecuteSql("drop table ${SqlIdentifier.renderTable(tableName)}")
   }
 
+  /**
+   * Drop the database table corresponding to the Matrix.
+   * The table name is derived from the Matrix name.
+   *
+   * @param table the Matrix whose name identifies the table to drop
+   * @return the result of the DDL execution
+   * @throws SQLException if a database access error occurs
+   */
   Object dropTable(Matrix table) {
     dropTable(tableName(table))
   }
@@ -332,17 +433,31 @@ class MatrixSql implements Closeable {
     return (int)dbExecuteSql(sqlQuery)
   }
 
+  /**
+   * Insert a single row into the named table using a prepared statement.
+   *
+   * @param tableName the name of the table to insert into
+   * @param row the row to insert; column names are taken from the Row
+   * @return the number of rows inserted
+   * @throws SQLException if a database access error occurs
+   */
   int insert(String tableName, Row row) throws SQLException, ExecutionException, InterruptedException {
     String sql = SqlGenerator.createPreparedInsertSql(tableName, row)
     try(PreparedStatement stm = connect().prepareStatement(sql)) {
-      int i = 1
-      row.each {
-        stm.setObject(i++, it)
-      }
-      return stm.executeUpdate()
+      bindParams(stm, row)
+      stm.executeUpdate()
     }
   }
 
+  /**
+   * Insert a single row into the table corresponding to the Matrix.
+   * The table name is derived from the Matrix name.
+   *
+   * @param table the Matrix identifying the target table
+   * @param row the row to insert
+   * @return the number of rows inserted
+   * @throws SQLException if a database access error occurs
+   */
   int insert(Matrix table, Row row) throws SQLException, ExecutionException, InterruptedException {
     insert(tableName(table), row)
   }
@@ -359,13 +474,28 @@ class MatrixSql implements Closeable {
     matrixDbUtil.insert(connect(), tableName, table)
   }
 
+  /**
+   * Insert all rows from the Matrix into the corresponding database table.
+   * The table name is derived from the Matrix name.
+   *
+   * @param table the Matrix containing the rows to insert
+   * @return the number of rows inserted
+   * @throws SQLException if a database access error occurs
+   */
   int insert(Matrix table) throws SQLException {
-    return matrixDbUtil.insert(connect(), table)
+    matrixDbUtil.insert(connect(), table)
   }
 
+  /**
+   * Execute a delete (or any DML) query.
+   *
+   * @param sql the sql delete statement to execute
+   * @return the number of rows deleted
+   * @throws SQLException if a database access error occurs
+   */
   int delete(String sql) throws SQLException {
     try(Statement stm = connect().createStatement()) {
-      return stm.executeUpdate(sql)
+      stm.executeUpdate(sql)
     }
   }
 
@@ -373,26 +503,23 @@ class MatrixSql implements Closeable {
    * Execute a prepared delete query.
    *
    * @param sql the sql delete statement, with '?' placeholders for parameters
-   * @param params the parameters to bind to the prepared statement
+   * @param params the parameters to bind to the prepared statement (raw List for Groovy generic compatibility)
    * @return the number of rows deleted
    * @throws SQLException if a database access error occurs
    */
   int delete(String sql, List params) throws SQLException {
     try(PreparedStatement stm = connect().prepareStatement(sql)) {
-      int i = 1
-      params.each {
-        stm.setObject(i++, it)
-      }
-      return stm.executeUpdate()
+      bindParams(stm, params)
+      stm.executeUpdate()
     }
   }
 
-  static Map<Integer, Object> dbExecute(Statement stm, String sqlQuery) throws SQLException {
-    return dbExecuteResults(stm, stm.execute(sqlQuery))
+  private static Map<Integer, Object> dbExecute(Statement stm, String sqlQuery) throws SQLException {
+    dbExecuteResults(stm, stm.execute(sqlQuery))
   }
 
-  static Map<Integer, Object> dbExecute(PreparedStatement stm) throws SQLException {
-    return dbExecuteResults(stm, stm.execute())
+  private static Map<Integer, Object> dbExecute(PreparedStatement stm) throws SQLException {
+    dbExecuteResults(stm, stm.execute())
   }
 
   private static Map<Integer, Object> dbExecuteResults(Statement stm, boolean initialIsResultSet) throws SQLException {
@@ -424,8 +551,8 @@ class MatrixSql implements Closeable {
     return allResults
   }
 
-  static int dbExecuteUpdate(Statement stm, String sqlQuery) throws SQLException {
-    return stm.executeUpdate(sqlQuery)
+  private static int dbExecuteUpdate(Statement stm, String sqlQuery) throws SQLException {
+    stm.executeUpdate(sqlQuery)
   }
 
   private int dbExecuteBatchUpdate(Matrix table, String[] matchColumnName) throws SQLException {
@@ -444,10 +571,7 @@ class MatrixSql implements Closeable {
     try(PreparedStatement stm = connect().prepareStatement(sql)) {
       for (Row row : table) {
         List<Object> values = SqlGenerator.updateValues(row, updateColumns, matchColumns)
-        int i = 1
-        values.each {
-          stm.setObject(i++, it)
-        }
+        bindParams(stm, values)
         stm.addBatch()
       }
       int[] results = stm.executeBatch()
@@ -459,6 +583,14 @@ class MatrixSql implements Closeable {
       matrixDbUtil.dbExecuteSql(connect(), sql)
   }
 
+  /**
+   * Return an open connection, creating one from the configured {@link ConnectionInfo} if needed.
+   * Reuses an existing open connection if one is already held.
+   *
+   * @return an open database connection
+   * @throws SQLException if no connection is available and no ConnectionInfo is configured,
+   *                      or if creating a new connection fails
+   */
   synchronized Connection connect() throws SQLException {
     if (con != null && !con.isClosed()) {
       return con
@@ -476,6 +608,12 @@ class MatrixSql implements Closeable {
     con
   }
 
+  /**
+   * Return true if the string is null or blank.
+   *
+   * @param str the string to test
+   * @return true if null or blank
+   */
   static boolean isBlank(String str) {
     if (str == null) {
       return true
@@ -483,6 +621,15 @@ class MatrixSql implements Closeable {
     return str.isBlank()
   }
 
+  /**
+   * Establish a physical database connection using the given ConnectionInfo.
+   * Downloads the JDBC driver via Maven if it is not already on the classpath.
+   *
+   * @param ci the connection info describing the driver dependency, URL, and credentials
+   * @return an open Connection
+   * @throws SQLException if a database access error occurs
+   * @throws IOException if the driver artifact cannot be resolved
+   */
   Connection dbConnect(ConnectionInfo ci) throws SQLException, IOException {
     Driver driver
     MavenUtils mvnUtils = new MavenUtils()
@@ -544,29 +691,62 @@ class MatrixSql implements Closeable {
     }
   }
 
+  private static void bindParams(PreparedStatement stm, List params) throws SQLException {
+    int i = 1
+    params.each {
+      stm.setObject(i++, it)
+    }
+  }
+
   private static boolean urlContainsLogin(String url) {
     String safeLcUrl = url.toLowerCase()
     return ( safeLcUrl.contains("user") && safeLcUrl.contains("pass") ) || safeLcUrl.contains("@")
   }
 
+  /**
+   * Validate that the ConnectionInfo has a non-blank dependency declaration.
+   *
+   * @param connectionInfo the connection info to validate
+   * @throws IllegalArgumentException if the dependency is null or blank
+   */
   static void check(ConnectionInfo connectionInfo) {
     if (connectionInfo.getDependency() == null || connectionInfo.getDependency().isBlank()) {
       throw new IllegalArgumentException("Dependency is required")
     }
   }
 
+  /**
+   * Return the ConnectionInfo used to create managed connections, or null for external connections.
+   *
+   * @return the ConnectionInfo, or null
+   */
   ConnectionInfo getConnectionInfo() {
     return ci
   }
 
+  /**
+   * Return the SqlTypeMapper used for SQL/Java type conversions.
+   *
+   * @return the SqlTypeMapper
+   */
   SqlTypeMapper getSqlTypeMapper() {
     return mapper
   }
 
+  /**
+   * Return the MatrixDbUtil used for low-level database operations.
+   *
+   * @return the MatrixDbUtil
+   */
   MatrixDbUtil getMatrixDbUtil() {
     return matrixDbUtil
   }
 
+  /**
+   * Return the current underlying connection, or null if none has been opened yet.
+   *
+   * @return the Connection, or null
+   */
   Connection getConnection() {
     return con
   }

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSql.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSql.groovy
@@ -18,7 +18,6 @@ import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.SQLException
 import java.sql.Statement
-import java.util.concurrent.ExecutionException
 import java.util.stream.IntStream
 
 /**
@@ -429,10 +428,6 @@ class MatrixSql implements Closeable {
     dropTable(tableName(table))
   }
 
-  private int dbInsert(String sqlQuery) throws SQLException, ExecutionException, InterruptedException {
-    return (int)dbExecuteSql(sqlQuery)
-  }
-
   /**
    * Insert a single row into the named table using a prepared statement.
    *
@@ -441,7 +436,7 @@ class MatrixSql implements Closeable {
    * @return the number of rows inserted
    * @throws SQLException if a database access error occurs
    */
-  int insert(String tableName, Row row) throws SQLException, ExecutionException, InterruptedException {
+  int insert(String tableName, Row row) throws SQLException {
     String sql = SqlGenerator.createPreparedInsertSql(tableName, row)
     try(PreparedStatement stm = connect().prepareStatement(sql)) {
       bindParams(stm, row)
@@ -458,7 +453,7 @@ class MatrixSql implements Closeable {
    * @return the number of rows inserted
    * @throws SQLException if a database access error occurs
    */
-  int insert(Matrix table, Row row) throws SQLException, ExecutionException, InterruptedException {
+  int insert(Matrix table, Row row) throws SQLException {
     insert(tableName(table), row)
   }
 
@@ -548,7 +543,7 @@ class MatrixSql implements Closeable {
       //    or an update count other than -1)
     } while (isResultSet || stm.getUpdateCount() != -1)
 
-    return allResults
+    allResults
   }
 
   private static int dbExecuteUpdate(Statement stm, String sqlQuery) throws SQLException {

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSql.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSql.groovy
@@ -140,17 +140,22 @@ class MatrixSql implements Closeable {
   }
 
   /**
-   * Update a row in the given table. This overload delegates to
-   * {@link #update(String, Row, String...)} with an empty matchColumnName array,
-   * which will throw {@link IllegalArgumentException} because match columns are required.
+   * Update all rows in the given table with the values from the given row.
    *
    * @param tableName the name of the table to update
-   * @param row the row data to update
+   * @param row the row data to apply to all rows
+   * @return the number of rows affected
    * @throws SQLException if a database access error occurs
-   * @throws IllegalArgumentException because matchColumnName is required
    */
   int update(String tableName, Row row) throws SQLException {
-    update(tableName, row, new String[0])
+    String sql = SqlGenerator.createPreparedUpdateSql(tableName, row.columnNames(), true)
+    try(PreparedStatement stm = connect().prepareStatement(sql)) {
+      int i = 1
+      row.each {
+        stm.setObject(i++, it)
+      }
+      return stm.executeUpdate()
+    }
   }
 
   int update(String tableName, Row row, String... matchColumnName) throws SQLException {

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSql.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSql.groovy
@@ -99,7 +99,7 @@ class MatrixSql implements Closeable {
    * @return a Matrix containing the query results
    * @throws SQLException if a database access error occurs
    */
-  Matrix select(String sqlQuery, List<Object> params, String matrixName = 'myMatrix') throws SQLException {
+  Matrix select(String sqlQuery, List params, String matrixName = 'myMatrix') throws SQLException {
     try(PreparedStatement stm = connect().prepareStatement(sqlQuery)) {
       int i = 1
       params.each {
@@ -123,7 +123,7 @@ class MatrixSql implements Closeable {
    * @return the number of rows affected
    * @throws SQLException if a database access error occurs
    */
-  int update(String sqlQuery, List<Object> params) throws SQLException {
+  int update(String sqlQuery, List params) throws SQLException {
     try(PreparedStatement stm = connect().prepareStatement(sqlQuery)) {
       int i = 1
       params.each {
@@ -195,7 +195,7 @@ class MatrixSql implements Closeable {
    * @return A Map with the result index as key and either a Matrix or an Integer as value
    * @throws SQLException if a database access error occurs
    */
-  Map<Integer, Object> execute(String sqlQuery, List<Object> params) throws SQLException {
+  Map<Integer, Object> execute(String sqlQuery, List params) throws SQLException {
     try(PreparedStatement stm = connect().prepareStatement(sqlQuery)) {
       int i = 1
       params.each {
@@ -377,7 +377,7 @@ class MatrixSql implements Closeable {
    * @return the number of rows deleted
    * @throws SQLException if a database access error occurs
    */
-  int delete(String sql, List<Object> params) throws SQLException {
+  int delete(String sql, List params) throws SQLException {
     try(PreparedStatement stm = connect().prepareStatement(sql)) {
       int i = 1
       params.each {

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSql.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSql.groovy
@@ -140,22 +140,17 @@ class MatrixSql implements Closeable {
   }
 
   /**
-   * Update all rows in the given table with the values from the given row.
+   * Update a row in the given table. This overload delegates to
+   * {@link #update(String, Row, String...)} with an empty matchColumnName array,
+   * which will throw {@link IllegalArgumentException} because match columns are required.
    *
    * @param tableName the name of the table to update
-   * @param row the row data to apply to all rows
-   * @return the number of rows affected
+   * @param row the row data to update
    * @throws SQLException if a database access error occurs
+   * @throws IllegalArgumentException because matchColumnName is required
    */
   int update(String tableName, Row row) throws SQLException {
-    String sql = SqlGenerator.createPreparedUpdateSql(tableName, row.columnNames(), true)
-    try(PreparedStatement stm = connect().prepareStatement(sql)) {
-      int i = 1
-      row.each {
-        stm.setObject(i++, it)
-      }
-      return stm.executeUpdate()
-    }
+    update(tableName, row, new String[0])
   }
 
   int update(String tableName, Row row, String... matchColumnName) throws SQLException {

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSql.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSql.groovy
@@ -34,6 +34,7 @@ class MatrixSql implements Closeable {
   private SqlTypeMapper mapper
   private MatrixDbUtil matrixDbUtil
   private Connection con
+  private boolean closeConnectionOnClose = true
 
   MatrixSql(ConnectionInfo ci) {
     check(ci)
@@ -49,9 +50,37 @@ class MatrixSql implements Closeable {
     matrixDbUtil = new MatrixDbUtil(mapper)
   }
 
+  /**
+   * Create a MatrixSql instance that wraps an externally managed connection.
+   * The connection will NOT be closed when {@link #close()} is called.
+   *
+   * @param connection the externally managed database connection
+   * @param dbProvider the database provider used for type mapping
+   */
+  MatrixSql(Connection connection, DataBaseProvider dbProvider) {
+    this.con = connection
+    this.mapper = SqlTypeMapper.create(dbProvider)
+    this.matrixDbUtil = new MatrixDbUtil(mapper)
+    this.closeConnectionOnClose = false
+  }
+
+  /**
+   * Create a MatrixSql instance that wraps an externally managed connection.
+   * The connection will NOT be closed when {@link #close()} is called.
+   *
+   * @param connection the externally managed database connection
+   * @param mapper the SQL type mapper to use
+   */
+  MatrixSql(Connection connection, SqlTypeMapper mapper) {
+    this.con = connection
+    this.mapper = mapper
+    this.matrixDbUtil = new MatrixDbUtil(mapper)
+    this.closeConnectionOnClose = false
+  }
+
   @Override
   void close() throws SQLException {
-    if (con != null) {
+    if (closeConnectionOnClose && con != null) {
       con.close()
     }
     con = null
@@ -61,14 +90,40 @@ class MatrixSql implements Closeable {
     matrixDbUtil.select(connect(), sqlQuery).withMatrixName(matrixName)
   }
 
+  Matrix select(String sqlQuery, List params, String matrixName = 'myMatrix') throws SQLException {
+    try(PreparedStatement stm = connect().prepareStatement(sqlQuery)) {
+      int i = 1
+      params.each {
+        stm.setObject(i++, it)
+      }
+      try (ResultSet rs = stm.executeQuery()) {
+        return Matrix.builder().data(rs).build().withMatrixName(matrixName)
+      }
+    }
+  }
+
   int update(String sqlQuery) {
     dbUpdate(sqlQuery)
+  }
+
+  int update(String sqlQuery, List params) throws SQLException {
+    try(PreparedStatement stm = connect().prepareStatement(sqlQuery)) {
+      int i = 1
+      params.each {
+        stm.setObject(i++, it)
+      }
+      return stm.executeUpdate()
+    }
   }
 
   private int dbUpdate(String sqlQuery) throws SQLException  {
     try(Statement stm = connect().createStatement()) {
       return dbExecuteUpdate(stm, sqlQuery)
     }
+  }
+
+  int update(String tableName, Row row) throws SQLException {
+    update(tableName, row, new String[0])
   }
 
   int update(String tableName, Row row, String... matchColumnName) throws SQLException {
@@ -99,6 +154,16 @@ class MatrixSql implements Closeable {
   Map<Integer, Object> execute(String sqlQuery) throws SQLException {
     try(Statement stm = connect().createStatement()) {
       return dbExecute(stm, sqlQuery)
+    }
+  }
+
+  Map<Integer, Object> execute(String sqlQuery, List params) throws SQLException {
+    try(PreparedStatement stm = connect().prepareStatement(sqlQuery)) {
+      int i = 1
+      params.each {
+        stm.setObject(i++, it)
+      }
+      return dbExecute(stm)
     }
   }
 
@@ -244,6 +309,10 @@ class MatrixSql implements Closeable {
     insert(tableName(table), row)
   }
 
+  int insert(String tableName, Matrix table) throws SQLException {
+    matrixDbUtil.insert(connect(), tableName, table)
+  }
+
   int insert(Matrix table) throws SQLException {
     return matrixDbUtil.insert(connect(), table)
   }
@@ -254,11 +323,29 @@ class MatrixSql implements Closeable {
     }
   }
 
+  int delete(String sql, List params) throws SQLException {
+    try(PreparedStatement stm = connect().prepareStatement(sql)) {
+      int i = 1
+      params.each {
+        stm.setObject(i++, it)
+      }
+      return stm.executeUpdate()
+    }
+  }
+
   static Map<Integer, Object> dbExecute(Statement stm, String sqlQuery) throws SQLException {
+    return dbExecuteResults(stm, stm.execute(sqlQuery))
+  }
+
+  static Map<Integer, Object> dbExecute(PreparedStatement stm) throws SQLException {
+    return dbExecuteResults(stm, stm.execute())
+  }
+
+  private static Map<Integer, Object> dbExecuteResults(Statement stm, boolean initialIsResultSet) throws SQLException {
     Map<Integer, Object> allResults = [:]
     int index = 0
 
-    boolean isResultSet = stm.execute(sqlQuery)
+    boolean isResultSet = initialIsResultSet
     do {
       if (isResultSet) {
         try (ResultSet rs = stm.getResultSet()) {
@@ -319,15 +406,19 @@ class MatrixSql implements Closeable {
   }
 
   synchronized Connection connect() throws SQLException {
-    if (con == null || con.isClosed()) {
-      String url = ci.getUrl().toLowerCase()
-      if (!url.contains(':h2:') && !url.contains(':derby:')
-          && isBlank(ci.getPassword()) && !url.contains("passw")
-          && !url.contains("integratedsecurity=true")) {
-        log.warn("Password probably required to ${ci.getName()} for ${ci.getUser()}")
-      }
-      con = dbConnect(ci)
+    if (con != null && !con.isClosed()) {
+      return con
     }
+    if (ci == null) {
+      throw new SQLException("Connection is not available and no ConnectionInfo is configured to create one")
+    }
+    String url = ci.getUrl().toLowerCase()
+    if (!url.contains(':h2:') && !url.contains(':derby:')
+        && isBlank(ci.getPassword()) && !url.contains("passw")
+        && !url.contains("integratedsecurity=true")) {
+      log.warn("Password probably required to ${ci.getName()} for ${ci.getUser()}")
+    }
+    con = dbConnect(ci)
     con
   }
 

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSql.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSql.groovy
@@ -90,7 +90,16 @@ class MatrixSql implements Closeable {
     matrixDbUtil.select(connect(), sqlQuery).withMatrixName(matrixName)
   }
 
-  Matrix select(String sqlQuery, List params, String matrixName = 'myMatrix') throws SQLException {
+  /**
+   * Execute a prepared select query and return the result as a Matrix.
+   *
+   * @param sqlQuery the sql query to execute, with '?' placeholders for parameters
+   * @param params the parameters to bind to the prepared statement
+   * @param matrixName the name of the resulting Matrix
+   * @return a Matrix containing the query results
+   * @throws SQLException if a database access error occurs
+   */
+  Matrix select(String sqlQuery, List<Object> params, String matrixName = 'myMatrix') throws SQLException {
     try(PreparedStatement stm = connect().prepareStatement(sqlQuery)) {
       int i = 1
       params.each {
@@ -106,7 +115,15 @@ class MatrixSql implements Closeable {
     dbUpdate(sqlQuery)
   }
 
-  int update(String sqlQuery, List params) throws SQLException {
+  /**
+   * Execute a prepared update query.
+   *
+   * @param sqlQuery the sql query to execute, with '?' placeholders for parameters
+   * @param params the parameters to bind to the prepared statement
+   * @return the number of rows affected
+   * @throws SQLException if a database access error occurs
+   */
+  int update(String sqlQuery, List<Object> params) throws SQLException {
     try(PreparedStatement stm = connect().prepareStatement(sqlQuery)) {
       int i = 1
       params.each {
@@ -122,6 +139,16 @@ class MatrixSql implements Closeable {
     }
   }
 
+  /**
+   * Update a row in the given table. This overload delegates to
+   * {@link #update(String, Row, String...)} with an empty matchColumnName array,
+   * which will throw {@link IllegalArgumentException} because match columns are required.
+   *
+   * @param tableName the name of the table to update
+   * @param row the row data to update
+   * @throws SQLException if a database access error occurs
+   * @throws IllegalArgumentException because matchColumnName is required
+   */
   int update(String tableName, Row row) throws SQLException {
     update(tableName, row, new String[0])
   }
@@ -157,7 +184,18 @@ class MatrixSql implements Closeable {
     }
   }
 
-  Map<Integer, Object> execute(String sqlQuery, List params) throws SQLException {
+  /**
+   * Execute a prepared sql query. The result can be one or more ResultSets
+   * or update counts. The key is the result index (0..n) and the value is either a Matrix
+   * (for ResultSets) or an Integer (for update counts). DDL statements (like CREATE TABLE)
+   * will yield an update count of -1.
+   *
+   * @param sqlQuery the sql query to execute, with '?' placeholders for parameters
+   * @param params the parameters to bind to the prepared statement
+   * @return A Map with the result index as key and either a Matrix or an Integer as value
+   * @throws SQLException if a database access error occurs
+   */
+  Map<Integer, Object> execute(String sqlQuery, List<Object> params) throws SQLException {
     try(PreparedStatement stm = connect().prepareStatement(sqlQuery)) {
       int i = 1
       params.each {
@@ -309,6 +347,14 @@ class MatrixSql implements Closeable {
     insert(tableName(table), row)
   }
 
+  /**
+   * Insert the data from the given Matrix into the given table in the database.
+   *
+   * @param tableName the name of the table to insert into
+   * @param table the Matrix containing the data to insert
+   * @return the number of inserted rows
+   * @throws SQLException if any sql error occurs
+   */
   int insert(String tableName, Matrix table) throws SQLException {
     matrixDbUtil.insert(connect(), tableName, table)
   }
@@ -323,7 +369,15 @@ class MatrixSql implements Closeable {
     }
   }
 
-  int delete(String sql, List params) throws SQLException {
+  /**
+   * Execute a prepared delete query.
+   *
+   * @param sql the sql delete statement, with '?' placeholders for parameters
+   * @param params the parameters to bind to the prepared statement
+   * @return the number of rows deleted
+   * @throws SQLException if a database access error occurs
+   */
+  int delete(String sql, List<Object> params) throws SQLException {
     try(PreparedStatement stm = connect().prepareStatement(sql)) {
       int i = 1
       params.each {

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlGenerator.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlGenerator.groovy
@@ -78,20 +78,6 @@ class SqlGenerator {
   }
 
   /**
-   * Create a prepared update statement without a WHERE clause (updates all rows).
-   *
-   * @param tableName the table name
-   * @param updateColumns columns to update in the SET clause
-   * @param addQuotes whether to quote identifiers
-   * @return the SQL update statement with placeholders
-   */
-  static String createPreparedUpdateSql(String tableName, List<String> updateColumns, boolean addQuotes) {
-    String sql = "update ${SqlIdentifier.renderTable(tableName, addQuotes)} set "
-    sql += updateColumns.collect { String column -> "${SqlIdentifier.render(column, addQuotes)} = ?" }.join(", ")
-    sql
-  }
-
-  /**
    * Determine the columns to update, excluding match columns.
    *
    * @param columnNames all column names

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlGenerator.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlGenerator.groovy
@@ -78,6 +78,20 @@ class SqlGenerator {
   }
 
   /**
+   * Create a prepared update statement without a WHERE clause (updates all rows).
+   *
+   * @param tableName the table name
+   * @param updateColumns columns to update in the SET clause
+   * @param addQuotes whether to quote identifiers
+   * @return the SQL update statement with placeholders
+   */
+  static String createPreparedUpdateSql(String tableName, List<String> updateColumns, boolean addQuotes) {
+    String sql = "update ${SqlIdentifier.renderTable(tableName, addQuotes)} set "
+    sql += updateColumns.collect { String column -> "${SqlIdentifier.render(column, addQuotes)} = ?" }.join(", ")
+    sql
+  }
+
+  /**
    * Determine the columns to update, excluding match columns.
    *
    * @param columnNames all column names

--- a/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
+++ b/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
@@ -168,15 +168,15 @@ class MatrixSqlTest {
   }
 
   @Test
-  void testUpdateRequiresMatchColumn() {
+  void testUpdateAllRowsWithRow() {
     Matrix data = Matrix.builder('people2').data([
-        id: [1],
-        name: ['Alice']
+        id: [1, 2],
+        name: ['Alice', 'Bob']
     ])
     .types(int, String)
     .build()
 
-    String url = h2MemUrl('update_match_testdb')
+    String url = h2MemUrl('update_all_testdb', 'DATABASE_TO_UPPER=FALSE')
     try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
       String tableName = matrixSql.tableName(data)
       if (matrixSql.tableExists(tableName)) {
@@ -185,8 +185,12 @@ class MatrixSqlTest {
       matrixSql.create(data)
 
       Row row = data.row(0)
-      row['name'] = 'Bob'
-      assertThrows(IllegalArgumentException) { matrixSql.update(tableName, row) }
+      row['name'] = 'Charlie'
+      assertEquals(2, matrixSql.update(tableName, row))
+
+      Matrix stored = matrixSql.select("select * from $tableName order by id")
+      assertEquals('Charlie', stored[0, 'name'])
+      assertEquals('Charlie', stored[1, 'name'])
     }
   }
 

--- a/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
+++ b/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
@@ -6,6 +6,7 @@ import it.AbstractDbTest
 import org.junit.jupiter.api.Test
 
 import se.alipsa.groovy.datautil.ConnectionInfo
+import se.alipsa.groovy.datautil.DataBaseProvider
 import se.alipsa.groovy.datautil.SqlUtil
 import se.alipsa.matrix.core.ListConverter
 import se.alipsa.matrix.core.Matrix
@@ -256,6 +257,104 @@ class MatrixSqlTest {
       assertEquals(ci.url, h2.connectionInfo.url, "Urls does not match")
     }
     assertEquals(ddl1, ddl2)
+  }
+
+  @Test
+  void testPreparedParameterSelectUpdateDeleteExecute() {
+    Matrix data = Matrix.builder('people').data([
+        id: [1, 2, 3],
+        name: ['Alice', 'Bob', 'Charlie']
+    ])
+    .types(int, String)
+    .build()
+
+    String url = h2MemUrl('prep_testdb', 'DATABASE_TO_UPPER=FALSE')
+    try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+      String tableName = matrixSql.tableName(data)
+      if (matrixSql.tableExists(tableName)) {
+        matrixSql.dropTable(tableName)
+      }
+      matrixSql.create(data)
+
+      // Prepared select
+      Matrix result = matrixSql.select("select * from $tableName where id > ?", [1], 'result')
+      assertEquals('result', result.matrixName)
+      assertEquals(2, result.rowCount())
+      assertEquals('Bob', result[0, 'name'])
+
+      // Prepared update
+      int updated = matrixSql.update("update $tableName set name = ? where id = ?", ['Robert', 2])
+      assertEquals(1, updated)
+
+      // Verify update
+      Matrix afterUpdate = matrixSql.select("select * from $tableName where id = ?", [2])
+      assertEquals('Robert', afterUpdate[0, 'name'])
+
+      // Prepared delete
+      int deleted = matrixSql.delete("delete from $tableName where id = ?", [3])
+      assertEquals(1, deleted)
+
+      // Verify delete
+      Matrix afterDelete = matrixSql.select("select * from $tableName")
+      assertEquals(2, afterDelete.rowCount())
+
+      // Prepared execute (update)
+      Map<Integer, Object> execResult = matrixSql.execute("update $tableName set name = ? where id = ?", ['Bobby', 2])
+      assertEquals(1, execResult[0])
+
+      // Prepared execute (select)
+      Map<Integer, Object> execSelect = matrixSql.execute("select * from $tableName where id = ?", [1])
+      assertTrue(execSelect[0] instanceof Matrix)
+      assertEquals(1, ((Matrix) execSelect[0]).rowCount())
+    }
+  }
+
+  @Test
+  void testInsertMatrixWithExplicitTableName() {
+    Matrix data = Matrix.builder('people').data([
+        id: [1],
+        name: ['Alice']
+    ])
+    .types(int, String)
+    .build()
+
+    String url = h2MemUrl('insert_matrix_testdb', 'DATABASE_TO_UPPER=FALSE')
+    try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+      String tableName = matrixSql.tableName(data)
+      if (matrixSql.tableExists(tableName)) {
+        matrixSql.dropTable(tableName)
+      }
+      matrixSql.create(data)
+
+      Matrix extra = Matrix.builder('extra').data([
+          id: [2],
+          name: ['Bob']
+      ])
+      .types(int, String)
+      .build()
+
+      assertEquals(1, matrixSql.insert(tableName, extra))
+
+      Matrix stored = matrixSql.select("select * from $tableName order by id")
+      assertEquals(2, stored.rowCount())
+      assertEquals('Alice', stored[0, 'name'])
+      assertEquals('Bob', stored[1, 'name'])
+    }
+  }
+
+  @Test
+  void testManagedConnectionDoesNotCloseExternallyOwnedConnection() {
+    String url = h2MemUrl('managed_con_testdb')
+    MatrixSql owner = MatrixSqlFactory.createH2(url, 'sa', '123')
+    try {
+      Connection con = owner.connect()
+      MatrixSql managed = new MatrixSql(con, DataBaseProvider.H2)
+      assertFalse(con.isClosed(), 'Expected external connection to be open')
+      managed.close()
+      assertFalse(con.isClosed(), 'Expected external connection to remain open after MatrixSql.close()')
+    } finally {
+      owner.close()
+    }
   }
 
   @Test

--- a/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
+++ b/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
@@ -12,6 +12,8 @@ import se.alipsa.matrix.core.ListConverter
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Row
 import se.alipsa.matrix.datasets.Dataset
+import se.alipsa.groovy.datautil.sqltypes.SqlTypeMapper
+import se.alipsa.matrix.sql.MatrixDbUtil
 import se.alipsa.matrix.sql.MatrixSql
 import se.alipsa.matrix.sql.MatrixSqlFactory
 import se.alipsa.matrix.sql.SqlIdentifier
@@ -276,34 +278,36 @@ class MatrixSqlTest {
       }
       matrixSql.create(data)
 
+      String tbl = SqlIdentifier.renderTable(tableName)
+
       // Prepared select
-      Matrix result = matrixSql.select("select * from $tableName where id > ?", [1], 'result')
+      Matrix result = matrixSql.select("select * from $tbl where id > ?", [1], 'result')
       assertEquals('result', result.matrixName)
       assertEquals(2, result.rowCount())
       assertEquals('Bob', result[0, 'name'])
 
       // Prepared update
-      int updated = matrixSql.update("update $tableName set name = ? where id = ?", ['Robert', 2])
+      int updated = matrixSql.update("update $tbl set name = ? where id = ?", ['Robert', 2])
       assertEquals(1, updated)
 
       // Verify update
-      Matrix afterUpdate = matrixSql.select("select * from $tableName where id = ?", [2])
+      Matrix afterUpdate = matrixSql.select("select * from $tbl where id = ?", [2])
       assertEquals('Robert', afterUpdate[0, 'name'])
 
       // Prepared delete
-      int deleted = matrixSql.delete("delete from $tableName where id = ?", [3])
+      int deleted = matrixSql.delete("delete from $tbl where id = ?", [3])
       assertEquals(1, deleted)
 
       // Verify delete
-      Matrix afterDelete = matrixSql.select("select * from $tableName")
+      Matrix afterDelete = matrixSql.select("select * from $tbl")
       assertEquals(2, afterDelete.rowCount())
 
       // Prepared execute (update)
-      Map<Integer, Object> execResult = matrixSql.execute("update $tableName set name = ? where id = ?", ['Bobby', 2])
+      Map<Integer, Object> execResult = matrixSql.execute("update $tbl set name = ? where id = ?", ['Bobby', 2])
       assertEquals(1, execResult[0])
 
       // Prepared execute (select)
-      Map<Integer, Object> execSelect = matrixSql.execute("select * from $tableName where id = ?", [1])
+      Map<Integer, Object> execSelect = matrixSql.execute("select * from $tbl where id = ?", [1])
       assertTrue(execSelect[0] instanceof Matrix)
       assertEquals(1, ((Matrix) execSelect[0]).rowCount())
     }
@@ -411,6 +415,263 @@ class MatrixSqlTest {
 
       matrixSql.dropTable(tableName)
       assertFalse(matrixSql.tableExists(tableName))
+    }
+  }
+
+  @Test
+  void testConstructorWithConnectionInfoAndDbProvider() {
+    ConnectionInfo ci = new ConnectionInfo()
+    ci.setDependency('com.h2database:h2:2.4.240')
+    ci.setUrl(h2MemUrl('ci_dbprovider_testdb'))
+    ci.setUser('sa')
+    ci.setPassword('123')
+    ci.setDriver('org.h2.Driver')
+
+    Matrix data = Matrix.builder('ci_prov').data([id: [1], val: ['x']]).types(int, String).build()
+    try (MatrixSql matrixSql = new MatrixSql(ci, DataBaseProvider.H2)) {
+      matrixSql.create(data)
+      Matrix stored = matrixSql.select("select * from ${SqlIdentifier.renderTable(matrixSql.tableName(data))}")
+      assertEquals(1, stored.rowCount())
+      assertEquals('x', stored[0, 'val'])
+    }
+  }
+
+  @Test
+  void testConstructorWithConnectionAndSqlTypeMapper() {
+    String url = h2MemUrl('con_mapper_testdb')
+    MatrixSql owner = MatrixSqlFactory.createH2(url, 'sa', '123')
+    try {
+      Connection con = owner.connect()
+      SqlTypeMapper mapper = SqlTypeMapper.create(DataBaseProvider.H2)
+      Matrix data = Matrix.builder('mapper_tbl').data([id: [1], val: ['y']]).types(int, String).build()
+      try (MatrixSql managed = new MatrixSql(con, mapper)) {
+        managed.create(data)
+        Matrix stored = managed.select("select * from ${SqlIdentifier.renderTable(managed.tableName(data))}")
+        assertEquals(1, stored.rowCount())
+        assertEquals('y', stored[0, 'val'])
+      }
+      assertFalse(con.isClosed(), 'External connection must stay open after managed MatrixSql close')
+    } finally {
+      owner.close()
+    }
+  }
+
+  @Test
+  void testUpdateUnprepared() {
+    Matrix data = Matrix.builder('upd_plain').data([id: [1, 2], name: ['Alice', 'Bob']]).types(int, String).build()
+    String url = h2MemUrl('upd_plain_testdb', 'DATABASE_TO_UPPER=FALSE')
+    try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+      matrixSql.create(data)
+      String tbl = SqlIdentifier.renderTable(matrixSql.tableName(data))
+      int affected = matrixSql.update("UPDATE $tbl SET name = 'Charlie' WHERE id = 1")
+      assertEquals(1, affected)
+      Matrix stored = matrixSql.select("SELECT * FROM $tbl WHERE id = 1")
+      assertEquals('Charlie', stored[0, 'name'])
+    }
+  }
+
+  @Test
+  void testBatchMatrixUpdate() {
+    Matrix original = Matrix.builder('batch_upd').data([
+        id: [1, 2, 3],
+        name: ['Alice', 'Bob', 'Charlie']
+    ]).types(int, String).build()
+
+    String url = h2MemUrl('batch_upd_testdb', 'DATABASE_TO_UPPER=FALSE')
+    try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+      matrixSql.create(original)
+
+      Matrix updates = Matrix.builder('batch_upd').data([
+          id: [1, 2, 3],
+          name: ['Alicia', 'Bobby', 'Chuck']
+      ]).types(int, String).build()
+
+      int total = matrixSql.update(updates, 'id')
+      assertEquals(3, total)
+
+      String tbl = SqlIdentifier.renderTable(matrixSql.tableName(original))
+      Matrix stored = matrixSql.select("SELECT * FROM $tbl ORDER BY id")
+      assertEquals('Alicia', stored[0, 'name'])
+      assertEquals('Bobby', stored[1, 'name'])
+      assertEquals('Chuck', stored[2, 'name'])
+    }
+  }
+
+  @Test
+  void testExecuteUnprepared() {
+    String url = h2MemUrl('exec_plain_testdb', 'DATABASE_TO_UPPER=FALSE')
+    try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+      Map<Integer, Object> ddlResult = matrixSql.execute('CREATE TABLE exec_t (id INT, val VARCHAR(50))')
+      assertEquals(0, ddlResult[0], 'DDL should return 0 update count')
+
+      matrixSql.execute("INSERT INTO exec_t VALUES (1, 'hello')")
+      Map<Integer, Object> selResult = matrixSql.execute('SELECT * FROM exec_t')
+      assertTrue(selResult[0] instanceof Matrix)
+      assertEquals(1, ((Matrix) selResult[0]).rowCount())
+    }
+  }
+
+  @Test
+  void testGetTableNames() {
+    Matrix a = Matrix.builder('tbl_a').data([id: [1]]).types(int).build()
+    Matrix b = Matrix.builder('tbl_b').data([id: [2]]).types(int).build()
+    String url = h2MemUrl('tablenames_testdb')
+    try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+      matrixSql.create(a)
+      matrixSql.create(b)
+      Set<String> names = matrixSql.getTableNames()
+      assertTrue(names.any { it.equalsIgnoreCase('tbl_a') }, "Expected tbl_a in $names")
+      assertTrue(names.any { it.equalsIgnoreCase('tbl_b') }, "Expected tbl_b in $names")
+    }
+  }
+
+  @Test
+  void testExecuteQuery() {
+    Matrix data = Matrix.builder('exec_q').data([id: [1], val: ['foo']]).types(int, String).build()
+    String url = h2MemUrl('executequery_testdb', 'DATABASE_TO_UPPER=FALSE')
+    try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+      matrixSql.create(data)
+      String tbl = SqlIdentifier.renderTable(matrixSql.tableName(data))
+      Object result = matrixSql.executeQuery("SELECT * FROM $tbl")
+      assertTrue(result instanceof Matrix, "Expected Matrix, got ${result?.class}")
+      assertEquals(1, ((Matrix) result).rowCount())
+    }
+  }
+
+  @Test
+  void testCreateWithExplicitTableName() {
+    Matrix data = Matrix.builder('original_name').data([id: [1], val: ['a']]).types(int, String).build()
+    String url = h2MemUrl('explicit_name_testdb', 'DATABASE_TO_UPPER=FALSE')
+    try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+      matrixSql.create('custom_table', data)
+      assertTrue(matrixSql.tableExists('custom_table'))
+      assertFalse(matrixSql.tableExists('original_name'))
+      Matrix stored = matrixSql.select("SELECT * FROM ${SqlIdentifier.renderTable('custom_table')}")
+      assertEquals(1, stored.rowCount())
+      assertEquals('a', stored[0, 'val'])
+    }
+  }
+
+  @Test
+  void testCreateWithScanRows() {
+    Matrix data = Matrix.builder('scan_rows').data([
+        id: [1, 2, 3, 4, 5],
+        name: ['a', 'b', 'c', 'd', 'e']
+    ]).types(int, String).build()
+    String url = h2MemUrl('scanrows_testdb', 'DATABASE_TO_UPPER=FALSE')
+    try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+      matrixSql.create(data, 2, true)
+      String tbl = SqlIdentifier.renderTable(matrixSql.tableName(data))
+      Matrix stored = matrixSql.select("SELECT * FROM $tbl ORDER BY id")
+      assertEquals(5, stored.rowCount())
+    }
+  }
+
+  @Test
+  void testCreateWithProps() {
+    Matrix data = Matrix.builder('props_tbl').data([
+        id: [1],
+        name: ['hello world']
+    ]).types(int, String).build()
+    String url = h2MemUrl('props_testdb', 'DATABASE_TO_UPPER=FALSE')
+    try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+      Map<String, Map<String, Integer>> props = [
+          'id': [:],
+          'name': [(SqlTypeMapper.VARCHAR_SIZE): 200]
+      ]
+      matrixSql.create(data, props)
+      String tbl = SqlIdentifier.renderTable(matrixSql.tableName(data))
+      Matrix stored = matrixSql.select("SELECT * FROM $tbl")
+      assertEquals(1, stored.rowCount())
+      assertEquals('hello world', stored[0, 'name'])
+    }
+  }
+
+  @Test
+  void testInsertMatrixAndInsertMatrixRow() {
+    Matrix schema = Matrix.builder('insert_tbl').data([id: [1], name: ['Alice']]).types(int, String).build()
+    String url = h2MemUrl('insert_ref_testdb', 'DATABASE_TO_UPPER=FALSE')
+    try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+      matrixSql.create(schema)
+
+      // insert(Matrix) uses the Matrix name to derive the table name
+      Matrix bulk = Matrix.builder('insert_tbl').data([id: [2, 3], name: ['Bob', 'Charlie']]).types(int, String).build()
+      assertEquals(2, matrixSql.insert(bulk))
+
+      // insert(Matrix, Row) uses the Matrix name for the table, Row carries column values
+      Matrix ref = Matrix.builder('insert_tbl').data([id: [0], name: ['x']]).types(int, String).build()
+      Row newRow = Matrix.builder('insert_tbl').data([id: [4], name: ['Diana']]).types(int, String).build().row(0)
+      assertEquals(1, matrixSql.insert(ref, newRow))
+
+      String tbl = SqlIdentifier.renderTable(matrixSql.tableName(schema))
+      Matrix stored = matrixSql.select("SELECT * FROM $tbl ORDER BY id")
+      assertEquals(4, stored.rowCount())
+      assertEquals('Alice', stored[0, 'name'])
+      assertEquals('Bob', stored[1, 'name'])
+      assertEquals('Charlie', stored[2, 'name'])
+      assertEquals('Diana', stored[3, 'name'])
+    }
+  }
+
+  @Test
+  void testDeleteUnprepared() {
+    Matrix data = Matrix.builder('del_plain').data([id: [1, 2, 3], name: ['a', 'b', 'c']]).types(int, String).build()
+    String url = h2MemUrl('del_plain_testdb', 'DATABASE_TO_UPPER=FALSE')
+    try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+      matrixSql.create(data)
+      String tbl = SqlIdentifier.renderTable(matrixSql.tableName(data))
+      int deleted = matrixSql.delete("DELETE FROM $tbl WHERE id = 2")
+      assertEquals(1, deleted)
+      Matrix stored = matrixSql.select("SELECT * FROM $tbl ORDER BY id")
+      assertEquals(2, stored.rowCount())
+      assertEquals(1, stored[0, 'id'])
+      assertEquals(3, stored[1, 'id'])
+    }
+  }
+
+  @Test
+  void testStaticHelpersAndAccessors() {
+    assertTrue(MatrixSql.isBlank(null))
+    assertTrue(MatrixSql.isBlank(''))
+    assertTrue(MatrixSql.isBlank('   '))
+    assertFalse(MatrixSql.isBlank('x'))
+
+    ConnectionInfo valid = new ConnectionInfo()
+    valid.setDependency('com.h2database:h2:2.4.240')
+    MatrixSql.check(valid)  // must not throw
+
+    ConnectionInfo invalid = new ConnectionInfo()
+    assertThrows(IllegalArgumentException) { MatrixSql.check(invalid) }
+
+    String url = h2MemUrl('accessors_testdb')
+    try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+      assertNotNull(matrixSql.getSqlTypeMapper())
+      assertNotNull(matrixSql.getMatrixDbUtil())
+      assertNull(matrixSql.getConnection(), 'Connection should be null before first use')
+      matrixSql.connect()
+      assertNotNull(matrixSql.getConnection(), 'Connection should be non-null after connect()')
+      assertTrue(matrixSql.getMatrixDbUtil() instanceof MatrixDbUtil)
+      assertTrue(matrixSql.getSqlTypeMapper() instanceof SqlTypeMapper)
+    }
+  }
+
+  @Test
+  void testManagedConnectionRemainsUsableAfterClose() {
+    String url = h2MemUrl('managed_usable_testdb', 'DATABASE_TO_UPPER=FALSE')
+    MatrixSql owner = MatrixSqlFactory.createH2(url, 'sa', '123')
+    try {
+      Matrix data = Matrix.builder('usable').data([id: [1]]).types(int).build()
+      owner.create(data)
+
+      Connection con = owner.connect()
+      MatrixSql managed = new MatrixSql(con, DataBaseProvider.H2)
+      managed.close()
+
+      String tbl = SqlIdentifier.renderTable('usable')
+      Matrix stored = managed.select("SELECT * FROM $tbl")
+      assertEquals(1, stored.rowCount(), 'Managed MatrixSql must remain usable after close()')
+    } finally {
+      owner.close()
     }
   }
 }

--- a/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
+++ b/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
@@ -168,15 +168,15 @@ class MatrixSqlTest {
   }
 
   @Test
-  void testUpdateAllRowsWithRow() {
+  void testUpdateRequiresMatchColumn() {
     Matrix data = Matrix.builder('people2').data([
-        id: [1, 2],
-        name: ['Alice', 'Bob']
+        id: [1],
+        name: ['Alice']
     ])
     .types(int, String)
     .build()
 
-    String url = h2MemUrl('update_all_testdb', 'DATABASE_TO_UPPER=FALSE')
+    String url = h2MemUrl('update_match_testdb')
     try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
       String tableName = matrixSql.tableName(data)
       if (matrixSql.tableExists(tableName)) {
@@ -185,12 +185,8 @@ class MatrixSqlTest {
       matrixSql.create(data)
 
       Row row = data.row(0)
-      row['name'] = 'Charlie'
-      assertEquals(2, matrixSql.update(tableName, row))
-
-      Matrix stored = matrixSql.select("select * from $tableName order by id")
-      assertEquals('Charlie', stored[0, 'name'])
-      assertEquals('Charlie', stored[1, 'name'])
+      row['name'] = 'Bob'
+      assertThrows(IllegalArgumentException) { matrixSql.update(tableName, row) }
     }
   }
 


### PR DESCRIPTION
Implements Phase 3 of the matrix-sql v2.4.0 roadmap (section 4: Add Safer Query Convenience APIs).

## Changes

### 4.1 Prepared parameter overloads
- `Matrix select(String sqlQuery, List params, String matrixName = 'myMatrix')`
- `int update(String sqlQuery, List params)`
- `int delete(String sqlQuery, List params)`
- `Map<Integer, Object> execute(String sqlQuery, List params)`

### 4.2 Explicit table-name matrix insert
- `int insert(String tableName, Matrix table)` delegates to `MatrixDbUtil.insert(Connection, String, Matrix)`

### 4.3 Managed connection facade constructors
- `MatrixSql(Connection connection, DataBaseProvider dbProvider)`
- `MatrixSql(Connection connection, SqlTypeMapper mapper)`
- Externally-provided connections are NOT closed by `MatrixSql.close()`

## Test commands run
- `./gradlew :matrix-sql:test --rerun-tasks` (45 tests passed)
- `./gradlew :matrix-sql:spotlessCheck`
- `./gradlew test` (full suite, all modules passed)