### PR TITLE
Rewrite Joiner: full join support, multi-key, one-to-many, type preservation

### DIFF
--- a/docs/R-comparison.md
+++ b/docs/R-comparison.md
@@ -101,6 +101,7 @@ This is similar to R's native vectorized math but with explicit method calls tha
 | **Grouping**     | `Stat.groupBy(t, 'grp')`          | `group_by(df, grp)`                       |
 | **Aggregation**  | `Stat.sumBy(t, 'val', 'grp')`     | `summarise(df, sum(val))`                 |
 | **Joins**        | `Joiner.merge(a, b, 'key', JoinType.LEFT)` | `left_join(a, b, by='key')`          |
+|                  | Also: INNER, RIGHT, FULL, SEMI, ANTI, cross join, multi-key, `_x`/`_y` suffix | Also: semi_join, anti_join, cross_join |
 | **Pivot wider**  | `table.pivot('id', 'var', 'val')` | `pivot_wider(names_from, values_from)`    |
 | **Pivot longer** | `table.unPivot(...)`              | `pivot_longer(cols, names_to, values_to)` |
 | **Mutate**       | `table.apply('col') { it * 2 }`   | `mutate(df, col = col * 2)`               |
@@ -536,6 +537,9 @@ For R users transitioning to Matrix, here's a quick reference:
 | `left_join(a, b, by='key')`             | `Joiner.merge(a, b, 'key', JoinType.LEFT)`     |
 | `right_join(a, b, by='key')`            | `Joiner.merge(a, b, 'key', JoinType.RIGHT)`    |
 | `full_join(a, b, by='key')`             | `Joiner.merge(a, b, 'key', JoinType.FULL)`     |
+| `semi_join(a, b, by='key')`            | `Joiner.merge(a, b, 'key', JoinType.SEMI)`     |
+| `anti_join(a, b, by='key')`            | `Joiner.merge(a, b, 'key', JoinType.ANTI)`     |
+| `cross_join(a, b)`                     | `Joiner.crossJoin(a, b)`                        |
 | `ggplot(df, aes(x, y)) + geom_point()`  | `ggplot(df, aes('x', 'y')) + geom_point()`     |
 | `ggplot(df, aes(x, y)) + geom_point()`  | `ggplot(df, aes { x = 'x'; y = 'y' }) + geom_point()` |
 | `qplot(x, y, data=df)`                  | `qplot(data: df, x: 'x', y: 'y')`              |

--- a/docs/R-comparison.md
+++ b/docs/R-comparison.md
@@ -100,7 +100,7 @@ This is similar to R's native vectorized math but with explicit method calls tha
 | **Sorting**      | `orderBy('col', DESC)`            | `arrange(df, desc(col))`                  |
 | **Grouping**     | `Stat.groupBy(t, 'grp')`          | `group_by(df, grp)`                       |
 | **Aggregation**  | `Stat.sumBy(t, 'val', 'grp')`     | `summarise(df, sum(val))`                 |
-| **Joins**        | `Joiner.merge(a, b, 'key')`       | `left_join(a, b, by='key')`               |
+| **Joins**        | `Joiner.merge(a, b, 'key', JoinType.LEFT)` | `left_join(a, b, by='key')`          |
 | **Pivot wider**  | `table.pivot('id', 'var', 'val')` | `pivot_wider(names_from, values_from)`    |
 | **Pivot longer** | `table.unPivot(...)`              | `pivot_longer(cols, names_to, values_to)` |
 | **Mutate**       | `table.apply('col') { it * 2 }`   | `mutate(df, col = col * 2)`               |
@@ -532,7 +532,10 @@ For R users transitioning to Matrix, here's a quick reference:
 | `df %>% arrange(desc(x))`               | `df.orderBy('x', Matrix.DESC)`                 |
 | `df %>% mutate(y = x * 2)`              | `df.apply('x') { it * 2 }`                     |
 | `df %>% group_by(g) %>% summarise(...)` | `Stat.sumBy(df, 'val', 'g')`                   |
-| `left_join(a, b, by='key')`             | `Joiner.merge(a, b, 'key', true)`              |
+| `inner_join(a, b, by='key')`            | `Joiner.merge(a, b, 'key', JoinType.INNER)`    |
+| `left_join(a, b, by='key')`             | `Joiner.merge(a, b, 'key', JoinType.LEFT)`     |
+| `right_join(a, b, by='key')`            | `Joiner.merge(a, b, 'key', JoinType.RIGHT)`    |
+| `full_join(a, b, by='key')`             | `Joiner.merge(a, b, 'key', JoinType.FULL)`     |
 | `ggplot(df, aes(x, y)) + geom_point()`  | `ggplot(df, aes('x', 'y')) + geom_point()`     |
 | `ggplot(df, aes(x, y)) + geom_point()`  | `ggplot(df, aes { x = 'x'; y = 'y' }) + geom_point()` |
 | `qplot(x, y, data=df)`                  | `qplot(data: df, x: 'x', y: 'y')`              |

--- a/docs/cookbook/matrix-core.md
+++ b/docs/cookbook/matrix-core.md
@@ -546,8 +546,22 @@ Stat methods
 - Grid<Object> grid()
 - Matrix clone()
 
-## Joining (merging) Matrices 
-- static Matrix merge(Matrix x, Matrix y, Map<String, String> by, boolean all = false)
+## Joining (merging) Matrices
+
+The `Joiner` class provides SQL-like join operations. `JoinType` values: `INNER`, `LEFT`, `RIGHT`, `FULL`, `CROSS`, `SEMI`, `ANTI`.
+
+- static Matrix merge(Matrix x, Matrix y, String by, boolean all = false)
+- static Matrix merge(Matrix x, Matrix y, Map by, boolean all = false)
+- static Matrix merge(Matrix x, Matrix y, String by, JoinType joinType)
+- static Matrix merge(Matrix x, Matrix y, Map by, JoinType joinType)
+- static Matrix merge(Matrix x, Matrix y, List\<String\> by, JoinType joinType)
+- static Matrix crossJoin(Matrix x, Matrix y)
+
+Multi-column keys use a map: `[x: ['dept', 'id'], y: ['department', 'empId']]`.
+Same-named multi-keys use a list: `['dept', 'id']`.
+Duplicate non-key column names are suffixed `_x` / `_y`.
+Semi and anti joins return only left-side columns.
+Self join: pass the same matrix as both arguments.
 
 ## Comparing data
 - boolean equals(Object o, boolean ignoreColumnNames = false, boolean ignoreName = false, boolean ignoreTypes = true)

--- a/docs/python-comparison.md
+++ b/docs/python-comparison.md
@@ -50,7 +50,7 @@ Matrix filtered = Matrix.builder().ginqResult(result).build()
 | **Filtering** | `subset { it.x > 5 }`             | `df[df.x > 5]`                        | Matrix uses closures, pandas uses boolean indexing |
 | **Sorting**   | `orderBy('col', DESC)`            | `sort_values('col', ascending=False)` | Similar                                            |
 | **Grouping**  | `Stat.sumBy(t, 'val', 'grp')`     | `df.groupby('grp')['val'].sum()`      | Pandas more flexible with agg()                    |
-| **Joins**     | `Joiner.merge(a, b, 'key', JoinType.LEFT)` | `pd.merge(a, b, on='key', how='left')` | Both support inner/left/right/full, multi-key, one-to-many, `_x`/`_y` suffix |
+| **Joins**     | `Joiner.merge(a, b, 'key', JoinType.LEFT)` | `pd.merge(a, b, on='key', how='left')` | Both support inner/left/right/full, multi-key, one-to-many, `_x`/`_y` suffix. Matrix also: SEMI, ANTI, cross join |
 | **Pivot**     | `table.pivot('id', 'var', 'val')` | `df.pivot(index, columns, values)`    | Similar                                            |
 | **Apply**     | `table.apply('col') { it * 2 }`   | `df['col'].apply(lambda x: x * 2)`    | Similar                                            |
 

--- a/docs/python-comparison.md
+++ b/docs/python-comparison.md
@@ -50,7 +50,7 @@ Matrix filtered = Matrix.builder().ginqResult(result).build()
 | **Filtering** | `subset { it.x > 5 }`             | `df[df.x > 5]`                        | Matrix uses closures, pandas uses boolean indexing |
 | **Sorting**   | `orderBy('col', DESC)`            | `sort_values('col', ascending=False)` | Similar                                            |
 | **Grouping**  | `Stat.sumBy(t, 'val', 'grp')`     | `df.groupby('grp')['val'].sum()`      | Pandas more flexible with agg()                    |
-| **Joins**     | `Joiner.merge(a, b, 'key')`       | `pd.merge(a, b, on='key')`            | Similar; both O(n+m) hash joins                    |
+| **Joins**     | `Joiner.merge(a, b, 'key', JoinType.LEFT)` | `pd.merge(a, b, on='key', how='left')` | Both support inner/left/right/full, multi-key, one-to-many, `_x`/`_y` suffix |
 | **Pivot**     | `table.pivot('id', 'var', 'val')` | `df.pivot(index, columns, values)`    | Similar                                            |
 | **Apply**     | `table.apply('col') { it * 2 }`   | `df['col'].apply(lambda x: x * 2)`    | Similar                                            |
 

--- a/docs/tutorial/18-advanced-operations.md
+++ b/docs/tutorial/18-advanced-operations.md
@@ -527,6 +527,8 @@ Matrix withManager = Joiner.merge(people, people,
 println withManager
 ```
 
+Note: columns from the left matrix appear in their original order, so `empId` (an x column) appears before the y-side columns.
+
 Output:
 ```
 Matrix (people, 3 x 5)

--- a/docs/tutorial/18-advanced-operations.md
+++ b/docs/tutorial/18-advanced-operations.md
@@ -265,12 +265,13 @@ data.apply('status') { status ->
 
 ## Joining and Merging Matrices
 
-The `Joiner` class provides SQL-like join operations.
+The `Joiner` class provides SQL-like join operations with support for inner, left, right, and full outer joins. It handles one-to-many relationships, composite (multi-column) keys, and automatically resolves duplicate column names with `_x`/`_y` suffixes.
 
 ### Inner Join
 
 ```groovy
 import se.alipsa.matrix.core.Joiner
+import se.alipsa.matrix.core.JoinType
 
 Matrix employees = Matrix.builder('employees')
     .data(
@@ -289,8 +290,10 @@ Matrix departments = Matrix.builder('departments')
     .types([Integer, String])
     .build()
 
-// Inner join - only matching rows
+// Inner join - only matching rows (default)
 Matrix joined = Joiner.merge(employees, departments, 'deptId')
+// Equivalent using explicit JoinType:
+// Matrix joined = Joiner.merge(employees, departments, 'deptId', JoinType.INNER)
 println "Inner Join:"
 println joined
 ```
@@ -351,6 +354,108 @@ Matrix ordersWithCustomers = Joiner.merge(
     [x: 'customerId', y: 'id']
 )
 println ordersWithCustomers
+```
+
+### Right Join
+
+```groovy
+// Right join - all rows from right table, nulls for non-matching left rows
+Matrix rightJoined = Joiner.merge(employees, departments, 'deptId', JoinType.RIGHT)
+println rightJoined
+```
+
+Output:
+```
+Matrix (employees, 3 x 4)
+empId	name   	deptId	deptName
+1    	Alice  	101   	Engineering
+2    	Bob    	102   	Sales
+null 	null   	104   	Marketing
+```
+
+### Full Outer Join
+
+```groovy
+// Full outer join - all rows from both tables
+Matrix fullJoined = Joiner.merge(employees, departments, 'deptId', JoinType.FULL)
+println fullJoined
+```
+
+Output:
+```
+Matrix (employees, 5 x 4)
+empId	name   	deptId	deptName
+1    	Alice  	101   	Engineering
+2    	Bob    	102   	Sales
+3    	Charlie	101   	Engineering
+4    	Diana  	103   	null
+null 	null   	104   	Marketing
+```
+
+### Multi-Column (Composite) Join Keys
+
+```groovy
+Matrix sales = Matrix.builder('sales')
+    .data(
+        dept: ['Sales', 'Sales', 'Eng'],
+        empId: [1, 2, 1],
+        revenue: [5000, 3000, 8000]
+    )
+    .types([String, Integer, Integer])
+    .build()
+
+Matrix ratings = Matrix.builder('ratings')
+    .data(
+        department: ['Sales', 'Eng', 'Sales'],
+        employeeId: [1, 1, 2],
+        rating: [5, 4, 3]
+    )
+    .types([String, Integer, Integer])
+    .build()
+
+// Join on multiple columns with different names
+Matrix result = Joiner.merge(sales, ratings,
+    [x: ['dept', 'empId'], y: ['department', 'employeeId']],
+    JoinType.INNER)
+
+// When key column names are the same in both matrices, use a list:
+// Joiner.merge(x, y, ['dept', 'empId'], JoinType.INNER)
+```
+
+### Duplicate Column Names
+
+When both matrices have non-key columns with the same name, the result columns are automatically suffixed `_x` and `_y`:
+
+```groovy
+Matrix q1 = Matrix.builder('q1').data(
+    id: [1, 2], revenue: [1000, 2000]
+).types([Integer, Integer]).build()
+
+Matrix q2 = Matrix.builder('q2').data(
+    id: [1, 2], revenue: [1500, 2500]
+).types([Integer, Integer]).build()
+
+Matrix compared = Joiner.merge(q1, q2, 'id')
+// Result columns: id, revenue_x, revenue_y
+println compared.columnNames()  // [id, revenue_x, revenue_y]
+```
+
+### One-to-Many Joins
+
+When a key in the right matrix has multiple matching rows, each match produces a separate result row:
+
+```groovy
+Matrix orders2 = Matrix.builder('orders')
+    .data(orderId: [1, 2], customer: ['Alice', 'Bob'])
+    .types([Integer, String]).build()
+
+Matrix items = Matrix.builder('items')
+    .data(orderId: [1, 1, 1, 2], product: ['Pen', 'Paper', 'Ink', 'Tape'])
+    .types([Integer, String]).build()
+
+Matrix detail = Joiner.merge(orders2, items, 'orderId')
+// 4 result rows: order 1 expanded to 3 rows (one per item), order 2 to 1
+println detail.rowCount()  // 4
 ```
 
 ### Combining Multiple Matrices Vertically

--- a/docs/tutorial/18-advanced-operations.md
+++ b/docs/tutorial/18-advanced-operations.md
@@ -458,6 +458,74 @@ Matrix detail = Joiner.merge(orders2, items, 'orderId')
 println detail.rowCount()  // 4
 ```
 
+### Cross Join
+
+A cross join produces the Cartesian product of two matrices — every row from the left is paired with every row from the right. No key column is required:
+
+```groovy
+Matrix colors = Matrix.builder('colors')
+    .data(color: ['Red', 'Blue'])
+    .types([String]).build()
+
+Matrix sizes = Matrix.builder('sizes')
+    .data(size: ['S', 'M', 'L'])
+    .types([String]).build()
+
+Matrix combinations = Joiner.crossJoin(colors, sizes)
+println combinations  // 6 rows: every color × every size
+```
+
+### Semi Join
+
+A semi join returns rows from the left matrix that have at least one match in the right matrix. Only the left columns are included in the result (no columns from the right are appended):
+
+```groovy
+Matrix allEmployees = Matrix.builder('employees')
+    .data(
+        empId: [1, 2, 3, 4],
+        name: ['Alice', 'Bob', 'Charlie', 'Diana']
+    )
+    .types([Integer, String]).build()
+
+Matrix activeProjects = Matrix.builder('projects')
+    .data(empId: [1, 3], project: ['Alpha', 'Beta'])
+    .types([Integer, String]).build()
+
+// Employees who have at least one project
+Matrix withProjects = Joiner.merge(allEmployees, activeProjects, 'empId', JoinType.SEMI)
+println withProjects  // Alice and Charlie only, no project column
+```
+
+### Anti Join
+
+An anti join is the complement of a semi join — it returns rows from the left matrix that have *no* match in the right matrix. Only the left columns are included:
+
+```groovy
+// Employees who have NO projects (opposite of semi join)
+Matrix noProjects = Joiner.merge(allEmployees, activeProjects, 'empId', JoinType.ANTI)
+println noProjects  // Bob and Diana only
+```
+
+### Self Join
+
+A self join joins a matrix with itself. This is a usage pattern, not a separate join type — simply pass the same matrix as both arguments:
+
+```groovy
+Matrix people = Matrix.builder('people')
+    .data(
+        name: ['Alice', 'Bob', 'Charlie'],
+        managerId: [null, 1, 1],
+        empId: [1, 2, 3]
+    )
+    .types([String, Integer, Integer]).build()
+
+// Find each employee's manager name
+Matrix withManager = Joiner.merge(people, people,
+    [x: 'managerId', y: 'empId'],
+    JoinType.LEFT)
+// Result includes name_x (employee) and name_y (manager)
+```
+
 ### Combining Multiple Matrices Vertically
 
 ```groovy
@@ -1075,7 +1143,7 @@ This chapter covered advanced Matrix operations including:
 
 - **Complex filtering** with multiple conditions, null handling, and dynamic columns
 - **Advanced transformations** using apply(), applyRows(), and derived columns
-- **Joining matrices** with inner and left joins
+- **Joining matrices** with inner, left, right, full, cross, semi, and anti joins
 - **Grouping and aggregation** for summary statistics
 - **Time series operations** including date extraction, filtering, and rolling calculations
 - **Matrix reshaping** with pivot and melt operations

--- a/docs/tutorial/18-advanced-operations.md
+++ b/docs/tutorial/18-advanced-operations.md
@@ -524,6 +524,16 @@ Matrix withManager = Joiner.merge(people, people,
     [x: 'managerId', y: 'empId'],
     JoinType.LEFT)
 // Result includes name_x (employee) and name_y (manager)
+println withManager
+```
+
+Output:
+```
+Matrix (people, 3 x 5)
+name_x 	managerId	empId	name_y	managerId_y
+Alice  	null     	null 	null  	null
+Bob    	1        	1    	Alice 	null
+Charlie	1        	1    	Alice 	null
 ```
 
 ### Combining Multiple Matrices Vertically

--- a/docs/tutorial/18-advanced-operations.md
+++ b/docs/tutorial/18-advanced-operations.md
@@ -531,9 +531,9 @@ Output:
 ```
 Matrix (people, 3 x 5)
 name_x 	managerId	empId	name_y	managerId_y
-Alice  	null     	null 	null  	null
-Bob    	1        	1    	Alice 	null
-Charlie	1        	1    	Alice 	null
+Alice  	null     	1    	null  	null
+Bob    	1        	2    	Alice 	null
+Charlie	1        	3    	Alice 	null
 ```
 
 ### Combining Multiple Matrices Vertically

--- a/matrix-core/release.md
+++ b/matrix-core/release.md
@@ -15,8 +15,9 @@
 - `countNulls()` — returns the count of null elements in the column
 
 ### Joiner rewrite
-- Added `JoinType` enum with `INNER`, `LEFT`, `RIGHT`, `FULL`
-- `Joiner.merge()` now supports all four SQL join types via `JoinType` parameter
+- Added `JoinType` enum with `INNER`, `LEFT`, `RIGHT`, `FULL`, `CROSS`
+- `Joiner.merge()` now supports all four key-based SQL join types via `JoinType` parameter
+- `Joiner.crossJoin(x, y)` — Cartesian product of two matrices (every x row paired with every y row, no key column needed)
 - Multi-column (composite) join keys: `merge(x, y, [x: ['dept', 'id'], y: ['department', 'empId']], JoinType.INNER)`
 - Same-name multi-key shorthand: `merge(x, y, ['dept', 'empId'], JoinType.INNER)`
 - One-to-many joins: multiple y matches per key now produce separate result rows (previously only the first match was kept)

--- a/matrix-core/release.md
+++ b/matrix-core/release.md
@@ -26,7 +26,10 @@
 - One-to-many joins: multiple y matches per key now produce separate result rows (previously only the first match was kept)
 - Type preservation: result Matrix now carries column types from both source matrices
 - Duplicate non-key column names are automatically suffixed `_x` / `_y`
+- Duplicate y non-key column names are also suffixed when they conflict with x key columns, preserving unique result column names for self joins
+- Null join keys match other null join keys, following common data-analysis merge behavior rather than SQL `NULL` semantics
 - Right join and full outer join key values are preserved from y for unmatched rows
+- `merge(..., JoinType.CROSS)` now delegates to `crossJoin(x, y)`
 - Joiner is now fully `@CompileStatic` (removed `@CompileDynamic` workaround)
 - Backward compatible: existing `merge(x, y, by, boolean)` signatures continue to work
 

--- a/matrix-core/release.md
+++ b/matrix-core/release.md
@@ -14,8 +14,19 @@
 - `hasNulls()` — returns true if the column contains at least one null value
 - `countNulls()` — returns the count of null elements in the column
 
+### Joiner rewrite
+- Added `JoinType` enum with `INNER`, `LEFT`, `RIGHT`, `FULL`
+- `Joiner.merge()` now supports all four SQL join types via `JoinType` parameter
+- Multi-column (composite) join keys: `merge(x, y, [x: ['dept', 'id'], y: ['department', 'empId']], JoinType.INNER)`
+- Same-name multi-key shorthand: `merge(x, y, ['dept', 'empId'], JoinType.INNER)`
+- One-to-many joins: multiple y matches per key now produce separate result rows (previously only the first match was kept)
+- Type preservation: result Matrix now carries column types from both source matrices
+- Duplicate non-key column names are automatically suffixed `_x` / `_y`
+- Right join and full outer join key values are preserved from y for unmatched rows
+- Joiner is now fully `@CompileStatic` (removed `@CompileDynamic` workaround)
+- Backward compatible: existing `merge(x, y, by, boolean)` signatures continue to work
+
 ### Fixes
-- `Joiner.merge()` — added `@CompileDynamic` to fix static compilation issue
 
 ### Build changes
 - Removed redundant `CodeNarc` and `repositories` blocks from matrix-core `build.gradle` (now handled by root project)

--- a/matrix-core/release.md
+++ b/matrix-core/release.md
@@ -15,9 +15,12 @@
 - `countNulls()` — returns the count of null elements in the column
 
 ### Joiner rewrite
-- Added `JoinType` enum with `INNER`, `LEFT`, `RIGHT`, `FULL`, `CROSS`
-- `Joiner.merge()` now supports all four key-based SQL join types via `JoinType` parameter
+- Added `JoinType` enum with `INNER`, `LEFT`, `RIGHT`, `FULL`, `CROSS`, `SEMI`, `ANTI`
+- `Joiner.merge()` now supports all key-based SQL join types via `JoinType` parameter
 - `Joiner.crossJoin(x, y)` — Cartesian product of two matrices (every x row paired with every y row, no key column needed)
+- Semi join (`JoinType.SEMI`) — returns x rows where the key exists in y (no y columns appended, no duplicate rows)
+- Anti join (`JoinType.ANTI`) — returns x rows where the key does *not* exist in y
+- Self join — documented as a usage pattern: `merge(m, m, [x: 'managerId', y: 'id'], JoinType.INNER)`
 - Multi-column (composite) join keys: `merge(x, y, [x: ['dept', 'id'], y: ['department', 'empId']], JoinType.INNER)`
 - Same-name multi-key shorthand: `merge(x, y, ['dept', 'empId'], JoinType.INNER)`
 - One-to-many joins: multiple y matches per key now produce separate result rows (previously only the first match was kept)

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/JoinType.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/JoinType.groovy
@@ -1,0 +1,13 @@
+package se.alipsa.matrix.core
+
+/**
+ * Specifies the type of join operation for {@link Joiner#merge}.
+ */
+enum JoinType {
+
+  INNER,
+  LEFT,
+  RIGHT,
+  FULL
+
+}

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/JoinType.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/JoinType.groovy
@@ -9,6 +9,8 @@ enum JoinType {
   LEFT,
   RIGHT,
   FULL,
-  CROSS
+  CROSS,
+  SEMI,
+  ANTI
 
 }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/JoinType.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/JoinType.groovy
@@ -8,6 +8,7 @@ enum JoinType {
   INNER,
   LEFT,
   RIGHT,
-  FULL
+  FULL,
+  CROSS
 
 }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
@@ -3,8 +3,8 @@ package se.alipsa.matrix.core
 /**
  * Join operations for combining matrices on one or more key columns.
  *
- * <p>Supports inner, left, right, and full outer joins with single or composite
- * (multi-column) keys. When both matrices contain non-key columns with the same
+ * <p>Supports inner, left, right, full outer, and cross joins with single or
+ * composite (multi-column) keys. When both matrices contain columns with the same
  * name, the result columns are suffixed {@code _x} and {@code _y}.</p>
  *
  * <p>One-to-many joins are fully supported: if a key in y has multiple matching
@@ -79,6 +79,40 @@ class Joiner {
    */
   static Matrix merge(Matrix x, Matrix y, List<String> by, JoinType joinType) {
     doMerge(x, y, by, by, joinType)
+  }
+
+  /**
+   * Produces the Cartesian product of two matrices (cross join). Every row from x
+   * is paired with every row from y, producing {@code x.rowCount() * y.rowCount()} rows.
+   * No key column is required. Columns with the same name are suffixed {@code _x} / {@code _y}.
+   *
+   * @param x the left Matrix
+   * @param y the right Matrix
+   * @return a new Matrix with all column combinations and {@code x.rowCount() * y.rowCount()} rows
+   */
+  static Matrix crossJoin(Matrix x, Matrix y) {
+    List<Integer> allYIndices = (0..<y.columnCount()) as List<Integer>
+    ResultColumns rc = computeResultColumns(x, y, [], allYIndices)
+
+    int xColCount = x.columnCount()
+    int yColCount = y.columnCount()
+    int xRowCount = x.rowCount()
+    int yRowCount = y.rowCount()
+    List<List<Object>> resultRows = new ArrayList<>(xRowCount * yRowCount)
+
+    for (int xr = 0; xr < xRowCount; xr++) {
+      List<Object> xRow = extractRow(x, xr, xColCount)
+      for (int yr = 0; yr < yRowCount; yr++) {
+        resultRows.add(xRow + extractRow(y, yr, yColCount))
+      }
+    }
+
+    Matrix.builder()
+        .matrixName(x.matrixName)
+        .columnNames(rc.names)
+        .rows(resultRows)
+        .types(rc.types)
+        .build()
   }
 
   @SuppressWarnings('ParameterCount')

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
@@ -146,7 +146,8 @@ class Joiner {
     Map<List<Object>, List<List<Object>>> yIndex = buildIndex(y, yKeyIndices, yNonKeyIndices)
 
     List<List<Object>> resultRows = []
-    Set<List<Object>> matchedYKeys = [] as Set<List<Object>>
+    boolean needsMatchTracking = joinType == JoinType.RIGHT || joinType == JoinType.FULL
+    Set<List<Object>> matchedYKeys = needsMatchTracking ? ([] as Set<List<Object>>) : null
     int xColCount = x.columnCount()
     int yNonKeyCount = yNonKeyIndices.size()
     List<Object> nullYRow = Collections.nCopies(yNonKeyCount, null)
@@ -164,7 +165,7 @@ class Joiner {
         if (joinType == JoinType.SEMI) {
           resultRows.add(xRow)
         } else if (joinType != JoinType.ANTI) {
-          if (joinType == JoinType.RIGHT || joinType == JoinType.FULL) {
+          if (needsMatchTracking) {
             matchedYKeys.add(key)
           }
           yMatches.each { List<Object> yVals ->
@@ -225,10 +226,13 @@ class Joiner {
 
   @SuppressWarnings('Instanceof')
   private static List<List<String>> normalizeKeys(Map<String, Object> by) {
+    if (!by.containsKey('x') || !by.containsKey('y')) {
+      throw new IllegalArgumentException("Join key map must contain both 'x' and 'y' entries")
+    }
     Object xVal = by.get('x')
     Object yVal = by.get('y')
     if (xVal == null || yVal == null) {
-      throw new IllegalArgumentException("Join key map must contain both 'x' and 'y' entries")
+      throw new IllegalArgumentException("Join key values for 'x' and 'y' must not be null")
     }
     List<String> xKeys = xVal instanceof List ? (xVal as List<String>) : [xVal as String]
     List<String> yKeys = yVal instanceof List ? (yVal as List<String>) : [yVal as String]

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
@@ -1,78 +1,262 @@
 package se.alipsa.matrix.core
 
-import groovy.transform.CompileDynamic
-
 /**
  * Join operations for combining matrices on one or more key columns.
  *
- * <p>The current implementation provides hash-based merge helpers for inner and
- * left joins while preserving the column order expected by existing callers.</p>
+ * <p>Supports inner, left, right, and full outer joins with single or composite
+ * (multi-column) keys. When both matrices contain non-key columns with the same
+ * name, the result columns are suffixed {@code _x} and {@code _y}.</p>
+ *
+ * <p>One-to-many joins are fully supported: if a key in y has multiple matching
+ * rows, each match produces a separate result row (cross product).</p>
  */
-@SuppressWarnings('JavadocEmptyFirstLine')
+@SuppressWarnings(['JavadocEmptyFirstLine', 'Instanceof', 'NestedForLoop'])
 class Joiner {
 
-    /**
-     * Merges two matrices on specified columns using a hash-based join algorithm.
-     * Complexity is O(n + m) where n = x.rowCount() and m = y.rowCount().
-     *
-     * @param x the Matrix to start from
-     * @param y the Matrix to join to x
-     * @param by a map of the x and y columns to join on e.g. [x:'id', y: 'GUID']
-     * @param all true for a left join, false for an inner join
-     * @return a new matrix with the two ones joined
-     */
-    @CompileDynamic
-    static Matrix merge(Matrix x, Matrix y, Map<String, String> by, boolean all = false) {
-        def xColIndex = x.columnIndex(by.x)
-        def yColIndex = y.columnIndex(by.y)
-        if (xColIndex < 0) {
-            throw new IllegalArgumentException("Join column '${by.x}' does not exist in matrix '${x.matrixName}'")
-        }
-        if (yColIndex < 0) {
-            throw new IllegalArgumentException("Join column '${by.y}' does not exist in matrix '${y.matrixName}'")
-        }
-        def nYcol = y.columnCount()
+  /**
+   * Merges two matrices on specified columns.
+   *
+   * @param x the left Matrix
+   * @param y the right Matrix
+   * @param by a map with keys 'x' and 'y' whose values are column name(s).
+   *           Single key: {@code [x: 'id', y: 'guid']}.
+   *           Multi-key: {@code [x: ['dept', 'id'], y: ['department', 'empId']]}
+   * @param all false for inner join, true for left join (backward compatible)
+   * @return a new Matrix with the joined rows
+   */
+  static Matrix merge(Matrix x, Matrix y, Map by, boolean all = false) {
+    merge(x, y, by, all ? JoinType.LEFT : JoinType.INNER)
+  }
 
-        // Build a hash map from y indexed by the join column for O(1) lookup
-        Map<Object, List> yIndex = [:]
-        y.each { List yRow ->
-            def key = yRow[yColIndex]
-            if (!yIndex.containsKey(key)) {
-                yIndex[key] = yRow
-            }
-            // Note: only keep first match per key (matches original behavior)
-        }
+  /**
+   * Merges two matrices on a column with the same name in both.
+   *
+   * @param x the left Matrix
+   * @param y the right Matrix
+   * @param by the column name present in both matrices
+   * @param all false for inner join, true for left join (backward compatible)
+   * @return a new Matrix with the joined rows
+   */
+  static Matrix merge(Matrix x, Matrix y, String by, boolean all = false) {
+    doMerge(x, y, [by], [by], all ? JoinType.LEFT : JoinType.INNER)
+  }
 
-        // Join x with y using the hash map
-        def resultRows = []
-        x.each { List row ->
-            def key = row[xColIndex]
-            List yRow = yIndex[key]
-            if (yRow != null) {
-                def yr = yRow.collect()
-                yr.remove(yColIndex)
-                resultRows << [*row, *yr]
-            } else if (all) {
-                // append nulls when we are doing a left join and we have no match
-                resultRows << [*row, *([null] * (nYcol - 1))]
-            }
-        }
+  /**
+   * Merges two matrices using an explicit {@link JoinType}.
+   *
+   * @param x the left Matrix
+   * @param y the right Matrix
+   * @param by a map with keys 'x' and 'y' (see {@link #merge(Matrix, Matrix, Map, boolean)})
+   * @param joinType the type of join to perform
+   * @return a new Matrix with the joined rows
+   */
+  static Matrix merge(Matrix x, Matrix y, Map by, JoinType joinType) {
+    List<List<String>> keys = normalizeKeys(by)
+    doMerge(x, y, keys[0], keys[1], joinType)
+  }
 
-        def yColNames = y.columnNames().collect()
-        yColNames.remove(yColIndex)
-        return Matrix.builder().matrixName(x.matrixName).columnNames([*x.columnNames(), *yColNames]).rows(resultRows).build()
+  /**
+   * Merges two matrices on a single column with the same name using an explicit {@link JoinType}.
+   *
+   * @param x the left Matrix
+   * @param y the right Matrix
+   * @param by the column name present in both matrices
+   * @param joinType the type of join to perform
+   * @return a new Matrix with the joined rows
+   */
+  static Matrix merge(Matrix x, Matrix y, String by, JoinType joinType) {
+    doMerge(x, y, [by], [by], joinType)
+  }
+
+  /**
+   * Merges two matrices on multiple columns with the same names using an explicit {@link JoinType}.
+   *
+   * @param x the left Matrix
+   * @param y the right Matrix
+   * @param by the column names present in both matrices
+   * @param joinType the type of join to perform
+   * @return a new Matrix with the joined rows
+   */
+  static Matrix merge(Matrix x, Matrix y, List<String> by, JoinType joinType) {
+    doMerge(x, y, by, by, joinType)
+  }
+
+  @SuppressWarnings('ParameterCount')
+  private static Matrix doMerge(Matrix x, Matrix y,
+                                List<String> xKeyNames, List<String> yKeyNames,
+                                JoinType joinType) {
+    List<Integer> xKeyIndices = resolveIndices(x, xKeyNames)
+    List<Integer> yKeyIndices = resolveIndices(y, yKeyNames)
+
+    Set<Integer> yKeyIndexSet = yKeyIndices as Set<Integer>
+    List<Integer> yNonKeyIndices = (0..<y.columnCount()).findAll { int i -> !yKeyIndexSet.contains(i) }
+
+    ResultColumns rc = computeResultColumns(x, y, xKeyNames, yNonKeyIndices)
+
+    Map<List<Object>, List<List<Object>>> yIndex = buildIndex(y, yKeyIndices, yNonKeyIndices)
+
+    List<List<Object>> resultRows = []
+    Set<List<Object>> matchedYKeys = [] as Set<List<Object>>
+    int xColCount = x.columnCount()
+    int yNonKeyCount = yNonKeyIndices.size()
+    List<Object> nullYRow = Collections.nCopies(yNonKeyCount, null)
+
+    for (int r = 0; r < x.rowCount(); r++) {
+      List<Object> key = extractKey(x, r, xKeyIndices)
+      List<Object> xRow = extractRow(x, r, xColCount)
+
+      List<List<Object>> yMatches = yIndex.get(key)
+      if (yMatches != null) {
+        matchedYKeys.add(key)
+        for (List<Object> yVals : yMatches) {
+          resultRows.add(xRow + yVals)
+        }
+      } else if (joinType == JoinType.LEFT || joinType == JoinType.FULL) {
+        resultRows.add(xRow + nullYRow)
+      }
     }
 
-    /**
-     *
-     * @param x the Matrix to start from
-     * @param y the Matrix to join to x
-     * @param by the column to join on
-     * @param all true for a left join, false for an inner join
-     * @return a new matrix with the two ones joined
-     */
-    static Matrix merge(Matrix x, Matrix y, String by, boolean all = false) {
-        return merge(x, y, [x: by, y: by], all)
+    if (joinType == JoinType.RIGHT || joinType == JoinType.FULL) {
+      appendUnmatchedYRows(resultRows, yIndex, matchedYKeys,
+          xColCount, xKeyIndices, yKeyNames.size(), joinType)
     }
+
+    Matrix.builder()
+        .matrixName(x.matrixName)
+        .columnNames(rc.names)
+        .rows(resultRows)
+        .types(rc.types)
+        .build()
+  }
+
+  private static void appendUnmatchedYRows(List<List<Object>> resultRows,
+                                           Map<List<Object>, List<List<Object>>> yIndex,
+                                           Set<List<Object>> matchedYKeys,
+                                           int xColCount, List<Integer> xKeyIndices,
+                                           int keyCount, JoinType joinType) {
+    for (Map.Entry<List<Object>, List<List<Object>>> entry : yIndex.entrySet()) {
+      List<Object> yKey = entry.key
+      if (joinType == JoinType.FULL && matchedYKeys.contains(yKey)) {
+        continue
+      }
+      if (joinType == JoinType.RIGHT && matchedYKeys.contains(yKey)) {
+        continue
+      }
+      for (List<Object> yVals : entry.value) {
+        List<Object> xRow = new ArrayList<Object>(Collections.nCopies(xColCount, null))
+        for (int k = 0; k < keyCount; k++) {
+          xRow.set(xKeyIndices[k], yKey[k])
+        }
+        resultRows.add(xRow + yVals)
+      }
+    }
+  }
+
+  private static List<Integer> resolveIndices(Matrix m, List<String> colNames) {
+    List<Integer> indices = new ArrayList<>(colNames.size())
+    for (String name : colNames) {
+      int idx = m.columnIndex(name)
+      if (idx < 0) {
+        throw new IllegalArgumentException(
+            "Join column '${name}' does not exist in matrix '${m.matrixName}'")
+      }
+      indices.add(idx)
+    }
+    indices
+  }
+
+  private static List<List<String>> normalizeKeys(Map by) {
+    Object xVal = by.get('x')
+    Object yVal = by.get('y')
+    if (xVal == null || yVal == null) {
+      throw new IllegalArgumentException("Join key map must contain both 'x' and 'y' entries")
+    }
+    List<String> xKeys = xVal instanceof List ? (xVal as List<String>) : [xVal as String]
+    List<String> yKeys = yVal instanceof List ? (yVal as List<String>) : [yVal as String]
+    if (xKeys.size() != yKeys.size()) {
+      throw new IllegalArgumentException(
+          "Join key lists must have the same size: x has ${xKeys.size()}, y has ${yKeys.size()}")
+    }
+    [xKeys, yKeys]
+  }
+
+  private static Map<List<Object>, List<List<Object>>> buildIndex(
+      Matrix m, List<Integer> keyIndices, List<Integer> valueIndices) {
+    Map<List<Object>, List<List<Object>>> index = [:]
+    int rowCount = m.rowCount()
+    for (int r = 0; r < rowCount; r++) {
+      List<Object> key = extractKey(m, r, keyIndices)
+      List<List<Object>> bucket = index.get(key)
+      if (bucket == null) {
+        bucket = []
+        index.put(key, bucket)
+      }
+      List<Object> vals = new ArrayList<>(valueIndices.size())
+      for (int vi : valueIndices) {
+        vals.add(m.column(vi)[r])
+      }
+      bucket.add(vals)
+    }
+    index
+  }
+
+  private static List<Object> extractKey(Matrix m, int row, List<Integer> keyIndices) {
+    List<Object> key = new ArrayList<>(keyIndices.size())
+    for (int ki : keyIndices) {
+      key.add(m.column(ki)[row])
+    }
+    key
+  }
+
+  private static List<Object> extractRow(Matrix m, int row, int colCount) {
+    List<Object> vals = new ArrayList<>(colCount)
+    for (int c = 0; c < colCount; c++) {
+      vals.add(m.column(c)[row])
+    }
+    vals
+  }
+
+  private static ResultColumns computeResultColumns(Matrix x, Matrix y,
+                                                    List<String> xKeyNames,
+                                                    List<Integer> yNonKeyIndices) {
+    Set<String> xKeyNameSet = xKeyNames as Set<String>
+    List<String> xColNames = x.columnNames()
+    List<Class> xColTypes = x.types()
+
+    List<String> yNonKeyNames = new ArrayList<>(yNonKeyIndices.size())
+    List<Class> yNonKeyTypes = new ArrayList<>(yNonKeyIndices.size())
+    List<String> yColNames = y.columnNames()
+    List<Class> yColTypes = y.types()
+    for (int i : yNonKeyIndices) {
+      yNonKeyNames.add(yColNames[i])
+      yNonKeyTypes.add(yColTypes[i])
+    }
+
+    Set<String> xNonKeyNames = new LinkedHashSet<>(xColNames)
+    xNonKeyNames.removeAll(xKeyNameSet)
+    Set<String> yNonKeyNameSet = new LinkedHashSet<>(yNonKeyNames)
+    Set<String> duplicates = new LinkedHashSet<>(xNonKeyNames)
+    duplicates.retainAll(yNonKeyNameSet)
+
+    List<String> resultNames = new ArrayList<>(xColNames.size() + yNonKeyNames.size())
+    for (String n : xColNames) {
+      resultNames.add(duplicates.contains(n) && !xKeyNameSet.contains(n) ? "${n}_x" as String : n)
+    }
+    for (String n : yNonKeyNames) {
+      resultNames.add(duplicates.contains(n) ? "${n}_y" as String : n)
+    }
+
+    List<Class> resultTypes = new ArrayList<>(xColTypes)
+    resultTypes.addAll(yNonKeyTypes)
+
+    new ResultColumns(names: resultNames, types: resultTypes)
+  }
+
+  private static class ResultColumns {
+
+    List<String> names
+    List<Class> types
+
+  }
 
 }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
@@ -122,10 +122,16 @@ class Joiner {
     List<Integer> xKeyIndices = resolveIndices(x, xKeyNames)
     List<Integer> yKeyIndices = resolveIndices(y, yKeyNames)
 
-    Set<Integer> yKeyIndexSet = yKeyIndices as Set<Integer>
-    List<Integer> yNonKeyIndices = (0..<y.columnCount()).findAll { int i -> !yKeyIndexSet.contains(i) }
+    boolean filterOnly = joinType == JoinType.SEMI || joinType == JoinType.ANTI
 
-    ResultColumns rc = computeResultColumns(x, y, xKeyNames, yNonKeyIndices)
+    Set<Integer> yKeyIndexSet = yKeyIndices as Set<Integer>
+    List<Integer> yNonKeyIndices = filterOnly
+        ? []
+        : (0..<y.columnCount()).findAll { int i -> !yKeyIndexSet.contains(i) }
+
+    ResultColumns rc = filterOnly
+        ? new ResultColumns(names: x.columnNames(), types: x.types())
+        : computeResultColumns(x, y, xKeyNames, yNonKeyIndices)
 
     Map<List<Object>, List<List<Object>>> yIndex = buildIndex(y, yKeyIndices, yNonKeyIndices)
 
@@ -141,10 +147,16 @@ class Joiner {
 
       List<List<Object>> yMatches = yIndex.get(key)
       if (yMatches != null) {
-        matchedYKeys.add(key)
-        for (List<Object> yVals : yMatches) {
-          resultRows.add(xRow + yVals)
+        if (joinType == JoinType.SEMI) {
+          resultRows.add(xRow)
+        } else if (joinType != JoinType.ANTI) {
+          matchedYKeys.add(key)
+          for (List<Object> yVals : yMatches) {
+            resultRows.add(xRow + yVals)
+          }
         }
+      } else if (joinType == JoinType.ANTI) {
+        resultRows.add(xRow)
       } else if (joinType == JoinType.LEFT || joinType == JoinType.FULL) {
         resultRows.add(xRow + nullYRow)
       }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
@@ -100,10 +100,13 @@ class Joiner {
     int yRowCount = y.rowCount()
     List<List<Object>> resultRows = new ArrayList<>(xRowCount * yRowCount)
 
+    List<List<Object>> xCols = (0..<xColCount).collect { x.column(it) as List<Object> }
+    List<List<Object>> yCols = (0..<yColCount).collect { y.column(it) as List<Object> }
+
     for (int xr = 0; xr < xRowCount; xr++) {
-      List<Object> xRow = extractRow(x, xr, xColCount)
+      List<Object> xRow = extractFromCols(xCols, xr)
       for (int yr = 0; yr < yRowCount; yr++) {
-        resultRows.add(xRow + extractRow(y, yr, yColCount))
+        resultRows.add(xRow + extractFromCols(yCols, yr))
       }
     }
 
@@ -119,6 +122,9 @@ class Joiner {
   private static Matrix doMerge(Matrix x, Matrix y,
                                 List<String> xKeyNames, List<String> yKeyNames,
                                 JoinType joinType) {
+    if (joinType == JoinType.CROSS) {
+      throw new IllegalArgumentException('Use Joiner.crossJoin(x, y) for cross joins')
+    }
     List<Integer> xKeyIndices = resolveIndices(x, xKeyNames)
     List<Integer> yKeyIndices = resolveIndices(y, yKeyNames)
 
@@ -141,9 +147,12 @@ class Joiner {
     int yNonKeyCount = yNonKeyIndices.size()
     List<Object> nullYRow = Collections.nCopies(yNonKeyCount, null)
 
+    List<List<Object>> xKeyCols = xKeyIndices.collect { x.column(it) as List<Object> }
+    List<List<Object>> xAllCols = (0..<xColCount).collect { x.column(it) as List<Object> }
+
     for (int r = 0; r < x.rowCount(); r++) {
-      List<Object> key = extractKey(x, r, xKeyIndices)
-      List<Object> xRow = extractRow(x, r, xColCount)
+      List<Object> key = extractFromCols(xKeyCols, r)
+      List<Object> xRow = extractFromCols(xAllCols, r)
 
       List<List<Object>> yMatches = yIndex.get(key)
       if (yMatches != null) {
@@ -164,7 +173,7 @@ class Joiner {
 
     if (joinType == JoinType.RIGHT || joinType == JoinType.FULL) {
       appendUnmatchedYRows(resultRows, yIndex, matchedYKeys,
-          xColCount, xKeyIndices, yKeyNames.size(), joinType)
+          xColCount, xKeyIndices, yKeyNames.size())
     }
 
     Matrix.builder()
@@ -179,13 +188,10 @@ class Joiner {
                                            Map<List<Object>, List<List<Object>>> yIndex,
                                            Set<List<Object>> matchedYKeys,
                                            int xColCount, List<Integer> xKeyIndices,
-                                           int keyCount, JoinType joinType) {
+                                           int keyCount) {
     for (Map.Entry<List<Object>, List<List<Object>>> entry : yIndex.entrySet()) {
       List<Object> yKey = entry.key
-      if (joinType == JoinType.FULL && matchedYKeys.contains(yKey)) {
-        continue
-      }
-      if (joinType == JoinType.RIGHT && matchedYKeys.contains(yKey)) {
+      if (matchedYKeys.contains(yKey)) {
         continue
       }
       for (List<Object> yVals : entry.value) {
@@ -199,7 +205,7 @@ class Joiner {
   }
 
   private static List<Integer> resolveIndices(Matrix m, List<String> colNames) {
-    List<Integer> indices = new ArrayList<>(colNames.size())
+    List<Integer> indices = []
     for (String name : colNames) {
       int idx = m.columnIndex(name)
       if (idx < 0) {
@@ -230,34 +236,31 @@ class Joiner {
       Matrix m, List<Integer> keyIndices, List<Integer> valueIndices) {
     Map<List<Object>, List<List<Object>>> index = [:]
     int rowCount = m.rowCount()
+    List<List<Object>> keyCols = keyIndices.collect { m.column(it) as List<Object> }
+    List<List<Object>> valCols = valueIndices.collect { m.column(it) as List<Object> }
     for (int r = 0; r < rowCount; r++) {
-      List<Object> key = extractKey(m, r, keyIndices)
+      List<Object> key = new ArrayList<>(keyIndices.size())
+      for (List<Object> col : keyCols) {
+        key.add(col[r])
+      }
       List<List<Object>> bucket = index.get(key)
       if (bucket == null) {
         bucket = []
         index.put(key, bucket)
       }
       List<Object> vals = new ArrayList<>(valueIndices.size())
-      for (int vi : valueIndices) {
-        vals.add(m.column(vi)[r])
+      for (List<Object> col : valCols) {
+        vals.add(col[r])
       }
       bucket.add(vals)
     }
     index
   }
 
-  private static List<Object> extractKey(Matrix m, int row, List<Integer> keyIndices) {
-    List<Object> key = new ArrayList<>(keyIndices.size())
-    for (int ki : keyIndices) {
-      key.add(m.column(ki)[row])
-    }
-    key
-  }
-
-  private static List<Object> extractRow(Matrix m, int row, int colCount) {
-    List<Object> vals = new ArrayList<>(colCount)
-    for (int c = 0; c < colCount; c++) {
-      vals.add(m.column(c)[row])
+  private static List<Object> extractFromCols(List<List<Object>> cols, int row) {
+    List<Object> vals = new ArrayList<>(cols.size())
+    for (List<Object> col : cols) {
+      vals.add(col[row])
     }
     vals
   }
@@ -269,8 +272,8 @@ class Joiner {
     List<String> xColNames = x.columnNames()
     List<Class> xColTypes = x.types()
 
-    List<String> yNonKeyNames = new ArrayList<>(yNonKeyIndices.size())
-    List<Class> yNonKeyTypes = new ArrayList<>(yNonKeyIndices.size())
+    List<String> yNonKeyNames = []
+    List<Class> yNonKeyTypes = []
     List<String> yColNames = y.columnNames()
     List<Class> yColTypes = y.types()
     for (int i : yNonKeyIndices) {
@@ -284,7 +287,7 @@ class Joiner {
     Set<String> duplicates = new LinkedHashSet<>(xNonKeyNames)
     duplicates.retainAll(yNonKeyNameSet)
 
-    List<String> resultNames = new ArrayList<>(xColNames.size() + yNonKeyNames.size())
+    List<String> resultNames = []
     for (String n : xColNames) {
       resultNames.add(duplicates.contains(n) && !xKeyNameSet.contains(n) ? "${n}_x" as String : n)
     }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
@@ -12,6 +12,10 @@ package se.alipsa.matrix.core
  *
  * <p>Null key values compare equal to other null key values, matching common data
  * analysis merge behavior rather than SQL {@code NULL} semantics.</p>
+ *
+ * <p><b>Column name collisions:</b> if x already contains a column whose name ends
+ * with {@code _y} (or {@code _x}) and a suffix is needed, the result may contain
+ * duplicate column names. This matches pandas behavior.</p>
  */
 @SuppressWarnings('JavadocEmptyFirstLine')
 class Joiner {
@@ -104,8 +108,13 @@ class Joiner {
     int yColCount = y.columnCount()
     int xRowCount = x.rowCount()
     int yRowCount = y.rowCount()
+    long resultSize = (long) xRowCount * yRowCount
+    if (resultSize > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException(
+          "Cross join would produce ${resultSize} rows, exceeding maximum list size")
+    }
     ArrayList<List<Object>> resultRows = [] as ArrayList<List<Object>>
-    resultRows.ensureCapacity(xRowCount * yRowCount)
+    resultRows.ensureCapacity((int) resultSize)
 
     List<List<Object>> xCols = (0..<xColCount).collect { x.column(it) as List<Object> }
     List<List<Object>> yCols = (0..<yColCount).collect { y.column(it) as List<Object> }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
@@ -9,8 +9,11 @@ package se.alipsa.matrix.core
  *
  * <p>One-to-many joins are fully supported: if a key in y has multiple matching
  * rows, each match produces a separate result row (cross product).</p>
+ *
+ * <p>Null key values compare equal to other null key values, matching common data
+ * analysis merge behavior rather than SQL {@code NULL} semantics.</p>
  */
-@SuppressWarnings(['JavadocEmptyFirstLine', 'Instanceof', 'NestedForLoop'])
+@SuppressWarnings('JavadocEmptyFirstLine')
 class Joiner {
 
   /**
@@ -24,7 +27,7 @@ class Joiner {
    * @param all false for inner join, true for left join (backward compatible)
    * @return a new Matrix with the joined rows
    */
-  static Matrix merge(Matrix x, Matrix y, Map by, boolean all = false) {
+  static Matrix merge(Matrix x, Matrix y, Map<String, Object> by, boolean all = false) {
     merge(x, y, by, all ? JoinType.LEFT : JoinType.INNER)
   }
 
@@ -50,7 +53,7 @@ class Joiner {
    * @param joinType the type of join to perform
    * @return a new Matrix with the joined rows
    */
-  static Matrix merge(Matrix x, Matrix y, Map by, JoinType joinType) {
+  static Matrix merge(Matrix x, Matrix y, Map<String, Object> by, JoinType joinType) {
     List<List<String>> keys = normalizeKeys(by)
     doMerge(x, y, keys[0], keys[1], joinType)
   }
@@ -98,15 +101,15 @@ class Joiner {
     int yColCount = y.columnCount()
     int xRowCount = x.rowCount()
     int yRowCount = y.rowCount()
-    List<List<Object>> resultRows = new ArrayList<>(xRowCount * yRowCount)
+    List<List<Object>> resultRows = []
 
     List<List<Object>> xCols = (0..<xColCount).collect { x.column(it) as List<Object> }
     List<List<Object>> yCols = (0..<yColCount).collect { y.column(it) as List<Object> }
 
-    for (int xr = 0; xr < xRowCount; xr++) {
+    (0..<xRowCount).each { int xr ->
       List<Object> xRow = extractFromCols(xCols, xr)
-      for (int yr = 0; yr < yRowCount; yr++) {
-        resultRows.add(xRow + extractFromCols(yCols, yr))
+      (0..<yRowCount).each { int yr ->
+        resultRows << xRow + extractFromCols(yCols, yr)
       }
     }
 
@@ -123,7 +126,7 @@ class Joiner {
                                 List<String> xKeyNames, List<String> yKeyNames,
                                 JoinType joinType) {
     if (joinType == JoinType.CROSS) {
-      throw new IllegalArgumentException('Use Joiner.crossJoin(x, y) for cross joins')
+      return crossJoin(x, y)
     }
     List<Integer> xKeyIndices = resolveIndices(x, xKeyNames)
     List<Integer> yKeyIndices = resolveIndices(y, yKeyNames)
@@ -146,11 +149,12 @@ class Joiner {
     int xColCount = x.columnCount()
     int yNonKeyCount = yNonKeyIndices.size()
     List<Object> nullYRow = Collections.nCopies(yNonKeyCount, null)
+    int xRowCount = x.rowCount()
 
     List<List<Object>> xKeyCols = xKeyIndices.collect { x.column(it) as List<Object> }
     List<List<Object>> xAllCols = (0..<xColCount).collect { x.column(it) as List<Object> }
 
-    for (int r = 0; r < x.rowCount(); r++) {
+    (0..<xRowCount).each { int r ->
       List<Object> key = extractFromCols(xKeyCols, r)
       List<Object> xRow = extractFromCols(xAllCols, r)
 
@@ -160,8 +164,8 @@ class Joiner {
           resultRows.add(xRow)
         } else if (joinType != JoinType.ANTI) {
           matchedYKeys.add(key)
-          for (List<Object> yVals : yMatches) {
-            resultRows.add(xRow + yVals)
+          yMatches.each { List<Object> yVals ->
+            resultRows << xRow + yVals
           }
         }
       } else if (joinType == JoinType.ANTI) {
@@ -189,35 +193,35 @@ class Joiner {
                                            Set<List<Object>> matchedYKeys,
                                            int xColCount, List<Integer> xKeyIndices,
                                            int keyCount) {
-    for (Map.Entry<List<Object>, List<List<Object>>> entry : yIndex.entrySet()) {
-      List<Object> yKey = entry.key
+    yIndex.each { List<Object> yKey, List<List<Object>> yRows ->
       if (matchedYKeys.contains(yKey)) {
-        continue
+        return
       }
-      for (List<Object> yVals : entry.value) {
-        List<Object> xRow = new ArrayList<Object>(Collections.nCopies(xColCount, null))
-        for (int k = 0; k < keyCount; k++) {
+      yRows.each { List<Object> yVals ->
+        List<Object> xRow = ([null] * xColCount) as List<Object>
+        (0..<keyCount).each { int k ->
           xRow.set(xKeyIndices[k], yKey[k])
         }
-        resultRows.add(xRow + yVals)
+        resultRows << xRow + yVals
       }
     }
   }
 
   private static List<Integer> resolveIndices(Matrix m, List<String> colNames) {
     List<Integer> indices = []
-    for (String name : colNames) {
+    colNames.each { String name ->
       int idx = m.columnIndex(name)
       if (idx < 0) {
         throw new IllegalArgumentException(
             "Join column '${name}' does not exist in matrix '${m.matrixName}'")
       }
-      indices.add(idx)
+      indices << idx
     }
     indices
   }
 
-  private static List<List<String>> normalizeKeys(Map by) {
+  @SuppressWarnings('Instanceof')
+  private static List<List<String>> normalizeKeys(Map<String, Object> by) {
     Object xVal = by.get('x')
     Object yVal = by.get('y')
     if (xVal == null || yVal == null) {
@@ -238,31 +242,20 @@ class Joiner {
     int rowCount = m.rowCount()
     List<List<Object>> keyCols = keyIndices.collect { m.column(it) as List<Object> }
     List<List<Object>> valCols = valueIndices.collect { m.column(it) as List<Object> }
-    for (int r = 0; r < rowCount; r++) {
-      List<Object> key = new ArrayList<>(keyIndices.size())
-      for (List<Object> col : keyCols) {
-        key.add(col[r])
-      }
+    (0..<rowCount).each { int r ->
+      List<Object> key = extractFromCols(keyCols, r)
       List<List<Object>> bucket = index.get(key)
       if (bucket == null) {
         bucket = []
         index.put(key, bucket)
       }
-      List<Object> vals = new ArrayList<>(valueIndices.size())
-      for (List<Object> col : valCols) {
-        vals.add(col[r])
-      }
-      bucket.add(vals)
+      bucket << extractFromCols(valCols, r)
     }
     index
   }
 
   private static List<Object> extractFromCols(List<List<Object>> cols, int row) {
-    List<Object> vals = new ArrayList<>(cols.size())
-    for (List<Object> col : cols) {
-      vals.add(col[row])
-    }
-    vals
+    cols.collect { List<Object> col -> col[row] }
   }
 
   private static ResultColumns computeResultColumns(Matrix x, Matrix y,
@@ -276,26 +269,23 @@ class Joiner {
     List<Class> yNonKeyTypes = []
     List<String> yColNames = y.columnNames()
     List<Class> yColTypes = y.types()
-    for (int i : yNonKeyIndices) {
-      yNonKeyNames.add(yColNames[i])
-      yNonKeyTypes.add(yColTypes[i])
+    yNonKeyIndices.each { int i ->
+      yNonKeyNames << yColNames[i]
+      yNonKeyTypes << yColTypes[i]
     }
 
-    Set<String> xNonKeyNames = new LinkedHashSet<>(xColNames)
-    xNonKeyNames.removeAll(xKeyNameSet)
     Set<String> yNonKeyNameSet = new LinkedHashSet<>(yNonKeyNames)
-    Set<String> duplicates = new LinkedHashSet<>(xNonKeyNames)
+    Set<String> duplicates = new LinkedHashSet<>(xColNames)
     duplicates.retainAll(yNonKeyNameSet)
 
-    List<String> resultNames = []
-    for (String n : xColNames) {
-      resultNames.add(duplicates.contains(n) && !xKeyNameSet.contains(n) ? "${n}_x" as String : n)
+    List<String> resultNames = xColNames.collect { String n ->
+      duplicates.contains(n) && !xKeyNameSet.contains(n) ? "${n}_x" as String : n
     }
-    for (String n : yNonKeyNames) {
-      resultNames.add(duplicates.contains(n) ? "${n}_y" as String : n)
-    }
+    resultNames.addAll(yNonKeyNames.collect { String n ->
+      duplicates.contains(n) ? "${n}_y" as String : n
+    })
 
-    List<Class> resultTypes = new ArrayList<>(xColTypes)
+    List<Class> resultTypes = [] + xColTypes
     resultTypes.addAll(yNonKeyTypes)
 
     new ResultColumns(names: resultNames, types: resultTypes)

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
@@ -164,7 +164,9 @@ class Joiner {
         if (joinType == JoinType.SEMI) {
           resultRows.add(xRow)
         } else if (joinType != JoinType.ANTI) {
-          matchedYKeys.add(key)
+          if (joinType == JoinType.RIGHT || joinType == JoinType.FULL) {
+            matchedYKeys.add(key)
+          }
           yMatches.each { List<Object> yVals ->
             resultRows << xRow + yVals
           }
@@ -245,12 +247,7 @@ class Joiner {
     List<List<Object>> valCols = valueIndices.collect { m.column(it) as List<Object> }
     (0..<rowCount).each { int r ->
       List<Object> key = extractFromCols(keyCols, r)
-      List<List<Object>> bucket = index[key]
-      if (bucket == null) {
-        bucket = []
-        index[key] = bucket
-      }
-      bucket << extractFromCols(valCols, r)
+      index.computeIfAbsent(key) { [] } << extractFromCols(valCols, r)
     }
     index
   }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
@@ -22,6 +22,9 @@ class Joiner {
    * @param x the left Matrix
    * @param y the right Matrix
    * @param by a map with keys 'x' and 'y' whose values are column name(s).
+   *           Values are typed as Object because they can be either String (single key)
+   *           or List&lt;String&gt; (composite key); Groovy type erasure prevents separate
+   *           Map&lt;String, String&gt; and Map&lt;String, List&lt;String&gt;&gt; overloads.
    *           Single key: {@code [x: 'id', y: 'guid']}.
    *           Multi-key: {@code [x: ['dept', 'id'], y: ['department', 'empId']]}
    * @param all false for inner join, true for left join (backward compatible)
@@ -257,7 +260,9 @@ class Joiner {
   }
 
   private static List<Object> extractFromCols(List<List<Object>> cols, int row) {
-    cols.collect { List<Object> col -> col[row] }
+    List<Object> result = new ArrayList<>(cols.size())
+    cols.each { List<Object> col -> result.add(col[row]) }
+    result
   }
 
   private static ResultColumns computeResultColumns(Matrix x, Matrix y,

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
@@ -101,7 +101,8 @@ class Joiner {
     int yColCount = y.columnCount()
     int xRowCount = x.rowCount()
     int yRowCount = y.rowCount()
-    List<List<Object>> resultRows = []
+    ArrayList<List<Object>> resultRows = [] as ArrayList<List<Object>>
+    resultRows.ensureCapacity(xRowCount * yRowCount)
 
     List<List<Object>> xCols = (0..<xColCount).collect { x.column(it) as List<Object> }
     List<List<Object>> yCols = (0..<yColCount).collect { y.column(it) as List<Object> }
@@ -244,10 +245,10 @@ class Joiner {
     List<List<Object>> valCols = valueIndices.collect { m.column(it) as List<Object> }
     (0..<rowCount).each { int r ->
       List<Object> key = extractFromCols(keyCols, r)
-      List<List<Object>> bucket = index.get(key)
+      List<List<Object>> bucket = index[key]
       if (bucket == null) {
         bucket = []
-        index.put(key, bucket)
+        index[key] = bucket
       }
       bucket << extractFromCols(valCols, r)
     }
@@ -274,8 +275,8 @@ class Joiner {
       yNonKeyTypes << yColTypes[i]
     }
 
-    Set<String> yNonKeyNameSet = new LinkedHashSet<>(yNonKeyNames)
-    Set<String> duplicates = new LinkedHashSet<>(xColNames)
+    Set<String> yNonKeyNameSet = yNonKeyNames as Set<String>
+    Set<String> duplicates = xColNames as Set<String>
     duplicates.retainAll(yNonKeyNameSet)
 
     List<String> resultNames = xColNames.collect { String n ->

--- a/matrix-core/src/test/groovy/JoinerTest.groovy
+++ b/matrix-core/src/test/groovy/JoinerTest.groovy
@@ -519,6 +519,25 @@ class JoinerTest {
   }
 
   @Test
+  void testManyToManyJoin() {
+    def x = Matrix.builder('x').data([
+        id  : [1, 1, 2],
+        name: ['A1', 'A2', 'B']
+    ]).types([Integer, String]).build()
+
+    def y = Matrix.builder('y').data([
+        id   : [1, 1, 2],
+        score: [80, 90, 70]
+    ]).types([Integer, Integer]).build()
+
+    def result = Joiner.merge(x, y, 'id')
+    assertEquals(5, result.rowCount())
+    assertEquals([1, 1, 1, 1, 2], result.column('id') as List)
+    assertEquals(['A1', 'A1', 'A2', 'A2', 'B'], result.column('name') as List)
+    assertEquals([80, 90, 80, 90, 70], result.column('score') as List)
+  }
+
+  @Test
   void testSelfJoin() {
     def employees = Matrix.builder('employees').data([
         id       : [1, 2, 3],

--- a/matrix-core/src/test/groovy/JoinerTest.groovy
+++ b/matrix-core/src/test/groovy/JoinerTest.groovy
@@ -555,4 +555,83 @@ class JoinerTest {
     assertEquals(['Alice', 'Alice'], result.column('name_y') as List)
   }
 
+  @Test
+  void testRightJoinDuplicateYKeys() {
+    def x = Matrix.builder('x').data([
+        id  : [1, 2],
+        name: ['A', 'B']
+    ]).types([Integer, String]).build()
+
+    def y = Matrix.builder('y').data([
+        id   : [1, 1, 3],
+        score: [80, 90, 70]
+    ]).types([Integer, Integer]).build()
+
+    def result = Joiner.merge(x, y, 'id', JoinType.RIGHT)
+    assertEquals(3, result.rowCount())
+    assertEquals([1, 1, 3], result.column('id') as List)
+    assertEquals(['A', 'A', null], result.column('name') as List)
+    assertEquals([80, 90, 70], result.column('score') as List)
+  }
+
+  @Test
+  void testFullOuterJoinBothSidesNullKey() {
+    def x = Matrix.builder('x').data([
+        id  : [1, null],
+        name: ['A', 'B']
+    ]).build()
+
+    def y = Matrix.builder('y').data([
+        id   : [null, 2],
+        score: [90, 70]
+    ]).build()
+
+    def result = Joiner.merge(x, y, 'id', JoinType.FULL)
+    assertEquals(3, result.rowCount())
+    assertEquals([1, null, 2], result.column('id') as List)
+    assertEquals(['A', 'B', null], result.column('name') as List)
+    assertEquals([null, 90, 70], result.column('score') as List)
+  }
+
+  @Test
+  void testThreeColumnCompositeKey() {
+    def x = Matrix.builder('x').data([
+        a: ['X', 'X', 'Y'],
+        b: [1, 1, 2],
+        c: ['p', 'q', 'p'],
+        val: [10, 20, 30]
+    ]).build()
+
+    def y = Matrix.builder('y').data([
+        a: ['X', 'Y'],
+        b: [1, 2],
+        c: ['p', 'p'],
+        score: [99, 88]
+    ]).build()
+
+    def result = Joiner.merge(x, y, ['a', 'b', 'c'], JoinType.INNER)
+    assertEquals(2, result.rowCount())
+    assertEquals([10, 30], result.column('val') as List)
+    assertEquals([99, 88], result.column('score') as List)
+  }
+
+  @Test
+  void testDefaultJoinTypeIsInner() {
+    def x = Matrix.builder('x').data([
+        id  : [1, 2, 3],
+        name: ['A', 'B', 'C']
+    ]).types([Integer, String]).build()
+
+    def y = Matrix.builder('y').data([
+        id   : [2, 3, 4],
+        score: [80, 90, 70]
+    ]).types([Integer, Integer]).build()
+
+    def result = Joiner.merge(x, y, 'id')
+    assertEquals(2, result.rowCount())
+    assertEquals([2, 3], result.column('id') as List)
+    assertEquals(['B', 'C'], result.column('name') as List)
+    assertEquals([80, 90], result.column('score') as List)
+  }
+
 }

--- a/matrix-core/src/test/groovy/JoinerTest.groovy
+++ b/matrix-core/src/test/groovy/JoinerTest.groovy
@@ -2,6 +2,7 @@ import static org.junit.jupiter.api.Assertions.*
 
 import org.junit.jupiter.api.Test
 
+import se.alipsa.matrix.core.JoinType
 import se.alipsa.matrix.core.Joiner
 import se.alipsa.matrix.core.Matrix
 
@@ -22,11 +23,9 @@ class JoinerTest {
     ]).build()
 
     def merged = Joiner.merge(e, f, 'id')
-    // println merged.toMarkdown()
     assertIterableEquals([1, 'Rick', 623.3, '2012-01-01', 'Smith'], merged.row(0))
     assertIterableEquals([5, 'Gary', 843.25, '2015-03-27', 'McDougal'], merged.row(4))
 
-    // Make sure the original matrices was unaltered
     assertEquals(Matrix.builder('employees').data([
         id       : 1..5,
         firstName: ['Rick', 'Dan', 'Michelle', 'Ryan', 'Gary'],
@@ -54,12 +53,10 @@ class JoinerTest {
         ])
         .build()
     def leftJoined = Joiner.merge(e, g, [x: 'id', y: 'employeeId'], true)
-    // println leftJoined.toMarkdown()
     assertEquals([1, 'Rick', 623.3, '2012-01-01', null], leftJoined.row(0))
     assertEquals([2, 'Dan', 515.2, '2013-09-23', 'Carpenter'], leftJoined.row(1))
     assertEquals([5, 'Gary', 843.25, '2015-03-27', null], leftJoined.row(4))
 
-    // Make sure the original matrices was unaltered
     assertEquals(Matrix.builder()
         .matrixName('employees')
         .columns([
@@ -99,6 +96,280 @@ class JoinerTest {
     }
 
     assertEquals('Join column \'missing\' does not exist in matrix \'employees\'', error.message)
+  }
+
+  @Test
+  void testOneToManyInnerJoin() {
+    def orders = Matrix.builder('orders').data([
+        orderId   : [1, 2, 3],
+        customerId: [10, 20, 10]
+    ]).types([Integer, Integer]).build()
+
+    def items = Matrix.builder('items').data([
+        orderId: [1, 1, 2, 3, 3, 3],
+        product: ['Pen', 'Paper', 'Ink', 'Tape', 'Glue', 'Clip']
+    ]).types([Integer, String]).build()
+
+    def result = Joiner.merge(orders, items, 'orderId')
+    assertEquals(6, result.rowCount())
+    assertEquals([1, 1, 2, 3, 3, 3], result.column('orderId') as List)
+    assertEquals(['Pen', 'Paper', 'Ink', 'Tape', 'Glue', 'Clip'], result.column('product') as List)
+    assertEquals([10, 10, 20, 10, 10, 10], result.column('customerId') as List)
+  }
+
+  @Test
+  void testOneToManyLeftJoin() {
+    def x = Matrix.builder('x').data([
+        id  : [1, 2, 3],
+        name: ['A', 'B', 'C']
+    ]).types([Integer, String]).build()
+
+    def y = Matrix.builder('y').data([
+        id  : [1, 1, 2],
+        item: ['X', 'Y', 'Z']
+    ]).types([Integer, String]).build()
+
+    def result = Joiner.merge(x, y, 'id', true)
+    assertEquals(4, result.rowCount())
+    assertEquals([1, 1, 2, 3], result.column('id') as List)
+    assertEquals(['A', 'A', 'B', 'C'], result.column('name') as List)
+    assertEquals(['X', 'Y', 'Z', null], result.column('item') as List)
+  }
+
+  @Test
+  void testTypePreservation() {
+    def x = Matrix.builder('x').data([
+        id   : [1, 2, 3],
+        value: [10.5, 20.3, 30.1]
+    ]).types([Integer, BigDecimal]).build()
+
+    def y = Matrix.builder('y').data([
+        id  : [1, 2, 3],
+        name: ['A', 'B', 'C']
+    ]).types([Integer, String]).build()
+
+    def result = Joiner.merge(x, y, 'id')
+    assertEquals([Integer, BigDecimal, String], result.types())
+  }
+
+  @Test
+  void testRightJoin() {
+    def x = Matrix.builder('x').data([
+        id  : [1, 2, 3],
+        name: ['A', 'B', 'C']
+    ]).types([Integer, String]).build()
+
+    def y = Matrix.builder('y').data([
+        id   : [2, 3, 4],
+        score: [80, 90, 70]
+    ]).types([Integer, Integer]).build()
+
+    def result = Joiner.merge(x, y, 'id', JoinType.RIGHT)
+    assertEquals(3, result.rowCount())
+    assertEquals([2, 3, 4], result.column('id') as List)
+    assertEquals(['B', 'C', null], result.column('name') as List)
+    assertEquals([80, 90, 70], result.column('score') as List)
+  }
+
+  @Test
+  void testFullOuterJoin() {
+    def x = Matrix.builder('x').data([
+        id  : [1, 2, 3],
+        name: ['A', 'B', 'C']
+    ]).types([Integer, String]).build()
+
+    def y = Matrix.builder('y').data([
+        id   : [2, 3, 4],
+        score: [80, 90, 70]
+    ]).types([Integer, Integer]).build()
+
+    def result = Joiner.merge(x, y, 'id', JoinType.FULL)
+    assertEquals(4, result.rowCount())
+    assertEquals([1, 2, 3, 4], result.column('id') as List)
+    assertEquals(['A', 'B', 'C', null], result.column('name') as List)
+    assertEquals([null, 80, 90, 70], result.column('score') as List)
+  }
+
+  @Test
+  void testMultiColumnJoinKeys() {
+    def x = Matrix.builder('x').data([
+        dept : ['Sales', 'Sales', 'Eng'],
+        empId: [1, 2, 1],
+        name : ['Alice', 'Bob', 'Carol']
+    ]).types([String, Integer, String]).build()
+
+    def y = Matrix.builder('y').data([
+        department: ['Sales', 'Eng', 'Sales'],
+        employeeId: [1, 1, 2],
+        rating    : [5, 4, 3]
+    ]).types([String, Integer, Integer]).build()
+
+    def result = Joiner.merge(x, y,
+        [x: ['dept', 'empId'], y: ['department', 'employeeId']],
+        JoinType.INNER)
+    assertEquals(3, result.rowCount())
+    assertEquals(['Alice', 'Bob', 'Carol'], result.column('name') as List)
+    assertEquals([5, 3, 4], result.column('rating') as List)
+  }
+
+  @Test
+  void testListOfStringByOverload() {
+    def x = Matrix.builder('x').data([
+        dept : ['Sales', 'Eng'],
+        empId: [1, 2],
+        name : ['A', 'B']
+    ]).types([String, Integer, String]).build()
+
+    def y = Matrix.builder('y').data([
+        dept  : ['Sales', 'Eng'],
+        empId : [1, 2],
+        rating: [5, 4]
+    ]).types([String, Integer, Integer]).build()
+
+    def result = Joiner.merge(x, y, ['dept', 'empId'], JoinType.INNER)
+    assertEquals(2, result.rowCount())
+    assertEquals([5, 4], result.column('rating') as List)
+  }
+
+  @Test
+  void testDuplicateColumnNames() {
+    def x = Matrix.builder('x').data([
+        id   : [1, 2],
+        value: [10, 20]
+    ]).types([Integer, Integer]).build()
+
+    def y = Matrix.builder('y').data([
+        id   : [1, 2],
+        value: [100, 200]
+    ]).types([Integer, Integer]).build()
+
+    def result = Joiner.merge(x, y, 'id')
+    assertTrue(result.columnNames().contains('value_x'))
+    assertTrue(result.columnNames().contains('value_y'))
+    assertEquals([10, 20], result.column('value_x') as List)
+    assertEquals([100, 200], result.column('value_y') as List)
+  }
+
+  @Test
+  void testNullKeys() {
+    def x = Matrix.builder('x').data([
+        id  : [1, null, 3],
+        name: ['A', 'B', 'C']
+    ]).build()
+
+    def y = Matrix.builder('y').data([
+        id   : [1, null, 4],
+        score: [80, 90, 70]
+    ]).build()
+
+    def result = Joiner.merge(x, y, 'id')
+    assertEquals(2, result.rowCount())
+    assertEquals([1, null], result.column('id') as List)
+    assertEquals([80, 90], result.column('score') as List)
+  }
+
+  @Test
+  void testEmptyLeftMatrix() {
+    def x = Matrix.builder('x')
+        .columnNames(['id', 'name'])
+        .types([Integer, String])
+        .rows([])
+        .build()
+
+    def y = Matrix.builder('y').data([
+        id   : [1, 2],
+        score: [80, 90]
+    ]).types([Integer, Integer]).build()
+
+    def result = Joiner.merge(x, y, 'id')
+    assertEquals(0, result.rowCount())
+    assertEquals(['id', 'name', 'score'], result.columnNames())
+  }
+
+  @Test
+  void testEmptyRightMatrix() {
+    def x = Matrix.builder('x').data([
+        id  : [1, 2],
+        name: ['A', 'B']
+    ]).types([Integer, String]).build()
+
+    def y = Matrix.builder('y')
+        .columnNames(['id', 'score'])
+        .types([Integer, Integer])
+        .rows([])
+        .build()
+
+    def result = Joiner.merge(x, y, 'id', true)
+    assertEquals(2, result.rowCount())
+    assertEquals([null, null], result.column('score') as List)
+  }
+
+  @Test
+  void testKeySizeMismatchThrows() {
+    def x = Matrix.builder('x').data([a: [1], b: [2]]).build()
+    def y = Matrix.builder('y').data([c: [1], d: [2]]).build()
+
+    def error = assertThrows(IllegalArgumentException) {
+      Joiner.merge(x, y, [x: ['a', 'b'], y: ['c']], JoinType.INNER)
+    }
+    assertTrue(error.message.contains('same size'))
+  }
+
+  @Test
+  void testMultiKeyRejectsMissingColumn() {
+    def x = Matrix.builder('x').data([a: [1], b: [2]]).build()
+    def y = Matrix.builder('y').data([c: [1], d: [2]]).build()
+
+    def error = assertThrows(IllegalArgumentException) {
+      Joiner.merge(x, y, [x: ['a', 'missing'], y: ['c', 'd']], JoinType.INNER)
+    }
+    assertTrue(error.message.contains('missing'))
+  }
+
+  @Test
+  void testJoinTypeEnumInnerJoin() {
+    def e = Matrix.builder('employees').data([
+        id       : 1..5,
+        firstName: ['Rick', 'Dan', 'Michelle', 'Ryan', 'Gary']
+    ]).types([Integer, String]).build()
+
+    def f = Matrix.builder('eln').data([
+        id      : 1..5,
+        lastName: ['Smith', 'Carpenter', 'Bowman', 'Carson', 'McDougal']
+    ]).types([Integer, String]).build()
+
+    def result = Joiner.merge(e, f, 'id', JoinType.INNER)
+    assertEquals(5, result.rowCount())
+    assertIterableEquals([1, 'Rick', 'Smith'], result.row(0))
+  }
+
+  @Test
+  void testRightJoinKeyValuesPreserved() {
+    def x = Matrix.builder('x').data([
+        id  : [1, 2],
+        name: ['A', 'B']
+    ]).types([Integer, String]).build()
+
+    def y = Matrix.builder('y').data([
+        id   : [3, 4],
+        score: [70, 80]
+    ]).types([Integer, Integer]).build()
+
+    def result = Joiner.merge(x, y, 'id', JoinType.RIGHT)
+    assertEquals(2, result.rowCount())
+    assertEquals([3, 4], result.column('id') as List)
+    assertEquals([null, null], result.column('name') as List)
+    assertEquals([70, 80], result.column('score') as List)
+  }
+
+  @Test
+  void testMissingByKeysThrows() {
+    def x = Matrix.builder('x').data([id: [1]]).build()
+    def y = Matrix.builder('y').data([id: [1]]).build()
+
+    assertThrows(IllegalArgumentException) {
+      Joiner.merge(x, y, [x: 'id'], JoinType.INNER)
+    }
   }
 
 }

--- a/matrix-core/src/test/groovy/JoinerTest.groovy
+++ b/matrix-core/src/test/groovy/JoinerTest.groovy
@@ -373,13 +373,16 @@ class JoinerTest {
   }
 
   @Test
-  void testCrossJoinTypeThroughMergeThrows() {
-    def x = Matrix.builder('x').data([id: [1]]).build()
-    def y = Matrix.builder('y').data([id: [1]]).build()
+  void testCrossJoinTypeThroughMergeDelegatesToCrossJoin() {
+    def x = Matrix.builder('x').data([id: [1, 2]]).build()
+    def y = Matrix.builder('y').data([id: [10, 20]]).build()
 
-    assertThrows(IllegalArgumentException) {
-      Joiner.merge(x, y, 'id', JoinType.CROSS)
-    }
+    def result = Joiner.merge(x, y, 'id', JoinType.CROSS)
+
+    assertEquals(4, result.rowCount())
+    assertEquals(['id_x', 'id_y'], result.columnNames())
+    assertEquals([1, 1, 2, 2], result.column('id_x') as List)
+    assertEquals([10, 20, 10, 20], result.column('id_y') as List)
   }
 
   @Test
@@ -526,7 +529,9 @@ class JoinerTest {
     def result = Joiner.merge(employees, employees,
         [x: 'managerId', y: 'id'], JoinType.INNER)
     assertEquals(2, result.rowCount())
+    assertEquals(['id', 'name_x', 'managerId', 'name_y', 'managerId_y'], result.columnNames())
     assertEquals([1, 1], result.column('managerId') as List)
+    assertEquals([null, null], result.column('managerId_y') as List)
     assertEquals(['Bob', 'Carol'], result.column('name_x') as List)
     assertEquals(['Alice', 'Alice'], result.column('name_y') as List)
   }

--- a/matrix-core/src/test/groovy/JoinerTest.groovy
+++ b/matrix-core/src/test/groovy/JoinerTest.groovy
@@ -373,6 +373,16 @@ class JoinerTest {
   }
 
   @Test
+  void testCrossJoinTypeThroughMergeThrows() {
+    def x = Matrix.builder('x').data([id: [1]]).build()
+    def y = Matrix.builder('y').data([id: [1]]).build()
+
+    assertThrows(IllegalArgumentException) {
+      Joiner.merge(x, y, 'id', JoinType.CROSS)
+    }
+  }
+
+  @Test
   void testCrossJoin() {
     def x = Matrix.builder('x').data([
         color: ['red', 'blue']

--- a/matrix-core/src/test/groovy/JoinerTest.groovy
+++ b/matrix-core/src/test/groovy/JoinerTest.groovy
@@ -372,4 +372,53 @@ class JoinerTest {
     }
   }
 
+  @Test
+  void testCrossJoin() {
+    def x = Matrix.builder('x').data([
+        color: ['red', 'blue']
+    ]).types([String]).build()
+
+    def y = Matrix.builder('y').data([
+        size: ['S', 'M', 'L']
+    ]).types([String]).build()
+
+    def result = Joiner.crossJoin(x, y)
+    assertEquals(6, result.rowCount())
+    assertEquals(['color', 'size'], result.columnNames())
+    assertEquals(['red', 'red', 'red', 'blue', 'blue', 'blue'], result.column('color') as List)
+    assertEquals(['S', 'M', 'L', 'S', 'M', 'L'], result.column('size') as List)
+    assertEquals([String, String], result.types())
+  }
+
+  @Test
+  void testCrossJoinDuplicateColumnNames() {
+    def x = Matrix.builder('x').data([
+        id: [1, 2], name: ['A', 'B']
+    ]).types([Integer, String]).build()
+
+    def y = Matrix.builder('y').data([
+        id: [10, 20], name: ['X', 'Y']
+    ]).types([Integer, String]).build()
+
+    def result = Joiner.crossJoin(x, y)
+    assertEquals(4, result.rowCount())
+    assertEquals(['id_x', 'name_x', 'id_y', 'name_y'], result.columnNames())
+    assertEquals([1, 1, 2, 2], result.column('id_x') as List)
+    assertEquals([10, 20, 10, 20], result.column('id_y') as List)
+  }
+
+  @Test
+  void testCrossJoinWithEmptyMatrix() {
+    def x = Matrix.builder('x').data([a: [1, 2]]).types([Integer]).build()
+    def y = Matrix.builder('y')
+        .columnNames(['b'])
+        .types([Integer])
+        .rows([])
+        .build()
+
+    def result = Joiner.crossJoin(x, y)
+    assertEquals(0, result.rowCount())
+    assertEquals(['a', 'b'], result.columnNames())
+  }
+
 }

--- a/matrix-core/src/test/groovy/JoinerTest.groovy
+++ b/matrix-core/src/test/groovy/JoinerTest.groovy
@@ -421,4 +421,104 @@ class JoinerTest {
     assertEquals(['a', 'b'], result.columnNames())
   }
 
+  @Test
+  void testSemiJoin() {
+    def x = Matrix.builder('x').data([
+        id  : [1, 2, 3, 4],
+        name: ['A', 'B', 'C', 'D']
+    ]).types([Integer, String]).build()
+
+    def y = Matrix.builder('y').data([
+        id   : [2, 3, 5],
+        score: [80, 90, 70]
+    ]).types([Integer, Integer]).build()
+
+    def result = Joiner.merge(x, y, 'id', JoinType.SEMI)
+    assertEquals(2, result.rowCount())
+    assertEquals(['id', 'name'], result.columnNames())
+    assertEquals([2, 3], result.column('id') as List)
+    assertEquals(['B', 'C'], result.column('name') as List)
+  }
+
+  @Test
+  void testSemiJoinNoDuplicateRows() {
+    def x = Matrix.builder('x').data([
+        id  : [1, 2],
+        name: ['A', 'B']
+    ]).types([Integer, String]).build()
+
+    def y = Matrix.builder('y').data([
+        id   : [1, 1, 1],
+        score: [80, 90, 70]
+    ]).types([Integer, Integer]).build()
+
+    def result = Joiner.merge(x, y, 'id', JoinType.SEMI)
+    assertEquals(1, result.rowCount())
+    assertEquals([1], result.column('id') as List)
+  }
+
+  @Test
+  void testAntiJoin() {
+    def x = Matrix.builder('x').data([
+        id  : [1, 2, 3, 4],
+        name: ['A', 'B', 'C', 'D']
+    ]).types([Integer, String]).build()
+
+    def y = Matrix.builder('y').data([
+        id   : [2, 3, 5],
+        score: [80, 90, 70]
+    ]).types([Integer, Integer]).build()
+
+    def result = Joiner.merge(x, y, 'id', JoinType.ANTI)
+    assertEquals(2, result.rowCount())
+    assertEquals(['id', 'name'], result.columnNames())
+    assertEquals([1, 4], result.column('id') as List)
+    assertEquals(['A', 'D'], result.column('name') as List)
+  }
+
+  @Test
+  void testAntiJoinNoMatches() {
+    def x = Matrix.builder('x').data([
+        id: [1, 2]
+    ]).types([Integer]).build()
+
+    def y = Matrix.builder('y').data([
+        id: [3, 4]
+    ]).types([Integer]).build()
+
+    def result = Joiner.merge(x, y, 'id', JoinType.ANTI)
+    assertEquals(2, result.rowCount())
+    assertEquals([1, 2], result.column('id') as List)
+  }
+
+  @Test
+  void testAntiJoinAllMatch() {
+    def x = Matrix.builder('x').data([
+        id: [1, 2]
+    ]).types([Integer]).build()
+
+    def y = Matrix.builder('y').data([
+        id: [1, 2]
+    ]).types([Integer]).build()
+
+    def result = Joiner.merge(x, y, 'id', JoinType.ANTI)
+    assertEquals(0, result.rowCount())
+  }
+
+  @Test
+  void testSelfJoin() {
+    def employees = Matrix.builder('employees').data([
+        id       : [1, 2, 3],
+        name     : ['Alice', 'Bob', 'Carol'],
+        managerId: [null, 1, 1]
+    ]).types([Integer, String, Integer]).build()
+
+    def result = Joiner.merge(employees, employees,
+        [x: 'managerId', y: 'id'], JoinType.INNER)
+    assertEquals(2, result.rowCount())
+    assertEquals([1, 1], result.column('managerId') as List)
+    assertEquals(['Bob', 'Carol'], result.column('name_x') as List)
+    assertEquals(['Alice', 'Alice'], result.column('name_y') as List)
+  }
+
 }

--- a/matrix-core/src/test/groovy/JoinerTest.groovy
+++ b/matrix-core/src/test/groovy/JoinerTest.groovy
@@ -634,4 +634,111 @@ class JoinerTest {
     assertEquals([80, 90], result.column('score') as List)
   }
 
+  @Test
+  void testMultiColumnKeyFullJoin() {
+    def x = Matrix.builder('x').data([
+        dept : ['Sales', 'Eng'],
+        empId: [1, 2],
+        name : ['Alice', 'Bob']
+    ]).types([String, Integer, String]).build()
+
+    def y = Matrix.builder('y').data([
+        dept : ['Sales', 'HR'],
+        empId: [1, 3],
+        score: [95, 80]
+    ]).types([String, Integer, Integer]).build()
+
+    def result = Joiner.merge(x, y, ['dept', 'empId'], JoinType.FULL)
+    assertEquals(3, result.rowCount())
+    assertEquals(['Sales', 'Eng', 'HR'], result.column('dept') as List)
+    assertEquals([1, 2, 3], result.column('empId') as List)
+    assertEquals(['Alice', 'Bob', null], result.column('name') as List)
+    assertEquals([95, null, 80], result.column('score') as List)
+  }
+
+  @Test
+  void testSemiJoinCompositeKey() {
+    def x = Matrix.builder('x').data([
+        a: ['X', 'X', 'Y'],
+        b: [1, 2, 1],
+        val: [10, 20, 30]
+    ]).build()
+
+    def y = Matrix.builder('y').data([
+        a: ['X', 'Y'],
+        b: [1, 1],
+        score: [99, 88]
+    ]).build()
+
+    def result = Joiner.merge(x, y, ['a', 'b'], JoinType.SEMI)
+    assertEquals(2, result.rowCount())
+    assertEquals(['a', 'b', 'val'], result.columnNames())
+    assertEquals(['X', 'Y'], result.column('a') as List)
+    assertEquals([1, 1], result.column('b') as List)
+    assertEquals([10, 30], result.column('val') as List)
+  }
+
+  @Test
+  void testAntiJoinCompositeKey() {
+    def x = Matrix.builder('x').data([
+        a: ['X', 'X', 'Y'],
+        b: [1, 2, 1],
+        val: [10, 20, 30]
+    ]).build()
+
+    def y = Matrix.builder('y').data([
+        a: ['X', 'Y'],
+        b: [1, 1],
+        score: [99, 88]
+    ]).build()
+
+    def result = Joiner.merge(x, y, ['a', 'b'], JoinType.ANTI)
+    assertEquals(1, result.rowCount())
+    assertEquals(['X'], result.column('a') as List)
+    assertEquals([2], result.column('b') as List)
+    assertEquals([20], result.column('val') as List)
+  }
+
+  @Test
+  void testDuplicateColumnNamesWithRightJoin() {
+    def x = Matrix.builder('x').data([
+        id   : [1, 2],
+        value: [10, 20]
+    ]).types([Integer, Integer]).build()
+
+    def y = Matrix.builder('y').data([
+        id   : [2, 3],
+        value: [200, 300]
+    ]).types([Integer, Integer]).build()
+
+    def result = Joiner.merge(x, y, 'id', JoinType.RIGHT)
+    assertEquals(2, result.rowCount())
+    assertTrue(result.columnNames().contains('value_x'))
+    assertTrue(result.columnNames().contains('value_y'))
+    assertEquals([2, 3], result.column('id') as List)
+    assertEquals([20, null], result.column('value_x') as List)
+    assertEquals([200, 300], result.column('value_y') as List)
+  }
+
+  @Test
+  void testCrossJoinOverflowGuard() {
+    // Verify the overflow guard produces a clear error, not NegativeArraySizeException
+    def x = Matrix.builder('x')
+        .columnNames(['a'])
+        .types([Integer])
+        .rows((1..50000).collect { [it] })
+        .build()
+
+    def y = Matrix.builder('y')
+        .columnNames(['b'])
+        .types([Integer])
+        .rows((1..50000).collect { [it] })
+        .build()
+
+    def error = assertThrows(IllegalArgumentException) {
+      Joiner.crossJoin(x, y)
+    }
+    assertTrue(error.message.contains('exceeding maximum'))
+  }
+
 }


### PR DESCRIPTION
## Summary
- Add `JoinType` enum (`INNER`, `LEFT`, `RIGHT`, `FULL`, `CROSS`, `SEMI`, `ANTI`) for explicit join type selection
- Fix one-to-many bug: multiple y matches per key now produce separate result rows (previously only first match was kept)
- Preserve column types from both source matrices in the result
- Support composite (multi-column) join keys: `merge(x, y, [x: ['dept', 'id'], y: ['department', 'empId']], JoinType.INNER)`
- Add same-name multi-key shorthand: `merge(x, y, ['dept', 'empId'], JoinType.INNER)`
- Add semi, anti, and cross join support, including `merge(..., JoinType.CROSS)` delegation to `crossJoin(x, y)`
- Auto-suffix duplicate result column names with `_x` / `_y`, including self-join key/non-key conflicts
- Document null-key matching semantics for `Joiner.merge()`
- Fully `@CompileStatic` (removed `@CompileDynamic` workaround)
- Backward compatible: existing `merge(x, y, by, boolean)` signatures unchanged

**Note:** The `Map<String, Object>` parameter type replaces the previous `Map<String, String>`. Existing compiled callers will need to recompile (binary-incompatible, source-compatible). Worth noting in release notes for the next minor version bump.

## Test plan
- [x] 39 `JoinerTest` cases
- [x] `./gradlew :matrix-core:test --tests JoinerTest`
- [x] `./gradlew test`