### PR TITLE
Add distribution-fit overloads and stateful encoders

### DIFF
--- a/matrix-smile/req/v0.2.0-api-cleanup-plan.md
+++ b/matrix-smile/req/v0.2.0-api-cleanup-plan.md
@@ -695,7 +695,7 @@ correct choice because both operands are `int` and the result must stay `int`.
 
 ### 6.1 `List<? extends Number>` and `Matrix + column` overloads in `SmileStats`
 
-**6.1.1** [ ] Add a package-private static utility `toDoubleArray(List<? extends Number>)` in
+**6.1.1** [x] Add a package-private static utility `toDoubleArray(List<? extends Number>)` in
 `SmileStats` that converts each element to a `double` (null → `Double.NaN`):
 ```groovy
 /**
@@ -726,7 +726,7 @@ static GaussianDistribution normalFit(List<? extends Number> data) {
 ```
 Add GroovyDoc noting that null elements are excluded before the distribution is fitted.
 
-**6.1.2** [ ] Add `Matrix + columnName` overloads for the same distribution fit methods,
+**6.1.2** [x] Add `Matrix + columnName` overloads for the same distribution fit methods,
 consistent with the existing `tTestOneSample(Matrix, String, double)` and
 `ksTestNormality(Matrix, String)` wrappers. Each overload delegates to the `double[]`
 overload via the already-compact `toDoubleArray`+`compactDoubleArray` path:
@@ -757,7 +757,7 @@ static LogNormalDistribution logNormalFit(Matrix matrix, String column) {
 is updated to use `compactDoubleArray` as part of Task 2.2.1 Step C rather than adding it again
 here.)
 
-**6.1.3** [ ] Add tests in `SmileStatsTest.groovy` for each new overload: basic fit, null
+**6.1.3** [x] Add tests in `SmileStatsTest.groovy` for each new overload: basic fit, null
 elements excluded, empty list throws `IllegalArgumentException` with a descriptive message
 (rather than an opaque Smile error).
 
@@ -769,7 +769,7 @@ would require silent truncation of non-integer values, which is misleading. The 
 
 ### 6.2 `LabelEncoder` and `OneHotEncoder` stateful classes in `SmileFeatures`
 
-**6.2.1** [ ] Add a `LabelEncoder` inner class (analogous to `StandardScaler`) with:
+**6.2.1** [x] Add a `LabelEncoder` inner class (analogous to `StandardScaler`) with:
 
 > **AGENTS.md deviation:** `Object` is used for label storage and map keys because Matrix
 > columns are erased to `List<?>` at runtime, making `Class<T>`-based generic inference
@@ -832,7 +832,7 @@ would require silent truncation of non-integer values, which is misleading. The 
 - `inverse(int index)` — throws `IllegalStateException` if `fitted` is false; otherwise
   returns `labels.get(index)` (the original `Object` value).
 
-**6.2.2** [ ] Add a `OneHotEncoder` inner class with:
+**6.2.2** [x] Add a `OneHotEncoder` inner class with:
 - `fit(Matrix matrix, String column)` — collects unique non-null values; if none exist
   (all-null or empty column), throw `IllegalArgumentException`("No non-null categories found
   for column '${column}'"). Otherwise stores the sorted list as `List<Object> categories`
@@ -861,7 +861,7 @@ would require silent truncation of non-integer values, which is misleading. The 
 > This keeps the two APIs consistent — callers switching from the stateless method to the
 > stateful encoder get the same default behaviour.
 
-**6.2.3** [ ] Add static factory methods `SmileFeatures.labelEncoder()` and
+**6.2.3** [x] Add static factory methods `SmileFeatures.labelEncoder()` and
 `SmileFeatures.oneHotEncoder()` mirroring `standardScaler()` and `minMaxScaler()`.
 
 > **Relationship with existing static methods:** `SmileFeatures` already has stateless
@@ -881,7 +881,7 @@ would require silent truncation of non-integer values, which is misleading. The 
 > would return an unfitted encoder with no link to the matrix. The factory pattern
 > (`SmileFeatures.labelEncoder()`) is the intended API.
 
-**6.2.4** [ ] Add tests in `SmileFeaturesTest.groovy` covering: fit on train, transform on test,
+**6.2.4** [x] Add tests in `SmileFeaturesTest.groovy` covering: fit on train, transform on test,
 unknown-label rejection, inverse lookup, round-trip. Also add tests verifying that calling
 `transform()`, `getLabels()`, `inverse()`, or `getCategories()` before `fit()` throws
 `IllegalStateException` for both `LabelEncoder` and `OneHotEncoder`.

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileFeatures.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileFeatures.groovy
@@ -805,7 +805,7 @@ class SmileFeatures {
         throw new IllegalStateException('Encoder must be fitted before transforming')
       }
       List<?> col = matrix.column(column)
-      List<Integer> encoded = new ArrayList<>(col.size())
+      List<Integer> encoded = []
       for (int i = 0; i < col.size(); i++) {
         Object val = col.get(i)
         if (val == null) {

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileFeatures.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileFeatures.groovy
@@ -10,6 +10,7 @@ import se.alipsa.matrix.smile.SmileUtil
  * Provides standardization, normalization, and encoding transformations.
  */
 @CompileStatic
+@SuppressWarnings('ClassSize')
 class SmileFeatures {
 
   private static final int HALF_DIVISOR = 2
@@ -443,6 +444,24 @@ class SmileFeatures {
     new MinMaxScaler()
   }
 
+  /**
+   * Create a LabelEncoder that can be fitted on training data and applied to new data.
+   *
+   * @return a new LabelEncoder instance
+   */
+  static LabelEncoder labelEncoder() {
+    new LabelEncoder()
+  }
+
+  /**
+   * Create a OneHotEncoder that can be fitted on training data and applied to new data.
+   *
+   * @return a new OneHotEncoder instance
+   */
+  static OneHotEncoder oneHotEncoder() {
+    new OneHotEncoder()
+  }
+
   // ============ Helper Methods ============
 
   private static Matrix transformColumns(Matrix matrix, List<String> columns, Closure<List<?>> transformer) {
@@ -766,6 +785,275 @@ class SmileFeatures {
      */
     Map<String, Double> getMaxs() {
       Collections.unmodifiableMap(maxs)
+    }
+
+  }
+
+  // ============ Encoder Classes ============
+
+  /**
+   * Stateful label encoder that maps categorical values to integer indices.
+   * Fit on training data, then apply the same mapping to test/production data.
+   *
+   * <p>For one-shot encoding without a reusable mapping, use the stateless
+   * {@link #labelEncode(Matrix, String)} method instead.
+   *
+   * <p><b>Identity model:</b> This encoder uses {@code Object.equals()} for label identity.
+   * Note that {@code SmileClassifier} uses {@code toString()} identity — {@code 1} (Integer)
+   * and {@code "1"} (String) are the same class in {@code SmileClassifier} but distinct labels
+   * in this encoder. Ensure your column types are consistent if using both APIs on the same data.
+   */
+  @CompileStatic
+  static class LabelEncoder {
+
+    private List<Object> labels
+    private Map<Object, Integer> labelMap
+    private boolean fitted = false
+
+    /**
+     * Fit the encoder on training data.
+     * Collects unique non-null values and sorts them by {@code toString()} for deterministic ordering.
+     *
+     * @param matrix the training data
+     * @param column the column to encode
+     * @return this encoder
+     * @throws IllegalArgumentException if no non-null labels are found
+     */
+    LabelEncoder fit(Matrix matrix, String column) {
+      List<?> col = matrix.column(column)
+      Set<Object> unique = new LinkedHashSet<>(col.findAll { it != null })
+      if (unique.isEmpty()) {
+        throw new IllegalArgumentException("No non-null labels found for column '${column}'")
+      }
+      labels = unique.toList().sort { it.toString() }
+      labelMap = [:]
+      labels.eachWithIndex { Object val, int idx -> labelMap[val] = idx }
+      fitted = true
+      this
+    }
+
+    /**
+     * Transform data using the fitted mapping.
+     *
+     * @param matrix the data to transform
+     * @param column the column to encode
+     * @return a new Matrix with the column replaced by integer labels
+     * @throws IllegalStateException if the encoder has not been fitted
+     * @throws IllegalArgumentException if a value is null or was not seen during fitting
+     */
+    Matrix transform(Matrix matrix, String column) {
+      if (!fitted) {
+        throw new IllegalStateException('Encoder must be fitted before transforming')
+      }
+      List<?> col = matrix.column(column)
+      List<Integer> encoded = new ArrayList<>(col.size())
+      for (int i = 0; i < col.size(); i++) {
+        Object val = col.get(i)
+        if (val == null) {
+          throw new IllegalArgumentException("Null value at row ${i} in column '${column}'")
+        }
+        Integer idx = labelMap.get(val)
+        if (idx == null) {
+          throw new IllegalArgumentException(
+              "Unseen label '${val}' at row ${i} in column '${column}'. Known labels: ${labels}")
+        }
+        encoded.add(idx)
+      }
+      replaceColumn(matrix, column, encoded, Integer)
+    }
+
+    /**
+     * Fit and transform in one step.
+     *
+     * @param matrix the data to fit and transform
+     * @param column the column to encode
+     * @return a new Matrix with the column replaced by integer labels
+     */
+    Matrix fitTransform(Matrix matrix, String column) {
+      fit(matrix, column)
+      transform(matrix, column)
+    }
+
+    /**
+     * Get the ordered list of labels.
+     *
+     * @return an unmodifiable list of labels in index order
+     * @throws IllegalStateException if the encoder has not been fitted
+     */
+    List<Object> getLabels() {
+      if (!fitted) {
+        throw new IllegalStateException('Encoder must be fitted before accessing labels')
+      }
+      Collections.unmodifiableList(labels)
+    }
+
+    /**
+     * Get the original label for a given integer index.
+     *
+     * @param index the integer index
+     * @return the original label value
+     * @throws IllegalStateException if the encoder has not been fitted
+     */
+    Object inverse(int index) {
+      if (!fitted) {
+        throw new IllegalStateException('Encoder must be fitted before inverse lookup')
+      }
+      labels.get(index)
+    }
+
+  }
+
+  /**
+   * Stateful one-hot encoder that creates binary columns for each category.
+   * Fit on training data, then apply the same mapping to test/production data.
+   *
+   * <p>For one-shot encoding without a reusable mapping, use the stateless
+   * {@link #oneHotEncode(Matrix, String)} method instead.
+   *
+   * <p><b>Identity model:</b> This encoder uses {@code Object.equals()} for category identity.
+   * Note that {@code SmileClassifier} uses {@code toString()} identity — {@code 1} (Integer)
+   * and {@code "1"} (String) are the same class in {@code SmileClassifier} but distinct
+   * categories in this encoder. Ensure your column types are consistent if using both APIs
+   * on the same data.
+   */
+  @CompileStatic
+  static class OneHotEncoder {
+
+    private List<Object> categories
+    private boolean fitted = false
+
+    /**
+     * Fit the encoder on training data.
+     * Collects unique non-null values and sorts them by {@code toString()} for deterministic ordering.
+     *
+     * @param matrix the training data
+     * @param column the column to encode
+     * @return this encoder
+     * @throws IllegalArgumentException if no non-null categories are found
+     */
+    OneHotEncoder fit(Matrix matrix, String column) {
+      List<?> col = matrix.column(column)
+      Set<Object> unique = new LinkedHashSet<>(col.findAll { it != null })
+      if (unique.isEmpty()) {
+        throw new IllegalArgumentException("No non-null categories found for column '${column}'")
+      }
+      categories = unique.toList().sort { it.toString() }
+      fitted = true
+      this
+    }
+
+    /**
+     * Transform data using the fitted categories.
+     * Produces one binary Integer column per category named {@code "${column}_${category}"}.
+     *
+     * @param matrix the data to transform
+     * @param column the column to encode
+     * @param dropOriginal whether to drop the original column (default true)
+     * @return a new Matrix with one-hot encoded columns
+     * @throws IllegalStateException if the encoder has not been fitted
+     * @throws IllegalArgumentException if a value is unseen or null, or if generated column names collide
+     */
+    @SuppressWarnings('NestedForLoop')
+    Matrix transform(Matrix matrix, String column, boolean dropOriginal = true) {
+      if (!fitted) {
+        throw new IllegalStateException('Encoder must be fitted before transforming')
+      }
+
+      List<String> generatedNames = categories.collect { "${column}_${it}" as String }
+
+      // Check for duplicate generated names
+      Set<String> seen = [] as Set
+      for (String name : generatedNames) {
+        if (!seen.add(name)) {
+          throw new IllegalArgumentException(
+              "Duplicate generated column name '${name}'. Distinct categories produce the same " +
+              'string representation. Pre-convert the column to a consistent type.')
+        }
+      }
+
+      // Check for collisions with existing retained columns
+      Set<String> retained = [] as Set
+      for (String col : matrix.columnNames()) {
+        if (col == column && dropOriginal) { continue }
+        retained.add(col)
+      }
+      for (String name : generatedNames) {
+        if (retained.contains(name)) {
+          throw new IllegalArgumentException(
+              "Generated column name '${name}' collides with an existing column. " +
+              'Rename the existing column before encoding.')
+        }
+      }
+
+      // Validate all values exist in categories
+      List<?> colData = matrix.column(column)
+      for (int i = 0; i < colData.size(); i++) {
+        Object val = colData.get(i)
+        if (val == null) {
+          throw new IllegalArgumentException("Null value at row ${i} in column '${column}'")
+        }
+        if (!categories.contains(val)) {
+          throw new IllegalArgumentException(
+              "Unseen category '${val}' at row ${i} in column '${column}'. " +
+              "Known categories: ${categories}")
+        }
+      }
+
+      // Build output
+      Map<String, List<?>> newData = [:]
+      List<Class<?>> newTypes = []
+      int colIndex = matrix.columnNames().indexOf(column)
+
+      for (int i = 0; i < matrix.columnCount(); i++) {
+        String colName = matrix.columnName(i)
+        if (i == colIndex) {
+          if (!dropOriginal) {
+            newData.put(colName, matrix.column(i))
+            newTypes.add(matrix.type(i))
+          }
+          for (int c = 0; c < categories.size(); c++) {
+            Object cat = categories.get(c)
+            List<Integer> binaryCol = colData.collect { it == cat ? 1 : 0 }
+            newData.put(generatedNames.get(c), binaryCol)
+            newTypes.add(Integer)
+          }
+        } else {
+          newData.put(colName, matrix.column(i))
+          newTypes.add(matrix.type(i))
+        }
+      }
+
+      Matrix.builder()
+          .data(newData)
+          .types(newTypes)
+          .matrixName(matrix.matrixName)
+          .build()
+    }
+
+    /**
+     * Fit and transform in one step.
+     *
+     * @param matrix the data to fit and transform
+     * @param column the column to encode
+     * @param dropOriginal whether to drop the original column (default true)
+     * @return a new Matrix with one-hot encoded columns
+     */
+    Matrix fitTransform(Matrix matrix, String column, boolean dropOriginal = true) {
+      fit(matrix, column)
+      transform(matrix, column, dropOriginal)
+    }
+
+    /**
+     * Get the ordered list of categories.
+     *
+     * @return an unmodifiable list of categories in index order
+     * @throws IllegalStateException if the encoder has not been fitted
+     */
+    List<Object> getCategories() {
+      if (!fitted) {
+        throw new IllegalStateException('Encoder must be fitted before accessing categories')
+      }
+      Collections.unmodifiableList(categories)
     }
 
   }

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileFeatures.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileFeatures.groovy
@@ -103,43 +103,8 @@ class SmileFeatures {
    * @param dropOriginal whether to drop the original column (default true)
    * @return a new Matrix with one-hot encoded columns
    */
-  @SuppressWarnings('NestedForLoop')
   static Matrix oneHotEncode(Matrix matrix, String column, boolean dropOriginal) {
-    List<?> originalColumn = matrix.column(column)
-    Set<Object> uniqueValues = new LinkedHashSet<>(originalColumn.findAll { it != null })
-    List<Object> sortedValues = uniqueValues.toList().sort { it.toString() }
-
-    // Build the new data structure
-    Map<String, List<?>> newData = [:]
-    List<Class<?>> newTypes = []
-
-    // Copy columns before the encoded column
-    int colIndex = matrix.columnNames().indexOf(column)
-    for (int i = 0; i < matrix.columnCount(); i++) {
-      String colName = matrix.columnName(i)
-      if (i == colIndex) {
-        if (!dropOriginal) {
-          newData.put(colName, matrix.column(i))
-          newTypes.add(matrix.type(i))
-        }
-        // Add one-hot columns
-        for (Object value : sortedValues) {
-          String newColName = "${column}_${value}"
-          List<Integer> binaryCol = originalColumn.collect { it == value ? 1 : 0 }
-          newData.put(newColName, binaryCol)
-          newTypes.add(Integer)
-        }
-      } else {
-        newData.put(colName, matrix.column(i))
-        newTypes.add(matrix.type(i))
-      }
-    }
-
-    Matrix.builder()
-        .data(newData)
-        .types(newTypes)
-        .matrixName(matrix.matrixName)
-        .build()
+    oneHotEncoder().fitTransform(matrix, column, dropOriginal)
   }
 
   /**
@@ -166,8 +131,7 @@ class SmileFeatures {
    */
   static Matrix labelEncode(Matrix matrix, String column) {
     List<?> originalColumn = matrix.column(column)
-    Set<Object> uniqueValues = new LinkedHashSet<>(originalColumn.findAll { it != null })
-    List<Object> sortedValues = uniqueValues.toList().sort { it.toString() }
+    List<Object> sortedValues = extractSortedUniqueValues(originalColumn, column, 'labels')
 
     Map<Object, Integer> labelMap = [:]
     sortedValues.eachWithIndex { val, idx -> labelMap[val] = idx }
@@ -487,6 +451,14 @@ class SmileFeatures {
         .types(newTypes)
         .matrixName(matrix.matrixName)
         .build()
+  }
+
+  private static List<Object> extractSortedUniqueValues(List<?> col, String column, String entityName) {
+    Set<Object> unique = new LinkedHashSet<>(col.findAll { it != null })
+    if (unique.isEmpty()) {
+      throw new IllegalArgumentException("No non-null ${entityName} found for column '${column}'")
+    }
+    unique.toList().sort { it.toString() }
   }
 
   private static Matrix replaceColumn(Matrix matrix, String column, List<?> newValues, Class<?> newType) {
@@ -820,12 +792,7 @@ class SmileFeatures {
      * @throws IllegalArgumentException if no non-null labels are found
      */
     LabelEncoder fit(Matrix matrix, String column) {
-      List<?> col = matrix.column(column)
-      Set<Object> unique = new LinkedHashSet<>(col.findAll { it != null })
-      if (unique.isEmpty()) {
-        throw new IllegalArgumentException("No non-null labels found for column '${column}'")
-      }
-      labels = unique.toList().sort { it.toString() }
+      labels = extractSortedUniqueValues(matrix.column(column), column, 'labels')
       labelMap = [:]
       labels.eachWithIndex { Object val, int idx -> labelMap[val] = idx }
       fitted = true
@@ -932,12 +899,7 @@ class SmileFeatures {
      * @throws IllegalArgumentException if no non-null categories are found
      */
     OneHotEncoder fit(Matrix matrix, String column) {
-      List<?> col = matrix.column(column)
-      Set<Object> unique = new LinkedHashSet<>(col.findAll { it != null })
-      if (unique.isEmpty()) {
-        throw new IllegalArgumentException("No non-null categories found for column '${column}'")
-      }
-      categories = unique.toList().sort { it.toString() }
+      categories = extractSortedUniqueValues(matrix.column(column), column, 'categories')
       fitted = true
       this
     }
@@ -987,12 +949,13 @@ class SmileFeatures {
 
       // Validate all values exist in categories
       List<?> colData = matrix.column(column)
+      Set<Object> categorySet = categories.toSet()
       for (int i = 0; i < colData.size(); i++) {
         Object val = colData.get(i)
         if (val == null) {
           throw new IllegalArgumentException("Null value at row ${i} in column '${column}'")
         }
-        if (!categories.contains(val)) {
+        if (!categorySet.contains(val)) {
           throw new IllegalArgumentException(
               "Unseen category '${val}' at row ${i} in column '${column}'. " +
               "Known categories: ${categories}")

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileFeatures.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileFeatures.groovy
@@ -130,15 +130,7 @@ class SmileFeatures {
    * @return a new Matrix with the column replaced by integer labels
    */
   static Matrix labelEncode(Matrix matrix, String column) {
-    List<?> originalColumn = matrix.column(column)
-    List<Object> sortedValues = extractSortedUniqueValues(originalColumn, column, 'labels')
-
-    Map<Object, Integer> labelMap = [:]
-    sortedValues.eachWithIndex { val, idx -> labelMap[val] = idx }
-
-    List<Integer> encodedColumn = originalColumn.collect { it != null ? labelMap[it] : null }
-
-    replaceColumn(matrix, column, encodedColumn, Integer)
+    labelEncoder().fitTransform(matrix, column)
   }
 
   /**
@@ -887,6 +879,7 @@ class SmileFeatures {
   static class OneHotEncoder {
 
     private List<Object> categories
+    private Set<Object> categorySet
     private boolean fitted = false
 
     /**
@@ -900,6 +893,7 @@ class SmileFeatures {
      */
     OneHotEncoder fit(Matrix matrix, String column) {
       categories = extractSortedUniqueValues(matrix.column(column), column, 'categories')
+      categorySet = categories.toSet()
       fitted = true
       this
     }
@@ -949,7 +943,6 @@ class SmileFeatures {
 
       // Validate all values exist in categories
       List<?> colData = matrix.column(column)
-      Set<Object> categorySet = categories.toSet()
       for (int i = 0; i < colData.size(); i++) {
         Object val = colData.get(i)
         if (val == null) {

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileFeatures.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileFeatures.groovy
@@ -454,7 +454,7 @@ class SmileFeatures {
   }
 
   private static List<Object> extractSortedUniqueValues(List<?> col, String column, String entityName) {
-    Set<Object> unique = new LinkedHashSet<>(col.findAll { it != null })
+    Set<Object> unique = col.findAll { it != null } as Set
     if (unique.isEmpty()) {
       throw new IllegalArgumentException("No non-null ${entityName} found for column '${column}'")
     }

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/stats/SmileStats.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/stats/SmileStats.groovy
@@ -1,6 +1,7 @@
 package se.alipsa.matrix.smile.stats
 
 import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
 
 import smile.stat.distribution.BernoulliDistribution
 import smile.stat.distribution.BetaDistribution
@@ -73,6 +74,19 @@ class SmileStats {
   }
 
   /**
+   * Fit a Normal distribution to a list of numbers.
+   * Null elements are excluded before fitting.
+   *
+   * @param data the data to fit
+   * @return a fitted GaussianDistribution
+   */
+  static GaussianDistribution normalFit(List<? extends Number> data) {
+    double[] compacted = compactDoubleArray(toDoubleArrayFromList(data))
+    requireMinimumSamples(compacted, MINIMUM_SAMPLES, 'normalFit on List data')
+    normalFit(compacted)
+  }
+
+  /**
    * Create a Poisson distribution.
    *
    * @param lambda the rate parameter (mean)
@@ -135,6 +149,33 @@ class SmileStats {
   }
 
   /**
+   * Fit an Exponential distribution to a Matrix column.
+   * Null values are excluded before fitting.
+   *
+   * @param matrix the Matrix containing the data
+   * @param column the column name
+   * @return a fitted ExponentialDistribution
+   */
+  static ExponentialDistribution exponentialFit(Matrix matrix, String column) {
+    double[] compacted = compactDoubleArray(toDoubleArray(matrix, column))
+    requireMinimumSamples(compacted, MINIMUM_SAMPLES, "exponentialFit on column '$column'")
+    exponentialFit(compacted)
+  }
+
+  /**
+   * Fit an Exponential distribution to a list of numbers.
+   * Null elements are excluded before fitting.
+   *
+   * @param data the data to fit
+   * @return a fitted ExponentialDistribution
+   */
+  static ExponentialDistribution exponentialFit(List<? extends Number> data) {
+    double[] compacted = compactDoubleArray(toDoubleArrayFromList(data))
+    requireMinimumSamples(compacted, MINIMUM_SAMPLES, 'exponentialFit on List data')
+    exponentialFit(compacted)
+  }
+
+  /**
    * Create a Gamma distribution.
    *
    * @param shape the shape parameter (k or alpha)
@@ -156,6 +197,33 @@ class SmileStats {
   }
 
   /**
+   * Fit a Gamma distribution to a Matrix column.
+   * Null values are excluded before fitting.
+   *
+   * @param matrix the Matrix containing the data
+   * @param column the column name
+   * @return a fitted GammaDistribution
+   */
+  static GammaDistribution gammaFit(Matrix matrix, String column) {
+    double[] compacted = compactDoubleArray(toDoubleArray(matrix, column))
+    requireMinimumSamples(compacted, MINIMUM_SAMPLES, "gammaFit on column '$column'")
+    gammaFit(compacted)
+  }
+
+  /**
+   * Fit a Gamma distribution to a list of numbers.
+   * Null elements are excluded before fitting.
+   *
+   * @param data the data to fit
+   * @return a fitted GammaDistribution
+   */
+  static GammaDistribution gammaFit(List<? extends Number> data) {
+    double[] compacted = compactDoubleArray(toDoubleArrayFromList(data))
+    requireMinimumSamples(compacted, MINIMUM_SAMPLES, 'gammaFit on List data')
+    gammaFit(compacted)
+  }
+
+  /**
    * Create a Beta distribution.
    *
    * @param alpha first shape parameter
@@ -174,6 +242,33 @@ class SmileStats {
    */
   static BetaDistribution betaFit(double[] data) {
     BetaDistribution.fit(data)
+  }
+
+  /**
+   * Fit a Beta distribution to a Matrix column.
+   * Null values are excluded before fitting. Values must be in [0,1].
+   *
+   * @param matrix the Matrix containing the data
+   * @param column the column name
+   * @return a fitted BetaDistribution
+   */
+  static BetaDistribution betaFit(Matrix matrix, String column) {
+    double[] compacted = compactDoubleArray(toDoubleArray(matrix, column))
+    requireMinimumSamples(compacted, MINIMUM_SAMPLES, "betaFit on column '$column'")
+    betaFit(compacted)
+  }
+
+  /**
+   * Fit a Beta distribution to a list of numbers.
+   * Null elements are excluded before fitting. Values must be in [0,1].
+   *
+   * @param data the data to fit
+   * @return a fitted BetaDistribution
+   */
+  static BetaDistribution betaFit(List<? extends Number> data) {
+    double[] compacted = compactDoubleArray(toDoubleArrayFromList(data))
+    requireMinimumSamples(compacted, MINIMUM_SAMPLES, 'betaFit on List data')
+    betaFit(compacted)
   }
 
   /**
@@ -239,6 +334,33 @@ class SmileStats {
    */
   static LogNormalDistribution logNormalFit(double[] data) {
     LogNormalDistribution.fit(data)
+  }
+
+  /**
+   * Fit a Log-Normal distribution to a Matrix column.
+   * Null values are excluded before fitting.
+   *
+   * @param matrix the Matrix containing the data
+   * @param column the column name
+   * @return a fitted LogNormalDistribution
+   */
+  static LogNormalDistribution logNormalFit(Matrix matrix, String column) {
+    double[] compacted = compactDoubleArray(toDoubleArray(matrix, column))
+    requireMinimumSamples(compacted, MINIMUM_SAMPLES, "logNormalFit on column '$column'")
+    logNormalFit(compacted)
+  }
+
+  /**
+   * Fit a Log-Normal distribution to a list of numbers.
+   * Null elements are excluded before fitting.
+   *
+   * @param data the data to fit
+   * @return a fitted LogNormalDistribution
+   */
+  static LogNormalDistribution logNormalFit(List<? extends Number> data) {
+    double[] compacted = compactDoubleArray(toDoubleArrayFromList(data))
+    requireMinimumSamples(compacted, MINIMUM_SAMPLES, 'logNormalFit on List data')
+    logNormalFit(compacted)
   }
 
   /**
@@ -863,6 +985,16 @@ class SmileStats {
       if (val != null) { buf[idx++] = val as int }
     }
     idx < col.size() ? Arrays.copyOf(buf, idx) : buf
+  }
+
+  @PackageScope
+  static double[] toDoubleArrayFromList(List<? extends Number> data) {
+    double[] buf = new double[data.size()]
+    int idx = 0
+    for (Number val : data) {
+      buf[idx++] = val != null ? val as double : Double.NaN
+    }
+    buf
   }
 
   @SuppressWarnings('NestedForLoop')

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/stats/SmileStats.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/stats/SmileStats.groovy
@@ -1,7 +1,6 @@
 package se.alipsa.matrix.smile.stats
 
 import groovy.transform.CompileStatic
-import groovy.transform.PackageScope
 
 import smile.stat.distribution.BernoulliDistribution
 import smile.stat.distribution.BetaDistribution
@@ -987,8 +986,7 @@ class SmileStats {
     idx < col.size() ? Arrays.copyOf(buf, idx) : buf
   }
 
-  @PackageScope
-  static double[] toDoubleArrayFromList(List<? extends Number> data) {
+  private static double[] toDoubleArrayFromList(List<? extends Number> data) {
     double[] buf = new double[data.size()]
     int idx = 0
     for (Number val : data) {

--- a/matrix-smile/src/test/groovy/SmileFeaturesTest.groovy
+++ b/matrix-smile/src/test/groovy/SmileFeaturesTest.groovy
@@ -620,4 +620,276 @@ class SmileFeaturesTest {
     assertEquals('id', encoded.columnName(0))
   }
 
+  // ============ LabelEncoder Tests ============
+
+  @Test
+  void testLabelEncoderFitTransform() {
+    Matrix train = Matrix.builder()
+        .data(color: ['red', 'green', 'blue', 'red'])
+        .types([String])
+        .build()
+    Matrix test = Matrix.builder()
+        .data(color: ['blue', 'red', 'green'])
+        .types([String])
+        .build()
+
+    def encoder = SmileFeatures.labelEncoder()
+    encoder.fit(train, 'color')
+    Matrix result = encoder.transform(test, 'color')
+
+    assertEquals(Integer, result.type(0))
+    // Sorted: blue=0, green=1, red=2
+    assertEquals(0, result[0, 'color'])
+    assertEquals(2, result[1, 'color'])
+    assertEquals(1, result[2, 'color'])
+  }
+
+  @Test
+  void testLabelEncoderFitTransformOneStep() {
+    Matrix data = Matrix.builder()
+        .data(color: ['red', 'green', 'blue'])
+        .types([String])
+        .build()
+
+    Matrix result = SmileFeatures.labelEncoder().fitTransform(data, 'color')
+
+    assertEquals(Integer, result.type(0))
+    assertEquals(3, result.rowCount())
+  }
+
+  @Test
+  void testLabelEncoderUnseenLabelThrows() {
+    Matrix train = Matrix.builder()
+        .data(color: ['red', 'green'])
+        .types([String])
+        .build()
+    Matrix test = Matrix.builder()
+        .data(color: ['blue'])
+        .types([String])
+        .build()
+
+    def encoder = SmileFeatures.labelEncoder().fit(train, 'color')
+
+    assertThrows(IllegalArgumentException) {
+      encoder.transform(test, 'color')
+    }
+  }
+
+  @Test
+  void testLabelEncoderNullValueThrows() {
+    Matrix train = Matrix.builder()
+        .data(color: ['red', 'green'])
+        .types([String])
+        .build()
+    Matrix test = Matrix.builder()
+        .data(color: ['red', null])
+        .types([String])
+        .build()
+
+    def encoder = SmileFeatures.labelEncoder().fit(train, 'color')
+
+    assertThrows(IllegalArgumentException) {
+      encoder.transform(test, 'color')
+    }
+  }
+
+  @Test
+  void testLabelEncoderInverseLookup() {
+    Matrix data = Matrix.builder()
+        .data(color: ['red', 'green', 'blue'])
+        .types([String])
+        .build()
+
+    def encoder = SmileFeatures.labelEncoder().fit(data, 'color')
+
+    // Sorted: blue=0, green=1, red=2
+    assertEquals('blue', encoder.inverse(0))
+    assertEquals('green', encoder.inverse(1))
+    assertEquals('red', encoder.inverse(2))
+  }
+
+  @Test
+  void testLabelEncoderNotFittedThrows() {
+    def encoder = SmileFeatures.labelEncoder()
+    Matrix data = Matrix.builder()
+        .data(color: ['red'])
+        .types([String])
+        .build()
+
+    assertThrows(IllegalStateException) { encoder.transform(data, 'color') }
+    assertThrows(IllegalStateException) { encoder.getLabels() }
+    assertThrows(IllegalStateException) { encoder.inverse(0) }
+  }
+
+  @Test
+  void testLabelEncoderAllNullThrows() {
+    Matrix data = Matrix.builder()
+        .data(color: [null, null, null])
+        .types([String])
+        .build()
+
+    assertThrows(IllegalArgumentException) {
+      SmileFeatures.labelEncoder().fit(data, 'color')
+    }
+  }
+
+  @Test
+  void testLabelEncoderRoundTrip() {
+    Matrix data = Matrix.builder()
+        .data(color: ['red', 'green', 'blue'])
+        .types([String])
+        .build()
+
+    def encoder = SmileFeatures.labelEncoder().fit(data, 'color')
+    Matrix encoded = encoder.transform(data, 'color')
+
+    List<String> recovered = encoded.column('color').collect { encoder.inverse(it as int).toString() }
+    assertEquals(['red', 'green', 'blue'], recovered)
+  }
+
+  // ============ OneHotEncoder Tests ============
+
+  @Test
+  void testOneHotEncoderFitTransform() {
+    Matrix train = Matrix.builder()
+        .data(
+            id: [1, 2, 3],
+            color: ['red', 'green', 'blue']
+        )
+        .types([Integer, String])
+        .build()
+    Matrix test = Matrix.builder()
+        .data(
+            id: [4, 5],
+            color: ['blue', 'red']
+        )
+        .types([Integer, String])
+        .build()
+
+    def encoder = SmileFeatures.oneHotEncoder().fit(train, 'color')
+    Matrix result = encoder.transform(test, 'color')
+
+    // Original column dropped, replaced by blue, green, red columns
+    assertFalse(result.columnNames().contains('color'))
+    assertTrue(result.columnNames().contains('color_blue'))
+    assertTrue(result.columnNames().contains('color_green'))
+    assertTrue(result.columnNames().contains('color_red'))
+
+    // Row 0 is 'blue'
+    assertEquals(1, result[0, 'color_blue'])
+    assertEquals(0, result[0, 'color_green'])
+    assertEquals(0, result[0, 'color_red'])
+
+    // Row 1 is 'red'
+    assertEquals(0, result[1, 'color_blue'])
+    assertEquals(0, result[1, 'color_green'])
+    assertEquals(1, result[1, 'color_red'])
+  }
+
+  @Test
+  void testOneHotEncoderDropOriginalFalse() {
+    Matrix data = Matrix.builder()
+        .data(color: ['red', 'green', 'blue'])
+        .types([String])
+        .build()
+
+    def encoder = SmileFeatures.oneHotEncoder().fit(data, 'color')
+    Matrix result = encoder.transform(data, 'color', false)
+
+    assertTrue(result.columnNames().contains('color'))
+    assertTrue(result.columnNames().contains('color_blue'))
+    assertEquals('color', result.columnName(0))
+    assertEquals('color_blue', result.columnName(1))
+  }
+
+  @Test
+  void testOneHotEncoderUnseenCategoryThrows() {
+    Matrix train = Matrix.builder()
+        .data(color: ['red', 'green'])
+        .types([String])
+        .build()
+    Matrix test = Matrix.builder()
+        .data(color: ['blue'])
+        .types([String])
+        .build()
+
+    def encoder = SmileFeatures.oneHotEncoder().fit(train, 'color')
+
+    assertThrows(IllegalArgumentException) {
+      encoder.transform(test, 'color')
+    }
+  }
+
+  @Test
+  void testOneHotEncoderNotFittedThrows() {
+    def encoder = SmileFeatures.oneHotEncoder()
+    Matrix data = Matrix.builder()
+        .data(color: ['red'])
+        .types([String])
+        .build()
+
+    assertThrows(IllegalStateException) { encoder.transform(data, 'color') }
+    assertThrows(IllegalStateException) { encoder.getCategories() }
+  }
+
+  @Test
+  void testOneHotEncoderAllNullThrows() {
+    Matrix data = Matrix.builder()
+        .data(color: [null, null])
+        .types([String])
+        .build()
+
+    assertThrows(IllegalArgumentException) {
+      SmileFeatures.oneHotEncoder().fit(data, 'color')
+    }
+  }
+
+  @Test
+  void testOneHotEncoderColumnCollisionThrows() {
+    Matrix data = Matrix.builder()
+        .data(
+            color: ['A', 'B'],
+            color_A: [0, 0]
+        )
+        .types([String, Integer])
+        .build()
+
+    def encoder = SmileFeatures.oneHotEncoder().fit(data, 'color')
+
+    assertThrows(IllegalArgumentException) {
+      encoder.transform(data, 'color')
+    }
+  }
+
+  @Test
+  void testOneHotEncoderFitTransformOneStep() {
+    Matrix data = Matrix.builder()
+        .data(color: ['red', 'green', 'blue'])
+        .types([String])
+        .build()
+
+    Matrix result = SmileFeatures.oneHotEncoder().fitTransform(data, 'color')
+
+    assertEquals(3, result.columnCount())
+    assertTrue(result.columnNames().contains('color_blue'))
+  }
+
+  @Test
+  void testOneHotEncoderPreservesColumnOrder() {
+    Matrix data = Matrix.builder()
+        .data(
+            id: [1, 2, 3],
+            color: ['red', 'green', 'blue'],
+            value: [10.0, 20.0, 30.0]
+        )
+        .types([Integer, String, Double])
+        .build()
+
+    Matrix result = SmileFeatures.oneHotEncoder().fitTransform(data, 'color')
+
+    // id first, then one-hot columns, then value
+    assertEquals('id', result.columnName(0))
+    assertEquals('value', result.columnNames().last())
+  }
+
 }

--- a/matrix-smile/src/test/groovy/SmileFeaturesTest.groovy
+++ b/matrix-smile/src/test/groovy/SmileFeaturesTest.groovy
@@ -875,6 +875,56 @@ class SmileFeaturesTest {
   }
 
   @Test
+  void testOneHotEncoderNullValueThrows() {
+    Matrix train = Matrix.builder()
+        .data(color: ['red', 'green', 'blue'])
+        .types([String])
+        .build()
+    Matrix test = Matrix.builder()
+        .data(color: ['red', null, 'blue'])
+        .types([String])
+        .build()
+
+    def encoder = SmileFeatures.oneHotEncoder().fit(train, 'color')
+
+    assertThrows(IllegalArgumentException) {
+      encoder.transform(test, 'color')
+    }
+  }
+
+  @Test
+  void testLabelEncoderWithIntegerCategories() {
+    Matrix data = Matrix.builder()
+        .data(grade: [3, 1, 2, 1, 3])
+        .types([Integer])
+        .build()
+
+    def encoder = SmileFeatures.labelEncoder().fit(data, 'grade')
+    Matrix result = encoder.transform(data, 'grade')
+
+    // Sorted by toString(): "1"=0, "2"=1, "3"=2
+    assertEquals([2, 0, 1, 0, 2], result.column('grade'))
+    assertEquals(1, encoder.inverse(0))
+    assertEquals(3, encoder.inverse(2))
+  }
+
+  @Test
+  void testOneHotEncoderWithIntegerCategories() {
+    Matrix data = Matrix.builder()
+        .data(grade: [1, 2, 3])
+        .types([Integer])
+        .build()
+
+    Matrix result = SmileFeatures.oneHotEncoder().fitTransform(data, 'grade')
+
+    assertTrue(result.columnNames().contains('grade_1'))
+    assertTrue(result.columnNames().contains('grade_2'))
+    assertTrue(result.columnNames().contains('grade_3'))
+    assertEquals(1, result[0, 'grade_1'])
+    assertEquals(0, result[0, 'grade_2'])
+  }
+
+  @Test
   void testOneHotEncoderPreservesColumnOrder() {
     Matrix data = Matrix.builder()
         .data(

--- a/matrix-smile/src/test/groovy/SmileStatsTest.groovy
+++ b/matrix-smile/src/test/groovy/SmileStatsTest.groovy
@@ -1,6 +1,11 @@
 import static org.junit.jupiter.api.Assertions.*
 
 import org.junit.jupiter.api.Test
+import smile.stat.distribution.BetaDistribution
+import smile.stat.distribution.ExponentialDistribution
+import smile.stat.distribution.GammaDistribution
+import smile.stat.distribution.GaussianDistribution
+import smile.stat.distribution.LogNormalDistribution
 import smile.stat.hypothesis.CorTest
 import smile.stat.hypothesis.FTest
 import smile.stat.hypothesis.KSTest
@@ -10,6 +15,7 @@ import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.smile.stats.CorrelationMethod
 import se.alipsa.matrix.smile.stats.SmileStats
 
+@SuppressWarnings('ClassSize')
 class SmileStatsTest {
 
   // ==================== Probability Distribution Tests ====================
@@ -898,6 +904,204 @@ class SmileStatsTest {
 
     assertNotNull(result)
     assertEquals(4.0, result.df(), 0.0001)
+  }
+
+  // ==================== List Overload Tests ====================
+
+  @Test
+  void testNormalFitFromList() {
+    List<Double> data = [1.0, 2.0, 3.0, 4.0, 5.0]
+    GaussianDistribution dist = SmileStats.normalFit(data)
+    assertNotNull(dist)
+    assertEquals(3.0, dist.mean(), 0.0001)
+  }
+
+  @Test
+  void testNormalFitFromListWithNulls() {
+    List<Double> data = [1.0, null, 3.0, null, 5.0]
+    GaussianDistribution dist = SmileStats.normalFit(data)
+    assertNotNull(dist)
+    assertEquals(3.0, dist.mean(), 0.0001)
+  }
+
+  @Test
+  void testNormalFitFromListAllNullsThrows() {
+    List<Double> data = [null, null, null]
+    assertThrows(IllegalArgumentException) {
+      SmileStats.normalFit(data)
+    }
+  }
+
+  @Test
+  void testExponentialFitFromList() {
+    List<Double> data = [0.5, 1.0, 1.5, 2.0, 2.5, 3.0]
+    ExponentialDistribution dist = SmileStats.exponentialFit(data)
+    assertNotNull(dist)
+    assertTrue(dist.mean() > 0)
+  }
+
+  @Test
+  void testExponentialFitFromListWithNulls() {
+    List<Double> data = [0.5, null, 1.5, 2.0, null, 3.0]
+    ExponentialDistribution dist = SmileStats.exponentialFit(data)
+    assertNotNull(dist)
+  }
+
+  @Test
+  void testExponentialFitFromListAllNullsThrows() {
+    List<Double> data = [null, null]
+    assertThrows(IllegalArgumentException) {
+      SmileStats.exponentialFit(data)
+    }
+  }
+
+  @Test
+  void testGammaFitFromList() {
+    List<Double> data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    GammaDistribution dist = SmileStats.gammaFit(data)
+    assertNotNull(dist)
+  }
+
+  @Test
+  void testGammaFitFromListWithNulls() {
+    List<Double> data = [1.0, null, 3.0, 4.0, null, 6.0]
+    GammaDistribution dist = SmileStats.gammaFit(data)
+    assertNotNull(dist)
+  }
+
+  @Test
+  void testGammaFitFromListAllNullsThrows() {
+    List<Double> data = [null, null]
+    assertThrows(IllegalArgumentException) {
+      SmileStats.gammaFit(data)
+    }
+  }
+
+  @Test
+  void testBetaFitFromList() {
+    List<Double> data = [0.1, 0.2, 0.3, 0.5, 0.7, 0.9]
+    BetaDistribution dist = SmileStats.betaFit(data)
+    assertNotNull(dist)
+  }
+
+  @Test
+  void testBetaFitFromListWithNulls() {
+    List<Double> data = [0.1, null, 0.3, 0.5, null, 0.9]
+    BetaDistribution dist = SmileStats.betaFit(data)
+    assertNotNull(dist)
+  }
+
+  @Test
+  void testBetaFitFromListAllNullsThrows() {
+    List<Double> data = [null, null]
+    assertThrows(IllegalArgumentException) {
+      SmileStats.betaFit(data)
+    }
+  }
+
+  @Test
+  void testLogNormalFitFromList() {
+    List<Double> data = [1.0, 2.0, 3.0, 5.0, 8.0, 13.0]
+    LogNormalDistribution dist = SmileStats.logNormalFit(data)
+    assertNotNull(dist)
+  }
+
+  @Test
+  void testLogNormalFitFromListWithNulls() {
+    List<Double> data = [1.0, null, 3.0, 5.0, null, 13.0]
+    LogNormalDistribution dist = SmileStats.logNormalFit(data)
+    assertNotNull(dist)
+  }
+
+  @Test
+  void testLogNormalFitFromListAllNullsThrows() {
+    List<Double> data = [null, null]
+    assertThrows(IllegalArgumentException) {
+      SmileStats.logNormalFit(data)
+    }
+  }
+
+  // ==================== Matrix+Column Overload Tests ====================
+
+  @Test
+  void testExponentialFitFromMatrix() {
+    Matrix matrix = Matrix.builder()
+        .data(values: [0.5, 1.0, 1.5, 2.0, 2.5, 3.0])
+        .types([Double])
+        .build()
+    ExponentialDistribution dist = SmileStats.exponentialFit(matrix, 'values')
+    assertNotNull(dist)
+    assertTrue(dist.mean() > 0)
+  }
+
+  @Test
+  void testExponentialFitFromMatrixWithNulls() {
+    Matrix matrix = Matrix.builder()
+        .data(values: [0.5, null, 1.5, 2.0, null, 3.0])
+        .types([Double])
+        .build()
+    ExponentialDistribution dist = SmileStats.exponentialFit(matrix, 'values')
+    assertNotNull(dist)
+  }
+
+  @Test
+  void testGammaFitFromMatrix() {
+    Matrix matrix = Matrix.builder()
+        .data(values: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        .types([Double])
+        .build()
+    GammaDistribution dist = SmileStats.gammaFit(matrix, 'values')
+    assertNotNull(dist)
+  }
+
+  @Test
+  void testGammaFitFromMatrixWithNulls() {
+    Matrix matrix = Matrix.builder()
+        .data(values: [1.0, null, 3.0, 4.0, null, 6.0])
+        .types([Double])
+        .build()
+    GammaDistribution dist = SmileStats.gammaFit(matrix, 'values')
+    assertNotNull(dist)
+  }
+
+  @Test
+  void testBetaFitFromMatrix() {
+    Matrix matrix = Matrix.builder()
+        .data(values: [0.1, 0.2, 0.3, 0.5, 0.7, 0.9])
+        .types([Double])
+        .build()
+    BetaDistribution dist = SmileStats.betaFit(matrix, 'values')
+    assertNotNull(dist)
+  }
+
+  @Test
+  void testBetaFitFromMatrixWithNulls() {
+    Matrix matrix = Matrix.builder()
+        .data(values: [0.1, null, 0.3, 0.5, null, 0.9])
+        .types([Double])
+        .build()
+    BetaDistribution dist = SmileStats.betaFit(matrix, 'values')
+    assertNotNull(dist)
+  }
+
+  @Test
+  void testLogNormalFitFromMatrix() {
+    Matrix matrix = Matrix.builder()
+        .data(values: [1.0, 2.0, 3.0, 5.0, 8.0, 13.0])
+        .types([Double])
+        .build()
+    LogNormalDistribution dist = SmileStats.logNormalFit(matrix, 'values')
+    assertNotNull(dist)
+  }
+
+  @Test
+  void testLogNormalFitFromMatrixWithNulls() {
+    Matrix matrix = Matrix.builder()
+        .data(values: [1.0, null, 3.0, 5.0, null, 13.0])
+        .types([Double])
+        .build()
+    LogNormalDistribution dist = SmileStats.logNormalFit(matrix, 'values')
+    assertNotNull(dist)
   }
 
 }

--- a/matrix-smile/src/test/groovy/SmileStatsTest.groovy
+++ b/matrix-smile/src/test/groovy/SmileStatsTest.groovy
@@ -933,6 +933,14 @@ class SmileStatsTest {
   }
 
   @Test
+  void testNormalFitFromEmptyListThrows() {
+    List<Double> data = []
+    assertThrows(IllegalArgumentException) {
+      SmileStats.normalFit(data)
+    }
+  }
+
+  @Test
   void testExponentialFitFromList() {
     List<Double> data = [0.5, 1.0, 1.5, 2.0, 2.5, 3.0]
     ExponentialDistribution dist = SmileStats.exponentialFit(data)
@@ -950,6 +958,14 @@ class SmileStatsTest {
   @Test
   void testExponentialFitFromListAllNullsThrows() {
     List<Double> data = [null, null]
+    assertThrows(IllegalArgumentException) {
+      SmileStats.exponentialFit(data)
+    }
+  }
+
+  @Test
+  void testExponentialFitFromEmptyListThrows() {
+    List<Double> data = []
     assertThrows(IllegalArgumentException) {
       SmileStats.exponentialFit(data)
     }
@@ -978,6 +994,14 @@ class SmileStatsTest {
   }
 
   @Test
+  void testGammaFitFromEmptyListThrows() {
+    List<Double> data = []
+    assertThrows(IllegalArgumentException) {
+      SmileStats.gammaFit(data)
+    }
+  }
+
+  @Test
   void testBetaFitFromList() {
     List<Double> data = [0.1, 0.2, 0.3, 0.5, 0.7, 0.9]
     BetaDistribution dist = SmileStats.betaFit(data)
@@ -1000,6 +1024,14 @@ class SmileStatsTest {
   }
 
   @Test
+  void testBetaFitFromEmptyListThrows() {
+    List<Double> data = []
+    assertThrows(IllegalArgumentException) {
+      SmileStats.betaFit(data)
+    }
+  }
+
+  @Test
   void testLogNormalFitFromList() {
     List<Double> data = [1.0, 2.0, 3.0, 5.0, 8.0, 13.0]
     LogNormalDistribution dist = SmileStats.logNormalFit(data)
@@ -1016,6 +1048,14 @@ class SmileStatsTest {
   @Test
   void testLogNormalFitFromListAllNullsThrows() {
     List<Double> data = [null, null]
+    assertThrows(IllegalArgumentException) {
+      SmileStats.logNormalFit(data)
+    }
+  }
+
+  @Test
+  void testLogNormalFitFromEmptyListThrows() {
+    List<Double> data = []
     assertThrows(IllegalArgumentException) {
       SmileStats.logNormalFit(data)
     }


### PR DESCRIPTION
## Summary
- **SmileStats**: Add `List<? extends Number>` overloads for 5 distribution-fit methods (normalFit, exponentialFit, gammaFit, betaFit, logNormalFit) and `Matrix + column` overloads for the 4 that lacked them. Includes a private `toDoubleArrayFromList` utility.
- **SmileFeatures**: Add stateful `LabelEncoder` and `OneHotEncoder` inner classes following the existing fit/transform/fitTransform scaler pattern, with factory methods `labelEncoder()` and `oneHotEncoder()`. OneHotEncoder includes collision detection for generated column names.
- **DRY**: Extracted `extractSortedUniqueValues` helper. Both `labelEncode` and `oneHotEncode` now delegate to their stateful counterparts (`LabelEncoder.fitTransform` / `OneHotEncoder.fitTransform`), eliminating duplicated unique-value extraction and column-building logic.
- **Tests**: 28 new List/Matrix overload tests (including empty-list edge cases) and 14 new encoder tests (389 total, all passing).
- **Plan**: Tasks 6.1.1–6.2.4 marked complete.

## Breaking changes
These are intentional fail-fast improvements over silently misleading behavior:
- **`oneHotEncode(Matrix, String, boolean)`** now throws `IllegalArgumentException` on null values (previously produced all-zero rows) and on all-null columns (previously produced zero one-hot columns). It also now validates for duplicate generated column names and collisions with existing columns.
- **`labelEncode(Matrix, String)`** now throws `IllegalArgumentException` on null values (previously passed them through as null in the encoded output) and on all-null columns (previously produced all-null encoded output).

## Test plan
- [x] All 389 matrix-smile tests pass
- [x] CodeNarc (main + test) clean
- [x] Spotless check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)