### PR TITLE
Phase 5: DRY and code quality cleanup

### DIFF
--- a/matrix-smile/req/v0.2.0-api-cleanup-plan.md
+++ b/matrix-smile/req/v0.2.0-api-cleanup-plan.md
@@ -620,10 +620,10 @@ all-null column.
 
 ### 5.1 Remove redundant `containsNull` in `DataframeConverter` — delegate to `SmileUtil.hasNulls`
 
-**5.1.1** [ ] Delete the private `containsNull(List<?> list)` method in `DataframeConverter.groovy:176`.
+**5.1.1** [x] Delete the private `containsNull(List<?> list)` method in `DataframeConverter.groovy:176`.
 It reimplements the same logic as `SmileUtil.hasNulls(List<?>)`.
 
-**5.1.2** [ ] Replace all call sites `containsNull(columnData)` with `SmileUtil.hasNulls(columnData)`.
+**5.1.2** [x] Replace all call sites `containsNull(columnData)` with `SmileUtil.hasNulls(columnData)`.
 
 ### 5.2 Remove redundant `"Warning: "` prefix in `log.warn`
 
@@ -632,12 +632,12 @@ already conveys severity), replace the period-separated sentences with a semicol
 conciseness, lower-case `"defaulting"` (no longer sentence-initial after the semicolon),
 and drop `.class` / `Vector` suffixes for readability.
 
-**5.2.1** [ ] `DataframeConverter.groovy:162`:
+**5.2.1** [x] `DataframeConverter.groovy:162`:
 ```
 "Warning: Unhandled data type ${...} for column ${...}. Defaulting to StringVector."
 → "Unhandled data type ${...} for column ${...}; defaulting to String"
 ```
-**5.2.2** [ ] `DataframeConverter.groovy:289`:
+**5.2.2** [x] `DataframeConverter.groovy:289`:
 ```
 "Warning: Unhandled Smile DataType ${...}. Defaulting to Object.class"
 → "Unhandled Smile DataType ${...}; defaulting to Object"
@@ -645,7 +645,7 @@ and drop `.class` / `Vector` suffixes for readability.
 
 ### 5.3 Consistent `as` cast in `toPrimitive*` helpers
 
-**5.3.1** [ ] In `DataframeConverter.groovy`, replace `((Number) list.get(i)).floatValue()`,
+**5.3.1** [x] In `DataframeConverter.groovy`, replace `((Number) list.get(i)).floatValue()`,
 `.intValue()`, `.longValue()`, `.shortValue()`, `.byteValue()` with idiomatic
 `list.get(i) as float`, `as int`, `as long`, `as short`, `as byte` to match the existing
 `as double` style in `toPrimitiveDoubleArray`. The same style applies to
@@ -654,7 +654,7 @@ rather than `((Number) val).intValue()`.
 
 ### 5.4 Replace `Math.log1p` in `logTransform` with extension method
 
-**5.4.1** [ ] After Task 1 is complete, in `SmileFeatures.groovy:204`, replace:
+**5.4.1** [x] After Task 1 is complete, in `SmileFeatures.groovy:204`, replace:
 ```groovy
 values.collect { v -> v != null ? Math.log1p(v) : null }
 ```
@@ -663,7 +663,7 @@ with:
 values.collect { v -> v != null ? v.log1p() as double : null }
 ```
 
-**5.4.2** [ ] Apply the same BigDecimal→double coercion to `sqrtTransform` (`SmileFeatures.groovy:228`), which already uses `v.sqrt()` (returns `BigDecimal`) but stores the result in a `Double`-typed column:
+**5.4.2** [x] Apply the same BigDecimal→double coercion to `sqrtTransform` (`SmileFeatures.groovy:228`), which already uses `v.sqrt()` (returns `BigDecimal`) but stores the result in a `Double`-typed column:
 ```groovy
 values.collect { v -> v != null ? v.sqrt() as double : null }
 ```
@@ -674,7 +674,7 @@ values.collect { v -> v != null ? v.sqrt() as double : null }
 `SmileDimensionality`. Rather than demoting it to `@PackageScope`, accept it as a
 supported utility and document its contract properly.
 
-**5.5.1** [ ] Add a full GroovyDoc block to both `round` overloads documenting: the method
+**5.5.1** [x] Add a full GroovyDoc block to both `round` overloads documenting: the method
 is a supported public utility; NaN and Infinite values are returned unchanged; a negative
 `numDecimals` throws `IllegalArgumentException`; callers inside the module use it directly
 rather than going through higher-level wrappers. Note why `double` is returned rather than

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/DataframeConverter.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/DataframeConverter.groovy
@@ -70,7 +70,7 @@ class DataframeConverter {
       List<Object> columnData = matrix.column(j)
 
       // Check if column contains nulls - use optimized primitive arrays when no nulls
-      boolean hasNulls = containsNull(columnData)
+      boolean hasNulls = SmileUtil.hasNulls(columnData)
 
       // Create the appropriate Smile ValueVector based on the type
       // Use of() variants (primitive arrays) when no nulls for better performance
@@ -159,7 +159,7 @@ class DataframeConverter {
         case Enum -> columns.add(ValueVector.nominal(colName, columnData as Enum[]))
         default -> {
           // Handle other types or default to StringVector
-          log.warn("Warning: Unhandled data type ${dataType.getSimpleName()} for column ${colName}. Defaulting to StringVector.")
+          log.warn("Unhandled data type ${dataType.getSimpleName()} for column ${colName}; defaulting to String")
           List<String> values = ListConverter.convert(columnData, String)
           columns.add(ValueVector.of(colName, values as String[]))
         }
@@ -171,24 +171,12 @@ class DataframeConverter {
   }
 
   /**
-   * Check if a list contains any null values.
-   */
-  private static boolean containsNull(List<?> list) {
-    for (Object item : list) {
-      if (item == null) {
-        return true
-      }
-    }
-    false
-  }
-
-  /**
    * Convert List to primitive float array.
    */
   private static float[] toPrimitiveFloatArray(List<?> list) {
     float[] result = new float[list.size()]
     for (int i = 0; i < list.size(); i++) {
-      result[i] = ((Number) list.get(i)).floatValue()
+      result[i] = list.get(i) as float
     }
     result
   }
@@ -210,7 +198,7 @@ class DataframeConverter {
   private static int[] toPrimitiveIntArray(List<?> list) {
     int[] result = new int[list.size()]
     for (int i = 0; i < list.size(); i++) {
-      result[i] = ((Number) list.get(i)).intValue()
+      result[i] = list.get(i) as int
     }
     result
   }
@@ -221,7 +209,7 @@ class DataframeConverter {
   private static long[] toPrimitiveLongArray(List<?> list) {
     long[] result = new long[list.size()]
     for (int i = 0; i < list.size(); i++) {
-      result[i] = ((Number) list.get(i)).longValue()
+      result[i] = list.get(i) as long
     }
     result
   }
@@ -232,7 +220,7 @@ class DataframeConverter {
   private static short[] toPrimitiveShortArray(List<?> list) {
     short[] result = new short[list.size()]
     for (int i = 0; i < list.size(); i++) {
-      result[i] = ((Number) list.get(i)).shortValue()
+      result[i] = list.get(i) as short
     }
     result
   }
@@ -243,7 +231,7 @@ class DataframeConverter {
   private static byte[] toPrimitiveByteArray(List<?> list) {
     byte[] result = new byte[list.size()]
     for (int i = 0; i < list.size(); i++) {
-      result[i] = ((Number) list.get(i)).byteValue()
+      result[i] = list.get(i) as byte
     }
     result
   }
@@ -286,7 +274,7 @@ class DataframeConverter {
       case DateType -> LocalDate
       case TimeType -> LocalTime
       default -> {
-        log.warn("Warning: Unhandled Smile DataType ${dataType}. Defaulting to Object.class")
+        log.warn("Unhandled Smile DataType ${dataType}; defaulting to Object")
         Object.class
       }
     }

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/SmileUtil.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/SmileUtil.groovy
@@ -179,22 +179,24 @@ class SmileUtil {
 
   /**
    * Round a double value to the default number of decimal places (4).
-   * Low-level utility method; prefer calling higher-level SmileStats/SmileFeatures methods.
+   * Returns NaN and Infinite values unchanged.
    *
    * @param value the value to round
-   * @return the rounded value
+   * @return the rounded value, or the original if NaN/Infinite
    */
   static double round(double value) {
     round(value, ROUND_DECIMALS)
   }
 
   /**
-   * Round a double value to specified decimal places.
-   * Low-level utility method; prefer calling higher-level SmileStats/SmileFeatures methods.
+   * Round a double value to specified decimal places using HALF_UP rounding.
+   * Returns NaN and Infinite values unchanged. Returns {@code double} rather
+   * than {@code BigDecimal} because callers store results in double-typed columns.
    *
    * @param value the value to round
-   * @param numDecimals the number of decimal places
-   * @return the rounded value
+   * @param numDecimals the number of decimal places (must be non-negative)
+   * @return the rounded value, or the original if NaN/Infinite
+   * @throws IllegalArgumentException if numDecimals is negative
    */
   static double round(double value, int numDecimals) {
     if (Double.isNaN(value) || Double.isInfinite(value)) { return value }

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileFeatures.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileFeatures.groovy
@@ -201,7 +201,7 @@ class SmileFeatures {
    */
   static Matrix logTransform(Matrix matrix, List<String> columns) {
     transformColumns(matrix, columns) { List<Double> values ->
-      values.collect { v -> v != null ? Math.log1p(v) : null }
+      values.collect { v -> v != null ? v.log1p() as double : null }
     }
   }
 
@@ -225,7 +225,7 @@ class SmileFeatures {
    */
   static Matrix sqrtTransform(Matrix matrix, List<String> columns) {
     transformColumns(matrix, columns) { List<Double> values ->
-      values.collect { v -> v != null ? v.sqrt() : null }
+      values.collect { v -> v != null ? v.sqrt() as double : null }
     }
   }
 


### PR DESCRIPTION
## Summary
- Remove redundant `containsNull` in `DataframeConverter`, delegate to `SmileUtil.hasNulls`
- Drop `"Warning: "` prefix from `log.warn` messages, normalize style
- Replace Java-style `((Number) x).xxxValue()` casts with idiomatic Groovy `x as xxx` in 5 toPrimitive helpers
- Use `log1p()` extension method instead of `Math.log1p()`; add `as double` coercion to `sqrtTransform`
- Formalise `SmileUtil.round` GroovyDoc as public API

## Test plan
- [x] All 335 matrix-smile tests pass
- [x] CodeNarc main + test clean (0 violations)
- [x] Spotless formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)