### PR TITLE
matrix-sql 2.4.0 phase 4: factory offline fallback behavior

### DIFF
--- a/docs/superpowers/plans/2026-04-30-matrix-sql-factory-offline.md
+++ b/docs/superpowers/plans/2026-04-30-matrix-sql-factory-offline.md
@@ -1,0 +1,280 @@
+# matrix-sql Factory Offline Behavior Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `MatrixSqlFactory` predictable when Maven Central is unreachable by centralising fallback versions and applying them in all three factory paths.
+
+**Architecture:** Add a single `FALLBACK_VERSIONS` map on `MatrixSqlFactory` keyed by `DataBaseProvider`. The two typed methods (`createH2`, `createDerby`) replace their hardcoded inline strings with lookups from that map. The generic `create(ConnectionInfo, String)` gains a new catch path that checks the map before re-throwing, using `DataBaseProvider.fromUrl()` to resolve the provider.
+
+**Tech Stack:** Groovy 5.0.5, `@CompileStatic`, JUnit 5, `se.alipsa.mavenutils.ArtifactLookup` (concrete class — subclassed anonymously in tests)
+
+---
+
+## Files
+
+| File | Change |
+|---|---|
+| `matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSqlFactory.groovy` | Add `FALLBACK_VERSIONS` map; update `createH2`, `createDerby`, and `create(ConnectionInfo, String)` catch blocks |
+| `matrix-sql/src/test/groovy/MatrixSqlTest.groovy` | Add `se.alipsa.mavenutils.ArtifactLookup` import; add 4 new tests |
+
+---
+
+## Task 1: Add `FALLBACK_VERSIONS` and update typed factory methods
+
+**Files:**
+- Modify: `matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSqlFactory.groovy`
+- Modify: `matrix-sql/src/test/groovy/MatrixSqlTest.groovy`
+
+- [ ] **Step 1: Add `ArtifactLookup` import to test file**
+
+Add this import after the existing imports in `MatrixSqlTest.groovy`:
+
+```groovy
+import se.alipsa.mavenutils.ArtifactLookup
+```
+
+- [ ] **Step 2: Write two failing tests**
+
+Add these two test methods to `MatrixSqlTest.groovy`:
+
+```groovy
+@Test
+void testCreateH2FallsBackOnNetworkFailure() {
+    String url = h2MemUrl('fallback_h2_testdb')
+    ArtifactLookup original = MatrixSqlFactory.artifactLookup
+    try {
+        MatrixSqlFactory.artifactLookup = new ArtifactLookup() {
+            @Override
+            String fetchLatestVersion(String g, String a) throws Exception {
+                throw new IOException("Simulated network failure")
+            }
+        }
+        MatrixSql ms = MatrixSqlFactory.createH2(url, 'sa', '123')
+        assertTrue(ms.connectionInfo.dependency.contains(MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.H2]),
+            "Expected dependency to contain H2 fallback version ${MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.H2]}")
+    } finally {
+        MatrixSqlFactory.artifactLookup = original
+    }
+}
+
+@Test
+void testCreateDerbyFallsBackOnNetworkFailure() {
+    ArtifactLookup original = MatrixSqlFactory.artifactLookup
+    try {
+        MatrixSqlFactory.artifactLookup = new ArtifactLookup() {
+            @Override
+            String fetchLatestVersion(String g, String a) throws Exception {
+                throw new IOException("Simulated network failure")
+            }
+        }
+        MatrixSql ms = MatrixSqlFactory.createDerby("memory:fallback_derby_${System.nanoTime()}")
+        assertTrue(ms.connectionInfo.dependency.contains(MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.DERBY]),
+            "Expected dependency to contain Derby fallback version ${MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.DERBY]}")
+    } finally {
+        MatrixSqlFactory.artifactLookup = original
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+./gradlew :matrix-sql:test --tests "MatrixSqlTest.testCreateH2FallsBackOnNetworkFailure" --tests "MatrixSqlTest.testCreateDerbyFallsBackOnNetworkFailure" --rerun-tasks
+```
+
+Expected: compile error — `FALLBACK_VERSIONS` does not exist on `MatrixSqlFactory`.
+
+- [ ] **Step 4: Add `FALLBACK_VERSIONS` to `MatrixSqlFactory`**
+
+Insert this field immediately after the `artifactLookup` field declaration (after line `static ArtifactLookup artifactLookup = new ArtifactLookup(REPO_URL)`):
+
+```groovy
+static final Map<DataBaseProvider, String> FALLBACK_VERSIONS = [
+    (DataBaseProvider.H2)   : '2.4.240',
+    (DataBaseProvider.DERBY): '10.17.1.0'
+].asImmutable()
+```
+
+- [ ] **Step 5: Update `createH2` catch block**
+
+Replace:
+```groovy
+      } catch (Exception e) {
+        dependencyVersion = '2.4.240'
+        log.warn("Failed to fetch latest H2 artifact, falling back to version $dependencyVersion: ${e.message}", e)
+      }
+```
+With:
+```groovy
+      } catch (Exception e) {
+        dependencyVersion = FALLBACK_VERSIONS[DataBaseProvider.H2]
+        log.warn("Failed to fetch latest H2 artifact, falling back to version $dependencyVersion: ${e.message}", e)
+      }
+```
+
+- [ ] **Step 6: Update `createDerby` catch block**
+
+Replace:
+```groovy
+      } catch (Exception e) {
+        dependencyVersion = '10.17.1.0'
+        log.warn("Failed to fetch latest Derby artifact, falling back to version $dependencyVersion: ${e.message}", e)
+      }
+```
+With:
+```groovy
+      } catch (Exception e) {
+        dependencyVersion = FALLBACK_VERSIONS[DataBaseProvider.DERBY]
+        log.warn("Failed to fetch latest Derby artifact, falling back to version $dependencyVersion: ${e.message}", e)
+      }
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+```bash
+./gradlew :matrix-sql:test --tests "MatrixSqlTest.testCreateH2FallsBackOnNetworkFailure" --tests "MatrixSqlTest.testCreateDerbyFallsBackOnNetworkFailure" --rerun-tasks
+```
+
+Expected: both pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSqlFactory.groovy \
+        matrix-sql/src/test/groovy/MatrixSqlTest.groovy
+git commit -m "Centralise factory fallback versions in FALLBACK_VERSIONS map"
+```
+
+---
+
+## Task 2: Add fallback to generic `create()` and cover the no-fallback error path
+
+**Files:**
+- Modify: `matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSqlFactory.groovy`
+- Modify: `matrix-sql/src/test/groovy/MatrixSqlTest.groovy`
+
+- [ ] **Step 1: Write two failing tests**
+
+Add these two test methods to `MatrixSqlTest.groovy`:
+
+```groovy
+@Test
+void testGenericCreateFallsBackOnNetworkFailure() {
+    String url = h2MemUrl('fallback_generic_testdb')
+    ArtifactLookup original = MatrixSqlFactory.artifactLookup
+    try {
+        MatrixSqlFactory.artifactLookup = new ArtifactLookup() {
+            @Override
+            String fetchLatestVersion(String g, String a) throws Exception {
+                throw new IOException("Simulated network failure")
+            }
+        }
+        MatrixSql ms = MatrixSqlFactory.create(url, 'sa', '123')
+        assertTrue(ms.connectionInfo.dependency.contains(MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.H2]),
+            "Expected dependency to contain H2 fallback version ${MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.H2]}")
+    } finally {
+        MatrixSqlFactory.artifactLookup = original
+    }
+}
+
+@Test
+void testGenericCreateThrowsWithCoordinatesWhenNoFallback() {
+    // PostgreSQL is a known provider but has no entry in FALLBACK_VERSIONS
+    String pgUrl = 'jdbc:postgresql://localhost:5432/testdb'
+    Map<String, String> pgDependency = MatrixSqlFactory.getDependencyName(pgUrl)
+    assertNotNull(pgDependency, 'Expected PostgreSQL to be a known provider in DataBaseProvider')
+
+    ArtifactLookup original = MatrixSqlFactory.artifactLookup
+    try {
+        MatrixSqlFactory.artifactLookup = new ArtifactLookup() {
+            @Override
+            String fetchLatestVersion(String g, String a) throws Exception {
+                throw new IOException("Simulated network failure")
+            }
+        }
+        RuntimeException ex = assertThrows(RuntimeException) {
+            MatrixSqlFactory.create(pgUrl, 'user', 'pass')
+        }
+        assertTrue(ex.message.contains(pgDependency.groupId),
+            "Expected message to contain groupId '${pgDependency.groupId}', was: ${ex.message}")
+        assertTrue(ex.message.contains(pgDependency.artifactId),
+            "Expected message to contain artifactId '${pgDependency.artifactId}', was: ${ex.message}")
+        assertTrue(ex.message.contains('no fallback version is configured'),
+            "Expected message to mention missing fallback, was: ${ex.message}")
+    } finally {
+        MatrixSqlFactory.artifactLookup = original
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+./gradlew :matrix-sql:test --tests "MatrixSqlTest.testGenericCreateFallsBackOnNetworkFailure" --tests "MatrixSqlTest.testGenericCreateThrowsWithCoordinatesWhenNoFallback" --rerun-tasks
+```
+
+Expected: both fail — `testGenericCreateFallsBackOnNetworkFailure` throws instead of falling back; `testGenericCreateThrowsWithCoordinatesWhenNoFallback` fails because the current error message lacks "no fallback version is configured".
+
+- [ ] **Step 3: Update the `create(ConnectionInfo, String)` catch block**
+
+In `MatrixSqlFactory.groovy`, locate the catch block inside `create(ConnectionInfo ci, String version)`:
+
+```groovy
+      } catch (Exception e) {
+        throw new RuntimeException ("Failed to fetch latest artifact for $dependency.groupId:$dependency.artifactId", e)
+      }
+```
+
+Replace it with:
+
+```groovy
+      } catch (Exception e) {
+        DataBaseProvider provider = DataBaseProvider.fromUrl(ci.url)
+        String fallback = FALLBACK_VERSIONS[provider]
+        if (fallback != null) {
+          dependencyVersion = fallback
+          log.warn("Failed to fetch latest artifact for $dependency.groupId:$dependency.artifactId, " +
+              "falling back to version $dependencyVersion: ${e.message}", e)
+        } else {
+          throw new RuntimeException(
+              "Failed to fetch latest artifact for $dependency.groupId:$dependency.artifactId" +
+              " and no fallback version is configured for this provider", e)
+        }
+      }
+```
+
+- [ ] **Step 4: Run new tests to verify they pass**
+
+```bash
+./gradlew :matrix-sql:test --tests "MatrixSqlTest.testGenericCreateFallsBackOnNetworkFailure" --tests "MatrixSqlTest.testGenericCreateThrowsWithCoordinatesWhenNoFallback" --rerun-tasks
+```
+
+Expected: both pass.
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+```bash
+./gradlew :matrix-sql:test --rerun-tasks
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSqlFactory.groovy \
+        matrix-sql/src/test/groovy/MatrixSqlTest.groovy
+git commit -m "Add offline fallback to generic create(); improve no-fallback error message"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run full module test suite**
+
+```bash
+./gradlew :matrix-sql:test --rerun-tasks
+```
+
+Expected: all tests pass, no regressions.

--- a/docs/superpowers/specs/2026-04-30-matrix-sql-factory-offline-design.md
+++ b/docs/superpowers/specs/2026-04-30-matrix-sql-factory-offline-design.md
@@ -1,0 +1,114 @@
+# matrix-sql Factory Offline Behavior — Design Spec
+
+**Phase:** 4 of matrix-sql 2.4.0 roadmap (section 5)
+**Date:** 2026-04-30
+
+## Problem
+
+`MatrixSqlFactory.create(ConnectionInfo, String version)` throws `RuntimeException` when
+`version == null` and the Maven Central version lookup fails. The typed factory methods
+`createH2` and `createDerby` already have inline fallback versions, but those are hardcoded
+strings scattered in method bodies rather than a centralized registry.
+
+## Goal
+
+Make generic factory creation predictable in offline or restricted-network environments:
+- Known providers fall back to a pinned version instead of throwing.
+- Fallback versions live in one place and are easy to update.
+- Lookup failures are logged as warnings, not silently swallowed.
+- Unsupported providers still fail with a clear message including dependency coordinates.
+
+## Design
+
+### 1. Fallback version registry
+
+Add one static field to `MatrixSqlFactory`:
+
+```groovy
+static final Map<DataBaseProvider, String> FALLBACK_VERSIONS = [
+    (DataBaseProvider.H2)   : '2.4.240',
+    (DataBaseProvider.DERBY): '10.17.1.0'
+].asImmutable()
+```
+
+Only H2 and DERBY receive entries initially — they are the only providers with typed
+factory methods and verified test coverage. Additional providers can be added as their
+versions are validated. `asImmutable()` prevents accidental mutation at runtime.
+
+### 2. `createH2` and `createDerby`
+
+Replace the inline string literals in each method's catch block with a lookup from
+`FALLBACK_VERSIONS`. Log message structure and flow are unchanged.
+
+```groovy
+// createH2
+dependencyVersion = FALLBACK_VERSIONS[DataBaseProvider.H2]
+log.warn("Failed to fetch latest H2 artifact, falling back to version $dependencyVersion: ${e.message}", e)
+
+// createDerby
+dependencyVersion = FALLBACK_VERSIONS[DataBaseProvider.DERBY]
+log.warn("Failed to fetch latest Derby artifact, falling back to version $dependencyVersion: ${e.message}", e)
+```
+
+### 3. Generic `create(ConnectionInfo, String version)`
+
+Replace the bare re-throw with fallback-aware logic. `getDependencyName()` already runs
+before the try/catch and provides the coordinates for the error message.
+`DataBaseProvider.fromUrl(ci.url)` resolves the URL to a provider for the map lookup.
+If it returns `UNKNOWN` (no match), the map lookup returns `null` and the error path is taken.
+
+```groovy
+} catch (Exception e) {
+    DataBaseProvider provider = DataBaseProvider.fromUrl(ci.url)
+    String fallback = FALLBACK_VERSIONS[provider]
+    if (fallback != null) {
+        dependencyVersion = fallback
+        log.warn("Failed to fetch latest artifact for $dependency.groupId:$dependency.artifactId, " +
+                 "falling back to version $dependencyVersion: ${e.message}", e)
+    } else {
+        throw new RuntimeException(
+            "Failed to fetch latest artifact for $dependency.groupId:$dependency.artifactId" +
+            " and no fallback version is configured for this provider", e)
+    }
+}
+```
+
+### 4. Tests
+
+`ArtifactLookup` is a non-final concrete class. Tests replace the static
+`MatrixSqlFactory.artifactLookup` field with an anonymous subclass that throws
+`IOException`, and restore it in a `finally` block.
+
+```groovy
+ArtifactLookup original = MatrixSqlFactory.artifactLookup
+try {
+    MatrixSqlFactory.artifactLookup = new ArtifactLookup() {
+        @Override String fetchLatestVersion(String g, String a) throws Exception {
+            throw new IOException("Simulated network failure")
+        }
+    }
+    // assertions
+} finally {
+    MatrixSqlFactory.artifactLookup = original
+}
+```
+
+Four test methods:
+
+| Test | What it verifies |
+|---|---|
+| `testGenericCreateFallsBackOnNetworkFailure` | `create(h2Url, user, pass)` succeeds; `connectionInfo.dependency` contains the H2 fallback version |
+| `testCreateH2FallsBackOnNetworkFailure` | `createH2(url, user, pass)` succeeds; dependency contains H2 fallback version |
+| `testCreateDerbyFallsBackOnNetworkFailure` | `createDerby(dbName)` succeeds; dependency contains Derby fallback version (no DB connection needed) |
+| `testGenericCreateThrowsWithCoordinatesWhenNoFallback` | PostgreSQL URL with no fallback throws `RuntimeException` whose message contains the dependency coordinates |
+
+## Files Changed
+
+- `matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSqlFactory.groovy`
+- `matrix-sql/src/test/groovy/MatrixSqlTest.groovy`
+
+## Out of Scope
+
+- Adding fallback versions for providers other than H2 and DERBY.
+- Changing `getDependencyName()` return type.
+- Any change to `MatrixSql`, `MatrixDbUtil`, or `MatrixResultSet`.

--- a/matrix-sql/req/v2.4.0-roadmap.md
+++ b/matrix-sql/req/v2.4.0-roadmap.md
@@ -25,11 +25,11 @@ Completed test commands:
 - `./gradlew :matrix-sql:spotlessCheck`
 - `./gradlew test`
 
-Phase 3 [ ] Convenience APIs.
+Phase 3 [X] Convenience APIs.
 - Covers roadmap section `4`.
 - Focus: source-compatible API additions for prepared-parameter operations, explicit table-name matrix inserts, and managed JDBC connections.
 
-Phase 4 [ ] Factory offline behavior.
+Phase 4 [X] Factory offline behavior.
 - Covers roadmap section `5`.
 - Focus: predictable generic factory creation when Maven Central version lookup is unavailable.
 

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSqlFactory.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSqlFactory.groovy
@@ -128,7 +128,17 @@ class MatrixSqlFactory {
         dependencyVersion = artifactLookup
             .fetchLatestVersion(dependency.groupId, dependency.artifactId)
       } catch (Exception e) {
-        throw new RuntimeException ("Failed to fetch latest artifact for $dependency.groupId:$dependency.artifactId", e)
+        DataBaseProvider provider = DataBaseProvider.fromUrl(ci.url)
+        String fallback = FALLBACK_VERSIONS[provider]
+        if (fallback != null) {
+          dependencyVersion = fallback
+          log.warn("Failed to fetch latest artifact for $dependency.groupId:$dependency.artifactId, " +
+              "falling back to version $dependencyVersion: ${e.message}", e)
+        } else {
+          throw new RuntimeException(
+              "Failed to fetch latest artifact for $dependency.groupId:$dependency.artifactId" +
+              " and no fallback version is configured for this provider", e)
+        }
       }
     }
     ci.setDependency("$dependency.groupId:$dependency.artifactId:$dependencyVersion")

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSqlFactory.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSqlFactory.groovy
@@ -14,6 +14,10 @@ class MatrixSqlFactory {
   private static final Logger log = Logger.getLogger(MatrixSqlFactory)
   static String REPO_URL = "https://repo1.maven.org/maven2/"
   static ArtifactLookup artifactLookup = new ArtifactLookup(REPO_URL)
+  static final Map<DataBaseProvider, String> FALLBACK_VERSIONS = [
+      (DataBaseProvider.H2)   : '2.4.240',
+      (DataBaseProvider.DERBY): '10.17.1.0'
+  ].asImmutable()
 
   static MatrixSql createH2(String url, String user, String password, String additionalUrlProperties = null, String version = null) {
     ConnectionInfo ci = new ConnectionInfo()
@@ -31,7 +35,7 @@ class MatrixSqlFactory {
         dependencyVersion = artifactLookup
             .fetchLatestVersion('com.h2database', 'h2')
       } catch (Exception e) {
-        dependencyVersion = '2.4.240'
+        dependencyVersion = FALLBACK_VERSIONS[DataBaseProvider.H2]
         log.warn("Failed to fetch latest H2 artifact, falling back to version $dependencyVersion: ${e.message}", e)
       }
     } else {
@@ -58,7 +62,7 @@ class MatrixSqlFactory {
         dependencyVersion = artifactLookup
             .fetchLatestVersion('org.apache.derby', 'derby')
       } catch (Exception e) {
-        dependencyVersion = '10.17.1.0'
+        dependencyVersion = FALLBACK_VERSIONS[DataBaseProvider.DERBY]
         log.warn("Failed to fetch latest Derby artifact, falling back to version $dependencyVersion: ${e.message}", e)
       }
     } else {

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSqlFactory.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixSqlFactory.groovy
@@ -12,8 +12,8 @@ import se.alipsa.mavenutils.ArtifactLookup
 class MatrixSqlFactory {
 
   private static final Logger log = Logger.getLogger(MatrixSqlFactory)
-  static String REPO_URL = "https://repo1.maven.org/maven2/"
-  static ArtifactLookup artifactLookup = new ArtifactLookup(REPO_URL)
+  static final String REPO_URL = "https://repo1.maven.org/maven2/"
+  static ArtifactLookup artifactLookup = new ArtifactLookup(REPO_URL) // visible for testing
   static final Map<DataBaseProvider, String> FALLBACK_VERSIONS = [
       (DataBaseProvider.H2)   : '2.4.240',
       (DataBaseProvider.DERBY): '10.17.1.0'
@@ -75,7 +75,7 @@ class MatrixSqlFactory {
   }
 
   /**
-   * Gues the dependency based on the url.
+   * Guess the dependency based on the url.
    *
    * @param url the jdbc url to connect to
    * @param user the username
@@ -92,7 +92,7 @@ class MatrixSqlFactory {
   }
 
   /**
-   * Gues the dependency based on the url.
+   * Guess the dependency based on the url.
    *
    * @param url the jdbc url to connect to
    * @param version the version of the dependency to use, if null, the latest version will be used
@@ -105,7 +105,7 @@ class MatrixSqlFactory {
   }
 
   /**
-   * Gues the dependency based on the url.
+   * Guess the dependency based on the url.
    *
    * @param url the jdbc url to connect to
    * @param version the version of the dependency to use, if null, the latest version will be used
@@ -155,7 +155,7 @@ class MatrixSqlFactory {
       url.startsWith(it.urlStart)
     } as DataBaseProvider
 
-    return matchingProvider?.with { mapDependency(it) } ?: null
+    return matchingProvider?.with { mapDependency(it) }
   }
 
   static Map<String, String> mapDependency(DataBaseProvider provider) {

--- a/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
+++ b/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
@@ -694,6 +694,53 @@ class MatrixSqlTest {
   }
 
   @Test
+  void testGenericCreateFallsBackOnNetworkFailure() {
+    String url = h2MemUrl('fallback_generic_testdb')
+    ArtifactLookup original = MatrixSqlFactory.artifactLookup
+    try {
+      MatrixSqlFactory.artifactLookup = new ArtifactLookup() {
+        @Override
+        String fetchLatestVersion(String g, String a) throws Exception {
+          throw new IOException("Simulated network failure")
+        }
+      }
+      MatrixSql ms = MatrixSqlFactory.create(url, 'sa', '123')
+      assertTrue(ms.connectionInfo.dependency.contains(MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.H2]),
+          "Expected dependency to contain H2 fallback version ${MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.H2]}")
+    } finally {
+      MatrixSqlFactory.artifactLookup = original
+    }
+  }
+
+  @Test
+  void testGenericCreateThrowsWithCoordinatesWhenNoFallback() {
+    String pgUrl = 'jdbc:postgresql://localhost:5432/testdb'
+    Map<String, String> pgDependency = MatrixSqlFactory.getDependencyName(pgUrl)
+    assertNotNull(pgDependency, 'Expected PostgreSQL to be a known provider in DataBaseProvider')
+
+    ArtifactLookup original = MatrixSqlFactory.artifactLookup
+    try {
+      MatrixSqlFactory.artifactLookup = new ArtifactLookup() {
+        @Override
+        String fetchLatestVersion(String g, String a) throws Exception {
+          throw new IOException("Simulated network failure")
+        }
+      }
+      RuntimeException ex = assertThrows(RuntimeException) {
+        MatrixSqlFactory.create(pgUrl, 'user', 'pass')
+      }
+      assertTrue(ex.message.contains(pgDependency.groupId),
+          "Expected message to contain groupId '${pgDependency.groupId}', was: ${ex.message}")
+      assertTrue(ex.message.contains(pgDependency.artifactId),
+          "Expected message to contain artifactId '${pgDependency.artifactId}', was: ${ex.message}")
+      assertTrue(ex.message.contains('no fallback version is configured'),
+          "Expected message to mention missing fallback, was: ${ex.message}")
+    } finally {
+      MatrixSqlFactory.artifactLookup = original
+    }
+  }
+
+  @Test
   void testManagedConnectionRemainsUsableAfterClose() {
     String url = h2MemUrl('managed_usable_testdb', 'DATABASE_TO_UPPER=FALSE')
     MatrixSql owner = MatrixSqlFactory.createH2(url, 'sa', '123')

--- a/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
+++ b/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
@@ -667,9 +667,10 @@ class MatrixSqlTest {
           throw new IOException("Simulated network failure")
         }
       }
-      MatrixSql ms = MatrixSqlFactory.createH2(url, 'sa', '123')
-      assertTrue(ms.connectionInfo.dependency.contains(MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.H2]),
-          "Expected dependency to contain H2 fallback version ${MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.H2]}")
+      try (MatrixSql ms = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+        assertTrue(ms.connectionInfo.dependency.contains(MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.H2]),
+            "Expected dependency to contain H2 fallback version ${MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.H2]}")
+      }
     } finally {
       MatrixSqlFactory.artifactLookup = original
     }
@@ -685,9 +686,10 @@ class MatrixSqlTest {
           throw new IOException("Simulated network failure")
         }
       }
-      MatrixSql ms = MatrixSqlFactory.createDerby("memory:fallback_derby_${System.nanoTime()}")
-      assertTrue(ms.connectionInfo.dependency.contains(MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.DERBY]),
-          "Expected dependency to contain Derby fallback version ${MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.DERBY]}")
+      try (MatrixSql ms = MatrixSqlFactory.createDerby("memory:fallback_derby_${System.nanoTime()}")) {
+        assertTrue(ms.connectionInfo.dependency.contains(MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.DERBY]),
+            "Expected dependency to contain Derby fallback version ${MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.DERBY]}")
+      }
     } finally {
       MatrixSqlFactory.artifactLookup = original
     }
@@ -704,9 +706,10 @@ class MatrixSqlTest {
           throw new IOException("Simulated network failure")
         }
       }
-      MatrixSql ms = MatrixSqlFactory.create(url, 'sa', '123')
-      assertTrue(ms.connectionInfo.dependency.contains(MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.H2]),
-          "Expected dependency to contain H2 fallback version ${MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.H2]}")
+      try (MatrixSql ms = MatrixSqlFactory.create(url, 'sa', '123')) {
+        assertTrue(ms.connectionInfo.dependency.contains(MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.H2]),
+            "Expected dependency to contain H2 fallback version ${MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.H2]}")
+      }
     } finally {
       MatrixSqlFactory.artifactLookup = original
     }

--- a/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
+++ b/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
@@ -14,6 +14,7 @@ import se.alipsa.matrix.core.Row
 import se.alipsa.matrix.datasets.Dataset
 import se.alipsa.groovy.datautil.sqltypes.SqlTypeMapper
 import se.alipsa.matrix.sql.MatrixDbUtil
+import se.alipsa.mavenutils.ArtifactLookup
 import se.alipsa.matrix.sql.MatrixSql
 import se.alipsa.matrix.sql.MatrixSqlFactory
 import se.alipsa.matrix.sql.SqlIdentifier
@@ -652,6 +653,43 @@ class MatrixSqlTest {
       assertNotNull(matrixSql.getConnection(), 'Connection should be non-null after connect()')
       assertTrue(matrixSql.getMatrixDbUtil() instanceof MatrixDbUtil)
       assertTrue(matrixSql.getSqlTypeMapper() instanceof SqlTypeMapper)
+    }
+  }
+
+  @Test
+  void testCreateH2FallsBackOnNetworkFailure() {
+    String url = h2MemUrl('fallback_h2_testdb')
+    ArtifactLookup original = MatrixSqlFactory.artifactLookup
+    try {
+      MatrixSqlFactory.artifactLookup = new ArtifactLookup() {
+        @Override
+        String fetchLatestVersion(String g, String a) throws Exception {
+          throw new IOException("Simulated network failure")
+        }
+      }
+      MatrixSql ms = MatrixSqlFactory.createH2(url, 'sa', '123')
+      assertTrue(ms.connectionInfo.dependency.contains(MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.H2]),
+          "Expected dependency to contain H2 fallback version ${MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.H2]}")
+    } finally {
+      MatrixSqlFactory.artifactLookup = original
+    }
+  }
+
+  @Test
+  void testCreateDerbyFallsBackOnNetworkFailure() {
+    ArtifactLookup original = MatrixSqlFactory.artifactLookup
+    try {
+      MatrixSqlFactory.artifactLookup = new ArtifactLookup() {
+        @Override
+        String fetchLatestVersion(String g, String a) throws Exception {
+          throw new IOException("Simulated network failure")
+        }
+      }
+      MatrixSql ms = MatrixSqlFactory.createDerby("memory:fallback_derby_${System.nanoTime()}")
+      assertTrue(ms.connectionInfo.dependency.contains(MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.DERBY]),
+          "Expected dependency to contain Derby fallback version ${MatrixSqlFactory.FALLBACK_VERSIONS[DataBaseProvider.DERBY]}")
+    } finally {
+      MatrixSqlFactory.artifactLookup = original
     }
   }
 


### PR DESCRIPTION
## Summary

- Add `FALLBACK_VERSIONS` map on `MatrixSqlFactory` keyed by `DataBaseProvider`, replacing the hardcoded inline strings in `createH2` and `createDerby`
- Extend the generic `create(ConnectionInfo, String)` with the same fallback pattern: on network failure, resolves the provider via `DataBaseProvider.fromUrl()`, uses the fallback version if one exists, and throws with dependency coordinates plus "no fallback version is configured for this provider" if not
- Add 4 tests covering H2 typed fallback, Derby typed fallback, H2 generic fallback, and PostgreSQL no-fallback error message — all using an anonymous `ArtifactLookup` subclass to simulate network failure without hitting Maven Central

## Test Plan

- [x] `./gradlew :matrix-sql:test --tests "MatrixSqlTest.testCreateH2FallsBackOnNetworkFailure"` — passes
- [x] `./gradlew :matrix-sql:test --tests "MatrixSqlTest.testCreateDerbyFallsBackOnNetworkFailure"` — passes
- [x] `./gradlew :matrix-sql:test --tests "MatrixSqlTest.testGenericCreateFallsBackOnNetworkFailure"` — passes
- [x] `./gradlew :matrix-sql:test --tests "MatrixSqlTest.testGenericCreateThrowsWithCoordinatesWhenNoFallback"` — passes
- [x] `./gradlew :matrix-sql:test --rerun-tasks` — 63/63 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)