### PR TITLE
Fix review findings for spreadsheet v2.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,8 @@ If a Groovy test needs GString-to-String coercion for JUnit assertions to compil
 ## Commit & Pull Request Guidelines
 Commit messages in this repo are short, imperative summaries (e.g., “Fix …”, “Update …”, “Add …”), optionally mentioning the module. For pull requests, include a concise summary, list the modules touched, and record the tests you ran (with commands). Link relevant issues and add screenshots for visual/chart output changes.
 
+**CRITICAL:** Always confirm with the user before committing and pushing to the main branch. When committing review fixes or follow-up changes, create a separate branch (e.g., `feature-followup`) rather than pushing directly to `main`.
+
 ## Environment & Constraints
 JDK 21 is required. Some modules (parquet/avro, charts, smile) enforce a maximum JDK 21 due to upstream dependencies, so keep toolchains aligned with that constraint.
 

--- a/matrix-spreadsheet/README.md
+++ b/matrix-spreadsheet/README.md
@@ -42,7 +42,7 @@ import se.alipsa.matrix.core.Matrix
 Matrix table = SpreadsheetImporter.importSpreadsheet(file: "Book1.xlsx", endRow: 11, endCol: 4)
 println(table.head(10))
 ```
-The SpreadSheetImporter.importSpreadSheetSheet takes the following parameters:
+The SpreadsheetImporter.importSpreadsheet method takes the following parameters:
 - _file_ the filePath or the file object pointing to the Excel file
 - _sheetName_ the name of the sheet to import, default is 'Sheet1'
 - _startRow_ the starting row for the import (as you would see the row number in Excel), defaults to 1
@@ -51,7 +51,7 @@ The SpreadSheetImporter.importSpreadSheetSheet takes the following parameters:
 - _endCol_ the end column name (K, L etc) or column number (11, 12 etc.)
 - _firstRowAsColNames_ whether the first row should be used for the names of each column, if false the column names will be v1, v2 etc. Defaults to true
 
-Note: there are seveal overloaded versions of the importSpreadsheet method e.g taking a sheet index instead of a sheet name,
+Note: there are several overloaded versions of the importSpreadsheet method e.g taking a sheet index instead of a sheet name,
 using column index instead of column name etc.
 
 ## Using Matrix.read() / matrix.write()
@@ -172,7 +172,7 @@ try (SpreadsheetReader reader = SpreadsheetReader.Factory.create(spreadsheet)) {
 }
 ```
 
-See [the tests](https://github.com/Alipsa/spreadsheet/tree/main/src/test/groovy/spreadsheet) for more usage examples!
+See [the tests](https://github.com/Alipsa/matrix/tree/main/matrix-spreadsheet/src/test/groovy/spreadsheet) for more usage examples!
 
 # Handling large files
 Matrix-spreadsheet uses FastExcel for .xlsx import/export and FastOds (streaming) for .ods import/reading/export by default to keep memory usage low. If you have Excel sheets with more than 150,000 rows you might still encounter out of memory errors; if increasing RAM is not an option, consider exporting the content to CSV and use matrix-csv to import the data instead. Note that the FastExcel backend only supports .xlsx (not legacy .xls). Appending/replacing sheets in existing .xlsx files is supported via SpreadsheetWriter/FExcelAppender, and appending/replacing sheets in existing .ods files is supported via SpreadsheetWriter/FOdsAppender.

--- a/matrix-spreadsheet/release.md
+++ b/matrix-spreadsheet/release.md
@@ -3,10 +3,6 @@
 ## v2.4.0, 2026-05-05
 **Refactoring, code quality, and usability improvements**
 
-### Breaking Changes
-- `Sheet.name` field type tightened from `Object` to `String`
-- `Importer` interface: `startColumn`/`endColumn` parameters renamed to `startCol`/`endCol` for consistency
-
 ### New Features
 - add whole-sheet convenience imports with auto-detected dimensions: `SpreadsheetImporter.importSpreadsheet(file, sheetNumber)` and `importSpreadsheet(file, sheetName)`
 - add `File`-accepting overloads to `SpreadsheetImporter` matching `SpreadsheetWriter`'s API shape
@@ -27,7 +23,7 @@
 - document why `FExcelExporter` cannot use `@CompileStatic` (fastexcel internal `GenericStyleSetter` access)
 
 ### Test Coverage
-- 124 tests passing (up from 105 in v2.3.0)
+- 134 tests passing (up from 105 in v2.3.0)
 
 ## v2.3.0, 2026-01-31
 **Major architectural refactoring with significant performance improvements**

--- a/matrix-spreadsheet/src/main/groovy/se/alipsa/matrix/spreadsheet/Importer.groovy
+++ b/matrix-spreadsheet/src/main/groovy/se/alipsa/matrix/spreadsheet/Importer.groovy
@@ -4,6 +4,16 @@ import se.alipsa.matrix.core.Matrix
 
 import java.text.NumberFormat
 
+/**
+ * Contract for spreadsheet importers.
+ *
+ * <p>Implementations handle a specific file format (e.g. {@link se.alipsa.matrix.spreadsheet.fastexcel.FExcelImporter}
+ * for .xlsx, {@link se.alipsa.matrix.spreadsheet.fastods.FOdsImporter} for .ods).
+ * Callers typically use the static facade {@link SpreadsheetImporter} instead of
+ * working with this interface directly.</p>
+ *
+ * @see SpreadsheetImporter
+ */
 interface Importer {
 
   Matrix importSpreadsheet(URL url, String sheetName,

--- a/matrix-spreadsheet/src/main/groovy/se/alipsa/matrix/spreadsheet/SpreadsheetReader.groovy
+++ b/matrix-spreadsheet/src/main/groovy/se/alipsa/matrix/spreadsheet/SpreadsheetReader.groovy
@@ -21,7 +21,7 @@ interface SpreadsheetReader extends Closeable {
       return new FExcelReader(file)
     }
 
-    static SpreadsheetReader create(String filePath) throws Exception {
+    static SpreadsheetReader create(String filePath) {
       if (filePath == null) {
         throw new IllegalArgumentException("filePath is null, cannot create SpreadsheetReader")
       }
@@ -34,16 +34,16 @@ interface SpreadsheetReader extends Closeable {
 
   }
 
-  int findRowNum(int sheetNumber, int colNumber, String content) throws Exception
-  int findRowNum(int sheetNumber, String colName, String content) throws Exception
-  int findRowNum(String sheetName, String colName, String content) throws Exception
-  int findRowNum(String sheetName, int colNumber, String content) throws Exception
-  int findColNum(int sheetNumber, int rowNumber, String content) throws Exception
-  int findColNum(String sheetName, int rowNumber, String content) throws Exception
+  int findRowNum(int sheetNumber, int colNumber, String content) throws IOException
+  int findRowNum(int sheetNumber, String colName, String content) throws IOException
+  int findRowNum(String sheetName, String colName, String content) throws IOException
+  int findRowNum(String sheetName, int colNumber, String content) throws IOException
+  int findColNum(int sheetNumber, int rowNumber, String content) throws IOException
+  int findColNum(String sheetName, int rowNumber, String content) throws IOException
   int findLastRow(int sheetNum)
   int findLastRow(String sheetName)
   int findLastCol(int sheetNum)
   int findLastCol(String sheetName)
-  List<String> getSheetNames() throws Exception
+  List<String> getSheetNames() throws IOException
 
 }

--- a/matrix-spreadsheet/src/main/groovy/se/alipsa/matrix/spreadsheet/SpreadsheetWriter.groovy
+++ b/matrix-spreadsheet/src/main/groovy/se/alipsa/matrix/spreadsheet/SpreadsheetWriter.groovy
@@ -208,7 +208,8 @@ class SpreadsheetWriter {
    * <ul>
    *   <li>{@code file} ({@link File}) — the target spreadsheet file (required)</li>
    *   <li>{@code data} ({@code List<Matrix>}) — the matrices to write, one per sheet (required)</li>
-   *   <li>{@code sheetNames} ({@code List<String>}) — names for each sheet (required)</li>
+   *   <li>{@code sheetNames} ({@code List<String>}) — names for each sheet (required unless sheetNamesAndPositions is provided)</li>
+   *   <li>{@code sheetNamesAndPositions} ({@code LinkedHashMap<String, String>}) — map of sheet name to start position, e.g. {@code ['Sheet1': 'B2']}</li>
    * </ul>
    *
    * @param params map of write parameters
@@ -217,6 +218,10 @@ class SpreadsheetWriter {
   static List<String> writeSheets(Map params) {
     def file = params.get("file") as File
     def data = (List<Matrix>) params.get("data")
+    def sheetNamesAndPositions = params.get("sheetNamesAndPositions") as LinkedHashMap<String, String>
+    if (sheetNamesAndPositions != null) {
+      return writeSheets(data, file, sheetNamesAndPositions)
+    }
     def sheetNames = params.get("sheetNames") as List<String>
     return writeSheets(data, file, sheetNames)
   }

--- a/matrix-spreadsheet/src/main/groovy/se/alipsa/matrix/spreadsheet/fastexcel/FExcelReader.groovy
+++ b/matrix-spreadsheet/src/main/groovy/se/alipsa/matrix/spreadsheet/fastexcel/FExcelReader.groovy
@@ -30,11 +30,11 @@ class FExcelReader implements SpreadsheetReader {
    * @return a List of the names of the sheets in the excel
    */
   @Override
-  List<String> getSheetNames() throws Exception {
+  List<String> getSheetNames() throws IOException {
     return getSheetNames(workbook)
   }
 
-  static List<String> getSheetNames(ReadableWorkbook workbook) throws Exception {
+  static List<String> getSheetNames(ReadableWorkbook workbook) throws IOException {
     workbook.sheets.collect { Sheet it -> it.name }
   }
 
@@ -44,7 +44,7 @@ class FExcelReader implements SpreadsheetReader {
    * @param colNumber the column number (1 indexed)
    * @param content the string to search for
    * @return the Row as seen in Excel (1 is first row)
-   * @throws Exception if something goes wrong
+   * @throws IOException if reading the workbook fails
    */
   @Override
   int findRowNum(int sheetNumber, int colNumber, String content) {
@@ -67,7 +67,7 @@ class FExcelReader implements SpreadsheetReader {
   }
 
   @Override
-  int findRowNum(int sheetNumber, String colName, String content) throws Exception {
+  int findRowNum(int sheetNumber, String colName, String content) throws IOException {
     Sheet sheet = workbook.getSheet(sheetNumber - 1)
         .orElseThrow(() -> new IllegalArgumentException("Failed to find sheet $sheetNumber"))
     return findRowNum(sheet, SpreadsheetUtil.asColumnNumber(colName), content)

--- a/matrix-spreadsheet/src/main/groovy/se/alipsa/matrix/spreadsheet/fastods/FOdsReader.groovy
+++ b/matrix-spreadsheet/src/main/groovy/se/alipsa/matrix/spreadsheet/fastods/FOdsReader.groovy
@@ -42,23 +42,23 @@ class FOdsReader implements SpreadsheetReader {
   }
 
   @Override
-  int findRowNum(int sheetNumber, int colNumber, String content) throws Exception {
+  int findRowNum(int sheetNumber, int colNumber, String content) throws IOException {
     Sheet sheet = readSheet(sheetNumber, 1, Integer.MAX_VALUE, colNumber, colNumber)
     return findRowNum(sheet, content)
   }
 
   @Override
-  int findRowNum(int sheetNumber, String colName, String content) throws Exception {
+  int findRowNum(int sheetNumber, String colName, String content) throws IOException {
     return findRowNum(sheetNumber, SpreadsheetUtil.asColumnNumber(colName), content)
   }
 
   @Override
-  int findRowNum(String sheetName, String colName, String content) throws Exception {
+  int findRowNum(String sheetName, String colName, String content) throws IOException {
     return findRowNum(sheetName, SpreadsheetUtil.asColumnNumber(colName), content)
   }
 
   @Override
-  int findRowNum(String sheetName, int colNumber, String content) throws Exception {
+  int findRowNum(String sheetName, int colNumber, String content) throws IOException {
     Sheet sheet = readSheet(sheetName, 1, Integer.MAX_VALUE, colNumber, colNumber)
     return findRowNum(sheet, content)
   }
@@ -78,13 +78,13 @@ class FOdsReader implements SpreadsheetReader {
   }
 
   @Override
-  int findColNum(int sheetNumber, int rowNumber, String content) throws Exception {
+  int findColNum(int sheetNumber, int rowNumber, String content) throws IOException {
     Sheet sheet = readSheet(sheetNumber, rowNumber, rowNumber, 1, Integer.MAX_VALUE)
     return findColNum(sheet, content)
   }
 
   @Override
-  int findColNum(String sheetName, int rowNumber, String content) throws Exception {
+  int findColNum(String sheetName, int rowNumber, String content) throws IOException {
     Sheet sheet = readSheet(sheetName, rowNumber, rowNumber, 1, Integer.MAX_VALUE)
     return findColNum(sheet, content)
   }
@@ -151,7 +151,7 @@ class FOdsReader implements SpreadsheetReader {
   }
 
   @Override
-  List<String> getSheetNames() throws Exception {
+  List<String> getSheetNames() throws IOException {
     if (sheetNamesCache == null) {
       sheetNamesCache = readSheetNames()
     }

--- a/matrix-spreadsheet/src/test/groovy/spreadsheet/SpreadsheetImporterTest.groovy
+++ b/matrix-spreadsheet/src/test/groovy/spreadsheet/SpreadsheetImporterTest.groovy
@@ -15,15 +15,14 @@ import se.alipsa.matrix.core.ValueConverter
 import se.alipsa.matrix.spreadsheet.Importer
 import se.alipsa.matrix.spreadsheet.SpreadsheetImporter
 import se.alipsa.matrix.spreadsheet.fastexcel.FExcelImporter
-
 import se.alipsa.matrix.spreadsheet.fastods.FastOdsException
 
 import java.io.File
 import java.io.InputStream
-import java.util.NoSuchElementException
 import java.math.RoundingMode
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import java.util.NoSuchElementException
 
 class SpreadsheetImporterTest {
 

--- a/matrix-spreadsheet/src/test/groovy/spreadsheet/SpreadsheetWriterTest.groovy
+++ b/matrix-spreadsheet/src/test/groovy/spreadsheet/SpreadsheetWriterTest.groovy
@@ -178,6 +178,29 @@ class SpreadsheetWriterTest {
   }
 
   @Test
+  void testWriteSheetsMapWithPositions() {
+    def file = File.createTempFile("matrix-writer-map-positions", ".xlsx")
+    if (file.exists()) {
+      file.delete()
+    }
+
+    List<String> sheetNames = SpreadsheetWriter.writeSheets([
+        file: file,
+        data: [table2, table3],
+        sheetNamesAndPositions: ['First': 'B2', 'Second': 'D4']
+    ])
+
+    assertNotNull(sheetNames)
+    assertEquals(['First', 'Second'], sheetNames)
+    assertTrue(file.exists())
+
+    try (def reader = SpreadsheetReader.Factory.create(file)) {
+      assertEquals(2, reader.sheetNames.size())
+      assertEquals(['First', 'Second'], reader.sheetNames)
+    }
+  }
+
+  @Test
   void testWriteOds() {
     File odsFile = File.createTempFile("matrix-writer-ods", ".ods")
     if (odsFile.exists()) {


### PR DESCRIPTION
## Summary
- Fix `writeSheets(Map)` to support `sheetNamesAndPositions` key, matching the README-documented API
- Fix README typos (`SpreadSheetImporter` → `SpreadsheetImporter`, `seveal` → `several`) and broken test link
- Add class-level GroovyDoc to `Importer` interface
- Narrow `throws Exception` to `throws IOException` across `SpreadsheetReader` SPI and implementations
- Remove false breaking changes from release notes (no actual breaking changes in v2.4.0)
- Update test count to 134
- Add AGENTS.md note to always confirm before pushing to main

## Modules touched
- `matrix-spreadsheet`
- root `AGENTS.md`

## Test plan
- [x] `./gradlew :matrix-spreadsheet:test --rerun-tasks` — 134 tests passing
- [x] `./gradlew :matrix-spreadsheet:spotlessCheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)