### PR TITLE
Throw on null values instead of silently corrupting ML/stats results

### DIFF
--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/SmileUtil.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/SmileUtil.groovy
@@ -145,10 +145,12 @@ class SmileUtil {
 
   /**
    * Convert a Matrix to a 2D double array.
-   * Null values are converted to 0.0.
+   * Null values are not permitted; throws {@code IllegalArgumentException} directing
+   * the caller to {@code SmileFeatures.dropna()} or {@code fillna()}.
    *
    * @param matrix the Matrix to convert
    * @return 2D array of double values
+   * @throws IllegalArgumentException if any column contains a null value
    */
   @SuppressWarnings('NestedForLoop')
   static double[][] matrixToArray(Matrix matrix) {
@@ -160,7 +162,12 @@ class SmileUtil {
       List<?> column = matrix.column(j)
       for (int i = 0; i < rows; i++) {
         Object val = column.get(i)
-        result[i][j] = val != null ? val as double : 0.0d
+        if (val == null) {
+          throw new IllegalArgumentException(
+              "Column '${matrix.columnName(j)}' contains a null at row ${i}. " +
+              "Use SmileFeatures.dropna() or fillna() before calling ML algorithms.")
+        }
+        result[i][j] = val as double
       }
     }
 

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/ml/SmileClassifier.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/ml/SmileClassifier.groovy
@@ -45,6 +45,11 @@ class SmileClassifier {
     if (ntrees <= 0) {
       throw new IllegalArgumentException("ntrees must be positive: was $ntrees")
     }
+    if (SmileUtil.hasNulls(matrix.column(targetColumn))) {
+      throw new IllegalArgumentException(
+          "Target column '${targetColumn}' contains null labels. " +
+          "Use SmileFeatures.dropna() or fillna() before training.")
+    }
     // Get feature columns (all except target)
     String[] featureColumns = matrix.columnNames().findAll { it != targetColumn } as String[]
 
@@ -68,6 +73,11 @@ class SmileClassifier {
    * @return a trained SmileClassifier
    */
   static SmileClassifier decisionTree(Matrix matrix, String targetColumn) {
+    if (SmileUtil.hasNulls(matrix.column(targetColumn))) {
+      throw new IllegalArgumentException(
+          "Target column '${targetColumn}' contains null labels. " +
+          "Use SmileFeatures.dropna() or fillna() before training.")
+    }
     String[] featureColumns = matrix.columnNames().findAll { it != targetColumn } as String[]
 
     // Extract class labels and encode target as integers
@@ -303,7 +313,12 @@ class SmileClassifier {
     for (int i = 0; i < values.size(); i++) {
       String label = values.get(i)?.toString()
       Integer index = labelToIndex.get(label)
-      result[i] = index != null ? index.intValue() : 0
+      if (index == null) {
+        throw new IllegalArgumentException(
+            "Label '${label ?: '<null>'}' at row ${i} was not seen during training. " +
+            "Known labels: ${labelToIndex.keySet()}")
+      }
+      result[i] = index.intValue()
     }
 
     result
@@ -321,10 +336,16 @@ class SmileClassifier {
 
     List<?> originalValues = matrix.column(targetColumn)
     List<Integer> encodedValues = new ArrayList<>(originalValues.size())
-    for (Object val : originalValues) {
+    for (int i = 0; i < originalValues.size(); i++) {
+      Object val = originalValues.get(i)
       String label = val?.toString()
       Integer index = labelToIndex.get(label)
-      encodedValues.add(index != null ? index : 0)
+      if (index == null) {
+        throw new IllegalArgumentException(
+            "Label '${label ?: '<null>'}' at row ${i} was not seen during training. " +
+            "Known labels: ${labelToIndex.keySet()}")
+      }
+      encodedValues.add(index)
     }
 
     // Create new matrix with encoded target column

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/ml/SmileClassifier.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/ml/SmileClassifier.groovy
@@ -45,11 +45,7 @@ class SmileClassifier {
     if (ntrees <= 0) {
       throw new IllegalArgumentException("ntrees must be positive: was $ntrees")
     }
-    if (SmileUtil.hasNulls(matrix.column(targetColumn))) {
-      throw new IllegalArgumentException(
-          "Target column '${targetColumn}' contains null labels. " +
-          "Use SmileFeatures.dropna() or fillna() before training.")
-    }
+    requireNonNullLabels(matrix, targetColumn)
     // Get feature columns (all except target)
     String[] featureColumns = matrix.columnNames().findAll { it != targetColumn } as String[]
 
@@ -73,11 +69,7 @@ class SmileClassifier {
    * @return a trained SmileClassifier
    */
   static SmileClassifier decisionTree(Matrix matrix, String targetColumn) {
-    if (SmileUtil.hasNulls(matrix.column(targetColumn))) {
-      throw new IllegalArgumentException(
-          "Target column '${targetColumn}' contains null labels. " +
-          "Use SmileFeatures.dropna() or fillna() before training.")
-    }
+    requireNonNullLabels(matrix, targetColumn)
     String[] featureColumns = matrix.columnNames().findAll { it != targetColumn } as String[]
 
     // Extract class labels and encode target as integers
@@ -288,6 +280,14 @@ class SmileClassifier {
   }
 
   // Helper methods
+
+  private static void requireNonNullLabels(Matrix matrix, String targetColumn) {
+    if (SmileUtil.hasNulls(matrix.column(targetColumn))) {
+      throw new IllegalArgumentException(
+          "Target column '${targetColumn}' contains null labels. " +
+          "Use SmileFeatures.dropna() or fillna() before training.")
+    }
+  }
 
   private static String[] extractClassLabels(Matrix matrix, String targetColumn) {
     List<?> values = matrix.column(targetColumn)

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/ml/SmileRegression.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/ml/SmileRegression.groovy
@@ -272,7 +272,12 @@ class SmileRegression {
 
     for (int i = 0; i < values.size(); i++) {
       Object val = values.get(i)
-      result[i] = val != null ? val as double : 0.0d
+      if (val == null) {
+        throw new IllegalArgumentException(
+            "Target column '${targetColumn}' contains a null at row ${i}. " +
+            "Use SmileFeatures.dropna() or fillna() to handle missing values before training.")
+      }
+      result[i] = val as double
     }
 
     result

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/stats/SmileStats.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/stats/SmileStats.groovy
@@ -24,8 +24,6 @@ import smile.stat.hypothesis.TTest
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.smile.SmileUtil
 
-import java.util.Arrays
-
 /**
  * Statistical utilities leveraging Smile's statistics library.
  * Complements matrix-stats with ML-focused statistics including:
@@ -809,7 +807,8 @@ class SmileStats {
     for (double v : data) {
       if (!Double.isNaN(v)) { buf[idx++] = v }
     }
-    idx < data.length ? Arrays.copyOf(buf, idx) : data
+    if (idx == data.length) { return data }
+    Arrays.copyOf(buf, idx)
   }
 
   private static double[][] toPairwiseComplete(double[] x, double[] y) {
@@ -834,8 +833,7 @@ class SmileStats {
   private static void requireMinimumPairs(double[][] pair, int minimum, String context) {
     if (pair[0].length < minimum) {
       throw new IllegalArgumentException(
-          "Fewer than $minimum complete pairs remain after removing rows with nulls " +
-          "(${pair[0].length} complete pair(s) found). " +
+          "$context requires at least $minimum complete pairs, but found ${pair[0].length}. " +
           "Use SmileFeatures.dropna() or fillna() before computing paired statistics.")
     }
   }

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/stats/SmileStats.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/stats/SmileStats.groovy
@@ -24,6 +24,8 @@ import smile.stat.hypothesis.TTest
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.smile.SmileUtil
 
+import java.util.Arrays
+
 /**
  * Statistical utilities leveraging Smile's statistics library.
  * Complements matrix-stats with ML-focused statistics including:
@@ -65,7 +67,9 @@ class SmileStats {
    * @return a fitted GaussianDistribution
    */
   static GaussianDistribution normalFit(Matrix matrix, String column) {
-    normalFit(toDoubleArray(matrix, column))
+    double[] compacted = compactDoubleArray(toDoubleArray(matrix, column))
+    requireMinimumSamples(compacted, 2, "normalFit on column '$column'")
+    normalFit(compacted)
   }
 
   /**
@@ -293,7 +297,9 @@ class SmileStats {
    * @return a TTest result
    */
   static TTest tTestOneSample(Matrix matrix, String column, double mu) {
-    tTestOneSample(toDoubleArray(matrix, column), mu)
+    double[] compacted = compactDoubleArray(toDoubleArray(matrix, column))
+    requireMinimumSamples(compacted, 2, "tTestOneSample on column '$column'")
+    tTestOneSample(compacted, mu)
   }
 
   /**
@@ -317,7 +323,11 @@ class SmileStats {
    * @return a TTest result
    */
   static TTest tTestTwoSample(Matrix matrix, String column1, String column2, boolean equalVariance = false) {
-    tTestTwoSample(toDoubleArray(matrix, column1), toDoubleArray(matrix, column2), equalVariance)
+    double[] x = compactDoubleArray(toDoubleArray(matrix, column1))
+    double[] y = compactDoubleArray(toDoubleArray(matrix, column2))
+    requireMinimumSamples(x, 2, "tTestTwoSample on column '$column1'")
+    requireMinimumSamples(y, 2, "tTestTwoSample on column '$column2'")
+    tTestTwoSample(x, y, equalVariance)
   }
 
   /**
@@ -340,7 +350,9 @@ class SmileStats {
    * @return a TTest result
    */
   static TTest tTestPaired(Matrix matrix, String column1, String column2) {
-    tTestPaired(toDoubleArray(matrix, column1), toDoubleArray(matrix, column2))
+    double[][] pair = toPairwiseComplete(toDoubleArray(matrix, column1), toDoubleArray(matrix, column2))
+    requireMinimumPairs(pair, 2, "tTestPaired on columns '$column1' and '$column2'")
+    tTestPaired(pair[0], pair[1])
   }
 
   /**
@@ -363,7 +375,11 @@ class SmileStats {
    * @return an FTest result
    */
   static FTest fTest(Matrix matrix, String column1, String column2) {
-    fTest(toDoubleArray(matrix, column1), toDoubleArray(matrix, column2))
+    double[] x = compactDoubleArray(toDoubleArray(matrix, column1))
+    double[] y = compactDoubleArray(toDoubleArray(matrix, column2))
+    requireMinimumSamples(x, 2, "fTest on column '$column1'")
+    requireMinimumSamples(y, 2, "fTest on column '$column2'")
+    fTest(x, y)
   }
 
   /**
@@ -386,7 +402,9 @@ class SmileStats {
    * @return a KSTest result
    */
   static KSTest ksTestNormality(Matrix matrix, String column) {
-    ksTestNormality(toDoubleArray(matrix, column))
+    double[] compacted = compactDoubleArray(toDoubleArray(matrix, column))
+    requireMinimumSamples(compacted, 2, "ksTestNormality on column '$column'")
+    ksTestNormality(compacted)
   }
 
   /**
@@ -410,7 +428,11 @@ class SmileStats {
    * @return a KSTest result
    */
   static KSTest ksTestTwoSample(Matrix matrix, String column1, String column2) {
-    ksTestTwoSample(toDoubleArray(matrix, column1), toDoubleArray(matrix, column2))
+    double[] x = compactDoubleArray(toDoubleArray(matrix, column1))
+    double[] y = compactDoubleArray(toDoubleArray(matrix, column2))
+    requireMinimumSamples(x, 2, "ksTestTwoSample on column '$column1'")
+    requireMinimumSamples(y, 2, "ksTestTwoSample on column '$column2'")
+    ksTestTwoSample(x, y)
   }
 
   /**
@@ -456,7 +478,9 @@ class SmileStats {
    * @return a CorTest result
    */
   static CorTest correlationTest(Matrix matrix, String column1, String column2) {
-    correlationTest(toDoubleArray(matrix, column1), toDoubleArray(matrix, column2))
+    double[][] pair = toPairwiseComplete(toDoubleArray(matrix, column1), toDoubleArray(matrix, column2))
+    requireMinimumPairs(pair, 2, "correlationTest on columns '$column1' and '$column2'")
+    correlationTest(pair[0], pair[1])
   }
 
   /**
@@ -479,7 +503,9 @@ class SmileStats {
    * @return a CorTest result
    */
   static CorTest spearmanTest(Matrix matrix, String column1, String column2) {
-    spearmanTest(toDoubleArray(matrix, column1), toDoubleArray(matrix, column2))
+    double[][] pair = toPairwiseComplete(toDoubleArray(matrix, column1), toDoubleArray(matrix, column2))
+    requireMinimumPairs(pair, 2, "spearmanTest on columns '$column1' and '$column2'")
+    spearmanTest(pair[0], pair[1])
   }
 
   /**
@@ -502,7 +528,9 @@ class SmileStats {
    * @return a CorTest result
    */
   static CorTest kendallTest(Matrix matrix, String column1, String column2) {
-    kendallTest(toDoubleArray(matrix, column1), toDoubleArray(matrix, column2))
+    double[][] pair = toPairwiseComplete(toDoubleArray(matrix, column1), toDoubleArray(matrix, column2))
+    requireMinimumPairs(pair, 2, "kendallTest on columns '$column1' and '$column2'")
+    kendallTest(pair[0], pair[1])
   }
 
   /**
@@ -619,7 +647,10 @@ class SmileStats {
       corMatrix[i][i] = 1.0
       pMatrix[i][i] = 0.0
       for (int j = i + 1; j < n; j++) {
-        CorTest result = method.correlate(data[i], data[j])
+        double[][] pair = toPairwiseComplete(data[i], data[j])
+        requireMinimumPairs(pair, 2,
+            "correlation between '${numericCols[i]}' and '${numericCols[j]}'")
+        CorTest result = method.correlate(pair[0], pair[1])
         corMatrix[i][j] = result.cor()
         corMatrix[j][i] = result.cor()
         pMatrix[i][j] = result.pvalue()
@@ -765,36 +796,66 @@ class SmileStats {
   private static double[] toDoubleArray(Matrix matrix, String column) {
     List<?> col = matrix.column(column)
     double[] result = new double[col.size()]
-    int idx = 0
-    for (Object val : col) {
-      if (val != null) {
-        result[idx++] = val as double
-      }
-    }
-    // Trim to actual size if there were nulls
-    if (idx < col.size()) {
-      double[] trimmed = new double[idx]
-      System.arraycopy(result, 0, trimmed, 0, idx)
-      return trimmed
+    for (int i = 0; i < col.size(); i++) {
+      Object val = col.get(i)
+      result[i] = val != null ? val as double : Double.NaN
     }
     result
   }
 
-  private static int[] toIntArray(Matrix matrix, String column) {
-    List<?> col = matrix.column(column)
-    int[] result = new int[col.size()]
+  private static double[] compactDoubleArray(double[] data) {
+    double[] buf = new double[data.length]
     int idx = 0
-    for (Object val : col) {
-      if (val != null) {
-        result[idx++] = ((Number) val).intValue()
+    for (double v : data) {
+      if (!Double.isNaN(v)) { buf[idx++] = v }
+    }
+    idx < data.length ? Arrays.copyOf(buf, idx) : data
+  }
+
+  private static double[][] toPairwiseComplete(double[] x, double[] y) {
+    int n = Math.min(x.length, y.length)
+    double[] xBuf = new double[n]
+    double[] yBuf = new double[n]
+    int idx = 0
+    for (int i = 0; i < n; i++) {
+      if (!Double.isNaN(x[i]) && !Double.isNaN(y[i])) {
+        xBuf[idx] = x[i]
+        yBuf[idx] = y[i]
+        idx++
       }
     }
-    if (idx < col.size()) {
-      int[] trimmed = new int[idx]
-      System.arraycopy(result, 0, trimmed, 0, idx)
-      return trimmed
+    if (idx < n) {
+      xBuf = Arrays.copyOf(xBuf, idx)
+      yBuf = Arrays.copyOf(yBuf, idx)
     }
-    result
+    [xBuf, yBuf] as double[][]
+  }
+
+  private static void requireMinimumPairs(double[][] pair, int minimum, String context) {
+    if (pair[0].length < minimum) {
+      throw new IllegalArgumentException(
+          "Fewer than $minimum complete pairs remain after removing rows with nulls " +
+          "(${pair[0].length} complete pair(s) found). " +
+          "Use SmileFeatures.dropna() or fillna() before computing paired statistics.")
+    }
+  }
+
+  private static void requireMinimumSamples(double[] data, int minimum, String context) {
+    if (data.length < minimum) {
+      throw new IllegalArgumentException(
+          "$context requires at least $minimum non-null values, but found ${data.length}. " +
+          "Use SmileFeatures.dropna() or fillna() before computing statistics.")
+    }
+  }
+
+  private static int[] toIntArray(Matrix matrix, String column) {
+    List<?> col = matrix.column(column)
+    int[] buf = new int[col.size()]
+    int idx = 0
+    for (Object val : col) {
+      if (val != null) { buf[idx++] = val as int }
+    }
+    idx < col.size() ? Arrays.copyOf(buf, idx) : buf
   }
 
   @SuppressWarnings('NestedForLoop')

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/stats/SmileStats.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/stats/SmileStats.groovy
@@ -791,6 +791,13 @@ class SmileStats {
 
   // ==================== Helper Methods ====================
 
+  /**
+   * Convert a Matrix column to a double array, mapping null to {@code Double.NaN}.
+   * Pre-existing NaN values in the source data are preserved as-is, so downstream
+   * helpers ({@code compactDoubleArray}, {@code toPairwiseComplete}) treat both
+   * null-originated and pre-existing NaN identically — both are excluded from
+   * statistical computations.
+   */
   private static double[] toDoubleArray(Matrix matrix, String column) {
     List<?> col = matrix.column(column)
     double[] result = new double[col.size()]

--- a/matrix-smile/src/test/groovy/SmileClassifierTest.groovy
+++ b/matrix-smile/src/test/groovy/SmileClassifierTest.groovy
@@ -263,4 +263,42 @@ class SmileClassifierTest {
     assertEquals('ntrees must be positive: was -5', exception2.message)
   }
 
+  @Test
+  void testTrainingWithNullLabelThrows() {
+    Matrix trainData = Matrix.builder()
+        .data(
+            x1: [1.0, 1.2, 1.5, 8.0, 8.2, 8.5],
+            x2: [1.1, 0.9, 1.3, 8.1, 7.9, 8.3],
+            label: ['A', null, 'A', 'B', 'B', 'B']
+        )
+        .types([Double, Double, String])
+        .build()
+
+    def ex = assertThrows(IllegalArgumentException) {
+      SmileClassifier.randomForest(trainData, 'label')
+    }
+    assertTrue(ex.message.contains('null'), "Expected 'null' in: ${ex.message}")
+    assertTrue(ex.message.contains('label'), "Expected 'label' in: ${ex.message}")
+  }
+
+  @Test
+  void testEvaluateWithUnknownLabelThrows() {
+    Matrix trainData = createBinaryData()
+    SmileClassifier classifier = SmileClassifier.randomForest(trainData, 'label')
+
+    Matrix testData = Matrix.builder()
+        .data(
+            x1: [1.3, 8.3],
+            x2: [1.4, 8.4],
+            label: ['A', 'C']
+        )
+        .types([Double, Double, String])
+        .build()
+
+    def ex = assertThrows(IllegalArgumentException) {
+      classifier.accuracy(testData)
+    }
+    assertTrue(ex.message.contains('C'), "Expected 'C' in: ${ex.message}")
+  }
+
 }

--- a/matrix-smile/src/test/groovy/SmileRegressionTest.groovy
+++ b/matrix-smile/src/test/groovy/SmileRegressionTest.groovy
@@ -392,4 +392,25 @@ class SmileRegressionTest {
     assertEquals('y', regression.targetColumn)
   }
 
+  @Test
+  void testExtractTargetThrowsOnNullInTarget() {
+    Matrix trainData = createLinearData()
+    SmileRegression regression = SmileRegression.ols(trainData, 'y')
+
+    Matrix testData = Matrix.builder()
+        .data(
+            x1: [1.0, 2.0, 3.0],
+            x2: [2.0, 3.0, 4.0],
+            y: [9.0, null, 14.0]
+        )
+        .types([Double, Double, Double])
+        .build()
+
+    def ex = assertThrows(IllegalArgumentException) {
+      regression.rSquared(testData)
+    }
+    assertTrue(ex.message.contains('null'), "Expected 'null' in: ${ex.message}")
+    assertTrue(ex.message.contains('y'), "Expected column name 'y' in: ${ex.message}")
+  }
+
 }

--- a/matrix-smile/src/test/groovy/SmileStatsTest.groovy
+++ b/matrix-smile/src/test/groovy/SmileStatsTest.groovy
@@ -741,4 +741,161 @@ class SmileStatsTest {
     assertEquals(3.0, dist.mean(), 0.0001) // Mean of [1, 3, 5]
   }
 
+  @Test
+  void testTTestPairedWithNullsInDifferentPositions() {
+    // 5 rows; row 1 null in col1, row 3 null in col2 → 3 complete pairs
+    Matrix matrix = Matrix.builder()
+        .data(
+            before: [85.0, null, 78.0, 92.0, 88.0],
+            after:  [88.0, 92.0, 82.0, null, 90.0]
+        )
+        .types([Double, Double])
+        .build()
+
+    TTest result = SmileStats.tTestPaired(matrix, 'before', 'after')
+
+    assertNotNull(result)
+    assertNotNull(result.pvalue())
+    // df = n-1 = 2 for 3 complete pairs
+    assertEquals(2.0, result.df(), 0.0001)
+  }
+
+  @Test
+  void testTTestPairedAllNullPairsThrowsDescriptive() {
+    // Every row has a null in at least one column → 0 complete pairs
+    Matrix matrix = Matrix.builder()
+        .data(
+            x: [null, 2.0, null, 4.0],
+            y: [1.0, null, 3.0, null]
+        )
+        .types([Double, Double])
+        .build()
+
+    def ex = assertThrows(IllegalArgumentException) {
+      SmileStats.tTestPaired(matrix, 'x', 'y')
+    }
+    assertTrue(ex.message.contains('complete pair'), "Expected 'complete pair' in: ${ex.message}")
+  }
+
+  @Test
+  void testNormalFitAllNullsThrowsDescriptive() {
+    Matrix matrix = Matrix.builder()
+        .data(values: [null, null, null])
+        .types([Double])
+        .build()
+
+    def ex = assertThrows(IllegalArgumentException) {
+      SmileStats.normalFit(matrix, 'values')
+    }
+    assertTrue(ex.message.contains('non-null'), "Expected 'non-null' in: ${ex.message}")
+  }
+
+  @Test
+  void testTTestTwoSampleWithNulls() {
+    Matrix matrix = Matrix.builder()
+        .data(
+            group1: [10.1, null, 9.9, 10.0, 10.3, 9.8, 10.1],
+            group2: [9.8, 9.7, null, 9.9, 9.6, 10.0, 9.5]
+        )
+        .types([Double, Double])
+        .build()
+
+    TTest result = SmileStats.tTestTwoSample(matrix, 'group1', 'group2')
+
+    assertNotNull(result)
+    assertNotNull(result.pvalue())
+    assertFalse(Double.isNaN(result.pvalue()), "p-value should not be NaN")
+  }
+
+  @Test
+  void testCorrelationWithMisalignedNulls() {
+    Matrix matrix = Matrix.builder()
+        .data(
+            x: [1.0, null, 3.0, 4.0, 5.0],
+            y: [2.0, 4.0, null, 8.0, 10.0]
+        )
+        .types([Double, Double])
+        .build()
+
+    CorTest result = SmileStats.correlationTest(matrix, 'x', 'y')
+
+    assertNotNull(result)
+    assertFalse(Double.isNaN(result.cor()), "Correlation should not be NaN")
+  }
+
+  @Test
+  void testCorrelationWithSignificanceAllNullColumn() {
+    Matrix matrix = Matrix.builder()
+        .data(
+            a: [1.0, 2.0, 3.0, 4.0, 5.0],
+            b: [null, null, null, null, null],
+            c: [5.0, 4.0, 3.0, 2.0, 1.0]
+        )
+        .types([Double, Double, Double])
+        .build()
+
+    def ex = assertThrows(IllegalArgumentException) {
+      SmileStats.correlationWithSignificance(matrix)
+    }
+    assertTrue(ex.message.contains('complete pair'), "Expected 'complete pair' in: ${ex.message}")
+  }
+
+  // Regression tests: clean data produces correct results after compaction/pairwise rewrite
+
+  @Test
+  void testNormalFitCleanDataRegression() {
+    Matrix matrix = Matrix.builder()
+        .data(values: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+        .types([Double])
+        .build()
+
+    def dist = SmileStats.normalFit(matrix, 'values')
+
+    assertEquals(5.5, dist.mean(), 0.0001)
+  }
+
+  @Test
+  void testTTestOneSampleCleanDataRegression() {
+    Matrix matrix = Matrix.builder()
+        .data(values: [10.2, 9.8, 10.1, 9.9, 10.0, 10.3, 9.7, 10.1, 10.0, 9.9])
+        .types([Double])
+        .build()
+
+    TTest result = SmileStats.tTestOneSample(matrix, 'values', 10.0)
+
+    assertNotNull(result)
+    assertTrue(result.pvalue() > 0.05)
+  }
+
+  @Test
+  void testCorrelationTestCleanDataRegression() {
+    Matrix matrix = Matrix.builder()
+        .data(
+            x: [1.0, 2.0, 3.0, 4.0, 5.0],
+            y: [2.0, 4.0, 6.0, 8.0, 10.0]
+        )
+        .types([Double, Double])
+        .build()
+
+    CorTest result = SmileStats.correlationTest(matrix, 'x', 'y')
+
+    assertEquals(1.0, result.cor(), 0.0001)
+  }
+
+  @Test
+  void testTTestPairedCleanDataRegression() {
+    Matrix matrix = Matrix.builder()
+        .data(
+            before: [85.0, 90.0, 78.0, 92.0, 88.0],
+            after:  [88.0, 92.0, 82.0, 95.0, 90.0]
+        )
+        .types([Double, Double])
+        .build()
+
+    TTest result = SmileStats.tTestPaired(matrix, 'before', 'after')
+
+    assertNotNull(result)
+    assertEquals(4.0, result.df(), 0.0001)
+  }
+
 }

--- a/matrix-smile/src/test/groovy/SmileStatsTest.groovy
+++ b/matrix-smile/src/test/groovy/SmileStatsTest.groovy
@@ -775,6 +775,7 @@ class SmileStatsTest {
       SmileStats.tTestPaired(matrix, 'x', 'y')
     }
     assertTrue(ex.message.contains('complete pair'), "Expected 'complete pair' in: ${ex.message}")
+    assertTrue(ex.message.contains('tTestPaired'), "Expected 'tTestPaired' in: ${ex.message}")
   }
 
   @Test
@@ -838,6 +839,7 @@ class SmileStatsTest {
       SmileStats.correlationWithSignificance(matrix)
     }
     assertTrue(ex.message.contains('complete pair'), "Expected 'complete pair' in: ${ex.message}")
+    assertTrue(ex.message.contains('correlation'), "Expected 'correlation' in: ${ex.message}")
   }
 
   // Regression tests: clean data produces correct results after compaction/pairwise rewrite

--- a/matrix-smile/src/test/groovy/SmileUtilTest.groovy
+++ b/matrix-smile/src/test/groovy/SmileUtilTest.groovy
@@ -327,6 +327,20 @@ class SmileUtilTest {
   }
 
   @Test
+  void testMatrixToArrayThrowsOnNull() {
+    def matrix = Matrix.builder()
+        .data(a: [1.0, null, 3.0], b: [4.0, 5.0, 6.0])
+        .types([Double, Double])
+        .build()
+
+    def ex = assertThrows(IllegalArgumentException) {
+      SmileUtil.matrixToArray(matrix)
+    }
+    assertTrue(ex.message.contains('null'), "Expected 'null' in: ${ex.message}")
+    assertTrue(ex.message.contains('a'), "Expected column name 'a' in: ${ex.message}")
+  }
+
+  @Test
   void testRound() {
     assertEquals(3.14, SmileUtil.round(3.14159, 2), 0.001)
     assertEquals(3.1416, SmileUtil.round(3.14159, 4), 0.00001)


### PR DESCRIPTION
## Summary
- **SmileStats**: Rewrote `toDoubleArray` to NaN-preserving; added `compactDoubleArray` for independent samples and `toPairwiseComplete` for paired methods; added `requireMinimumSamples`/`requireMinimumPairs` guards with descriptive error messages; refactored `toIntArray` to use `Arrays.copyOf`
- **SmileRegression**: `extractTarget` now throws `IllegalArgumentException` on null instead of silently substituting `0.0`
- **SmileClassifier**: Added null-label guard to `randomForest`/`decisionTree` training; `extractTargetAsInt` and `encodeTarget` now throw on unknown/null labels with row number and known-labels in the message

## Test plan
- [x] 14 new tests across SmileStatsTest, SmileRegressionTest, SmileClassifierTest, SmileUtilTest
- [x] All-nulls column throws descriptive `IllegalArgumentException` (not opaque Smile error)
- [x] Pairwise-complete correctly drops misaligned nulls (verified via `df` in paired t-test)
- [x] Independent-sample compaction produces correct results with sparse nulls
- [x] Unknown classifier label during evaluation throws with label name and known-labels
- [x] Null classifier label during training throws immediately
- [x] Null regression target during evaluation throws with column name and row number
- [x] Clean-data regression tests verify no corruption from compaction/pairwise rewrite
- [x] Full suite: 307 tests passing (up from 293)

🤖 Generated with [Claude Code](https://claude.com/claude-code)