### PR TITLE
Deprecate SmileUtil wrappers, add Gsmile extensions (Phase 6)

### DIFF
--- a/matrix-smile/req/v0.2.0-api-cleanup-plan.md
+++ b/matrix-smile/req/v0.2.0-api-cleanup-plan.md
@@ -103,7 +103,7 @@ Include a **regression test** for existing `Matrix.head(int)` and `Matrix.tail(i
 verify they still return `String` (via `MatrixPrinter`) after the new `top()`/`bottom()`
 methods are added — the two method families coexist with different return types.
 
-**1.5.3** [ ] Update `SmileUtil` to delegate to matrix-core where equivalents now exist:
+**1.5.3** [x] Update `SmileUtil` to delegate to matrix-core where equivalents now exist:
 - `hasNulls` → add `Column.hasNulls()` instance method. Keep `SmileUtil.hasNulls(List<?>)`
   un-deprecated; it serves raw `List<?>` callers that cannot use `Column.hasNulls()`.
 - `countNulls` → add `Column.countNulls()` instance method. Keep `SmileUtil.countNulls(List<?>)`
@@ -981,7 +981,7 @@ missing feature column at prediction time, empty matrix passed to an evaluation 
 
 ### 6.4 Expand `Gsmile` extension methods
 
-**6.4.1** [ ] Add the following Matrix extensions to `Gsmile.groovy` (each delegates directly
+**6.4.1** [x] Add the following Matrix extensions to `Gsmile.groovy` (each delegates directly
 to the matrix-core equivalent, bypassing the deprecated `SmileUtil` wrappers). Also add
 `import se.alipsa.matrix.core.Stat` and `import java.util.Random` to `Gsmile.groovy` so
 `Stat.frequency` and the `smileSample(Matrix, *, Random)` overloads resolve under static
@@ -993,7 +993,7 @@ static Matrix smileInfo(Matrix self) { self.info() }
 static Matrix smileFrequency(Matrix self, String column) { Stat.frequency(self, column) }
 ```
 
-**6.4.2** [ ] Add missing `smileSample` overloads, and update the existing `smileSample(Matrix, int)`
+**6.4.2** [x] Add missing `smileSample` overloads, and update the existing `smileSample(Matrix, int)`
 method to bypass the deprecated `SmileUtil` wrapper:
 ```groovy
 // Update existing method
@@ -1006,7 +1006,7 @@ static Matrix smileSample(Matrix self, int n, Random random) { self.sample(n, ra
 static Matrix smileSample(Matrix self, double fraction, Random random) { self.sample(fraction, random) }
 ```
 
-**6.4.3** [ ] Add tests in `GsmileTest.groovy` for each new extension method.
+**6.4.3** [x] Add tests in `GsmileTest.groovy` for each new extension method.
 
 ---
 

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/Gsmile.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/Gsmile.groovy
@@ -6,6 +6,7 @@ import smile.data.DataFrame
 import smile.data.vector.ValueVector
 
 import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.core.Stat
 
 /**
  * Groovy extension class that adds convenience methods to Matrix and Smile DataFrame.
@@ -51,14 +52,92 @@ class Gsmile {
   }
 
   /**
-   * Take a random sample from the Matrix.
+   * Take a random sample of rows from the Matrix.
    *
    * @param self the Matrix to sample from
    * @param n the number of rows to sample
    * @return a new Matrix with randomly selected rows
    */
   static Matrix smileSample(Matrix self, int n) {
-    SmileUtil.sample(self, n)
+    self.sample(n)
+  }
+
+  /**
+   * Take a random sample of a fraction of rows from the Matrix.
+   *
+   * @param self the Matrix to sample from
+   * @param fraction the fraction of rows to sample (0.0 to 1.0)
+   * @return a new Matrix with randomly selected rows
+   */
+  static Matrix smileSample(Matrix self, double fraction) {
+    self.sampleFraction(fraction)
+  }
+
+  /**
+   * Take a random sample of rows from the Matrix with a specific Random.
+   *
+   * @param self the Matrix to sample from
+   * @param n the number of rows to sample
+   * @param random the Random instance to use
+   * @return a new Matrix with randomly selected rows
+   */
+  static Matrix smileSample(Matrix self, int n, Random random) {
+    self.sample(n, random)
+  }
+
+  /**
+   * Take a random sample of a fraction of rows from the Matrix with a specific Random.
+   *
+   * @param self the Matrix to sample from
+   * @param fraction the fraction of rows to sample (0.0 to 1.0)
+   * @param random the Random instance to use
+   * @return a new Matrix with randomly selected rows
+   */
+  static Matrix smileSample(Matrix self, double fraction, Random random) {
+    self.sampleFraction(fraction, random)
+  }
+
+  /**
+   * Get the first n rows of the Matrix as a new Matrix.
+   *
+   * @param self the Matrix
+   * @param n the number of rows (default 5)
+   * @return a new Matrix with the first n rows
+   */
+  static Matrix smileHead(Matrix self, int n = 5) {
+    self.top(n)
+  }
+
+  /**
+   * Get the last n rows of the Matrix as a new Matrix.
+   *
+   * @param self the Matrix
+   * @param n the number of rows (default 5)
+   * @return a new Matrix with the last n rows
+   */
+  static Matrix smileTail(Matrix self, int n = 5) {
+    self.bottom(n)
+  }
+
+  /**
+   * Get column metadata for the Matrix (name, type, null counts, unique count).
+   *
+   * @param self the Matrix to analyze
+   * @return a Matrix with column information
+   */
+  static Matrix smileInfo(Matrix self) {
+    self.info()
+  }
+
+  /**
+   * Create a frequency table for a column.
+   *
+   * @param self the Matrix containing the column
+   * @param column the name of the column to analyze
+   * @return a Matrix with Value, Frequency, and Percent columns
+   */
+  static Matrix smileFrequency(Matrix self, String column) {
+    Stat.frequency(self, column)
   }
 
   // ==================== DataFrame Extensions ====================

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/SmileUtil.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/SmileUtil.groovy
@@ -208,106 +208,51 @@ class SmileUtil {
   }
 
   /**
-   * Take a random sample of rows from a Matrix.
-   *
-   * @param matrix the Matrix to sample from
-   * @param n the number of rows to sample
-   * @return a new Matrix containing the sampled rows
+   * @deprecated Use {@link Matrix#sample(int, Random)} instead.
    */
+  @Deprecated
   static Matrix sample(Matrix matrix, int n) {
-    sample(matrix, n, new Random())
+    matrix.sample(n)
   }
 
   /**
-   * Take a random sample of rows from a Matrix with a specific random seed.
-   *
-   * @param matrix the Matrix to sample from
-   * @param n the number of rows to sample
-   * @param random the Random instance to use
-   * @return a new Matrix containing the sampled rows
+   * @deprecated Use {@link Matrix#sample(int, Random)} instead.
    */
+  @Deprecated
   static Matrix sample(Matrix matrix, int n, Random random) {
-    if (n <= 0) {
-      throw new IllegalArgumentException("Sample size must be positive: was $n")
-    }
-    if (n > matrix.rowCount()) {
-      throw new IllegalArgumentException("Sample size ($n) cannot exceed matrix row count (${matrix.rowCount()})")
-    }
-
-    List<Integer> indices = (0..<matrix.rowCount()).toList()
-    Collections.shuffle(indices, random)
-    List<Integer> sampleIndices = indices.take(n).sort()
-
-    Matrix.builder()
-        .rows(matrix.rows(sampleIndices) as List<List>)
-        .matrixName(matrix.matrixName)
-        .columnNames(matrix.columnNames() as List<String>)
-        .types(matrix.types())
-        .build()
+    matrix.sample(n, random)
   }
 
   /**
-   * Take a random sample of a fraction of rows from a Matrix.
-   *
-   * @param matrix the Matrix to sample from
-   * @param fraction the fraction of rows to sample (0.0 to 1.0)
-   * @return a new Matrix containing the sampled rows
+   * @deprecated Use {@link Matrix#sampleFraction(Number, Random)} instead.
    */
+  @Deprecated
   static Matrix sample(Matrix matrix, double fraction) {
-    sample(matrix, fraction, new Random())
+    matrix.sampleFraction(fraction)
   }
 
   /**
-   * Take a random sample of a fraction of rows from a Matrix with a specific random seed.
-   *
-   * @param matrix the Matrix to sample from
-   * @param fraction the fraction of rows to sample (0.0 to 1.0)
-   * @param random the Random instance to use
-   * @return a new Matrix containing the sampled rows
+   * @deprecated Use {@link Matrix#sampleFraction(Number, Random)} instead.
    */
+  @Deprecated
   static Matrix sample(Matrix matrix, double fraction, Random random) {
-    if (fraction <= 0.0 || fraction > 1.0) {
-      throw new IllegalArgumentException("Fraction must be between 0 and 1 (exclusive of 0): was $fraction")
-    }
-    int n = Math.max(1, (int) Math.round(matrix.rowCount() * fraction))
-    sample(matrix, n, random)
+    matrix.sampleFraction(fraction, random)
   }
 
   /**
-   * Get the first n rows of a Matrix (convenience method).
-   *
-   * @param matrix the Matrix
-   * @param n the number of rows
-   * @return a new Matrix with the first n rows
+   * @deprecated Use {@link Matrix#top(Number)} instead.
    */
+  @Deprecated
   static Matrix head(Matrix matrix, int n = 5) {
-    int take = Math.min(n, matrix.rowCount())
-    List<Integer> indices = (0..<take).toList()
-    Matrix.builder()
-        .rows(matrix.rows(indices) as List<List>)
-        .matrixName(matrix.matrixName)
-        .columnNames(matrix.columnNames() as List<String>)
-        .types(matrix.types())
-        .build()
+    matrix.top(n)
   }
 
   /**
-   * Get the last n rows of a Matrix (convenience method).
-   *
-   * @param matrix the Matrix
-   * @param n the number of rows
-   * @return a new Matrix with the last n rows
+   * @deprecated Use {@link Matrix#bottom(Number)} instead.
    */
+  @Deprecated
   static Matrix tail(Matrix matrix, int n = 5) {
-    int rowCount = matrix.rowCount()
-    int start = Math.max(0, rowCount - n)
-    List<Integer> indices = (start..<rowCount).toList()
-    Matrix.builder()
-        .rows(matrix.rows(indices) as List<List>)
-        .matrixName(matrix.matrixName)
-        .columnNames(matrix.columnNames() as List<String>)
-        .types(matrix.types())
-        .build()
+    matrix.bottom(n)
   }
 
   /**
@@ -331,37 +276,20 @@ class SmileUtil {
   }
 
   /**
-   * Get column information including type, null count, and unique count.
-   *
-   * @param matrix the Matrix to analyze
-   * @return a Matrix with column information
+   * @deprecated Use {@link Matrix#info()} instead. Note: the matrix-core version uses
+   * column names {@code nonNullCount} and {@code nullCount} instead of {@code non-null}
+   * and {@code null}.
    */
+  @Deprecated
   static Matrix info(Matrix matrix) {
-    List<String> columnNames = []
-    List<String> types = []
-    List<Integer> nonNullCounts = []
-    List<Integer> nullCounts = []
-    List<Integer> uniqueCounts = []
-
-    for (int i = 0; i < matrix.columnCount(); i++) {
-      String colName = matrix.columnName(i)
-      List<?> column = matrix.column(i)
-
-      columnNames << colName
-      types << matrix.type(i).simpleName
-      int nullCount = countNulls(column)
-      nullCounts << nullCount
-      nonNullCounts << (column.size() - nullCount)
-      uniqueCounts << column.findAll { it != null }.toSet().size()
-    }
-
+    Matrix result = matrix.info()
     Matrix.builder()
         .data(
-            column: columnNames,
-            type: types,
-            'non-null': nonNullCounts,
-            'null': nullCounts,
-            unique: uniqueCounts
+            column: result.column('column') as List<Object>,
+            type: result.column('type') as List<Object>,
+            'non-null': result.column('nonNullCount') as List<Object>,
+            'null': result.column('nullCount') as List<Object>,
+            unique: result.column('unique') as List<Object>
         )
         .types([String, String, Integer, Integer, Integer])
         .build()
@@ -438,39 +366,20 @@ class SmileUtil {
   }
 
   /**
-   * Create a frequency table for a column.
-   *
-   * @param matrix the Matrix containing the column
-   * @param columnName the name of the column to analyze
-   * @return a Matrix with value, frequency, and percentage
+   * @deprecated Use {@link Stat#frequency(Matrix, String)} instead. Note: the matrix-core
+   * version uses uppercase column names ({@code Value}, {@code Frequency}, {@code Percent})
+   * and {@code BigDecimal} percent. This wrapper preserves the v0.1.0 lowercase names and
+   * {@code Double} percent type.
    */
+  @Deprecated
   static Matrix frequency(Matrix matrix, String columnName) {
-    List<?> column = matrix[columnName] as List<?>
-    Map<Object, Integer> freq = [:]
-
-    for (Object val : column) {
-      freq.merge(val, 1) { old, v -> old + v }
-    }
-
-    int total = column.size()
-    List<Object> values = []
-    List<Integer> frequencies = []
-    List<Double> percentages = []
-
-    // Sort by frequency descending
-    freq.entrySet()
-        .sort { -it.value }
-        .each { entry ->
-          values << (entry.key == null ? 'null' : entry.key.toString())
-          frequencies << entry.value
-          percentages << round(entry.value * PERCENT / total, 2)
-        }
-
+    Matrix result = Stat.frequency(matrix, columnName)
+    List<Double> percentAsDouble = result[Stat.FREQUENCY_PERCENT].collect { it as double }
     Matrix.builder()
         .data(
-            value: values,
-            frequency: frequencies,
-            percent: percentages
+            value: result[Stat.FREQUENCY_VALUE] as List<Object>,
+            frequency: result[Stat.FREQUENCY_FREQUENCY] as List<Object>,
+            percent: percentAsDouble as List<Object>
         )
         .types([String, Integer, Double])
         .build()

--- a/matrix-smile/src/test/groovy/GsmileTest.groovy
+++ b/matrix-smile/src/test/groovy/GsmileTest.groovy
@@ -274,6 +274,121 @@ class GsmileTest {
     assertEquals([25, 30, 35, 28, 42], ages)
   }
 
+  // ==================== New Matrix Extension Tests ====================
+
+  @Test
+  void testSmileHead() {
+    Matrix matrix = createTestMatrix()
+
+    Matrix head = Gsmile.smileHead(matrix, 3)
+
+    assertEquals(3, head.rowCount())
+    assertEquals(matrix.columnCount(), head.columnCount())
+    assertEquals('Alice', head[0, 'name'])
+    assertEquals('Charlie', head[2, 'name'])
+  }
+
+  @Test
+  void testSmileHeadDefault() {
+    Matrix matrix = createTestMatrix()
+
+    Matrix head = Gsmile.smileHead(matrix)
+
+    assertEquals(5, head.rowCount())
+  }
+
+  @Test
+  void testSmileHeadClamped() {
+    Matrix matrix = createTestMatrix()
+
+    Matrix head = Gsmile.smileHead(matrix, 100)
+
+    assertEquals(5, head.rowCount())
+  }
+
+  @Test
+  void testSmileTail() {
+    Matrix matrix = createTestMatrix()
+
+    Matrix tail = Gsmile.smileTail(matrix, 2)
+
+    assertEquals(2, tail.rowCount())
+    assertEquals('Diana', tail[0, 'name'])
+    assertEquals('Eve', tail[1, 'name'])
+  }
+
+  @Test
+  void testSmileTailDefault() {
+    Matrix matrix = createTestMatrix()
+
+    Matrix tail = Gsmile.smileTail(matrix)
+
+    assertEquals(5, tail.rowCount())
+  }
+
+  @Test
+  void testSmileInfo() {
+    Matrix matrix = createTestMatrix()
+
+    Matrix info = Gsmile.smileInfo(matrix)
+
+    assertNotNull(info)
+    assertEquals(4, info.rowCount())
+    assertTrue(info.columnNames().contains('column'))
+    assertTrue(info.columnNames().contains('type'))
+    assertTrue(info.columnNames().contains('nonNullCount'))
+    assertTrue(info.columnNames().contains('nullCount'))
+    assertTrue(info.columnNames().contains('unique'))
+  }
+
+  @Test
+  void testSmileFrequency() {
+    Matrix matrix = createTestMatrix()
+
+    Matrix freq = Gsmile.smileFrequency(matrix, 'active')
+
+    assertNotNull(freq)
+    assertTrue(freq.rowCount() > 0)
+    assertTrue(freq.columnNames().contains('Value'))
+    assertTrue(freq.columnNames().contains('Frequency'))
+    assertTrue(freq.columnNames().contains('Percent'))
+  }
+
+  @Test
+  void testSmileSampleFraction() {
+    Matrix matrix = createTestMatrix()
+
+    Matrix sample = Gsmile.smileSample(matrix, 0.6)
+
+    assertNotNull(sample)
+    assertTrue(sample.rowCount() > 0)
+    assertTrue(sample.rowCount() <= matrix.rowCount())
+    assertEquals(matrix.columnCount(), sample.columnCount())
+  }
+
+  @Test
+  void testSmileSampleWithRandom() {
+    Matrix matrix = createTestMatrix()
+    Random random = new Random(42)
+
+    Matrix sample = Gsmile.smileSample(matrix, 3, random)
+
+    assertEquals(3, sample.rowCount())
+    assertEquals(matrix.columnCount(), sample.columnCount())
+  }
+
+  @Test
+  void testSmileSampleFractionWithRandom() {
+    Matrix matrix = createTestMatrix()
+    Random random = new Random(42)
+
+    Matrix sample = Gsmile.smileSample(matrix, 0.6, random)
+
+    assertNotNull(sample)
+    assertTrue(sample.rowCount() > 0)
+    assertTrue(sample.rowCount() <= matrix.rowCount())
+  }
+
   // ==================== Integration Tests ====================
 
   @Test


### PR DESCRIPTION
## Summary
- **SmileUtil deprecations:** `head`, `tail`, `info`, `frequency`, and all `sample` overloads are now `@Deprecated`, delegating to matrix-core equivalents (`Matrix.top`, `Matrix.bottom`, `Matrix.info`, `Stat.frequency`, `Matrix.sample`/`sampleFraction`). The `info` and `frequency` wrappers preserve v0.1.0 column names and types for backward compatibility.
- **New Gsmile extensions:** `smileHead`, `smileTail`, `smileInfo`, `smileFrequency` delegate directly to matrix-core (not through deprecated wrappers). Three new `smileSample` overloads added (fraction, int+Random, fraction+Random), and the existing `smileSample(int)` updated to bypass the deprecated `SmileUtil.sample`.
- **Tests:** 9 new tests in `GsmileTest.groovy` covering all new extensions.

## Test plan
- [x] `./gradlew :matrix-smile:spotlessCheck` — clean
- [x] `./gradlew :matrix-smile:codenarcMain :matrix-smile:codenarcTest` — clean
- [x] `./gradlew :matrix-smile:test` — 345 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)