### PR TITLE
Fix data correctness: temporal round-trips, cluster null elimination, stratified split warning

### DIFF
--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileData.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileData.groovy
@@ -3,6 +3,7 @@ package se.alipsa.matrix.smile.data
 import groovy.transform.CompileStatic
 
 import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.core.util.Logger
 
 /**
  * Utility class for data splitting operations commonly used in machine learning workflows.
@@ -11,6 +12,7 @@ import se.alipsa.matrix.core.Matrix
 @CompileStatic
 class SmileData {
 
+  private static final Logger log = Logger.getLogger(SmileData)
   private static final int MIN_PARTITION = 2
   private static final double MIN_RATIO = 0.0d
   private static final double MAX_RATIO = 1.0d
@@ -255,6 +257,11 @@ class SmileData {
 
     // Split each class proportionally
     for (Map.Entry<Object, List<Integer>> entry : classSamples.entrySet()) {
+      if (entry.value.size() < 2) {
+        log.warn("Class '${entry.key}' has only ${entry.value.size()} sample(s) and will " +
+            "appear only in the training set. Consider removing rare classes or using " +
+            "non-stratified splitting if test-set coverage for all classes is required.")
+      }
       List<Integer> classIndices = new ArrayList<>(entry.value)
       Collections.shuffle(classIndices, random)
 

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileData.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileData.groovy
@@ -258,7 +258,7 @@ class SmileData {
     // Split each class proportionally
     for (Map.Entry<Object, List<Integer>> entry : classSamples.entrySet()) {
       if (entry.value.size() < 2) {
-        log.warn("Class '${entry.key}' has only ${entry.value.size()} sample(s) and will " +
+        log.warn("Class '${entry.key}' has fewer than 2 samples and will " +
             "appear only in the training set. Consider removing rare classes or using " +
             "non-stratified splitting if test-set coverage for all classes is required.")
       }

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/ml/SmileCluster.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/ml/SmileCluster.groovy
@@ -154,30 +154,29 @@ class SmileCluster {
 
   /**
    * Get cluster centroids.
-   * Note: Only available for centroid-based clustering (KMeans).
+   * Only available for centroid-based clustering (KMeans).
    *
-   * @return the cluster centroids or null if not available
+   * @return the cluster centroids
+   * @throws UnsupportedOperationException if the algorithm does not produce centroids
    */
-  @SuppressWarnings('ReturnsNullInsteadOfEmptyArray')
   double[][] getCentroids() {
-    if (centroidModel != null) {
-      return centroidModel.centers()
+    if (centroidModel == null) {
+      throw new UnsupportedOperationException(
+          'Centroids are not available for this clustering algorithm — only centroid-based methods (e.g. KMeans) support this')
     }
-    null
+    centroidModel.centers()
   }
 
   /**
    * Get cluster centroids as a Matrix.
-   * Note: Only available for centroid-based clustering (KMeans).
+   * Only available for centroid-based clustering (KMeans).
    *
    * @return a Matrix containing the cluster centroids
+   * @throws UnsupportedOperationException if the algorithm does not produce centroids
    */
   @SuppressWarnings('NestedForLoop')
   Matrix getCentroidsMatrix() {
     double[][] centroids = getCentroids()
-    if (centroids == null) {
-      return null
-    }
 
     Map<String, List<?>> data = [:]
     for (int j = 0; j < featureColumns.length; j++) {

--- a/matrix-smile/src/test/groovy/SmileClusterTest.groovy
+++ b/matrix-smile/src/test/groovy/SmileClusterTest.groovy
@@ -224,6 +224,22 @@ class SmileClusterTest {
   }
 
   @Test
+  void testDBSCANCentroidsThrows() {
+    Matrix data = createDBSCANData()
+    SmileCluster cluster = SmileCluster.dbscan(data, 2, 0.5)
+
+    def ex1 = assertThrows(UnsupportedOperationException) {
+      cluster.centroids
+    }
+    assertTrue(ex1.message.contains('centroid'), "Expected 'centroid' in: ${ex1.message}")
+
+    def ex2 = assertThrows(UnsupportedOperationException) {
+      cluster.centroidsMatrix
+    }
+    assertTrue(ex2.message.contains('centroid'), "Expected 'centroid' in: ${ex2.message}")
+  }
+
+  @Test
   void testDBSCANClusterCounts() {
     Matrix data = createDBSCANData()
 

--- a/matrix-smile/src/test/groovy/SmileDataTest.groovy
+++ b/matrix-smile/src/test/groovy/SmileDataTest.groovy
@@ -295,6 +295,26 @@ class SmileDataTest {
     assertEquals(test1.rowCount(), test2.rowCount())
   }
 
+  @Test
+  void testStratifiedSplitSingleSampleClassGoesToTrainOnly() {
+    Matrix data = Matrix.builder()
+        .data(
+            x: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+            label: ['A', 'A', 'A', 'B', 'B', 'B', 'C']
+        )
+        .types([Double, String])
+        .build()
+
+    def (Matrix train, Matrix test) = SmileData.stratifiedSplit(data, 'label', 0.3, 42L)
+
+    List<String> trainLabels = train.column('label') as List<String>
+    List<String> testLabels = test.column('label') as List<String>
+
+    assertTrue(trainLabels.contains('C'), 'Single-sample class C should appear in training set')
+    assertFalse(testLabels.contains('C'), 'Single-sample class C should not appear in test set')
+    assertEquals(7, train.rowCount() + test.rowCount())
+  }
+
   // ============ bootstrap Tests ============
 
   @Test

--- a/matrix-smile/src/test/groovy/test/alipsa/matrix/smile/DataframeConverterTest.groovy
+++ b/matrix-smile/src/test/groovy/test/alipsa/matrix/smile/DataframeConverterTest.groovy
@@ -412,12 +412,12 @@ class DataframeConverterTest {
   void testTemporalRoundTripLossyTypes() {
     // Smile collapses Timestamp, Instant, ZonedDateTime → DateTimeType → LocalDateTime
     // and OffsetTime → TimeType → LocalTime. This is a lossy conversion.
-    def ts = java.sql.Timestamp.valueOf('2023-01-15 10:30:00')
+    def ts = Timestamp.valueOf('2023-01-15 10:30:00')
     def inst = Instant.parse('2023-01-15T10:30:00Z')
-    def zdt = ZonedDateTime.of(2023, 1, 15, 10, 30, 0, 0, java.time.ZoneId.of('UTC'))
-    def ot = OffsetTime.of(10, 30, 0, 0, java.time.ZoneOffset.UTC)
+    def zdt = ZonedDateTime.of(2023, 1, 15, 10, 30, 0, 0, ZoneId.of('UTC'))
+    def ot = OffsetTime.of(10, 30, 0, 0, ZoneOffset.UTC)
 
-    def tsMatrix = Matrix.builder().data(c: [ts]).types(java.sql.Timestamp).build()
+    def tsMatrix = Matrix.builder().data(c: [ts]).types(Timestamp).build()
     Matrix tsRound = DataframeConverter.convert(DataframeConverter.convert(tsMatrix))
     assertEquals(LocalDateTime, tsRound.type(0), 'Timestamp round-trips as LocalDateTime')
 

--- a/matrix-smile/src/test/groovy/test/alipsa/matrix/smile/DataframeConverterTest.groovy
+++ b/matrix-smile/src/test/groovy/test/alipsa/matrix/smile/DataframeConverterTest.groovy
@@ -388,6 +388,53 @@ class DataframeConverterTest {
   }
 
   @Test
+  void testTemporalRoundTrip() {
+    def ldt = LocalDateTime.of(2023, 1, 15, 10, 30, 0)
+    def ld = LocalDate.of(2023, 1, 15)
+    def lt = LocalTime.of(10, 30, 0)
+
+    def matrix = Matrix.builder()
+        .data(ldt_col: [ldt], ld_col: [ld], lt_col: [lt])
+        .types(LocalDateTime, LocalDate, LocalTime)
+        .build()
+
+    Matrix roundTripped = DataframeConverter.convert(DataframeConverter.convert(matrix))
+
+    assertEquals(LocalDateTime, roundTripped.type(0))
+    assertEquals(LocalDate, roundTripped.type(1))
+    assertEquals(LocalTime, roundTripped.type(2))
+    assertEquals(ldt, roundTripped[0, 0])
+    assertEquals(ld, roundTripped[0, 1])
+    assertEquals(lt, roundTripped[0, 2])
+  }
+
+  @Test
+  void testTemporalRoundTripLossyTypes() {
+    // Smile collapses Timestamp, Instant, ZonedDateTime → DateTimeType → LocalDateTime
+    // and OffsetTime → TimeType → LocalTime. This is a lossy conversion.
+    def ts = java.sql.Timestamp.valueOf('2023-01-15 10:30:00')
+    def inst = Instant.parse('2023-01-15T10:30:00Z')
+    def zdt = ZonedDateTime.of(2023, 1, 15, 10, 30, 0, 0, java.time.ZoneId.of('UTC'))
+    def ot = OffsetTime.of(10, 30, 0, 0, java.time.ZoneOffset.UTC)
+
+    def tsMatrix = Matrix.builder().data(c: [ts]).types(java.sql.Timestamp).build()
+    Matrix tsRound = DataframeConverter.convert(DataframeConverter.convert(tsMatrix))
+    assertEquals(LocalDateTime, tsRound.type(0), 'Timestamp round-trips as LocalDateTime')
+
+    def instMatrix = Matrix.builder().data(c: [inst]).types(Instant).build()
+    Matrix instRound = DataframeConverter.convert(DataframeConverter.convert(instMatrix))
+    assertEquals(LocalDateTime, instRound.type(0), 'Instant round-trips as LocalDateTime')
+
+    def zdtMatrix = Matrix.builder().data(c: [zdt]).types(ZonedDateTime).build()
+    Matrix zdtRound = DataframeConverter.convert(DataframeConverter.convert(zdtMatrix))
+    assertEquals(LocalDateTime, zdtRound.type(0), 'ZonedDateTime round-trips as LocalDateTime')
+
+    def otMatrix = Matrix.builder().data(c: [ot]).types(OffsetTime).build()
+    Matrix otRound = DataframeConverter.convert(DataframeConverter.convert(otMatrix))
+    assertEquals(LocalTime, otRound.type(0), 'OffsetTime round-trips as LocalTime')
+  }
+
+  @Test
   void testMatrixToDataFrameWithMixedTypes() {
     def matrix = Matrix.builder()
         .data(


### PR DESCRIPTION
## Summary
- **DataframeConverter temporal round-trip tests**: Confirmed `getType()` reverse mapping is already complete. Added tests documenting lossless round-trips (LocalDateTime, LocalDate, LocalTime) and lossy conversions where Smile collapses types (Timestamp→LocalDateTime, Instant→LocalDateTime, ZonedDateTime→LocalDateTime, OffsetTime→LocalTime)
- **SmileCluster null elimination**: Replaced `getCentroids()` and `getCentroidsMatrix()` null returns with `UnsupportedOperationException`, matching the existing `predict()` pattern for non-centroid algorithms (e.g. DBSCAN)
- **SmileData.stratifiedSplit warning**: Added `log.warn` for classes with fewer than 2 samples that cannot be stratified across train/test sets. Added behavioral test confirming single-sample classes appear only in training set

Phase 3 of `matrix-smile/req/v0.2.0-api-cleanup-plan.md` (Tasks 3.1, 3.2, 3.3).

## Test plan
- [x] 311 matrix-smile tests passing (was 307 before Phase 3)
- [x] `testTemporalRoundTrip` — lossless LocalDateTime/LocalDate/LocalTime round-trip
- [x] `testTemporalRoundTripLossyTypes` — Timestamp/Instant/ZonedDateTime/OffsetTime lossy conversion documented
- [x] `testDBSCANCentroidsThrows` — both `getCentroids()` and `getCentroidsMatrix()` throw for DBSCAN
- [x] `testStratifiedSplitSingleSampleClassGoesToTrainOnly` — single-sample class C in train only

🤖 Generated with [Claude Code](https://claude.com/claude-code)