### PR TITLE
Handle Number-typed columns in DataframeConverter

### DIFF
--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/DataframeConverter.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/DataframeConverter.groovy
@@ -149,6 +149,13 @@ class DataframeConverter {
         case LocalDate -> columns.add(ValueVector.of(colName, columnData as LocalDate[]))
         case LocalTime -> columns.add(ValueVector.of(colName, columnData as LocalTime[]))
         case OffsetTime -> columns.add(ValueVector.of(colName, columnData as OffsetTime[]))
+        case Number -> {
+          if (hasNulls) {
+            columns.add(ValueVector.ofNullable(colName, columnData.collect { it != null ? it as Double : null } as Double[]))
+          } else {
+            columns.add(ValueVector.of(colName, toPrimitiveDoubleArray(columnData)))
+          }
+        }
         case Enum -> columns.add(ValueVector.nominal(colName, columnData as Enum[]))
         default -> {
           // Handle other types or default to StringVector
@@ -264,8 +271,7 @@ class DataframeConverter {
   }
 
   static Class getType(DataType dataType) {
-
-    return switch (dataType) {
+    switch (dataType) {
       case FloatType -> Float
       case DoubleType -> Double
       case IntType -> Integer

--- a/matrix-smile/src/test/groovy/test/alipsa/matrix/smile/DataframeConverterTest.groovy
+++ b/matrix-smile/src/test/groovy/test/alipsa/matrix/smile/DataframeConverterTest.groovy
@@ -729,4 +729,37 @@ class DataframeConverterTest {
     assertEquals('Name500', roundTrip[499, 'name'])
   }
 
+  @Test
+  void testMatrixToDataFrameWithNumberType() {
+    def matrix = Matrix.builder()
+        .data(
+            value: [1.5, 2.5, 3.5]
+        )
+        .types(Number)
+        .build()
+
+    DataFrame df = DataframeConverter.convert(matrix)
+
+    assertEquals(3, df.nrow())
+    assertEquals(1.5, df.get(0).get('value') as double, 0.001)
+    assertEquals(3.5, df.get(2).get('value') as double, 0.001)
+  }
+
+  @Test
+  void testMatrixToDataFrameWithNullableNumberType() {
+    def matrix = Matrix.builder()
+        .data(
+            value: [1.5, null, 3.5]
+        )
+        .types(Number)
+        .build()
+
+    DataFrame df = DataframeConverter.convert(matrix)
+
+    assertEquals(3, df.nrow())
+    assertEquals(1.5, df.get(0).get('value') as double, 0.001)
+    assertNull(df.get(1).get('value'))
+    assertEquals(3.5, df.get(2).get('value') as double, 0.001)
+  }
+
 }


### PR DESCRIPTION
Columns typed as Number were silently falling through to the default case and being converted to String[], corrupting numeric data. Add a Number case after all specific numeric types so it converts to double[].