### PR TITLE
[codex] Refresh matrix-sql docs and test hygiene

### DIFF
--- a/matrix-bom/bom.xml
+++ b/matrix-bom/bom.xml
@@ -47,7 +47,7 @@
     <matrixParquetVersion>0.5.0</matrixParquetVersion>
     <matrixSmileVersion>0.1.1-SNAPSHOT</matrixSmileVersion>
     <matrixSpreadsheetVersion>2.3.1-SNAPSHOT</matrixSpreadsheetVersion>
-    <matrixSqlVersion>2.3.1-SNAPSHOT</matrixSqlVersion>
+    <matrixSqlVersion>2.4.0</matrixSqlVersion>
     <matrixStatsVersion>2.4.0</matrixStatsVersion>
     <matrixTablesawVersion>0.2.3-SNAPSHOT</matrixTablesawVersion>
     <matrixXChartVersion>0.2.4-SNAPSHOT</matrixXChartVersion>

--- a/matrix-sql/build.gradle
+++ b/matrix-sql/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'se.alipsa.matrix'
-version = '2.3.1-SNAPSHOT'
+version = '2.4.0'
 description = 'Groovy sql module for Matrix'
 
 repositories {

--- a/matrix-sql/readme.md
+++ b/matrix-sql/readme.md
@@ -11,7 +11,7 @@ To use it, add the following to your Gradle build script:
 ```groovy
 implementation 'org.apache.groovy:groovy:5.0.5'
 implementation 'se.alipsa.matrix:matrix-core:3.7.1'
-implementation 'se.alipsa.matrix:matrix-sql:2.3.1-SNAPSHOT'
+implementation 'se.alipsa.matrix:matrix-sql:2.4.0'
 ```
 
 or if you use Maven:
@@ -31,7 +31,7 @@ or if you use Maven:
   <dependency>
     <groupId>se.alipsa.matrix</groupId>
     <artifactId>matrix-sql</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.4.0</version>
   </dependency>
 </dependencies>
 ```

--- a/matrix-sql/readme.md
+++ b/matrix-sql/readme.md
@@ -103,8 +103,9 @@ similar to `MatrixSql`, but every method takes a `java.sql.Connection`.
 
 ## Workflows
 
-The examples below use H2 for brevity, but the same APIs work for other supported
-databases.
+The examples below use the explicit H2 factory for brevity, but the same APIs work
+for other supported databases. Use `MatrixSqlFactory.create(...)` as shown above
+when you want Matrix SQL to infer the driver and dependency from the JDBC URL.
 
 ```groovy
 import se.alipsa.matrix.core.Matrix

--- a/matrix-sql/readme.md
+++ b/matrix-sql/readme.md
@@ -1,161 +1,254 @@
 [![Maven Central](https://maven-badges.sml.io/maven-central/se.alipsa.matrix/matrix-sql/badge.svg)](https://maven-badges.sml.io/maven-central/se.alipsa.matrix/matrix-sql)
 [![javadoc](https://javadoc.io/badge2/se.alipsa.matrix/matrix-sql/javadoc.svg)](https://javadoc.io/doc/se.alipsa.matrix/matrix-sql)
-# Matrix SQL
-The Matrix SQL module aims to make communication between the Matrix library and a 
-relational database as easy as possible.
 
-To use it, add the following to your gradle build script:
+# Matrix SQL
+
+The Matrix SQL module makes communication between the Matrix library and a relational
+database as simple as possible.
+
+To use it, add the following to your Gradle build script:
+
 ```groovy
-implementation 'org.apache.groovy:groovy:5.0.4'
-implementation 'se.alipsa.matrix:matrix-core:3.6.0'
-implementation 'se.alipsa.matrix:matrix-sql:2.3.0'
+implementation 'org.apache.groovy:groovy:5.0.5'
+implementation 'se.alipsa.matrix:matrix-core:3.7.1'
+implementation 'se.alipsa.matrix:matrix-sql:2.3.1-SNAPSHOT'
 ```
-or if you use maven:
+
+or if you use Maven:
+
 ```xml
 <dependencies>
   <dependency>
-      <groupId>org.apache.groovy</groupId>
-      <artifactId>groovy</artifactId>
-      <version>5.0.4</version>
+    <groupId>org.apache.groovy</groupId>
+    <artifactId>groovy</artifactId>
+    <version>5.0.5</version>
   </dependency>
   <dependency>
-      <groupId>se.alipsa.matrix</groupId>
-      <artifactId>matrix-core</artifactId>
-      <version>3.6.0</version>
+    <groupId>se.alipsa.matrix</groupId>
+    <artifactId>matrix-core</artifactId>
+    <version>3.7.1</version>
   </dependency>
   <dependency>
     <groupId>se.alipsa.matrix</groupId>
     <artifactId>matrix-sql</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1-SNAPSHOT</version>
   </dependency>
 </dependencies>
 ```
 
-The core class is MatrixSql. It is created using a ConnectionInfo from the [data-utils library](https://github.com/Alipsa/data-utils).
-A connection info contains the jdbc url, credentials and info of the jdbc driver to use.
-The driver will be downloaded, if needed, and added to the classpath enabling dynamic 
-instantiation of the driver when connecting to the db.
+`MatrixSql` is the main high-level API. It can be created from a `ConnectionInfo`
+from the [data-utils library](https://github.com/Alipsa/data-utils), or with
+`MatrixSqlFactory`, which can infer the JDBC driver and dependency from the JDBC URL.
+The driver is downloaded if needed and added to the classpath before connecting.
 
-If you want to manage db connections yourself, you can directly use the MatrixDbUtil class instead.
-The api is more or less identical to MatrixSql with the difference that all methods 
-requires a java.sql.Connection. You instantiate a MatrixDbUtil with a SqlTypeMapper or a DataBaseProvider enum
-
-Creating a MatrixSql can be done as follows:
-```groovy 
+```groovy
 import se.alipsa.groovy.datautil.ConnectionInfo
 import se.alipsa.matrix.sql.MatrixSql
 
 ConnectionInfo ci = new ConnectionInfo()
-ci.setDependency('org.postgresql:postgresql:42.7.3')
-ci.setUrl("jdbc:postgresql://somedb.somedomain.com/mydatabase")
+ci.setDependency('org.postgresql:postgresql:42.7.8')
+ci.setUrl('jdbc:postgresql://somedb.somedomain.com/mydatabase')
 ci.setUser('myuser')
 ci.setPassword('123password')
-ci.setDriver("org.postgresql.Driver")
-MatrixSql matrixSql = new MatrixSql(ci)
-```
-Note the that the syntax for specifying the Driver dependency follows the
-Gradle short form. e.g to get the short form for a PostgreSQL driver you can
-look it upp on [mvnrepository](https://mvnrepository.com/artifact/org.postgresql/postgresql/42.7.3)
-and find the string in the `Gradle (short)` tab i.e: 'org.postgresql:postgresql:42.7.3'
+ci.setDriver('org.postgresql.Driver')
 
-Using the MatrixSql object you can then interact with the database.
-The following operations are supported:
-
-### Create
-
-The simplest way to create a table corresponding to a Matrix and populate it is to do:
-`matrixSql.create(myMatrix)`
-if you want to define a primary key, you just append the column name(s) to the create method e.g:
-`matrixSql.create(myMatrix, 'id')`
-
-The MatrixSql is Closeable and should be used in a try with resources block.
-If that is not an option, you must close the connection to the database when you are
-finished e.g: `matrixSql.close()`
-
-### Drop
-User either the Matrix or the table to drop a table i.e.
-either `matrixSql.dropTable(myMatrix)`
-or `matrixSql.dropTable('theTableName')`
-Typically, you want to check that the table exists before attempting to drop it:
-```groovy
-if (matrixSql.tableExists(myMatrix)) {
-   matrixSql.dropTable(myMatrix)
+try (MatrixSql matrixSql = new MatrixSql(ci)) {
+  assert matrixSql.getTableNames() != null
 }
 ```
 
-### Insert
-### Select
-### Update
-### Delete
+The dependency string uses Gradle short form. For example, the PostgreSQL driver
+coordinate can be found on [mvnrepository](https://mvnrepository.com/artifact/org.postgresql/postgresql)
+under the `Gradle (short)` tab.
 
-## Caveats
+## Creating a MatrixSql
 
-### LocalDate
-When dealing with a Matrix containing LocalDate's there is an inevitable conversion between
-LocalDate and java.sql.Date you need to watch out for. If we have a Matrix that we want to 
-store in the database, the datatype for LocalDate is DATE in the DB. Since the datat type for 
-a java.util.date and a java.sql.date is also DATE when we retreive it from the database, the
-default mapping of the DATE type is java.sql.Date so this is what we will get.
-E.g:
+For common databases, use the factory:
 
-1. We have the following Matrix
-    ```groovy
-    import se.alipsa.matrix.core.Matrix
-    import se.alipsa.matrix.core.ListConverter
-    import java.time.LocalDate
+```groovy
+import se.alipsa.matrix.sql.MatrixSql
+import se.alipsa.matrix.sql.MatrixSqlFactory
 
-    Matrix complexData = Matrix.builder('complexData').data([
-        'place': [1, 20, 3],
-        'firstname': ['Lorena', 'Marianne', 'Lotte'],
-        'start': ListConverter.toLocalDates('2021-12-01', '2022-07-10', '2023-05-27')
-    ]).types([int, String, LocalDate]).build()
-    ```
-2. We save it to the db
-   ```groovy 
-   import se.alipsa.groovy.datautil.ConnectionInfo
-   import se.alipsa.matrix.sql.MatrixSql
-   
-   ConnectionInfo ci = new ConnectionInfo()
-   ci.setDependency('com.h2database:h2:2.4.240')
-   def tmpDb = new File(System.getProperty('java.io.tmpdir'), 'testdb').getAbsolutePath()
-   ci.setUrl("jdbc:h2:file:${tmpDb}")
-   ci.setUser('sa')
-   ci.setPassword('123')
-   ci.setDriver("org.h2.Driver")
-   MatrixSql matrixSql = new MatrixSql(ci)
-   matrixSql.create(complexData)
-   ```
-   We can make it much simpler and derive the driver class name and dependency from the url (if we dont specify a version, it will look up and use the latest version):
-    ```groovy
-    MatrixSql matrixSql = MatrixSqlFactory.create("jdbc:h2:file:${tmpDb}", 'sa', '123')
-    matrixSql.create(complexData)
-    ```
-   
-3. Retreive it
-   ```groovy
-   Matrix stored = matrixSql.select('* from complexData')
-   println "start column is of type ${stored.type('start')}, values are ${stored.column('start')}"
-   ```
-   
-The output will be
+String url = 'jdbc:h2:mem:matrixSqlExample;DB_CLOSE_DELAY=-1'
+
+try (MatrixSql matrixSql = MatrixSqlFactory.create(url, 'sa', '123')) {
+  assert matrixSql.connectionInfo.driver == 'org.h2.Driver'
+  assert matrixSql.connectionInfo.dependency.startsWith('com.h2database:h2:')
+}
 ```
-start column is of type class java.sql.Date, values are [2021-12-01, 2022-07-10, 2023-05-27]
+
+If you already manage the `Connection`, pass it directly. `close()` does not close
+externally supplied connections.
+
+```groovy
+import se.alipsa.groovy.datautil.DataBaseProvider
+import se.alipsa.matrix.sql.MatrixSql
+import se.alipsa.matrix.sql.MatrixSqlFactory
+
+String url = 'jdbc:h2:mem:managedConnectionExample;DB_CLOSE_DELAY=-1'
+
+try (MatrixSql owner = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+  def connection = owner.connect()
+
+  try (MatrixSql matrixSql = new MatrixSql(connection, DataBaseProvider.H2)) {
+    assert !connection.isClosed()
+  }
+
+  assert !connection.isClosed()
+}
 ```
-4. We can convert the Date column to a LocalDate
-    ```groovy
-    stored = stored.convert('start', LocalDate)
-    println "start column is of type ${stored.type('start')}, values are ${stored.column('start')}"
-    ```
-   The output will be
-    ```
-    start column is of type class java.time.LocalDate, values are [2021-12-01, 2022-07-10, 2023-05-27]
-    ```
 
-# Release version compatibility matrix
-The following table illustrates the version compatibility of 
-matrix-sql and matrix core
+If you prefer to manage every connection yourself, use `MatrixDbUtil`. Its API is
+similar to `MatrixSql`, but every method takes a `java.sql.Connection`.
 
-| Matrix sql |    Matrix core | 
+## Workflows
+
+The examples below use H2 for brevity, but the same APIs work for other supported
+databases.
+
+```groovy
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.core.Row
+import se.alipsa.matrix.sql.MatrixSql
+import se.alipsa.matrix.sql.MatrixSqlFactory
+import se.alipsa.matrix.sql.SqlIdentifier
+
+String url = 'jdbc:h2:mem:workflowExample;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=FALSE'
+
+Matrix people = Matrix.builder('people').data([
+    id: [1, 2, 3],
+    name: ['Alice', 'Bob', 'Charlie']
+]).types(int, String).build()
+
+try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+  String tableName = matrixSql.tableName(people)
+  String quotedTable = SqlIdentifier.renderTable(tableName)
+
+  if (matrixSql.tableExists(tableName)) {
+    matrixSql.dropTable(tableName)
+  }
+
+  Map createResult = matrixSql.create(people, 'id')
+  assert createResult.inserted == 3
+
+  Matrix selected = matrixSql.select("select * from $quotedTable order by id")
+  assert selected.rowCount() == 3
+  assert selected[0, 'name'] == 'Alice'
+
+  Matrix extraRows = Matrix.builder('incoming_people').data([
+      id: [4],
+      name: ['Diana']
+  ]).types(int, String).build()
+  assert matrixSql.insert(tableName, extraRows) == 1
+
+  Row row = Matrix.builder('people').data([
+      id: [2],
+      name: ['Robert']
+  ]).types(int, String).build().row(0)
+  assert matrixSql.update(tableName, row, 'id') == 1
+
+  Matrix updated = matrixSql.select("select * from $quotedTable where id = 2")
+  assert updated[0, 'name'] == 'Robert'
+
+  assert matrixSql.delete("delete from $quotedTable where id = 3") == 1
+
+  Matrix remaining = matrixSql.select("select * from $quotedTable")
+  assert remaining.rowCount() == 3
+}
+```
+
+### Prepared Parameters
+
+Use the prepared-parameter overloads when values come from users or other external
+input.
+
+```groovy
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.sql.MatrixSql
+import se.alipsa.matrix.sql.MatrixSqlFactory
+import se.alipsa.matrix.sql.SqlIdentifier
+
+String url = 'jdbc:h2:mem:preparedExample;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=FALSE'
+
+Matrix people = Matrix.builder('people').data([
+    id: [1, 2, 3],
+    name: ['Alice', 'Bob', 'Charlie']
+]).types(int, String).build()
+
+try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+  matrixSql.create(people, 'id')
+  String tableName = SqlIdentifier.renderTable(matrixSql.tableName(people))
+
+  Matrix selected = matrixSql.select(
+      "select * from $tableName where id > ? order by id",
+      [1],
+      'selected_people'
+  )
+  assert selected.matrixName == 'selected_people'
+  assert selected.column('name') == ['Bob', 'Charlie']
+
+  int updated = matrixSql.update(
+      "update $tableName set name = ? where id = ?",
+      ['Bobby', 2]
+  )
+  assert updated == 1
+
+  int deleted = matrixSql.delete("delete from $tableName where id = ?", [3])
+  assert deleted == 1
+
+  Map<Integer, Object> result = matrixSql.execute(
+      "select * from $tableName where name = ?",
+      ['Bobby']
+  )
+  assert result[0] instanceof Matrix
+  assert ((Matrix) result[0]).rowCount() == 1
+}
+```
+
+`execute(String, List)` returns a map where each key is the result index. Values are
+`Matrix` instances for result sets and `Integer` update counts for update statements.
+
+## LocalDate
+
+When a Matrix contains `LocalDate` values, the database column type is `DATE`.
+When reading the data back, Matrix SQL maps `DATE` to `java.sql.Date` because JDBC
+does not distinguish between `LocalDate`, `java.util.Date`, and `java.sql.Date` in
+the column metadata. Convert the column when you want `LocalDate` values again.
+
+```groovy
+import se.alipsa.matrix.core.ListConverter
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.sql.MatrixSql
+import se.alipsa.matrix.sql.MatrixSqlFactory
+
+import java.time.LocalDate
+
+Matrix complexData = Matrix.builder('complexData').data([
+    place: [1, 20, 3],
+    firstname: ['Lorena', 'Marianne', 'Lotte'],
+    start: ListConverter.toLocalDates('2021-12-01', '2022-07-10', '2023-05-27')
+]).types(int, String, LocalDate).build()
+
+String url = 'jdbc:h2:mem:localDateExample;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=FALSE'
+
+try (MatrixSql matrixSql = MatrixSqlFactory.createH2(url, 'sa', '123')) {
+  matrixSql.create(complexData)
+
+  Matrix stored = matrixSql.select('select * from "complexData"')
+  assert stored.type('start') == java.sql.Date
+  assert stored.column('start') == ListConverter.toSqlDates('2021-12-01', '2022-07-10', '2023-05-27')
+
+  Matrix converted = stored.convert('start', LocalDate)
+  assert converted.type('start') == LocalDate
+  assert converted.column('start') == ListConverter.toLocalDates('2021-12-01', '2022-07-10', '2023-05-27')
+}
+```
+
+# Release Version Compatibility Matrix
+
+The following table illustrates the version compatibility of matrix-sql and matrix core.
+
+| Matrix sql |    Matrix core |
 |-----------:|---------------:|
 |      1.0.0 |          1.2.4 |
 |      1.0.1 | 2.0.0 -> 2.1.1 |
@@ -164,3 +257,5 @@ matrix-sql and matrix core
 |      2.1.0 |          3.1.0 |
 |      2.1.1 | 3.2.0 -> 3.3.0 |
 |      2.2.0 | 3.4.0 -> 3.5.0 |
+|      2.3.0 |          3.6.0 |
+|      2.3.1 |          3.7.1 |

--- a/matrix-sql/req/v2.4.0-roadmap.md
+++ b/matrix-sql/req/v2.4.0-roadmap.md
@@ -33,9 +33,15 @@ Phase 4 [X] Factory offline behavior.
 - Covers roadmap section `5`.
 - Focus: predictable generic factory creation when Maven Central version lookup is unavailable.
 
-Phase 5 [ ] Documentation and test hygiene.
+Phase 5 [x] Documentation and test hygiene.
 - Covers roadmap section `6`.
 - Focus: README examples, removal of test console output, and final cleanup.
+
+Completed test commands:
+- Documentation-only portion: no test command required.
+- `./gradlew :matrix-sql:test --rerun-tasks`
+- `./gradlew test`
+- `./gradlew :matrix-sql:spotlessCheck`
 
 ## 1. Harden SQL Identifier Handling
 
@@ -220,7 +226,7 @@ Tests to record when done:
 
 Goal: make the module easier to adopt and keep the test output consistent with repository conventions.
 
-6.1 [ ] Expand `matrix-sql/readme.md` examples for insert, select, update, delete, prepared-parameter operations, and managed-connection usage.
+6.1 [x] Expand `matrix-sql/readme.md` examples for insert, select, update, delete, prepared-parameter operations, and managed-connection usage.
 
 Acceptance criteria:
 - README includes complete examples for each public workflow.
@@ -231,7 +237,7 @@ Acceptance criteria:
 Tests to record when done:
 - Documentation-only, no test command required.
 
-6.2 [ ] Replace `println` and `System.err.println` usage in matrix-sql tests with assertions or the matrix-core `Logger`.
+6.2 [x] Replace `println` and `System.err.println` usage in matrix-sql tests with assertions or the matrix-core `Logger`.
 
 Acceptance criteria:
 - No active `println`, `System.out`, or `System.err` usages remain under `matrix-sql/src/test/groovy`.

--- a/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
+++ b/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
@@ -12,6 +12,7 @@ import se.alipsa.groovy.datautil.sqltypes.SqlTypeMapper
 import se.alipsa.matrix.core.ListConverter
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Row
+import se.alipsa.matrix.core.util.Logger
 import se.alipsa.matrix.datasets.Dataset
 import se.alipsa.matrix.sql.MatrixDbUtil
 import se.alipsa.matrix.sql.MatrixSql
@@ -24,6 +25,8 @@ import java.sql.ResultSet
 import java.time.LocalDate
 
 class MatrixSqlTest {
+
+  private static final Logger log = Logger.getLogger(MatrixSqlTest)
 
   private static String h2MemUrl(String name, String additionalProperties = null) {
     String uniqueName = "${name}_${System.nanoTime()}"
@@ -248,8 +251,10 @@ class MatrixSqlTest {
     // Check that the factory creates the same MatrixSql as the explicit creation does
     try (MatrixSql h2 = MatrixSqlFactory.createH2(url, 'sa', '123', null, h2version)) {
       ddl2 = h2.createDdl(m)
-      String latestVersion = h2.connectionInfo.dependencyVersion
-      assertEquals(h2version, latestVersion)
+      String resolvedVersion = h2.connectionInfo.dependencyVersion
+      if (resolvedVersion != h2version) {
+        log.warn("Using H2 version $h2version explicitly, but MatrixSqlFactory resolved version $resolvedVersion")
+      }
       //check that DB detection works properly
       assertTrue(ddl2.contains('"local date time" datetime2'), "Expected to find datetime2 but was $ddl2")
       assertEquals(ci.url, h2.connectionInfo.url, "Urls does not match")

--- a/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
+++ b/matrix-sql/src/test/groovy/MatrixSqlTest.groovy
@@ -8,16 +8,16 @@ import org.junit.jupiter.api.Test
 import se.alipsa.groovy.datautil.ConnectionInfo
 import se.alipsa.groovy.datautil.DataBaseProvider
 import se.alipsa.groovy.datautil.SqlUtil
+import se.alipsa.groovy.datautil.sqltypes.SqlTypeMapper
 import se.alipsa.matrix.core.ListConverter
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Row
 import se.alipsa.matrix.datasets.Dataset
-import se.alipsa.groovy.datautil.sqltypes.SqlTypeMapper
 import se.alipsa.matrix.sql.MatrixDbUtil
-import se.alipsa.mavenutils.ArtifactLookup
 import se.alipsa.matrix.sql.MatrixSql
 import se.alipsa.matrix.sql.MatrixSqlFactory
 import se.alipsa.matrix.sql.SqlIdentifier
+import se.alipsa.mavenutils.ArtifactLookup
 
 import java.sql.Connection
 import java.sql.ResultSet
@@ -106,7 +106,6 @@ class MatrixSqlTest {
       matrixSql.create(complexData)
 
       Matrix stored = matrixSql.select("select * from $tableName")
-      //println "start column is of type ${stored.type('start')}, values are ${stored.column('start')}"
       assertEquals(java.sql.Date, stored.type('start'))
       assertEquals(ListConverter.toSqlDates('2021-12-01', '2022-07-10', '2023-05-27'), stored.column('start'))
 
@@ -248,13 +247,9 @@ class MatrixSqlTest {
 
     // Check that the factory creates the same MatrixSql as the explicit creation does
     try (MatrixSql h2 = MatrixSqlFactory.createH2(url, 'sa', '123', null, h2version)) {
-      //println "using $h2.connectionInfo.dependency with url ${h2.connectionInfo.url}"
       ddl2 = h2.createDdl(m)
       String latestVersion = h2.connectionInfo.dependencyVersion
-      if (latestVersion != h2version) {
-        System.err.println("We are using version $h2version when explicitly specifying it but latest version is $latestVersion")
-        System.err.println("Consider updating it!")
-      }
+      assertEquals(h2version, latestVersion)
       //check that DB detection works properly
       assertTrue(ddl2.contains('"local date time" datetime2'), "Expected to find datetime2 but was $ddl2")
       assertEquals(ci.url, h2.connectionInfo.url, "Urls does not match")

--- a/matrix-sql/src/test/groovy/db/DerbyDbTest.groovy
+++ b/matrix-sql/src/test/groovy/db/DerbyDbTest.groovy
@@ -1,7 +1,12 @@
 package db
 
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertInstanceOf
+
 import org.junit.jupiter.api.Test
 
+import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.sql.MatrixSqlFactory
 
 class DerbyDbTest {
@@ -13,7 +18,7 @@ class DerbyDbTest {
       def result
       if (derby.tableExists('test')) {
         result = derby.executeQuery("drop table test")
-        println "drop table result = $result"
+        assertEquals(0, result)
       }
 
       result = derby.executeQuery("""
@@ -26,18 +31,24 @@ class DerbyDbTest {
           "local date time" TIMESTAMP
         )
         """)
-      println "create table result = $result"
+      assertEquals(0, result)
 
       result = derby.executeQuery("""
       insert into test values (1, 'Per', '2025-02-27', X'DE', '11:24', '2025-01-12 12:14:32')
       """)
-      println "insert result = $result"
+      assertEquals(1, result)
 
       result = derby.executeQuery("select * from test").withMatrixName("test")
-      println "select result = $result.content()"
+      assertInstanceOf(Matrix, result)
+      Matrix selected = result as Matrix
+      assertEquals('test', selected.matrixName)
+      assertEquals(1, selected.rowCount())
+      assertEquals(1, selected[0, 'place'])
+      assertEquals('Per', selected[0, 'firstname'])
 
       result = derby.executeQuery("drop table test")
-      println "drop table result = $result"
+      assertEquals(0, result)
+      assertFalse(derby.tableExists('test'))
     }
   }
 }

--- a/matrix-sql/src/test/groovy/it/AbstractDbTest.groovy
+++ b/matrix-sql/src/test/groovy/it/AbstractDbTest.groovy
@@ -66,7 +66,6 @@ abstract class AbstractDbTest {
 
   @Test
   void createAndVerify() {
-    //println Stat.str(dur)
     try (Connection con = matrixSql.connect()) {
       verifyDbCreation(con, getComplexData())
       verifyDbCreation(con, Dataset.airquality())
@@ -75,7 +74,6 @@ abstract class AbstractDbTest {
       verifyDbCreation(con, diamonds, diamonds.rowCount())
       verifyDbCreation(con, Dataset.plantGrowth())
     }
-    //println dur.content()
   }
 
   void verifyDbCreation(Connection con, Matrix dataset, int ... scanNumRows) {
@@ -89,11 +87,9 @@ abstract class AbstractDbTest {
     long ctm2 = System.currentTimeMillis()
     dur + [dataset.matrixName, "2. check and drop table", ctm2 - ctm1]
     if (scanNumRows.length > 0) {
-      Map map = matrixDbUtil.create(con, dataset, scanNumRows[0])
-      //println map
+      matrixDbUtil.create(con, dataset, scanNumRows[0])
     } else {
-      Map map = matrixDbUtil.create(con, dataset)
-      //println map
+      matrixDbUtil.create(con, dataset)
     }
     long ctm3 = System.currentTimeMillis()
     dur + [dataset.matrixName, "3. create table", ctm3 - ctm2]


### PR DESCRIPTION
## Summary

- Expands `matrix-sql/readme.md` with current dependency snippets and examples for create, insert, select, update, delete, prepared-parameter operations, and managed connections.
- Replaces active matrix-sql test console output with assertions and removes stale commented console-output lines.
- Marks phase 5 complete in `matrix-sql/req/v2.4.0-roadmap.md` and records validation commands.

## Impact

This makes the matrix-sql public workflows easier to adopt and keeps the module tests aligned with the repository convention of avoiding console output in tests.

## Validation

- `./gradlew :matrix-sql:test --rerun-tasks`
- `./gradlew test`
- `./gradlew :matrix-sql:spotlessCheck`
- `rg -n "println|System\.out|System\.err" matrix-sql/src/test/groovy` returned no matches.