### PR TITLE
matrix-core 3.8.0: API improvements, security fixes, and deprecation cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 # Repository Guidelines
 
+## Code Review Standards
+When reviewing PRs, report ONLY issues and suggestions. Do NOT report observations, praise, or summaries. Before flagging an issue, verify it doesn't already exist in the codebase and confirm the code is actually wrong — avoid false positives. For Java/Groovy code, be aware of `@CompileStatic` semantics, Groovy constructor dispatch with null values, and type boxing differences (e.g., `int` vs `Integer`).
+
 ## Project Structure & Module Organization
 This is a Gradle multi-module Groovy/Java project. Each module lives in a `matrix-*` directory (for example `matrix-core`, `matrix-stats`, `matrix-csv`, `matrix-charts`, `matrix-sql`). Source code is primarily in `matrix-*/src/main/groovy` (with some `src/main/java`), and tests live in `matrix-*/src/test/groovy` or `matrix-*/src/test/java`. Shared docs are under `docs/` (tutorial and cookbook), while runnable examples live in `matrix-examples/`.
 
@@ -29,13 +32,14 @@ Before an implementation can be considered done, run these checks in order:
 3. `./gradlew :<module>:test` — ensure all tests pass.
 
 ## Coding Style & Naming Conventions
-Use Groovy 5.0.6 and target Java 21.
-Follow the existing 2-space indentation and import style in each file. 
-Prefer `@CompileStatic` and only fall back to @CompileDynamic when the static compilation would be significantly more convoluted. 
-Classes are PascalCase, methods/fields are camelCase, and packages follow `se.alipsa.matrix.*`. 
-Test classes are named `*Test.groovy` or `*Test.java` and live in module test directories. 
-Always add GroovyDoc for public classes and public methods. 
-Formatting is enforced by Spotless (`./gradlew spotlessApply` to auto-format).
+- Use Groovy 5.0.6 and target Java 21.
+- Follow the existing 2-space indentation and import style in each file.
+- Prefer `@CompileStatic` (enable by default through build script config) and only fall back to @CompileDynamic when the static compilation would be significantly more convoluted.
+- Classes are PascalCase, methods/fields are camelCase, and packages follow `se.alipsa.matrix.*`.
+- Test classes are named `*Test.groovy` or `*Test.java` and live in module test directories.
+- Always add GroovyDoc for public classes and public methods.
+- Formatting is enforced by Spotless (`./gradlew spotlessApply` to auto-format).
+- Understand Groovy constructor dispatch ambiguity (especially with null arguments), `@CompileStatic` type requirements (e.g., explicit casts that look redundant but are required), and `int` vs `Integer` behavioral differences (e.g., `sample(int)` vs `sample(Integer)`).
 
 ### Avoid `Object` Parameters — Use Typed Overloads
 **CRITICAL:** Never use `Object` as a method parameter or field type when specific types are known. `Object` parameters are not type-safe and provide no IDE assistance. Instead, use method overloads with concrete types:
@@ -1112,6 +1116,14 @@ File I/O:         15ms+ per test
 ```
 
 For a test suite with 200+ tests, this optimization saves ~30 seconds per run.
+
+## Documentation
+When generating documentation, always include:
+- concrete usage examples
+- all parameter descriptions with defaults
+- complete end-to-end instructions on first attempt.
+
+Do not produce minimal stubs that require multiple rounds of refinement.
 
 ## Key Dependencies
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,14 @@ Authoritative project metadata:
 - `./gradlew spotlessApply`: auto-format all source files.
 - `./gradlew spotlessCheck`: verify formatting without modifying files (runs as part of `build`).
 - `./gradlew dependencyUpdates`: report newer dependency versions.
+- `./gradlew :matrix-core:codenarcMain`: run CodeNarc static analysis on main sources for a single module.
+- `./gradlew :matrix-core:codenarcTest`: run CodeNarc static analysis on test sources for a single module.
+
+### Verification order
+Before an implementation can be considered done, run these checks in order:
+1. `./gradlew :<module>:codenarcMain` — fix any static analysis violations first.
+2. `./gradlew :<module>:spotlessCheck` — verify formatting (or run `spotlessApply` to auto-fix).
+3. `./gradlew :<module>:test` — ensure all tests pass.
 
 ## Coding Style & Naming Conventions
 Use Groovy 5.0.6 and target Java 21.

--- a/matrix-core/release.md
+++ b/matrix-core/release.md
@@ -38,9 +38,16 @@
 - `Column.removeNulls()` now correctly returns `Column` instead of `List`.
 - `Matrix.diff()` and `Matrix.equals()` / `Matrix.checkValues()` now use `BigDecimal` arithmetic for numeric tolerance comparisons, eliminating `double`/`Double.NaN` imprecision. The `allowedDiff` parameter type changed from `double`/`Double` to `BigDecimal` — Groovy call sites are unaffected; Java callers that pass a `double` literal need a cast or `BigDecimal` literal.
 - `Matrix.equals()` — a `null` value in the compared matrix is now correctly reported as differing from a numeric value (was silently masked by `NaN` comparison semantics).
+- `Matrix.equals()` now checks row counts before comparing values, so matrices with matching prefixes but different numbers of rows no longer compare equal.
+- `Matrix.equals(..., ignoreTypes: true)` preserves numeric/string comparison behavior after the row-count fix.
+- Matrix's Groovy version guard now accepts qualified version strings such as `6.0.0-alpha-1` instead of failing during class initialization.
 - `Stat.sd(Matrix, List<String>)` was incorrectly collecting `Double` values via `.doubleValue()`; it now delegates to the existing `sd(List<?>, boolean)` overload, giving consistent BigDecimal-precision results.
+- `Stat.medians(List<List<?>>, List<Integer>)` now returns `null` for columns with no numeric values instead of throwing a null pointer exception.
 - `Stat.mean()` no longer applies `setScale` to every summand before adding; scale is applied only at the final divide, producing more accurate intermediate sums.
 - `Stat.min(Matrix, List<String>)`, `Stat.max(Matrix, List<String>)`, and `Stat.max(Matrix, String)` now use direct columnar access instead of building a full row list, matching the columnar-access pattern used elsewhere in `Stat`.
+- `ValueConverter.convert(..., LocalDate, ..., Locale)` now honors the supplied locale for patterned date parsing.
+- `ValueConverter.asLong(String)` now avoids `Double` conversion so large integer strings do not lose precision.
+- Typed `Grid` mutators now reject values that do not match the grid element type, matching typed constructor validation.
 - `MatrixAssertions` tolerance constants changed from `double` to `BigDecimal` to match the updated `equals()` signature.
 
 ### Build changes

--- a/matrix-core/release.md
+++ b/matrix-core/release.md
@@ -39,6 +39,11 @@
 - Removed redundant `CodeNarc` and `repositories` blocks from matrix-core `build.gradle` (now handled by root project)
 - Removed deprecated `afterSuite` closure from test configuration (replaced by `addTestListener` in root project)
 - Additional CodeNarc `@SuppressWarnings` for `DuplicateNumberLiteral` and `MethodCount` in `Matrix.groovy`
+- MatrixBuilder
+  - rows(...) now rejects ragged row data instead of silently losing values during transpose().
+  - addRow(...) now enforces a stable row width. If column names exist and no rows have been added yet, their count is used as the initial width.
+  - columns(Map) / data(Map) now replace pending builder data consistently.
+  - csvString(...) now treats delimiters literally and respects quoted delimiters, including round-tripping values like "C,k".
 
 ### 3.7.1, 2026-04-22
 - Preserve row count for zero-column matrices created from empty-row input so

--- a/matrix-core/release.md
+++ b/matrix-core/release.md
@@ -45,7 +45,7 @@
 - Backward compatible: existing `merge(x, y, by, boolean)` signatures continue to work
 
 ### Performance
-- `Matrix.apply(int, List<Integer>, Closure)` and `Matrix.apply(int, Closure<Boolean>, Closure)` now mutate the target column in place instead of rebuilding the entire column (or transposing all rows). This is significantly more efficient when applying to a small subset of rows.
+- `Matrix.apply(int, List<Integer>, Closure)` and `Matrix.apply(int, Closure<Boolean>, Closure)` now mutate the target column in place instead of rebuilding the entire column (or transposing all rows). This is significantly more efficient when applying to a small subset of rows. **Note:** code that holds a direct reference to a column object before calling `apply` will now observe the mutation in place, whereas the old implementation created fresh `Column` objects via `Grid.transpose()`.
 
 ### Fixes
 - `Column.unique()` now preserves the column's `name` and `type` on the returned copy (previously both were lost).
@@ -66,10 +66,10 @@
 
 ### API changes
 - `withColumn(String, Closure)` and `withColumn(int, Closure)` now return `Column` instead of `List`, preserving the source column's name and type. This enables fluent chaining with Column's arithmetic and cumulative methods.
-- `withColumns(List<String>, Closure)` and index-based `withColumns` variants now return `Column` instead of `List`.
+- `withColumns(List<String>, Closure)` and index-based `withColumns` variants now return `Column` instead of `List`. Because the operation spans multiple source columns, the returned Column has no name or type set (unlike `withColumn` which preserves the single source column's identity).
 - Added `select(String...)`, `select(List<String>)`, and `select(IntRange)` as shorter aliases for `selectColumns(...)`. The `selectColumns` methods are now deprecated in favor of `select`.
 - Added `dropExcept(List<String>)` overload so callers with a `List<String>` variable no longer need to cast to `String[]`.
-- `toHtml()` now escapes HTML special characters (`<`, `>`, `&`, `'`, `"`) in column names and cell values, preventing malformed or injectable HTML output.
+- `toHtml()` now escapes HTML special characters (`<`, `>`, `&`, `'`, `"`) in column names and cell values, preventing malformed or injectable HTML output. Escaped names are also used in CSS class attributes; browsers parse these back to the original form, so CSS selectors should match the unescaped column name.
 - `diff()` now returns an empty string when two matrices are equal, matching its GroovyDoc contract (previously returned `'No differences between the two matrices detected!'`).
 - Removed redundant `@CompileStatic` annotation from `Matrix.groovy` (static compilation is already enabled globally via compiler config).
 

--- a/matrix-core/release.md
+++ b/matrix-core/release.md
@@ -34,6 +34,14 @@
 - Backward compatible: existing `merge(x, y, by, boolean)` signatures continue to work
 
 ### Fixes
+- `Column.unique()` now preserves the column's `name` and `type` on the returned copy (previously both were lost).
+- `Column.removeNulls()` now correctly returns `Column` instead of `List`.
+- `Matrix.diff()` and `Matrix.equals()` / `Matrix.checkValues()` now use `BigDecimal` arithmetic for numeric tolerance comparisons, eliminating `double`/`Double.NaN` imprecision. The `allowedDiff` parameter type changed from `double`/`Double` to `BigDecimal` — Groovy call sites are unaffected; Java callers that pass a `double` literal need a cast or `BigDecimal` literal.
+- `Matrix.equals()` — a `null` value in the compared matrix is now correctly reported as differing from a numeric value (was silently masked by `NaN` comparison semantics).
+- `Stat.sd(Matrix, List<String>)` was incorrectly collecting `Double` values via `.doubleValue()`; it now delegates to the existing `sd(List<?>, boolean)` overload, giving consistent BigDecimal-precision results.
+- `Stat.mean()` no longer applies `setScale` to every summand before adding; scale is applied only at the final divide, producing more accurate intermediate sums.
+- `Stat.min(Matrix, List<String>)`, `Stat.max(Matrix, List<String>)`, and `Stat.max(Matrix, String)` now use direct columnar access instead of building a full row list, matching the columnar-access pattern used elsewhere in `Stat`.
+- `MatrixAssertions` tolerance constants changed from `double` to `BigDecimal` to match the updated `equals()` signature.
 
 ### Build changes
 - Removed redundant `CodeNarc` and `repositories` blocks from matrix-core `build.gradle` (now handled by root project)

--- a/matrix-core/release.md
+++ b/matrix-core/release.md
@@ -10,9 +10,20 @@
 - `sample(Number n, Random random = new Random())` — same as above but accepts any Number (truncated to int, with overflow protection)
 - `sampleFraction(Number fraction, Random random = new Random())` — random sample by fraction of total rows (0 < fraction <= 1.0), minimum 1 row
 
+### New Matrix methods (continued)
+- `merge(Matrix y, String by, JoinType joinType = JoinType.INNER)` — instance method for joining on a single same-name column, delegating to `Joiner.merge`
+- `merge(Matrix y, Map<String, Object> by, JoinType joinType = JoinType.INNER)` — instance method for joining with a key map (single or composite keys)
+- `merge(Matrix y, List<String> by, JoinType joinType)` — instance method for multi-column same-name joins
+- `crossJoin(Matrix y)` — instance method for Cartesian product, delegating to `Joiner.crossJoin`
+- `rename(Map<String, String> nameMapping)` — bulk rename of columns in a single call
+
 ### New Column methods
 - `hasNulls()` — returns true if the column contains at least one null value
 - `countNulls()` — returns the count of null elements in the column
+
+### Column improvements
+- Arithmetic operators (`+`, `-`, `*`, `/`, `**`) now return `Column` instead of `List`, preserving `name` and `type` from the source column. This enables fluent chaining such as `(column + 1) - 2` without losing the Column identity.
+- `removeNulls()` now preserves the column's `name` and `type` on the returned copy.
 
 ### Joiner rewrite
 - Added `JoinType` enum with `INNER`, `LEFT`, `RIGHT`, `FULL`, `CROSS`, `SEMI`, `ANTI`
@@ -32,6 +43,9 @@
 - `merge(..., JoinType.CROSS)` now delegates to `crossJoin(x, y)`
 - Joiner is now fully `@CompileStatic` (removed `@CompileDynamic` workaround)
 - Backward compatible: existing `merge(x, y, by, boolean)` signatures continue to work
+
+### Performance
+- `Matrix.apply(int, List<Integer>, Closure)` and `Matrix.apply(int, Closure<Boolean>, Closure)` now mutate the target column in place instead of rebuilding the entire column (or transposing all rows). This is significantly more efficient when applying to a small subset of rows.
 
 ### Fixes
 - `Column.unique()` now preserves the column's `name` and `type` on the returned copy (previously both were lost).

--- a/matrix-core/release.md
+++ b/matrix-core/release.md
@@ -64,6 +64,26 @@
 - Typed `Grid` mutators now reject values that do not match the grid element type, matching typed constructor validation.
 - `MatrixAssertions` tolerance constants changed from `double` to `BigDecimal` to match the updated `equals()` signature.
 
+### API changes
+- `withColumn(String, Closure)` and `withColumn(int, Closure)` now return `Column` instead of `List`, preserving the source column's name and type. This enables fluent chaining with Column's arithmetic and cumulative methods.
+- `withColumns(List<String>, Closure)` and index-based `withColumns` variants now return `Column` instead of `List`.
+- Added `select(String...)`, `select(List<String>)`, and `select(IntRange)` as shorter aliases for `selectColumns(...)`. The `selectColumns` methods are now deprecated in favor of `select`.
+- Added `dropExcept(List<String>)` overload so callers with a `List<String>` variable no longer need to cast to `String[]`.
+- `toHtml()` now escapes HTML special characters (`<`, `>`, `&`, `'`, `"`) in column names and cell values, preventing malformed or injectable HTML output.
+- `diff()` now returns an empty string when two matrices are equal, matching its GroovyDoc contract (previously returned `'No differences between the two matrices detected!'`).
+- Removed redundant `@CompileStatic` annotation from `Matrix.groovy` (static compilation is already enabled globally via compiler config).
+
+### Removed deprecated methods
+The following methods deprecated since 3.7.0 have been removed:
+- `Matrix.dropColumnsExcept(String...)` — use `dropExcept(String...)`
+- `Matrix.dropColumnsExcept(int...)` — use `dropExcept(int...)`
+- `Matrix.dropColumns(String...)` — use `drop(String...)`
+- `Matrix.dropColumns(IntRange)` — use `drop(IntRange)`
+- `Matrix.dropColumns(List<Integer>)` — use `drop(List<Integer>)`
+- `Matrix.dropColumns(int...)` — use `drop(int...)`
+- `Matrix.removeEmptyColumns()` — use `dropEmptyColumns()`
+- `ValueConverter.asSqlTIme(Object, Time)` — use `asSqlTime(Object, Time)` (typo fix)
+
 ### Build changes
 - Removed redundant `CodeNarc` and `repositories` blocks from matrix-core `build.gradle` (now handled by root project)
 - Removed deprecated `afterSuite` closure from test configuration (replaced by `addTestListener` in root project)

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Column.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Column.groovy
@@ -91,23 +91,12 @@ class Column extends ArrayList {
     if (list == null) {
       throw new IllegalArgumentException('Cannot add a null list to a column')
     }
-    List result = new Column()
-    def that = fill(list)
-    this.eachWithIndex { it, idx ->
-      def val = that[idx]
-      if (it == null || val == null) {
-        result.add(null)
-      } else if (it instanceof Number) {
-        result.add(it + (val as Number))
-      } else if (it instanceof Character) {
-        result.add(it + (val as Character))
-      } else if (it instanceof String) {
-        result.add(it + (val as String))
-      } else {
-        result.add(it + val)
-      }
+    applyListOp(list) { a, b ->
+      if (a instanceof Number) return a + (b as Number)
+      if (a instanceof Character) return a + (b as Character)
+      if (a instanceof String) return a + (b as String)
+      a + b
     }
-    result
   }
 
   @CompileDynamic
@@ -123,23 +112,12 @@ class Column extends ArrayList {
     if (list == null) {
       throw new IllegalArgumentException('Cannot subtract a null list from a column')
     }
-    List result = new Column()
-    def that = fill(list)
-    this.eachWithIndex { it, idx ->
-      def val = that[idx]
-      if (it == null || val == null) {
-        result.add(null)
-      } else if (it instanceof Number) {
-        result.add(it - (val as Number))
-      } else if (it instanceof Character) {
-        result.add(it - (val as Character))
-      } else if (it instanceof String) {
-        result.add(it - (val as String))
-      } else {
-        result.add(it - val)
-      }
+    applyListOp(list) { a, b ->
+      if (a instanceof Number) return a - (b as Number)
+      if (a instanceof Character) return a - (b as Character)
+      if (a instanceof String) return a - (b as String)
+      a - b
     }
-    result
   }
 
   @CompileDynamic
@@ -155,19 +133,7 @@ class Column extends ArrayList {
     if (list == null) {
       throw new IllegalArgumentException('Cannot multiply a column by a null list')
     }
-    List result = new Column()
-    def that = fill(list)
-    this.eachWithIndex { it, idx ->
-      def val = that[idx]
-      if (it == null || val == null) {
-        result.add(null)
-      } else if (it instanceof Number) {
-        result.add(it * (val as Number))
-      } else {
-        result.add(it * val)
-      }
-    }
-    result
+    applyListOp(list) { a, b -> a instanceof Number ? a * (b as Number) : a * b }
   }
 
   @CompileDynamic
@@ -183,19 +149,7 @@ class Column extends ArrayList {
     if (list == null) {
       throw new IllegalArgumentException('Cannot divide a column by a null list')
     }
-    List result = new Column()
-    def that = fill(list)
-    this.eachWithIndex { it, idx ->
-      def val = that[idx]
-      if (it == null || val == null) {
-        result.add(null)
-      } else if (it instanceof Number) {
-        result.add(it / (val as Number))
-      } else {
-        result.add(it / val)
-      }
-    }
-    result
+    applyListOp(list) { a, b -> a instanceof Number ? a / (b as Number) : a / b }
   }
 
   @CompileDynamic
@@ -211,16 +165,19 @@ class Column extends ArrayList {
     if (list == null) {
       throw new IllegalArgumentException('Cannot raise a column to the power of a null list')
     }
+    applyListOp(list) { a, b -> a instanceof Number ? a ** (b as Number) : a ** b }
+  }
+
+  @CompileDynamic
+  private List applyListOp(List list, Closure<Object> op) {
     List result = new Column()
     def that = fill(list)
     this.eachWithIndex { it, idx ->
       def val = that[idx]
       if (it == null || val == null) {
         result.add(null)
-      } else if (it instanceof Number) {
-        result.add(it ** (val as Number))
       } else {
-        result.add(it ** val)
+        result.add(op(it, val))
       }
     }
     result
@@ -262,7 +219,7 @@ class Column extends ArrayList {
     Collections.frequency(this, null)
   }
 
-  List removeNulls() {
+  Column removeNulls() {
     this.findAll { it != null } as Column
   }
 
@@ -311,12 +268,14 @@ class Column extends ArrayList {
   /**
    * Change the default behavior of the unique method to not mutate
    * (otherwise the rest of the column values will be filled with null).
-   * Returns a new Column with unique values from this column.
+   * Returns a new Column with unique values from this column, preserving name and type.
    *
    * @return a new Column with unique values
    */
-  List unique() {
-    unique(false)
+  Column unique() {
+    Column result = new Column(name, type)
+    result.addAll(new LinkedHashSet(this))
+    result
   }
 
   @CompileDynamic
@@ -472,7 +431,7 @@ class Column extends ArrayList {
   }
 
   List getValues() {
-    this.collect { it }
+    new ArrayList(this)
   }
 
 }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Column.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Column.groovy
@@ -11,6 +11,15 @@ import se.alipsa.matrix.core.util.ShiftHelper
  * A column is a list with some arithmetic operations changed compared to how lists normally behaves in Groovy.
  * the multiply, div, plus, minus, and power applies to each element in the list instead of on the list itself. E.g.
  * new Column([1,2,3]) * 2 == [2,4,6] instead of [2,4,6,2,4,6] which the default result would on a list i Groovy.
+ *
+ * <h3>Mutability convention</h3>
+ * <ul>
+ *   <li><b>Size-preserving</b> operations ({@link #replace}, {@link #replaceNulls}) mutate this column
+ *       in place and return {@code this}.</li>
+ *   <li><b>Size-changing</b> operations ({@link #removeNulls}, {@link #unique}) and <b>transformations</b>
+ *       (arithmetic, cumulative, shift/lag/lead/diff) return a new {@code Column} with name and type
+ *       preserved from the source.</li>
+ * </ul>
  */
 @CompileStatic
 @SuppressWarnings('Instanceof')
@@ -66,8 +75,8 @@ class Column extends ArrayList {
   }
 
   @CompileDynamic
-  private List applyOperation(Object val, Closure operation) {
-    List result = new Column()
+  private Column applyOperation(Object val, Closure operation) {
+    Column result = newLike()
     this.each {
       if (it == null) {
         result.add(null)
@@ -79,7 +88,7 @@ class Column extends ArrayList {
   }
 
   @CompileDynamic
-  List plus(Object val) {
+  Column plus(Object val) {
     if (val == null) {
       throw new IllegalArgumentException('Cannot add null to a column, use removeNulls() to remove nulls from the column or replaceNulls() to replace nulls with a value before adding')
     }
@@ -87,7 +96,7 @@ class Column extends ArrayList {
   }
 
   @CompileDynamic
-  List plus(List list) {
+  Column plus(List list) {
     if (list == null) {
       throw new IllegalArgumentException('Cannot add a null list to a column')
     }
@@ -100,7 +109,7 @@ class Column extends ArrayList {
   }
 
   @CompileDynamic
-  List minus(Object val) {
+  Column minus(Object val) {
     if (val == null) {
       throw new IllegalArgumentException('Cannot subtract null from a column, use removeNulls() to remove nulls from the column or replaceNulls() to replace nulls with a value before subtracting')
     }
@@ -108,7 +117,7 @@ class Column extends ArrayList {
   }
 
   @CompileDynamic
-  List minus(List list) {
+  Column minus(List list) {
     if (list == null) {
       throw new IllegalArgumentException('Cannot subtract a null list from a column')
     }
@@ -121,7 +130,7 @@ class Column extends ArrayList {
   }
 
   @CompileDynamic
-  List multiply(Number val) {
+  Column multiply(Number val) {
     if (val == null) {
       throw new IllegalArgumentException('Cannot multiply null with a column, use removeNulls() to remove nulls from the column or replaceNulls() to replace nulls with a value before multiplying')
     }
@@ -129,7 +138,7 @@ class Column extends ArrayList {
   }
 
   @CompileDynamic
-  List multiply(List list) {
+  Column multiply(List list) {
     if (list == null) {
       throw new IllegalArgumentException('Cannot multiply a column by a null list')
     }
@@ -137,7 +146,7 @@ class Column extends ArrayList {
   }
 
   @CompileDynamic
-  List div(Number val) {
+  Column div(Number val) {
     if (val == null) {
       throw new IllegalArgumentException('Cannot divide a column by null, use removeNulls() to remove nulls from the column or replaceNulls() to replace nulls with a value before dividing')
     }
@@ -145,7 +154,7 @@ class Column extends ArrayList {
   }
 
   @CompileDynamic
-  List div(List list) {
+  Column div(List list) {
     if (list == null) {
       throw new IllegalArgumentException('Cannot divide a column by a null list')
     }
@@ -153,7 +162,7 @@ class Column extends ArrayList {
   }
 
   @CompileDynamic
-  List power(Number val) {
+  Column power(Number val) {
     if (val == null) {
       throw new IllegalArgumentException('Cannot raise a column to the power of null, use removeNulls() to remove nulls from the column or replaceNulls() to replace nulls with a value before exponentiating')
     }
@@ -161,7 +170,7 @@ class Column extends ArrayList {
   }
 
   @CompileDynamic
-  List power(List list) {
+  Column power(List list) {
     if (list == null) {
       throw new IllegalArgumentException('Cannot raise a column to the power of a null list')
     }
@@ -169,8 +178,8 @@ class Column extends ArrayList {
   }
 
   @CompileDynamic
-  private List applyListOp(List list, Closure<Object> op) {
-    List result = new Column()
+  private Column applyListOp(List list, Closure<Object> op) {
+    Column result = newLike()
     def that = fill(list)
     this.eachWithIndex { it, idx ->
       def val = that[idx]
@@ -220,7 +229,9 @@ class Column extends ArrayList {
   }
 
   Column removeNulls() {
-    this.findAll { it != null } as Column
+    Column result = newLike()
+    result.addAll(this.findAll { it != null })
+    result
   }
 
   /**
@@ -249,6 +260,12 @@ class Column extends ArrayList {
       }
     }
     this
+  }
+
+  private Column newLike() {
+    Column col = new Column(this.type)
+    col.name = this.name
+    col
   }
 
   private Column fill(List list) {

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Column.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Column.groovy
@@ -101,9 +101,9 @@ class Column extends ArrayList {
       throw new IllegalArgumentException('Cannot add a null list to a column')
     }
     applyListOp(list) { a, b ->
-      if (a instanceof Number) return a + (b as Number)
-      if (a instanceof Character) return a + (b as Character)
-      if (a instanceof String) return a + (b as String)
+      if (a instanceof Number) { return a + (b as Number) }
+      if (a instanceof Character) { return a + (b as Character) }
+      if (a instanceof String) { return a + (b as String) }
       a + b
     }
   }
@@ -122,9 +122,9 @@ class Column extends ArrayList {
       throw new IllegalArgumentException('Cannot subtract a null list from a column')
     }
     applyListOp(list) { a, b ->
-      if (a instanceof Number) return a - (b as Number)
-      if (a instanceof Character) return a - (b as Character)
-      if (a instanceof String) return a - (b as String)
+      if (a instanceof Number) { return a - (b as Number) }
+      if (a instanceof Character) { return a - (b as Character) }
+      if (a instanceof String) { return a - (b as String) }
       a - b
     }
   }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Grid.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Grid.groovy
@@ -19,12 +19,15 @@ import java.text.NumberFormat
 class Grid<T> implements Iterable<List<T>> {
 
   List<List<T>> data
+  private final Class<?> elementType
 
   Grid() {
     data = []
+    elementType = Object
   }
 
   Grid(List<List<T>> data) {
+    elementType = Object
     if (isValid(data)) {
       this.data = data
     } else if (data instanceof List) {
@@ -43,21 +46,24 @@ class Grid<T> implements Iterable<List<T>> {
    * @throws IllegalArgumentException if the row structure is invalid or contains incompatible values
    */
   Grid(List<List<T>> data, Class<T> elementType) {
-    if (isValid(data, elementType)) {
+    this.elementType = safeElementType(elementType)
+    if (isValid(data, this.elementType)) {
       this.data = data
-    } else if (data instanceof List && isValid([data], elementType)) {
+    } else if (data instanceof List && isValid([data], this.elementType)) {
       this.data = [data]
     } else {
-      throw new IllegalArgumentException("data is invalid for element type ${safeElementType(elementType).simpleName}")
+      throw new IllegalArgumentException("data is invalid for element type ${this.elementType.simpleName}")
     }
   }
 
   Grid(int nrow) {
     data = new ArrayList<List<T>>(nrow)
+    elementType = Object
   }
 
   Grid(int nrow, int ncol) {
     data = new ArrayList<List<T>>(nrow)
+    elementType = Object
     nrow.times {
       data << ([null] * ncol) as List<T>
     }
@@ -65,6 +71,7 @@ class Grid<T> implements Iterable<List<T>> {
 
   Grid(T value, int nrow, int ncol) {
     data = new ArrayList<List<T>>(nrow)
+    elementType = value == null ? Object : safeElementType(value.class)
     nrow.times {
       data << ([value] * ncol) as List<T>
     }
@@ -83,10 +90,12 @@ class Grid<T> implements Iterable<List<T>> {
   }
 
   def leftShift(List<T> row) {
+    validateNewRow(row)
     data << row
   }
 
   boolean add(List<T> row) {
+    validateNewRow(row)
     data.add(row)
   }
 
@@ -97,10 +106,12 @@ class Grid<T> implements Iterable<List<T>> {
    * @param row the row data
    */
   void add(int position, List<T> row) {
+    validateNewRow(row)
     data.add(position, row)
   }
 
   boolean addAll(List<List<T>> grid) {
+    grid.each { List<T> row -> validateNewRow(row) }
     data.addAll(grid)
   }
 
@@ -161,7 +172,9 @@ class Grid<T> implements Iterable<List<T>> {
     if (rowIdx < data.size()) {
       replaceRow(rowIdx, values.collect())
     } else if (rowIdx == data.size()) {
-      data << values.collect()
+      List<T> row = values.collect() as List<T>
+      validateNewRow(row)
+      data << row
     } else {
       throw new IndexOutOfBoundsException("Index $rowIdx cannot be greater than ${data.size()}")
     }
@@ -205,6 +218,7 @@ class Grid<T> implements Iterable<List<T>> {
   }
 
   Grid replaceRow(int index, List<T> row) {
+    validateNewRow(row)
     def r = data.get(index)
     r.clear()
     r.addAll(row)
@@ -212,6 +226,15 @@ class Grid<T> implements Iterable<List<T>> {
   }
 
   Grid replaceColumn(int column, List<T> values) {
+    if (values == null) {
+      throw new IllegalArgumentException('Column values cannot be null')
+    }
+    if (values.size() != data.size()) {
+      throw new IllegalArgumentException("Column values size (${values.size()}) must match row count (${data.size()})")
+    }
+    values.eachWithIndex { T value, int i ->
+      validateValue(value, "Value at row $i")
+    }
     data.eachWithIndex { List row, int i ->
       row[column] = values[i]
     }
@@ -394,6 +417,21 @@ class Grid<T> implements Iterable<List<T>> {
 
   private static Class<?> safeElementType(Class<?> elementType) {
     ClassUtils.convertPrimitiveToWrapper(elementType) ?: Object
+  }
+
+  private void validateNewRow(List<T> row) {
+    if (row == null) {
+      throw new IllegalArgumentException('Row cannot be null')
+    }
+    row.eachWithIndex { T value, int i ->
+      validateValue(value, "Value at column $i")
+    }
+  }
+
+  private void validateValue(T value, String context) {
+    if (value != null && elementType != Object && !elementType.isInstance(value)) {
+      throw new IllegalArgumentException("${context} is ${value.class.simpleName} but expected ${elementType.simpleName}")
+    }
   }
 
 }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Grid.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Grid.groovy
@@ -116,8 +116,7 @@ class Grid<T> implements Iterable<List<T>> {
   }
 
   Grid plus(List<T> row) {
-    def grid = new Grid()
-    grid.addAll(data)
+    def grid = new Grid<T>(copyRows(), elementType as Class<T>)
     grid.add(row)
     grid
   }
@@ -246,11 +245,12 @@ class Grid<T> implements Iterable<List<T>> {
   }
 
   Grid<T> transpose() {
-    new Grid<T>(transpose(this.data))
+    new Grid<T>(transpose(this.data), elementType as Class<T>)
   }
 
   static <N> Grid<N> convert(Grid grid, Integer colNum, Class<N> type, NumberFormat format = null) {
-    new Grid(convert(grid.data, [colNum], type, format))
+    List<List<N>> converted = convert(grid.data, colNum, type, format)
+    coversAllColumns(grid.data, [colNum]) ? new Grid<N>(converted, type) : new Grid<N>(converted)
   }
 
   // Null in means "no single target column was supplied", so preserve the legacy null result.
@@ -272,7 +272,8 @@ class Grid<T> implements Iterable<List<T>> {
   }
 
   static <N> Grid<N> convert(Grid grid, List<Integer> colNums, Class<N> type, NumberFormat format = null) {
-    new Grid(convert(grid.data, colNums, type, format))
+    List<List<?>> converted = convert(grid.data, colNums, type, format)
+    coversAllColumns(grid.data, colNums) ? new Grid<N>(converted as List<List<N>>, type) : new Grid<N>(converted as List<List<N>>)
   }
 
   @CompileDynamic
@@ -417,6 +418,18 @@ class Grid<T> implements Iterable<List<T>> {
 
   private static Class<?> safeElementType(Class<?> elementType) {
     ClassUtils.convertPrimitiveToWrapper(elementType) ?: Object
+  }
+
+  private static boolean coversAllColumns(List<List<?>> rowList, List<Integer> colNums) {
+    if (rowList == null || rowList.isEmpty()) {
+      return true
+    }
+    Set<Integer> columns = colNums as Set<Integer>
+    columns == (0..<rowList[0].size()) as Set<Integer>
+  }
+
+  private List<List<T>> copyRows() {
+    data.collect { List<T> row -> row.collect() as List<T> }
   }
 
   private void validateNewRow(List<T> row) {

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Grid.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Grid.groovy
@@ -228,8 +228,10 @@ class Grid<T> implements Iterable<List<T>> {
     if (values == null) {
       throw new IllegalArgumentException('Column values cannot be null')
     }
-    if (values.size() != data.size()) {
-      throw new IllegalArgumentException("Column values size (${values.size()}) must match row count (${data.size()})")
+    int valSize = values.size()
+    int rowCount = data.size()
+    if (valSize != rowCount) {
+      throw new IllegalArgumentException("Column values size ($valSize) must match row count ($rowCount)")
     }
     values.eachWithIndex { T value, int i ->
       validateValue(value, "Value at row $i")

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Grid.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Grid.groovy
@@ -171,11 +171,11 @@ class Grid<T> implements Iterable<List<T>> {
    * @return a Map<String, Integer> of the number of observations (rows) and the number of
    * variables (columns) in the Grid with the keys 'observations' and 'variables'
    */
-  @SuppressWarnings('UnnecessaryCollectCall')
   Map<String, Integer> dimensions() {
-    ['observations': data.size(), 'variables': data.isEmpty() ? 0 : data.collect { it.size() }.max()]
+    ['observations': data.size(), 'variables': data.isEmpty() ? 0 : data.max { it.size() }.size()]
   }
 
+  @Override
   String toString() {
     StringBuilder sb = new StringBuilder('[\n')
     data.each { sb.append('  ').append(String.valueOf(it)).append('\n') }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
@@ -113,8 +113,7 @@ class Joiner {
       throw new IllegalArgumentException(
           "Cross join would produce ${resultSize} rows, exceeding maximum list size")
     }
-    ArrayList<List<Object>> resultRows = [] as ArrayList<List<Object>>
-    resultRows.ensureCapacity((int) resultSize)
+    List<List<Object>> resultRows = new ArrayList<>((int) resultSize)
 
     List<List<Object>> xCols = (0..<xColCount).collect { x.column(it) as List<Object> }
     List<List<Object>> yCols = (0..<yColCount).collect { y.column(it) as List<Object> }
@@ -236,7 +235,7 @@ class Joiner {
     indices
   }
 
-  @SuppressWarnings('Instanceof')
+  @SuppressWarnings(['Instanceof', 'DuplicateStringLiteral'])
   private static List<List<String>> normalizeKeys(Map<String, Object> by) {
     if (!by.containsKey('x') || !by.containsKey('y')) {
       throw new IllegalArgumentException("Join key map must contain both 'x' and 'y' entries")

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/ListConverter.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/ListConverter.groovy
@@ -220,43 +220,23 @@ class ListConverter {
   }
 
   static List<BigDecimal> toBigDecimals(List<?> numbers) {
-    List<BigDecimal> list = []
-    numbers.each {
-      list.add(ValueConverter.asBigDecimal(it))
-    }
-    return list
+    numbers.collect { ValueConverter.asBigDecimal(it) }
   }
 
   static List<BigDecimal> toBigDecimals(Object... numbers) {
-    List<BigDecimal> list = []
-    numbers.each {
-      list.add(ValueConverter.asBigDecimal(it))
-    }
-    return list
+    numbers.collect { ValueConverter.asBigDecimal(it) }
   }
 
   static List<Short> toShorts(Object... numbers) {
-    List<Short> list = []
-    numbers.each {
-      list.add(ValueConverter.asShort(it))
-    }
-    return list
+    numbers.collect { ValueConverter.asShort(it) }
   }
 
   static List<LocalTime> toLocalTimes(Object... times) {
-    List<LocalTime> list = []
-    times.each {
-      list.add(ValueConverter.asLocalTime(it))
-    }
-    return list
+    times.collect { ValueConverter.asLocalTime(it) }
   }
 
-  static List<Byte> toBytes(Object ... bytes) {
-    List<Byte> list = []
-    bytes.each {
-      list.add(ValueConverter.asByte(it))
-    }
-    return list
+  static List<Byte> toBytes(Object... bytes) {
+    bytes.collect { ValueConverter.asByte(it) }
   }
 
 }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Matrix.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Matrix.groovy
@@ -617,7 +617,7 @@ class Matrix implements Iterable<Row>, Cloneable {
    *
    * <p>Useful for building readable left-to-right pipelines:</p>
    * <pre>
-   * matrix.pipe { it.selectColumns('a', 'b') }
+   * matrix.pipe { it.select('a', 'b') }
    *       .pipe { it.orderBy('a') }
    * </pre>
    *

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Matrix.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Matrix.groovy
@@ -1607,22 +1607,6 @@ class Matrix implements Iterable<Row>, Cloneable {
     builder(mName).columnNames(headers).types(types).build()
   }
 
-  private List<Class> createTypeListWithNewValue(int columnNumber, Class updatedClass, boolean findCommonGround) {
-    List<Class> types = []
-    for (int i = 0; i < mColumns.size(); i++) {
-      if (i == columnNumber) {
-        if (findCommonGround) {
-          types.add(findClosestCommonSuper(updatedClass, type(columnNumber)))
-        } else {
-          types.add(updatedClass)
-        }
-      } else {
-        types.add(type(i))
-      }
-    }
-    return types
-  }
-
 
   /**
    * Compare this matrix with another and return a human-readable diff.
@@ -1658,16 +1642,7 @@ class Matrix implements Iterable<Row>, Cloneable {
         thatRow = other.row(i)
         boolean valueDiff = false
         thisRow.eachWithIndex { Object entry, int c ->
-          if (entry instanceof Number) {
-            def thatVal = thatRow[c]
-            if (thatVal instanceof Number) {
-              if (((entry as Number).toBigDecimal() - (thatVal as Number).toBigDecimal()).abs() > allowedDiff) {
-                valueDiff = true
-              }
-            } else {
-              valueDiff = true
-            }
-          } else if (entry != thatRow[c]) {
+          if (valuesAreDifferent(entry, thatRow[c], allowedDiff)) {
             valueDiff = true
           }
         }
@@ -1681,6 +1656,17 @@ class Matrix implements Iterable<Row>, Cloneable {
     } else {
       return 'No differences between the two matrices detected!'
     }
+  }
+
+  @SuppressWarnings('Instanceof')
+  private static boolean valuesAreDifferent(Object entry, Object thatVal, BigDecimal allowedDiff) {
+    if (entry instanceof Number) {
+      if (thatVal instanceof Number) {
+        return ((entry as Number).toBigDecimal() - (thatVal as Number).toBigDecimal()).abs() > allowedDiff
+      }
+      return true
+    }
+    entry != thatVal
   }
 
   /**

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Matrix.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Matrix.groovy
@@ -3,7 +3,6 @@ package se.alipsa.matrix.core
 import static se.alipsa.matrix.core.util.ClassUtils.*
 
 import groovy.transform.CompileDynamic
-import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import groovyjarjarantlr4.v4.runtime.misc.NotNull
 
@@ -45,7 +44,6 @@ import java.time.LocalDateTime
  * or to assign / create a column <code> myMatrix['bar'] = [1..12]</code> to assign the range 1 to 12 to the column bar
  *
  */
-@CompileStatic
 @SuppressWarnings([
     'JavadocEmptyLastLine',
     'ClassSize',
@@ -319,7 +317,7 @@ class Matrix implements Iterable<Row>, Cloneable {
       }
     }
 
-    if (columns != null && headerList == null) {
+    if (headerList == null) {
       if (columns.isEmpty()) {
         headerList = []
       } else {
@@ -452,7 +450,6 @@ class Matrix implements Iterable<Row>, Cloneable {
    * @return this matrix (mutated) to allow method chaining
    */
   Matrix addColumns(Matrix table, List<Integer> columns) {
-    List<String> names
     columns.each {
       addColumn(
           table.columnName(it),
@@ -1654,7 +1651,7 @@ class Matrix implements Iterable<Row>, Cloneable {
     if (sb.length() > 0) {
       return sb.toString()
     } else {
-      return 'No differences between the two matrices detected!'
+      return ''
     }
   }
 
@@ -1670,23 +1667,20 @@ class Matrix implements Iterable<Row>, Cloneable {
   }
 
   /**
+   * Drop all columns except the specified ones.
    *
-   * @param columnNames
-   * @return this modified matrix
-   * @deprecated use dropExcept(String...) instead
+   * @param columnNames the column names to keep
+   * @return this modified matrix with only the specified columns
    */
-  @Deprecated(forRemoval = true, since = "3.7.0")
-  Matrix dropColumnsExcept(String... columnNames) {
-    dropExcept(columnNames)
+  Matrix dropExcept(List<String> columnNames) {
+    dropExcept(columnNames as String[])
   }
-
-
 
   /**
    * Drop all columns except the specified ones.
    *
    * @param columnNames the column names to keep
-   * @return a matrix with only the specified columns
+   * @return this modified matrix with only the specified columns
    */
   Matrix dropExcept(String... columnNames) {
     def retainColNames = columnNames.length > 0 ? columnNames as List : []
@@ -1707,18 +1701,6 @@ class Matrix implements Iterable<Row>, Cloneable {
     }
     return this
   }
-
-  /**
-   *
-   * @param columnIndices
-   * @return
-   * @deprecated use dropExcept(int...) instead
-   */
-  @Deprecated(forRemoval = true, since = "3.7.0")
-  Matrix dropColumnsExcept(int ... columnIndices) {
-    dropExcept(columnIndices)
-  }
-
 
   /**
    * Drop all columns except the specified indices.
@@ -1744,18 +1726,6 @@ class Matrix implements Iterable<Row>, Cloneable {
   }
 
   /**
-   *
-   * @param columnNames
-   * @return
-   * @deprecated use drop(String...) instead
-   */
-  @Deprecated(forRemoval = true, since = "3.7.0")
-  Matrix dropColumns(String... columnNames) {
-    drop(columnNames)
-  }
-
-
-  /**
    * Drop the specified columns by name.
    *
    * @param columnNames the column names to remove
@@ -1775,17 +1745,6 @@ class Matrix implements Iterable<Row>, Cloneable {
   }
 
   /**
-   *
-   * @param columnIndices
-   * @return
-   * @deprecated use drop(int...) instead. Will be removed in 3.6.0
-   */
-  @Deprecated(forRemoval = true, since = "3.7.0")
-  Matrix dropColumns(IntRange columnIndices) {
-    drop(columnIndices)
-  }
-
-  /**
    * Drop the range of columns specified.
    *
    * @param columnIndices the range of columns to drop
@@ -1793,17 +1752,6 @@ class Matrix implements Iterable<Row>, Cloneable {
    */
   Matrix drop(IntRange columnIndices) {
     drop(columnIndices.toList())
-  }
-
-  /**
-   *
-   * @param columnIndices
-   * @return
-   * @deprecated use drop(int...) instead
-   */
-  @Deprecated(forRemoval = true, since = "3.7.0")
-  Matrix dropColumns(List<Integer> columnIndices) {
-    drop(columnIndices)
   }
 
   /**
@@ -1841,17 +1789,6 @@ class Matrix implements Iterable<Row>, Cloneable {
       mColumns.remove(colIdx - idx)
     }
     return this
-  }
-
-  /**
-   *
-   * @param columnIndices
-   * @return
-   * @deprecated use drop(int...) instead. Will be removed in 3.6.0
-   */
-  @Deprecated(forRemoval = true, since = "3.7.0")
-  Matrix dropColumns(int ... columnIndices) {
-    drop(columnIndices)
   }
 
   /**
@@ -2945,17 +2882,6 @@ class Matrix implements Iterable<Row>, Cloneable {
   }
 
   /**
-   *
-   * @return this matrix without the empty columns
-   * @deprecated Use dropEmptyColumns() instead
-   */
-  @Deprecated(forRemoval = true, since = "3.7.0")
-  Matrix removeEmptyColumns() {
-    dropEmptyColumns()
-  }
-
-
-  /**
    * Get the row at the specified index
    *
    * @param index the index of the row
@@ -3064,9 +2990,11 @@ class Matrix implements Iterable<Row>, Cloneable {
    *
    * @param columnNames the column names to include
    * @return a new Matrix with the selected columns
+   * @deprecated use select(List) instead
    */
+  @Deprecated(forRemoval = true, since = "3.8.0")
   Matrix selectColumns(List<String> columnNames) {
-    selectColumns(columnNames as String[])
+    select(columnNames as String[])
   }
 
 
@@ -3075,8 +3003,43 @@ class Matrix implements Iterable<Row>, Cloneable {
    *
    * @param columnNames the column names to include
    * @return a matrix with the selected columns
+   * @deprecated use select(String...) instead
    */
+  @Deprecated(forRemoval = true, since = "3.8.0")
   Matrix selectColumns(String... columnNames) {
+    select(columnNames)
+  }
+
+
+  /**
+   * Return a new matrix containing the columns in the specified index range.
+   *
+   * @param range the column index range to include
+   * @return a matrix with the selected columns
+   * @deprecated use select(IntRange) instead
+   */
+  @Deprecated(forRemoval = true, since = "3.8.0")
+  Matrix selectColumns(IntRange range) {
+    select(columnNames(range) as String[])
+  }
+
+  /**
+   * Select columns by name and return a new Matrix containing only those columns.
+   *
+   * @param columnNames the column names to include
+   * @return a new Matrix with the selected columns
+   */
+  Matrix select(List<String> columnNames) {
+    select(columnNames as String[])
+  }
+
+  /**
+   * Return a new matrix containing only the specified columns.
+   *
+   * @param columnNames the column names to include
+   * @return a matrix with the selected columns
+   */
+  Matrix select(String... columnNames) {
     List<List> cols = []
     List<String> colNames = []
     List<Class> dataTypes = []
@@ -3100,15 +3063,14 @@ class Matrix implements Iterable<Row>, Cloneable {
     result
   }
 
-
   /**
    * Return a new matrix containing the columns in the specified index range.
    *
    * @param range the column index range to include
    * @return a matrix with the selected columns
    */
-  Matrix selectColumns(IntRange range) {
-    selectColumns(columnNames(range) as String[])
+  Matrix select(IntRange range) {
+    select(columnNames(range) as String[])
   }
 
   /**
@@ -3719,11 +3681,12 @@ class Matrix implements Iterable<Row>, Cloneable {
       sb.append('    <tr>\n')
 
       columnNames().eachWithIndex { String colName, int idx ->
-        sb.append("      <th class='$colName ${typeName(idx)}'")
+        String escaped = escapeHtml(colName)
+        sb.append("      <th class='${escaped} ${typeName(idx)}'")
         if (alignment.containsKey(colName)) {
           sb.append(" style='text-align: ${alignment[colName]}'")
         }
-        sb.append('>').append(colName).append('</th>\n')
+        sb.append('>').append(escaped).append('</th>\n')
       }
       sb.append('    </tr>\n  </thead>\n')
     }
@@ -3735,12 +3698,12 @@ class Matrix implements Iterable<Row>, Cloneable {
       rowBuilder.setLength(0)
       sb.append('    <tr>\n')
       row.eachWithIndex { Object val, int i ->
-        String colName = colNames[i]
-        rowBuilder.append("      <td class='${colName} ${typeNames[i]}'")
-        if (alignment.containsKey(colName)) {
-          rowBuilder.append(" style='text-align: ${alignment[colName]}'")
+        String escapedName = escapeHtml(colNames[i])
+        rowBuilder.append("      <td class='${escapedName} ${typeNames[i]}'")
+        if (alignment.containsKey(colNames[i])) {
+          rowBuilder.append(" style='text-align: ${alignment[colNames[i]]}'")
         }
-        rowBuilder.append('>').append(ValueConverter.asString(val)).append('</td>\n')
+        rowBuilder.append('>').append(escapeHtml(ValueConverter.asString(val))).append('</td>\n')
       }
       sb.append(rowBuilder).append('    </tr>\n')
     }
@@ -3952,28 +3915,29 @@ class Matrix implements Iterable<Row>, Cloneable {
   }
 
   /**
-   * Apply a closure to each value in the specified column and return the resulting list.
+   * Apply a closure to each value in the specified column and return the resulting Column.
    *
    * @param columnName the column to apply the operation to
    * @param operation the closure to apply to each value
-   * @return a list containing the transformed values
+   * @return a Column containing the transformed values, preserving the source column's name and type
    */
-  List withColumn(String columnName, Closure operation) {
-    def result = []
-    column(columnName).each {
+  Column withColumn(String columnName, Closure operation) {
+    Column src = column(columnName)
+    Column result = new Column(src.name, [], src.type)
+    src.each {
       result << operation.call(it)
     }
     result
   }
 
   /**
-   * Apply a closure to each value in the specified column and return the resulting list.
+   * Apply a closure to each value in the specified column and return the resulting Column.
    *
    * @param columnIndex the column to apply the operation to
    * @param operation the closure to apply to each value
-   * @return a list containing the transformed values
+   * @return a Column containing the transformed values, preserving the source column's name and type
    */
-  List withColumn(int columnIndex, Closure operation) {
+  Column withColumn(int columnIndex, Closure operation) {
     withColumn(columnName(columnIndex), operation)
   }
 
@@ -4001,47 +3965,47 @@ class Matrix implements Iterable<Row>, Cloneable {
    *
    * @param columnNames the names of the columns to include
    * @param operation the closure operation doing the calculation
-   * @return a list with the result of the operations
+   * @return a Column with the result of the operations
    */
-  List withColumns(List<String> columnNames, Closure operation) {
-    def result = []
+  Column withColumns(List<String> columnNames, Closure operation) {
+    Column result = new Column()
     columns(columnNames).transpose().each {
       result << operation.call(it)
     }
-    return result
+    result
   }
 
   /**
    * @see #withColumns(List < String >, Closure)
    * @param colIndices the column indices to include
    * @param operation the closure operation doing the calculation
-   * @return a list with the result of the operations
+   * @return a Column with the result of the operations
    */
-  List withColumns(Number[] colIndices, Closure operation) {
-    return withColumns(colIndices as int[], operation)
+  Column withColumns(Number[] colIndices, Closure operation) {
+    withColumns(colIndices as int[], operation)
   }
 
   /**
    * @see #withColumns(List < String >, Closure)
    * @param colIndices the column indices to include
    * @param operation the closure operation doing the calculation
-   * @return a list (a new column) with the result of the operations
+   * @return a Column with the result of the operations
    */
-  List withColumns(int[] colIndices, Closure operation) {
-    def result = []
+  Column withColumns(int[] colIndices, Closure operation) {
+    Column result = new Column()
     columns(colIndices as Integer[]).transpose().each {
       result << operation.call(it)
     }
-    return result
+    result
   }
 
   /**
    * @see #withColumns(List < String >, Closure)
    * @param colIndices the column index range to include
    * @param operation the closure operation doing the calculation
-   * @return a list (a new column) with the result of the operations
+   * @return a Column with the result of the operations
    */
-  List withColumns(IntRange colIndices, Closure operation) {
+  Column withColumns(IntRange colIndices, Closure operation) {
     withColumns(colIndices as int[], operation)
   }
 
@@ -4434,6 +4398,18 @@ class Matrix implements Iterable<Row>, Cloneable {
       return buildEmptyLike()
     }
     subset((rows - count)..(rows - 1))
+  }
+
+  @SuppressWarnings('DuplicateStringLiteral')
+  private static String escapeHtml(String text) {
+    if (text == null) {
+      return ''
+    }
+    text.replace('&', '&amp;')
+        .replace('<', '&lt;')
+        .replace('>', '&gt;')
+        .replace("'", '&#39;')
+        .replace('"', '&quot;')
   }
 
   private static void requireFiniteNumber(Number n, String label) {

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Matrix.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Matrix.groovy
@@ -701,23 +701,18 @@ class Matrix implements Iterable<Row>, Cloneable {
     if (columnNumber < 0 || columnNumber > lastColIdx) {
       throw new IndexOutOfBoundsException("The column number must be within the available columns (0-${lastColIdx}) but was $columnNumber")
     }
-    Set<Integer> rowSet = rows as Set<Integer>
-    def col = new Column()
+    Column col = mColumns[columnNumber]
     Class updatedClass = null
-    column(columnNumber).eachWithIndex { it, idx ->
-      if (rowSet.contains(idx)) {
-        def val = function(it)
-        if (updatedClass == null && val != null) {
-          updatedClass = val.class
-        }
-        col.add(val)
-      } else {
-        col.add(it)
+    for (int idx : rows) {
+      def val = function(col.get(idx))
+      if (updatedClass == null && val != null) {
+        updatedClass = val.class
       }
+      col.set(idx, val)
     }
-    col.type = updatedClass ?: type(columnNumber) ?: Object
-    col.name = columnName(columnNumber)
-    mColumns[columnNumber] = col
+    if (updatedClass != null) {
+      col.type = updatedClass
+    }
     invalidateIndex()
     this
   }
@@ -743,41 +738,20 @@ class Matrix implements Iterable<Row>, Cloneable {
    * @return this Matrix (mutated)
    */
   Matrix apply(int columnNumber, Closure<Boolean> criteria, Closure function) {
-    List<List> updatedRows = []
+    Column col = mColumns[columnNumber]
     Class updatedClass = null
-    Class originalType = type(columnNumber) ?: Object
-    def orgVal
-    rows().each { it ->
-      def row = it as List
-      if (criteria.call(row)) {
-        def r = []
-        for (int i = 0; i < columnCount(); i++) {
-          orgVal = row[i]
-          if (columnNumber == i) {
-            def val = function.call(orgVal)
-            if (updatedClass == null && val != null) {
-              updatedClass = val.class
-            }
-            r.add(val)
-          } else {
-            r.add(orgVal)
-          }
+    rows().eachWithIndex { row, idx ->
+      if (criteria.call(row as List)) {
+        def val = function.call(col.get(idx))
+        if (updatedClass == null && val != null) {
+          updatedClass = val.class
         }
-        updatedRows.add(r)
-      } else {
-        updatedRows.add(row)
+        col.set(idx, val)
       }
     }
-
-    Class targetType = updatedClass ?: originalType
-    List<Class> dataTypes = targetType != originalType
-        ? createTypeListWithNewValue(columnNumber, targetType, true)
-        : types()
-    List<Column> cols = []
-    Grid.transpose(updatedRows).eachWithIndex { it, idx ->
-      cols << new Column(columnName(idx), it as List, dataTypes[idx])
+    if (updatedClass != null) {
+      col.type = updatedClass
     }
-    mColumns = cols
     invalidateIndex()
     this
   }
@@ -2849,6 +2823,19 @@ class Matrix implements Iterable<Row>, Cloneable {
   }
 
   /**
+   * Renames multiple columns at once.
+   *
+   * @param nameMapping a map from existing column names to new column names
+   * @return this matrix (mutated) to allow for method chaining
+   */
+  Matrix rename(Map<String, String> nameMapping) {
+    nameMapping.each { String before, String after ->
+      rename(before, after)
+    }
+    this
+  }
+
+  /**
    * Replace all values in the entire matrix that matches the value
    *
    * @param from the value to search for
@@ -4375,6 +4362,56 @@ class Matrix implements Iterable<Row>, Cloneable {
    */
   GroupedMatrix groupBy(List<String> columnNames) {
     Stat.groupBy(this, columnNames)
+  }
+
+  /**
+   * Merge this matrix with another on a single column present in both.
+   *
+   * @param y the right-hand matrix
+   * @param by the column name present in both matrices
+   * @param joinType the type of join (default {@link JoinType#INNER})
+   * @return a new Matrix with the joined rows
+   * @see Joiner#merge(Matrix, Matrix, String, JoinType)
+   */
+  Matrix merge(Matrix y, String by, JoinType joinType = JoinType.INNER) {
+    Joiner.merge(this, y, by, joinType)
+  }
+
+  /**
+   * Merge this matrix with another using a key map or composite keys.
+   *
+   * @param y the right-hand matrix
+   * @param by a map with keys {@code 'x'} and {@code 'y'} whose values are column name(s)
+   * @param joinType the type of join (default {@link JoinType#INNER})
+   * @return a new Matrix with the joined rows
+   * @see Joiner#merge(Matrix, Matrix, Map, JoinType)
+   */
+  Matrix merge(Matrix y, Map<String, Object> by, JoinType joinType = JoinType.INNER) {
+    Joiner.merge(this, y, by, joinType)
+  }
+
+  /**
+   * Merge this matrix with another on multiple columns with the same names.
+   *
+   * @param y the right-hand matrix
+   * @param by the column names present in both matrices
+   * @param joinType the type of join
+   * @return a new Matrix with the joined rows
+   * @see Joiner#merge(Matrix, Matrix, List, JoinType)
+   */
+  Matrix merge(Matrix y, List<String> by, JoinType joinType) {
+    Joiner.merge(this, y, by, joinType)
+  }
+
+  /**
+   * Produce the Cartesian product of this matrix with another.
+   *
+   * @param y the right-hand matrix
+   * @return a new Matrix with {@code this.rowCount() * y.rowCount()} rows
+   * @see Joiner#crossJoin(Matrix, Matrix)
+   */
+  Matrix crossJoin(Matrix y) {
+    Joiner.crossJoin(this, y)
   }
 
   /**

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Matrix.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Matrix.groovy
@@ -3965,7 +3965,7 @@ class Matrix implements Iterable<Row>, Cloneable {
    *
    * @param columnNames the names of the columns to include
    * @param operation the closure operation doing the calculation
-   * @return a Column with the result of the operations
+   * @return a Column (without name or type) with the result of the operations
    */
   Column withColumns(List<String> columnNames, Closure operation) {
     Column result = new Column()
@@ -3979,7 +3979,7 @@ class Matrix implements Iterable<Row>, Cloneable {
    * @see #withColumns(List < String >, Closure)
    * @param colIndices the column indices to include
    * @param operation the closure operation doing the calculation
-   * @return a Column with the result of the operations
+   * @return a Column (without name or type) with the result of the operations
    */
   Column withColumns(Number[] colIndices, Closure operation) {
     withColumns(colIndices as int[], operation)
@@ -3989,7 +3989,7 @@ class Matrix implements Iterable<Row>, Cloneable {
    * @see #withColumns(List < String >, Closure)
    * @param colIndices the column indices to include
    * @param operation the closure operation doing the calculation
-   * @return a Column with the result of the operations
+   * @return a Column (without name or type) with the result of the operations
    */
   Column withColumns(int[] colIndices, Closure operation) {
     Column result = new Column()
@@ -4003,7 +4003,7 @@ class Matrix implements Iterable<Row>, Cloneable {
    * @see #withColumns(List < String >, Closure)
    * @param colIndices the column index range to include
    * @param operation the closure operation doing the calculation
-   * @return a Column with the result of the operations
+   * @return a Column (without name or type) with the result of the operations
    */
   Column withColumns(IntRange colIndices, Closure operation) {
     withColumns(colIndices as int[], operation)

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Matrix.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Matrix.groovy
@@ -639,10 +639,11 @@ class Matrix implements Iterable<Row>, Cloneable {
    * @return this Matrix (mutated)
    */
   Matrix apply(String columnName, Closure function) {
-    if (!columnNames().contains(columnName)) {
+    int idx = columnIndex(columnName)
+    if (idx < 0) {
       throw new IllegalArgumentException("There is no column called $columnName in this matrix")
     }
-    return apply(columnIndex(columnName), function)
+    return apply(idx, function)
   }
 
   /**
@@ -698,10 +699,11 @@ class Matrix implements Iterable<Row>, Cloneable {
     if (columnNumber < 0 || columnNumber > lastColIdx) {
       throw new IndexOutOfBoundsException("The column number must be within the available columns (0-${lastColIdx}) but was $columnNumber")
     }
+    Set<Integer> rowSet = rows as Set<Integer>
     def col = new Column()
     Class updatedClass = null
     column(columnNumber).eachWithIndex { it, idx ->
-      if (idx in rows) {
+      if (rowSet.contains(idx)) {
         def val = function(it)
         if (updatedClass == null && val != null) {
           updatedClass = val.class
@@ -976,7 +978,7 @@ class Matrix implements Iterable<Row>, Cloneable {
    * @return the column name
    */
   String columnName(int index) {
-    return columnNames()[index]
+    mColumns[index].name
   }
 
   /**
@@ -1655,7 +1657,7 @@ class Matrix implements Iterable<Row>, Cloneable {
    * @return a diff string describing any differences, or an empty string if equal
    */
   @SuppressWarnings(['DuplicateStringLiteral', 'DuplicateNumberLiteral'])
-  String diff(Matrix other, boolean forceRowComparing = false, double allowedDiff = 0.0001) {
+  String diff(Matrix other, boolean forceRowComparing = false, BigDecimal allowedDiff = 0.0001) {
     StringBuilder sb = new StringBuilder()
     if (this.matrixName != other.matrixName) {
       sb.append("Names differ: \n\tthis: ${matrixName} \n\tthat: ${other.matrixName}\n")
@@ -1681,9 +1683,12 @@ class Matrix implements Iterable<Row>, Cloneable {
         boolean valueDiff = false
         thisRow.eachWithIndex { Object entry, int c ->
           if (entry instanceof Number) {
-            def thatVal = (thatRow[c] != null ? thatRow[c] : Double.NaN) as double
-            double thisVal = entry as double
-            if (Math.abs(thisVal - thatVal as double) > allowedDiff) {
+            def thatVal = thatRow[c]
+            if (thatVal instanceof Number) {
+              if (((entry as Number).toBigDecimal() - (thatVal as Number).toBigDecimal()).abs() > allowedDiff) {
+                valueDiff = true
+              }
+            } else {
               valueDiff = true
             }
           } else if (entry != thatRow[c]) {
@@ -1900,7 +1905,7 @@ class Matrix implements Iterable<Row>, Cloneable {
 
   @Override
   boolean equals(Object o) {
-    equals(o, true, true, false, 0.0001d, false)
+    equals(o, true, true, false, 0.0001, false)
   }
 
 
@@ -1918,7 +1923,7 @@ class Matrix implements Iterable<Row>, Cloneable {
    */
   @SuppressWarnings('EqualsOverloaded')
   boolean equals(Object o, boolean ignoreColumnNames, boolean ignoreMatrixName, boolean ignoreTypes = true,
-                 Double allowedDiff = 0.0001, boolean throwException = false, String message = '') {
+                 BigDecimal allowedDiff = 0.0001, boolean throwException = false, String message = '') {
     if (this.is(o)) {
       return true
     }
@@ -1943,7 +1948,6 @@ class Matrix implements Iterable<Row>, Cloneable {
       ComparisonHelper.handleError("$message - Matrix.equals: column types differ", throwException)
       return false
     }
-    //if (mColumns != matrix.mColumns) return false
     List valueDiff = checkValues(matrix, allowedDiff, ignoreTypes)
     if (valueDiff.size() > 0) {
       ComparisonHelper.handleError("$message - Matrix.equals: value(s) differ: row ${valueDiff[0]}, column ${valueDiff[1]} expected ${valueDiff[2]} but was ${valueDiff[3]}", throwException)
@@ -1954,7 +1958,7 @@ class Matrix implements Iterable<Row>, Cloneable {
   }
 
 
-  private List checkValues(Matrix matrix, Double allowedDiff, boolean ignoreTypes = false) {
+  private List checkValues(Matrix matrix, BigDecimal allowedDiff, boolean ignoreTypes = false) {
     List valueDiff = []
     int i = 0
     for (List column in mColumns) {
@@ -1963,8 +1967,11 @@ class Matrix implements Iterable<Row>, Cloneable {
       for (entry in column) {
         def thatVal = thatCol[r]
         if (entry instanceof Number) {
-          def diff = Math.abs((entry as double) - ((thatVal != null ? thatVal : Double.NaN) as double))
-          if (diff > allowedDiff) {
+          if (thatVal instanceof Number) {
+            if (((entry as Number).toBigDecimal() - (thatVal as Number).toBigDecimal()).abs() > allowedDiff) {
+              return [r, i, entry, thatVal]
+            }
+          } else {
             return [r, i, entry, thatVal]
           }
         } else {
@@ -2273,7 +2280,7 @@ class Matrix implements Iterable<Row>, Cloneable {
    * @return the matching Column, or the default property value if not a column name
    */
   Object getProperty(String name) {
-    if (columnNames().contains(name)) {
+    if (columnIndex(name) >= 0) {
       return column(name)
     }
     return getProperties().get(name)
@@ -3055,16 +3062,16 @@ class Matrix implements Iterable<Row>, Cloneable {
       return Collections.emptyList()
     }
     int nRows = mColumns[0].size()
-    Map<Integer, Row> r = [:]
-    for (Integer i = 0; i < nRows; i++) {
-      r[i] = new Row(i, this)
+    List<Row> r = new ArrayList<>(nRows)
+    for (int i = 0; i < nRows; i++) {
+      r.add(new Row(i, this))
     }
     mColumns.eachWithIndex { List column, int col ->
-      for (Integer row = 0; row < nRows; row++) {
+      for (int row = 0; row < nRows; row++) {
         r.get(row).addElement(column[row])
       }
     }
-    return r.values() as List
+    r
   }
 
 
@@ -3311,14 +3318,14 @@ class Matrix implements Iterable<Row>, Cloneable {
 
     List<Matrix> chunks = []
     int startRow = 0
+    List<Row> allRows = rows()
 
     for (int i = 0; i < numChunks; i++) {
       // First 'remainder' chunks get an extra row
       int chunkSize = (i < remainder) ? baseSize + 1 : baseSize
       int endRow = startRow + chunkSize
 
-      def rowsForChunk = rows().subList(startRow, endRow)
-      chunks << builder(matrixName + MATRIX_NAME_SEPARATOR + i).rowList(rowsForChunk).build()
+      chunks << builder(matrixName + MATRIX_NAME_SEPARATOR + i).rowList(allRows.subList(startRow, endRow)).build()
 
       startRow = endRow
     }
@@ -3346,8 +3353,12 @@ class Matrix implements Iterable<Row>, Cloneable {
    */
   Matrix subset(@NotNull String columnName, @NotNull Closure<Boolean> condition) {
     List<Integer> r = column(columnName).findIndexValues(condition) as List<Integer>
+    buildSubset(this.rows(r) as List<List>)
+  }
+
+  private Matrix buildSubset(List<List> rowData) {
     Matrix result = builder()
-        .rows(this.rows(r) as List<List>)
+        .rows(rowData)
         .matrixName(this.matrixName)
         .columnNames(this.columnNames())
         .types(this.types())
@@ -3371,14 +3382,7 @@ class Matrix implements Iterable<Row>, Cloneable {
    * @return a new Matrix with the rows matching the criteria supplied retained
    */
   Matrix subset(Closure<Boolean> criteria) {
-    Matrix result = builder()
-        .rows(rows(criteria) as List<List>)
-        .matrixName(this.matrixName)
-        .columnNames(this.columnNames())
-        .types(this.types())
-        .build()
-    copyIndexTo(result)
-    result
+    buildSubset(rows(criteria) as List<List>)
   }
 
   /**
@@ -3402,14 +3406,7 @@ class Matrix implements Iterable<Row>, Cloneable {
    * @return a new Matrix with the selected rows
    */
   Matrix subset(IntRange rows) {
-    Matrix result = builder()
-        .rows(this.rows(rows) as List<List>)
-        .matrixName(this.matrixName)
-        .columnNames(this.columnNames())
-        .types(this.types())
-        .build()
-    copyIndexTo(result)
-    result
+    buildSubset(this.rows(rows) as List<List>)
   }
 
   /**
@@ -3419,14 +3416,7 @@ class Matrix implements Iterable<Row>, Cloneable {
    * @return a new Matrix with the selected rows
    */
   Matrix subset(List<Integer> rows) {
-    Matrix result = builder()
-        .rows(this.rows(rows) as List<List>)
-        .matrixName(this.matrixName)
-        .columnNames(this.columnNames())
-        .types(this.types())
-        .build()
-    copyIndexTo(result)
-    result
+    buildSubset(this.rows(rows) as List<List>)
   }
 
   /**
@@ -3439,14 +3429,7 @@ class Matrix implements Iterable<Row>, Cloneable {
     if (rows == null || rows.length == 0) {
       return this.clone()
     }
-    Matrix result = builder()
-        .rows(this.rows(rows as List) as List<List>)
-        .matrixName(this.matrixName)
-        .columnNames(this.columnNames())
-        .types(this.types())
-        .build()
-    copyIndexTo(result)
-    result
+    buildSubset(this.rows(rows as List) as List<List>)
   }
 
   /**
@@ -3752,24 +3735,25 @@ class Matrix implements Iterable<Row>, Cloneable {
       sb.append('  <thead>\n')
       sb.append('    <tr>\n')
 
-      columnNames().eachWithIndex { it, idx ->
-        String colName = columnName(idx)
+      columnNames().eachWithIndex { String colName, int idx ->
         sb.append("      <th class='$colName ${typeName(idx)}'")
         if (alignment.containsKey(colName)) {
           sb.append(" style='text-align: ${alignment[colName]}'")
         }
-        sb.append('>').append(it).append('</th>\n')
+        sb.append('>').append(colName).append('</th>\n')
       }
       sb.append('    </tr>\n  </thead>\n')
     }
+    List<String> colNames = columnNames()
+    List<String> typeNames = colNames.collect { typeName(columnIndex(it)) }
     StringBuilder rowBuilder = new StringBuilder()
     sb.append('  <tbody>\n')
     for (row in rows) {
       rowBuilder.setLength(0)
       sb.append('    <tr>\n')
       row.eachWithIndex { Object val, int i ->
-        rowBuilder.append("      <td class='${columnName(i)} ${typeName(i)}'")
-        String colName = columnName(i)
+        String colName = colNames[i]
+        rowBuilder.append("      <td class='${colName} ${typeNames[i]}'")
         if (alignment.containsKey(colName)) {
           rowBuilder.append(" style='text-align: ${alignment[colName]}'")
         }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Matrix.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Matrix.groovy
@@ -110,9 +110,7 @@ class Matrix implements Iterable<Row>, Cloneable {
   private boolean indexDirty = false
 
   static {
-    // Splits "5.0.1" into [5, 0, 1]
-    def versionParts = GroovySystem.version.tokenize('.')*.toInteger()
-    def majorVersion = versionParts[0]
+    int majorVersion = parseGroovyMajorVersion(GroovySystem.version)
 
     if (majorVersion < 5) {
       throw new IllegalStateException(
@@ -124,6 +122,10 @@ class Matrix implements Iterable<Row>, Cloneable {
 
   static MatrixBuilder builder() {
     new MatrixBuilder()
+  }
+
+  private static int parseGroovyMajorVersion(String version) {
+    version.tokenize('.').first().toInteger()
   }
 
   static MatrixBuilder builder(String matrixName) {
@@ -1940,6 +1942,10 @@ class Matrix implements Iterable<Row>, Cloneable {
       ComparisonHelper.handleError("$message - Matrix.equals: number of columns differ", throwException)
       return false
     }
+    if (rowCount() != matrix.rowCount()) {
+      ComparisonHelper.handleError("$message - Matrix.equals: number of rows differ", throwException)
+      return false
+    }
     if (!ignoreColumnNames && columnNames() != matrix.columnNames()) {
       ComparisonHelper.handleError("$message - Matrix.equals: column names differ", throwException)
       return false
@@ -1969,6 +1975,10 @@ class Matrix implements Iterable<Row>, Cloneable {
         if (entry instanceof Number) {
           if (thatVal instanceof Number) {
             if (((entry as Number).toBigDecimal() - (thatVal as Number).toBigDecimal()).abs() > allowedDiff) {
+              return [r, i, entry, thatVal]
+            }
+          } else if (ignoreTypes) {
+            if (String.valueOf(entry) != String.valueOf(thatVal)) {
               return [r, i, entry, thatVal]
             }
           } else {

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/MatrixAssertions.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/MatrixAssertions.groovy
@@ -8,8 +8,8 @@ package se.alipsa.matrix.core
  */
 class MatrixAssertions {
 
-  private static final double STRUCTURE_TOLERANCE = 0.0001d
-  private static final double CONTENT_TOLERANCE = 0.00001d
+  private static final BigDecimal STRUCTURE_TOLERANCE = 0.0001
+  private static final BigDecimal CONTENT_TOLERANCE = 0.00001
 
   static void assertEquals(Matrix expected, Matrix actual, String message = '') {
     expected.equals(actual, true, true, false, STRUCTURE_TOLERANCE, true, message)

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/MatrixBuilder.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/MatrixBuilder.groovy
@@ -393,11 +393,7 @@ class MatrixBuilder {
   MatrixBuilder data(File file, String delimiter = ',', String stringQuote = '', boolean firstRowAsHeader = true, List<String> nullStrings=['NULL', 'null', 'NA']) {
     data(Files.newInputStream(file.toPath()), delimiter, stringQuote, firstRowAsHeader, nullStrings)
     if (noName()) {
-      int endIdx = file.name.length()
-      if (file.name.contains('.')) {
-        endIdx = file.name.lastIndexOf('.')
-      }
-      matrixName(file.name.substring(0, endIdx))
+      matrixName(stripExtension(file.name))
     }
     this
   }
@@ -415,12 +411,7 @@ class MatrixBuilder {
   MatrixBuilder data(Path file, String delimiter = ',', String stringQuote = '', boolean firstRowAsHeader = true, List<String> nullStrings=['NULL', 'null', 'NA']) {
     data(Files.newInputStream(file), delimiter, stringQuote, firstRowAsHeader, nullStrings)
     if (noName()) {
-      String fileName = file.getFileName().toString()
-      int endIdx = fileName.length()
-      if (fileName.contains('.')) {
-        endIdx = fileName.lastIndexOf('.')
-      }
-      matrixName(fileName.substring(0, endIdx))
+      matrixName(stripExtension(file.getFileName().toString()))
     }
     this
   }
@@ -924,5 +915,10 @@ class MatrixBuilder {
       case Types.STRUCT -> Map
       default -> Object
     }
+  }
+
+  private static String stripExtension(String fileName) {
+    int dot = fileName.lastIndexOf('.')
+    dot > 0 ? fileName.substring(0, dot) : fileName
   }
 }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/MatrixBuilder.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/MatrixBuilder.groovy
@@ -671,6 +671,11 @@ class MatrixBuilder {
     }
   }
 
+  /**
+   * Splits a delimited line respecting quoted fields.
+   * An unclosed quote (odd number of quote characters) causes the rest of the line
+   * to be treated as part of the current field — a warning is logged in that case.
+   */
   private static List<String> splitDelimitedLine(String line, String delimiter, String quoteString) {
     if (quoteString == null || quoteString.isEmpty()) {
       return line.split(Pattern.quote(delimiter), -1) as List<String>
@@ -698,6 +703,9 @@ class MatrixBuilder {
         current.append(line.charAt(i))
         i++
       }
+    }
+    if (inQuotes) {
+      log.warn("Unclosed quote in CSV line — remainder treated as part of current field: ${line}")
     }
     values << current.toString()
     values

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/MatrixBuilder.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/MatrixBuilder.groovy
@@ -246,13 +246,17 @@ class MatrixBuilder {
       return this
     }
     Map<String, ?> row = rows.first()
-    columnNames(row.keySet())
+    List keys = row.keySet() as List
+    List<String> headers = keys.collect { String.valueOf(it) }
+    columnNames(headers)
     List<Class> t = []
     row.each {
       t << it.value?.class ?: Object
     }
     types(t)
-    def r = rows.collect { it.values() as List}
+    def r = rows.collect { Map values ->
+      keys.collect { key -> values[key] }
+    }
     this.rows(r)
   }
 

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/MatrixBuilder.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/MatrixBuilder.groovy
@@ -34,6 +34,7 @@ import java.time.YearMonth
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
+import java.util.regex.Pattern
 
 @CompileStatic
 class MatrixBuilder {
@@ -142,12 +143,8 @@ class MatrixBuilder {
       headers << String.valueOf(k)
       cols << v.collect()
     }
-    if (noColumnNames()) {
-      columnNames(headers)
-    }
-    if (noColumns()) {
-      columns(cols)
-    }
+    columnNames(headers)
+    columns(cols)
     this
   }
 
@@ -169,6 +166,7 @@ class MatrixBuilder {
       this.explicitRowCount = rows.size()
       return this
     }
+    validateRowWidths(rows)
     this.explicitRowCount = 0
     this.columns = rows.transpose()
     this
@@ -182,8 +180,17 @@ class MatrixBuilder {
    */
   MatrixBuilder addRow(List row) {
     clearPendingIndexColumns()
+    if (row == null) {
+      throw new IllegalArgumentException('Row cannot be null')
+    }
     if (columns == null) {
       columns = []
+    }
+    int expectedSize = columns.isEmpty() && !noColumnNames() ? headerList.size() : columns.size()
+    if (expectedSize > 0 && row.size() != expectedSize) {
+      throw new IllegalArgumentException(
+          "The number of elements in the row (${row.size()}) does not match the number of columns (${expectedSize})"
+      )
     }
     row.eachWithIndex { it, idx ->
       if (columns.size() <= idx) {
@@ -560,7 +567,6 @@ class MatrixBuilder {
     // Parsing a new CSV input should not inherit index metadata from a previous parse on the same builder.
     indexColumns = null
     List<List> data = []
-    final boolean stripQuotes = stringQuote != ''
     int maxCols = 0
     List<Class> parsedTypes = null
     String parsedName = null
@@ -600,15 +606,10 @@ class MatrixBuilder {
       }
       List row = []
       // if there are empty columns in the end, split does not take those into account unless we set the limit to -1
-      def values = line.split(delimiter, -1)
-      maxCols = Math.max(maxCols, values.length)
+      List<String> values = splitDelimitedLine(line, delimiter, stringQuote)
+      maxCols = Math.max(maxCols, values.size())
       for (String val in values) {
-        String value
-        if (stripQuotes) {
-          value = (val.replaceAll(~/^$stringQuote|$stringQuote$/, '').trim())
-        } else {
-          value = val.trim()
-        }
+        String value = val.trim()
         if (nullStrings.contains(value)) {
           value = null
         }
@@ -657,6 +658,54 @@ class MatrixBuilder {
       indexColumns = parsedIndex
     }
     this
+  }
+
+  private static void validateRowWidths(List<List> rows) {
+    int expectedSize = -1
+    rows.eachWithIndex { List row, int index ->
+      if (row == null) {
+        throw new IllegalArgumentException("Row ${index} cannot be null")
+      }
+      if (expectedSize < 0) {
+        expectedSize = row.size()
+      } else if (row.size() != expectedSize) {
+        throw new IllegalArgumentException(
+            "Row ${index} has ${row.size()} elements but expected ${expectedSize}; all rows must have the same size"
+        )
+      }
+    }
+  }
+
+  private static List<String> splitDelimitedLine(String line, String delimiter, String quoteString) {
+    if (quoteString == null || quoteString.isEmpty()) {
+      return line.split(Pattern.quote(delimiter), -1) as List<String>
+    }
+
+    List<String> values = []
+    StringBuilder current = new StringBuilder()
+    boolean inQuotes = false
+    int i = 0
+    while (i < line.length()) {
+      if (line.startsWith(quoteString, i)) {
+        int nextQuoteIndex = i + quoteString.length()
+        if (inQuotes && line.startsWith(quoteString, nextQuoteIndex)) {
+          current.append(quoteString)
+          i += quoteString.length() * 2
+        } else {
+          inQuotes = !inQuotes
+          i += quoteString.length()
+        }
+      } else if (!inQuotes && line.startsWith(delimiter, i)) {
+        values << current.toString()
+        current.setLength(0)
+        i += delimiter.length()
+      } else {
+        current.append(line.charAt(i))
+        i++
+      }
+    }
+    values << current.toString()
+    values
   }
 
   private static Class resolveTypeName(String rawName) {

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Stat.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Stat.groovy
@@ -204,7 +204,6 @@ class Stat {
             for (colNum in colNums) {
                 value = row[colNum]
                 if (value instanceof Number) {
-                    // s.set(idx, s.get(colNum) + value)
                     s[idx] = s[idx] + value as T
                 }
                 idx++
@@ -221,22 +220,20 @@ class Stat {
      * @return a list (a column) with the sum of the rows for the columns specified
      */
     static <T extends Number> List<T> sumRows(Matrix m, List<Integer> colNums) {
-        List<T> means = []
+        List<T> sums = []
         m.each { Row row ->
-            means << (sum(row[colNums]) as T)
+            sums << (sum(row[colNums]) as T)
         }
-        means
+        sums
     }
 
     static <T extends Number> List<T> sumRows(Matrix m, String... colNames) {
-        List<T> means = []
-        if (colNames.length == 0) {
-            colNames = m.columnNames()
-        }
+        List<T> sums = []
+        String[] cols = resolveColumns(m, colNames) as String[]
         m.each { row ->
-            means << (sum(row.subList(colNames)) as T)
+            sums << (sum(row.subList(cols)) as T)
         }
-        means
+        sums
     }
 
     /**
@@ -478,11 +475,9 @@ class Stat {
      */
     static List<BigDecimal> meanRows(Matrix m, String... colNames) {
         List<BigDecimal> means = []
-        if (colNames.length == 0) {
-            colNames = m.columnNames()
-        }
+        String[] cols = resolveColumns(m, colNames) as String[]
         m.each { row ->
-            means << mean(row.subList(colNames))
+            means << mean(row.subList(cols))
         }
         means
     }
@@ -508,11 +503,11 @@ class Stat {
         if (list == null || list.isEmpty()) {
             return null
         }
-        BigDecimal sum = BigDecimal.ZERO.setScale(scale, RoundingMode.HALF_UP)
+        BigDecimal sum = BigDecimal.ZERO
         int nVals = 0
         for (value in list) {
             if (value != null && value instanceof Number) {
-                sum += (value as BigDecimal).setScale(scale, RoundingMode.HALF_UP)
+                sum += value as BigDecimal
                 nVals++
             }
         }
@@ -522,7 +517,7 @@ class Stat {
         if (sum == 0) {
             return BigDecimal.ZERO.setScale(scale, RoundingMode.HALF_UP)
         }
-        return sum.divide((nVals as BigDecimal), scale, RoundingMode.HALF_UP)
+        return sum.divide(nVals as BigDecimal, scale, RoundingMode.HALF_UP)
     }
 
     static BigDecimal mean(Matrix table, String colName) {
@@ -559,15 +554,10 @@ class Stat {
     }
 
     static List<BigDecimal> medians(Matrix table, List<String> colNames) {
-        // Optimized: use columnar access instead of row iteration
-        List<BigDecimal> results = []
-        colNames.each { colName ->
-            List<?> columnData = table.column(colName)
-            List<Number> numericValues = columnData.findAll { it != null && it instanceof Number } as List<Number>
-            // median() handles sorting internally, no need to pre-sort
-            results << median(numericValues)
+        colNames.collect { colName ->
+            List<Number> numericValues = table.column(colName).findAll { it != null && it instanceof Number } as List<Number>
+            median(numericValues)
         }
-        return results
     }
 
     /**
@@ -578,27 +568,25 @@ class Stat {
      * @return a list (a column) with the mean of the rows for the columns specified
      */
     static List<BigDecimal> medianRows(Matrix table, List<Integer> columns) {
-        List<BigDecimal> means = []
+        List<BigDecimal> medians = []
         table.each { row ->
-            means << median(row.subList(columns) as List<? extends Number>)
+            medians << median(row.subList(columns) as List<? extends Number>)
         }
-        means
+        medians
     }
 
     /**
      * @param m the matrix containing the data
      * @param colNames the names of the columns to include, if omitted, all columns will be included
-     * @return a list of the row sums
+     * @return a list of the row medians
      */
     static List<BigDecimal> medianRows(Matrix m, String... colNames) {
-        List<BigDecimal> means = []
-        if (colNames.length == 0) {
-            colNames = m.columnNames()
-        }
+        List<BigDecimal> medians = []
+        String[] cols = resolveColumns(m, colNames) as String[]
         m.each { row ->
-            means << median(row.subList(colNames) as List<? extends Number>)
+            medians << median(row.subList(cols) as List<? extends Number>)
         }
-        means
+        medians
     }
 
     /**
@@ -714,7 +702,7 @@ class Stat {
     }
 
     static <T extends Comparable> List<T> min(Matrix table, List<String> colNames, boolean ignoreNonNumerics = false) {
-        return min(table.rows() as List<List<T>>, table.columnIndices(colNames), ignoreNonNumerics)
+        colNames.collect { colName -> min(table.column(colName) as List<T>, ignoreNonNumerics) }
     }
 
     static <T> T max(List<T> list, boolean ignoreNonNumerics = false) {
@@ -763,11 +751,11 @@ class Stat {
     }
 
     static <T extends Comparable> List<T> max(Matrix table, List<String> colNames, boolean ignoreNonNumerics = false) {
-        return max(table.rows() as List<List<T>>, table.columnIndices(colNames), ignoreNonNumerics)
+        colNames.collect { colName -> max(table.column(colName) as List<T>, ignoreNonNumerics) }
     }
 
     static <T extends Comparable> T max(Matrix table, String colName) {
-        max(table.rows() as List<List<T>>, table.columnIndex(colName))
+        max(table.column(colName) as List<T>)
     }
     static List<BigDecimal> sd(List<List<?>> matrix, boolean isBiasCorrected = true, Integer colNum) {
         return sd(matrix, isBiasCorrected, [colNum])
@@ -786,7 +774,6 @@ class Stat {
             for (colNum in colNums) {
                 value = row[colNum]
                 if (value instanceof Number) {
-                    // numberMap[String.valueOf(colNum)].add(value.doubleValue())
                     numberMap[String.valueOf(colNum)].add(value)
                 }
             }
@@ -803,19 +790,7 @@ class Stat {
     }
 
     static List<BigDecimal> sd(Matrix table, List<String> columnNames, boolean isBiasCorrected = true) {
-        // Optimized: use columnar access instead of row iteration
-        List<BigDecimal> results = []
-        columnNames.each { colName ->
-            List<?> columnData = table.column(colName)
-            List<Double> numericValues = []
-            columnData.each { value ->
-                if (value instanceof Number) {
-                    numericValues.add(value.doubleValue())
-                }
-            }
-            results << sd(numericValues, isBiasCorrected)
-        }
-        return results
+        columnNames.collect { colName -> sd(table.column(colName), isBiasCorrected) }
     }
 
     static BigDecimal variance(BigDecimal[] values, BigDecimal mean) {
@@ -979,6 +954,10 @@ class Stat {
             }
         }
         return null
+    }
+
+    private static List<String> resolveColumns(Matrix m, String[] colNames) {
+        colNames.length == 0 ? m.columnNames() : colNames as List<String>
     }
 
 }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Stat.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Stat.groovy
@@ -545,7 +545,8 @@ class Stat {
         }
         List<BigDecimal> medians = new ArrayList<BigDecimal>(colNums.size())
         for (Integer colNum in colNums) {
-            List<Number> list = (List<Number>) valueList[String.valueOf(colNum)].sort()
+            List<Number> list = valueList[String.valueOf(colNum)]
+            list = list == null ? [] : list.sort() as List<Number>
             BigDecimal m = median(list)
             medians.add(m)
         }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/ValueConverter.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/ValueConverter.groovy
@@ -70,7 +70,7 @@ class ValueConverter {
       case Date -> (E) asSqlDate(o)
       case Time -> (E) asSqlTime(o)
       case Timestamp -> (E) asTimestamp(o)
-      case java.util.Date -> (E) asDate(o, dateTimePattern)
+      case java.util.Date -> (E) asDate(o, dateTimePattern, null, locale)
       case Number -> (E) asNumber(o)
       case ZonedDateTime -> (E) asZonedDateTime(o, dateTimeFormatter(dateTimePattern, locale))
       default -> try {

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/ValueConverter.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/ValueConverter.groovy
@@ -55,7 +55,7 @@ class ValueConverter {
     }
     return switch (type) {
       case String -> (E) asString(o, dateTimeFormatter(dateTimePattern, locale), numberFormat)
-      case LocalDate -> (E) asLocalDate(o, dateTimePattern)
+      case LocalDate -> (E) asLocalDate(o, dateTimePattern, null, locale)
       case LocalDateTime -> (E) asLocalDateTime(o, dateTimeFormatter(dateTimePattern, locale))
       case LocalTime -> (E) asLocalTime(o)
       case YearMonth -> (E) asYearMonth(o)
@@ -435,7 +435,7 @@ class ValueConverter {
     if (o instanceof Number) {
       return o.longValue()
     }
-    Double.valueOf(String.valueOf(o)).longValue()
+    new BigDecimal(String.valueOf(o)).longValue()
   }
 
   static java.util.Date asDate(java.util.Date o, java.util.Date valueIfNull = null) {

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/ValueConverter.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/ValueConverter.groovy
@@ -591,14 +591,6 @@ class ValueConverter {
     return Time.valueOf(String.valueOf(o))
   }
 
-  /**
-   * @deprecated use asSqlTime(Object, Time) instead
-   */
-  @Deprecated(forRemoval = true, since = "3.7.0")
-  static Time asSqlTIme(Object o, Time valueIfNull = null) {
-    asSqlTime(o, valueIfNull)
-  }
-
   static LocalTime asLocalTime(Object o, LocalTime valueIfNull = null) {
     if (o == null || '' == o) {
       return valueIfNull

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/ValueConverter.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/ValueConverter.groovy
@@ -36,6 +36,9 @@ class ValueConverter {
   private static final char C_E = 'E'
   private static final char C_e = 'e'
 
+  // Threshold below which a Number is treated as yyyyMMdd date integer rather than epoch millis
+  private static final long MAX_COMPACT_DATE_INT = 22991231L
+
   static ConcurrentHashMap<String, ThreadLocal<SimpleDateFormat>> simpleDateCache = new ConcurrentHashMap<>()
   static ConcurrentHashMap<String, DateTimeFormatter> dateTimeFormatterCache = new ConcurrentHashMap<>()
 
@@ -318,18 +321,18 @@ class ValueConverter {
     }
     String val = asDecimalNumber(strVal)
     if (val.isBlank()) return null
-    return Double.parseDouble(val).intValue()
+    return new BigDecimal(val).intValue()
   }
 
   static Integer asIntegerRound(Object o, Integer valueIfNull = null) {
     if (o == null || '' == o) return valueIfNull
     if (o instanceof Number) {
-      return Math.round(o.doubleValue()).intValue()
+      return o.toBigDecimal().setScale(0, java.math.RoundingMode.HALF_UP).intValue()
     }
 
     String val = asDecimalNumber(String.valueOf(o))
     if (val.isBlank()) return null
-    return Math.round(Double.parseDouble(val)).intValue()
+    return new BigDecimal(val).setScale(0, java.math.RoundingMode.HALF_UP).intValue()
   }
 
   static BigInteger asBigInteger(Object o, BigInteger valueIfNull = null) {
@@ -366,11 +369,14 @@ class ValueConverter {
   static String asDecimalNumber(String txt, char decimalSeparator = '.', String valueIfNull = null) {
     if (txt == null) return valueIfNull
     StringBuilder result = new StringBuilder()
-    txt.chars().mapToObj(i -> i as char)
-        .filter(c -> c.isDigit() || decimalSeparator == c || C_MINUS == c || C_HYPHEN == c
-            || C_PLUS == c || C_e == c || C_E == c)
-        .forEach(c -> result.append(c))
-    return result.toString()
+    for (int i = 0; i < txt.length(); i++) {
+      char c = txt.charAt(i)
+      if (Character.isDigit(c) || c == decimalSeparator || c == C_MINUS || c == C_HYPHEN
+          || c == C_PLUS || c == C_e || c == C_E) {
+        result.append(c)
+      }
+    }
+    result.toString()
   }
 
   static YearMonth asYearMonth(Object o, YearMonth valueIfNull = null) {
@@ -439,7 +445,7 @@ class ValueConverter {
 
   static java.util.Date asDate(Number o, java.util.Date valueIfNull = null) {
     if (o == null || '' == o) return valueIfNull
-    if (o < 22991231) {
+    if (o < MAX_COMPACT_DATE_INT) {
       return new Date(simpleDateFormatCache('yyyyMMdd').parse(String.valueOf(o.longValue())).getTime())
     }
     // assume millis since 1970-01-01
@@ -537,7 +543,7 @@ class ValueConverter {
       return Date.valueOf(o)
     }
     if (o instanceof Number) {
-      if (o < 22991231) {
+      if (o < MAX_COMPACT_DATE_INT) {
         return new Date(simpleDateFormatCache('yyyyMMdd').parse(String.valueOf(o.longValue())).getTime())
       }
       // assume millis since 1970-01-01

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/ext/PipeExtension.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/ext/PipeExtension.groovy
@@ -21,7 +21,7 @@ class PipeExtension {
    * {@link Matrix#pipe(Closure)}.
    *
    * <pre>
-   * matrix | { it.selectColumns('a') } | { it.orderBy('a') }
+   * matrix | { it.select('a') } | { it.orderBy('a') }
    * </pre>
    *
    * @param self the matrix instance

--- a/matrix-core/src/test/groovy/ColumnTest.groovy
+++ b/matrix-core/src/test/groovy/ColumnTest.groovy
@@ -828,4 +828,70 @@ class ColumnTest {
     assertEquals(3, new Column([null, null, null]).countNulls())
   }
 
+  @Test
+  void testArithmeticPreservesNameAndType() {
+    Column c = new Column('salary', [100, 200, 300], Integer)
+
+    Column plusScalar = c + 10
+    assert plusScalar instanceof Column
+    assertEquals('salary', plusScalar.name)
+    assertEquals(Integer, plusScalar.type)
+    assert [110, 210, 310] == plusScalar
+
+    Column plusList = c + [1, 2, 3]
+    assert plusList instanceof Column
+    assertEquals('salary', plusList.name)
+
+    Column minusScalar = c - 50
+    assert minusScalar instanceof Column
+    assertEquals('salary', minusScalar.name)
+
+    Column minusList = c - [10, 20, 30]
+    assert minusList instanceof Column
+    assertEquals('salary', minusList.name)
+
+    Column mul = c * 2
+    assert mul instanceof Column
+    assertEquals('salary', mul.name)
+
+    Column mulList = c * [1, 2, 3]
+    assert mulList instanceof Column
+    assertEquals('salary', mulList.name)
+
+    Column divided = c / 10
+    assert divided instanceof Column
+    assertEquals('salary', divided.name)
+
+    Column divList = c / [10, 20, 30]
+    assert divList instanceof Column
+    assertEquals('salary', divList.name)
+
+    Column pow = c ** 2
+    assert pow instanceof Column
+    assertEquals('salary', pow.name)
+
+    Column powList = c ** [1, 2, 3]
+    assert powList instanceof Column
+    assertEquals('salary', powList.name)
+  }
+
+  @Test
+  void testArithmeticChainingReturnsColumn() {
+    Column c = new Column('val', [10, 20, 30], Integer)
+    Column result = (c + 1) - 1
+    assert result instanceof Column
+    assertEquals('val', result.name)
+    assert [10, 20, 30] == result
+  }
+
+  @Test
+  void testRemoveNullsPreservesNameAndType() {
+    Column c = new Column('score', [1, null, 3, null, 5], Integer)
+    Column noNulls = c.removeNulls()
+    assert [1, 3, 5] == noNulls
+    assertEquals('score', noNulls.name)
+    assertEquals(Integer, noNulls.type)
+    assert [1, null, 3, null, 5] == c
+  }
+
 }

--- a/matrix-core/src/test/groovy/GridTest.groovy
+++ b/matrix-core/src/test/groovy/GridTest.groovy
@@ -57,6 +57,35 @@ class GridTest {
     }
 
     @Test
+    void testPlusCopiesExistingRows() {
+        Grid<Integer> grid = new Grid<Integer>([[1, 2]], Integer)
+
+        Grid<Integer> result = grid + [3, 4]
+        result[0][0] = 99
+
+        assertEquals(1, grid[0, 0])
+        assertEquals(99, result[0, 0])
+        assertEquals(2, result.dimensions().observations)
+    }
+
+    @Test
+    void testTypedGridResultsPreserveElementType() {
+        Grid<Integer> grid = new Grid<Integer>([[1, 2]], Integer)
+
+        Grid<Integer> transposed = grid.transpose()
+        IllegalArgumentException transposeError = assertThrows(IllegalArgumentException) {
+            transposed.add(['x'])
+        }
+        assertTrue(transposeError.message.contains('expected Integer'))
+
+        Grid<BigDecimal> converted = Grid.convert(grid, [0, 1], BigDecimal)
+        IllegalArgumentException convertError = assertThrows(IllegalArgumentException) {
+            converted.add(['x', 3.0])
+        }
+        assertTrue(convertError.message.contains('expected BigDecimal'))
+    }
+
+    @Test
     void testGridCreationWithDimensionsInitializesNullCells() {
         Grid<String> grid = new Grid<String>(3, 4)
 

--- a/matrix-core/src/test/groovy/GridTest.groovy
+++ b/matrix-core/src/test/groovy/GridTest.groovy
@@ -275,6 +275,21 @@ class GridTest {
     }
 
     @Test
+    void testTypedGridMutatorsMaintainElementType() {
+        Grid<Number> grid = new Grid<Number>([[1, 2], [3, 4]], Number)
+
+        def rowError = assertThrows(IllegalArgumentException) {
+            grid.add([5, '6'] as List<Number>)
+        }
+        assertTrue(rowError.message.contains('expected Number'))
+
+        def columnError = assertThrows(IllegalArgumentException) {
+            grid.replaceColumn(0, [7, '8'] as List<Number>)
+        }
+        assertTrue(columnError.message.contains('expected Number'))
+    }
+
+    @Test
     void testIteration() {
         Grid foo = new Grid()
         foo.addAll([

--- a/matrix-core/src/test/groovy/GridTest.groovy
+++ b/matrix-core/src/test/groovy/GridTest.groovy
@@ -308,12 +308,12 @@ class GridTest {
         Grid<Number> grid = new Grid<Number>([[1, 2], [3, 4]], Number)
 
         def rowError = assertThrows(IllegalArgumentException) {
-            grid.add([5, '6'] as List<Number>)
+            grid.add([5, '6'])
         }
         assertTrue(rowError.message.contains('expected Number'))
 
         def columnError = assertThrows(IllegalArgumentException) {
-            grid.replaceColumn(0, [7, '8'] as List<Number>)
+            grid.replaceColumn(0, [7, '8'])
         }
         assertTrue(columnError.message.contains('expected Number'))
     }

--- a/matrix-core/src/test/groovy/MatrixBuilderTest.groovy
+++ b/matrix-core/src/test/groovy/MatrixBuilderTest.groovy
@@ -195,6 +195,69 @@ class MatrixBuilderTest {
   }
 
   @Test
+  void testRowsRejectsRaggedData() {
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException) {
+      Matrix.builder()
+          .rows([
+              [1, 'Lorena'],
+              [2]
+          ])
+    }
+
+    assertTrue(ex.message.contains('all rows must have the same size'))
+  }
+
+  @Test
+  void testAddRowUsesColumnNamesAsInitialWidth() {
+    Matrix matrix = Matrix.builder()
+        .columnNames(['id', 'name'])
+        .addRow([1, 'Lorena'])
+        .addRow([2, 'Marianne'])
+        .build()
+
+    assertEquals(['id', 'name'], matrix.columnNames())
+    assertEquals(2, matrix.rowCount())
+    assertEquals([1, 'Lorena'], matrix.row(0) as List)
+    assertEquals([2, 'Marianne'], matrix.row(1) as List)
+  }
+
+  @Test
+  void testAddRowRejectsMismatchedRowWidth() {
+    MatrixBuilder builder = Matrix.builder()
+        .columnNames(['id', 'name'])
+
+    IllegalArgumentException firstRowEx = assertThrows(IllegalArgumentException) {
+      builder.addRow([1])
+    }
+    assertTrue(firstRowEx.message.contains('does not match the number of columns'))
+
+    MatrixBuilder rowsBuilder = Matrix.builder()
+        .addRow([1, 'Lorena'])
+
+    IllegalArgumentException secondRowEx = assertThrows(IllegalArgumentException) {
+      rowsBuilder.addRow([2])
+    }
+    assertTrue(secondRowEx.message.contains('does not match the number of columns'))
+  }
+
+  @Test
+  void testMapDataReplacesExistingBuilderData() {
+    Matrix matrix = Matrix.builder()
+        .columnNames(['old'])
+        .columns([[99]])
+        .data([
+            id: [1, 2],
+            name: ['Lorena', 'Marianne']
+        ])
+        .build()
+
+    assertEquals(['id', 'name'], matrix.columnNames())
+    assertEquals(2, matrix.rowCount())
+    assertEquals([1, 'Lorena'], matrix.row(0) as List)
+    assertEquals([2, 'Marianne'], matrix.row(1) as List)
+  }
+
+  @Test
   void testCreationFromAllEmptyRowsPreservesRowCount() {
     Matrix matrix = Matrix.builder()
         .rows([[], [], []])
@@ -245,6 +308,24 @@ class MatrixBuilderTest {
     assertEquals(1, m[0, 1])
     assertEquals('B', m[1, 0])
     assertEquals(2, m[1, 1])
+  }
+
+  @Test
+  void testCsvStringParsesRegexCharactersAsLiteralDelimiters() {
+    Matrix pipeDelimited = Matrix.builder()
+        .csvString('name|value\nA|1\nB|2', [delimiter: '|'])
+        .build()
+
+    assertEquals(['name', 'value'], pipeDelimited.columnNames())
+    assertEquals(['A', '1'], pipeDelimited.row(0) as List)
+    assertEquals(['B', '2'], pipeDelimited.row(1) as List)
+
+    Matrix dotDelimited = Matrix.builder()
+        .csvString('name.value\nA.1', [delimiter: '.'])
+        .build()
+
+    assertEquals(['name', 'value'], dotDelimited.columnNames())
+    assertEquals(['A', '1'], dotDelimited.row(0) as List)
   }
 
   @SuppressWarnings('SqlNoDataSourceInspection')

--- a/matrix-core/src/test/groovy/MatrixBuilderTest.groovy
+++ b/matrix-core/src/test/groovy/MatrixBuilderTest.groovy
@@ -184,7 +184,7 @@ class MatrixBuilderTest {
     r7.addColumn('c4', int, [7,8,9])
     r7.content()
     assertNotEquals(m7, r7, m7.diff(r7))
-    r7.dropColumns('c4')
+    r7.drop('c4')
     assertEquals(m7, r7, m7.diff(r7))
   }
 

--- a/matrix-core/src/test/groovy/MatrixBuilderTest.groovy
+++ b/matrix-core/src/test/groovy/MatrixBuilderTest.groovy
@@ -117,6 +117,18 @@ class MatrixBuilderTest {
   }
 
   @Test
+  void testMapListAlignsValuesByFirstRowKeys() {
+    Matrix matrix = Matrix.builder().mapList([
+        [a: 1, b: 2],
+        [b: 20, a: 10]
+    ]).build()
+
+    assertEquals(['a', 'b'], matrix.columnNames())
+    assertEquals([1, 2], matrix.row(0))
+    assertEquals([10, 20], matrix.row(1))
+  }
+
+  @Test
   void testDataTypesOnly() {
     Matrix m4 = Matrix.builder()
         .types([int, String, Number, LocalDate]).build()

--- a/matrix-core/src/test/groovy/MatrixTest.groovy
+++ b/matrix-core/src/test/groovy/MatrixTest.groovy
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.*
 import se.alipsa.matrix.core.Column
 import se.alipsa.matrix.core.Converter
 import se.alipsa.matrix.core.Grid
+import se.alipsa.matrix.core.JoinType
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Row
 import se.alipsa.matrix.core.Stat
@@ -990,6 +991,22 @@ class MatrixTest {
     assertEquals('id', empData.columnNames()[0])
     assertEquals('name', empData.columnNames()[1])
 
+  }
+
+  @Test
+  void testBulkRename() {
+    def table = Matrix.builder().data(
+        emp_id: 1..3,
+        emp_name: ['Rick', 'Dan', 'Michelle'],
+        start_date: toLocalDates('2013-01-01', '2012-03-27', '2013-09-23')
+    ).types(int, String, LocalDate).build()
+
+    table.rename(emp_id: 'id', emp_name: 'name', start_date: 'started')
+
+    assertIterableEquals(['id', 'name', 'started'], table.columnNames())
+    assertEquals(3, table.rowCount())
+    assertEquals(1, table[0, 0])
+    assertEquals('Rick', table[0, 1])
   }
 
   @Test
@@ -3217,5 +3234,56 @@ class MatrixTest {
     fracSampled.each { row ->
       assertEquals(row['id'] * 10, row['score'])
     }
+  }
+
+  @Test
+  void testMergeInstanceMethod() {
+    Matrix x = Matrix.builder('left').data(
+        id: [1, 2, 3],
+        name: ['Alice', 'Bob', 'Carol']
+    ).types(int, String).build()
+
+    Matrix y = Matrix.builder('right').data(
+        id: [2, 3, 4],
+        salary: [100, 200, 300]
+    ).types(int, int).build()
+
+    Matrix inner = x.merge(y, 'id')
+    assertEquals(2, inner.rowCount())
+    assertIterableEquals(['id', 'name', 'salary'], inner.columnNames())
+    assertEquals('Bob', inner[0, 'name'])
+    assertEquals(100, inner[0, 'salary'])
+
+    Matrix left = x.merge(y, 'id', JoinType.LEFT)
+    assertEquals(3, left.rowCount())
+    assertEquals('Alice', left[0, 'name'])
+    assertNull(left[0, 'salary'])
+  }
+
+  @Test
+  void testMergeInstanceMethodWithMap() {
+    Matrix x = Matrix.builder().data(
+        emp_id: [1, 2],
+        name: ['Alice', 'Bob']
+    ).types(int, String).build()
+
+    Matrix y = Matrix.builder().data(
+        person_id: [1, 2],
+        dept: ['HR', 'Eng']
+    ).types(int, String).build()
+
+    Matrix result = x.merge(y, [x: 'emp_id', y: 'person_id'])
+    assertEquals(2, result.rowCount())
+    assertIterableEquals(['emp_id', 'name', 'dept'], result.columnNames())
+  }
+
+  @Test
+  void testCrossJoinInstanceMethod() {
+    Matrix x = Matrix.builder().data(color: ['red', 'blue']).types(String).build()
+    Matrix y = Matrix.builder().data(size: ['S', 'M']).types(String).build()
+
+    Matrix result = x.crossJoin(y)
+    assertEquals(4, result.rowCount())
+    assertIterableEquals(['color', 'size'], result.columnNames())
   }
 }

--- a/matrix-core/src/test/groovy/MatrixTest.groovy
+++ b/matrix-core/src/test/groovy/MatrixTest.groovy
@@ -841,19 +841,19 @@ class MatrixTest {
         start_date: toLocalDates("2013-01-01", "2012-03-27", "2013-09-23", "2014-11-15", "2014-05-11"))
         .types(int, String, Number, LocalDate)
         .build()
-    def noId = empData.clone().dropColumns('emp_id')
+    def noId = empData.clone().drop('emp_id')
     assertEquals(3, noId.columnCount())
     assertIterableEquals(['emp_name', 'salary', 'start_date'], noId.columnNames())
     assertIterableEquals([String, Number, LocalDate], noId.types())
 
-    def empList = empData.clone().dropColumns("salary", "start_date")
+    def empList = empData.clone().drop("salary", "start_date")
     //println(empList.content())
     assertEquals(2, empList.columnCount(), "Number of columns after drop")
     assertEquals(5, empList.rowCount(), "Number of rows after drop")
     assertIterableEquals(["emp_id", "emp_name"], empList.columnNames(), "column names after drop")
     assertIterableEquals([Integer, String], empList.types(), "Column types after drop")
 
-    def empRange = empData.clone().dropColumns(2..3)
+    def empRange = empData.clone().drop(2..3)
     assertEquals(empList, empRange, empList.diff(empRange))
   }
 
@@ -868,7 +868,7 @@ class MatrixTest {
         )
         .types(int, String, Number, LocalDate)
         .build()
-    def empList = empData.dropColumnsExcept("emp_id", "start_date")
+    def empList = empData.dropExcept("emp_id", "start_date")
     //println(empList.content())
     assertEquals(2, empList.columnCount(), "Number of columns after drop")
     assertEquals(5, empList.rowCount(), "Number of rows after drop")
@@ -1405,7 +1405,7 @@ class MatrixTest {
     assertNull(m[0, 3])
     assertIterableEquals([0, 1, 2], m.row(2)[0..2])
     assertNull(m[2, 3])
-    m.removeEmptyColumns()
+    m.dropEmptyColumns()
     assertEquals(3, m.rowCount())
     assertEquals(3, m.columnCount())
   }
@@ -1422,7 +1422,7 @@ class MatrixTest {
         .types(int, String, Number, LocalDate, String)
         .build()
     assertIterableEquals(['emp_id', 'emp_name', 'salary', 'start_date', 'other'], empData.columnNames())
-    empData.removeEmptyColumns()
+    empData.dropEmptyColumns()
     assertEquals(2, empData.columnCount())
     assertIterableEquals(['emp_id', 'salary'], empData.columnNames())
   }
@@ -1439,7 +1439,7 @@ class MatrixTest {
         .types(int, String, Number, String, String)
         .build()
     assertIterableEquals(['emp_id', 'emp_name', 'salary', 'start_date', 'other'], empData.columnNames())
-    empData.removeEmptyColumns()
+    empData.dropEmptyColumns()
     assertEquals(2, empData.columnCount())
     assertIterableEquals(['emp_id', 'salary'], empData.columnNames())
   }

--- a/matrix-core/src/test/groovy/MatrixTest.groovy
+++ b/matrix-core/src/test/groovy/MatrixTest.groovy
@@ -1214,6 +1214,44 @@ class MatrixTest {
   }
 
   @Test
+  void testEqualsRejectsDifferentRowCounts() {
+    Matrix shortMatrix = Matrix.builder()
+        .data(id: [1], name: ['Rick'])
+        .types(Integer, String)
+        .build()
+    Matrix longMatrix = Matrix.builder()
+        .data(id: [1, 2], name: ['Rick', 'Dan'])
+        .types(Integer, String)
+        .build()
+
+    assertNotEquals(shortMatrix, longMatrix)
+    assertNotEquals(longMatrix, shortMatrix)
+  }
+
+  @Test
+  void testEqualsCanIgnoreNumericStringTypeDifferences() {
+    Matrix numeric = Matrix.builder()
+        .data(id: [1], name: ['Rick'])
+        .types(Integer, String)
+        .build()
+    Matrix stringy = Matrix.builder()
+        .data(id: ['1'], name: ['Rick'])
+        .types(String, String)
+        .build()
+
+    assertTrue(numeric.equals(stringy, false, true, true))
+  }
+
+  @Test
+  void testParseGroovyMajorVersionAllowsQualifiedVersions() {
+    def method = Matrix.getDeclaredMethod('parseGroovyMajorVersion', String)
+    method.accessible = true
+
+    assertEquals(5, method.invoke(null, '5.0.6'))
+    assertEquals(6, method.invoke(null, '6.0.0-alpha-1'))
+  }
+
+  @Test
   void testDiff() {
     def empData = Matrix.builder().data(
         emp_id: [1, 2],

--- a/matrix-core/src/test/groovy/StatTest.groovy
+++ b/matrix-core/src/test/groovy/StatTest.groovy
@@ -588,5 +588,6 @@ class StatTest {
         [5, null, null]
     ]
     assertIterableEquals([3.0g, null, 12.0g], means(rowList, [0, 1, 2]))
+    assertIterableEquals([3 as BigDecimal, null, 12 as BigDecimal], medians(rowList, [0, 1, 2]))
   }
 }

--- a/matrix-core/src/test/groovy/ValueConverterTest.groovy
+++ b/matrix-core/src/test/groovy/ValueConverterTest.groovy
@@ -60,6 +60,18 @@ class ValueConverterTest {
   }
 
   @Test
+  void testConvertJavaUtilDateUsesLocale() {
+    Locale swedish = Locale.of('sv', 'SE')
+
+    assertEquals(
+        '2024-10-27',
+        new SimpleDateFormat('yyyy-MM-dd').format(
+            ValueConverter.convert('27 oktober 2024', java.util.Date, 'd MMMM yyyy', null, null, swedish)
+        )
+    )
+  }
+
+  @Test
   void testAsDate() {
     assertEquals(new Date(1728667826640), ValueConverter.asDate(1728667826640))
     assertEquals(java.sql.Date.valueOf('2024-10-11'), ValueConverter.asDate(20241011))

--- a/matrix-core/src/test/groovy/ValueConverterTest.groovy
+++ b/matrix-core/src/test/groovy/ValueConverterTest.groovy
@@ -46,6 +46,17 @@ class ValueConverterTest {
     assertEquals(2001251L, ValueConverter.convert('2001251.0', Long))
     assertEquals(2001251L, ValueConverter.convert(2001251, Long))
     assertEquals(2001251L, ValueConverter.convert(2001251.9, Long))
+    assertEquals(9007199254740993L, ValueConverter.asLong('9007199254740993'))
+  }
+
+  @Test
+  void testConvertLocalDateUsesLocale() {
+    Locale swedish = Locale.of('sv', 'SE')
+
+    assertEquals(
+        LocalDate.of(2024, 10, 27),
+        ValueConverter.convert('27 oktober 2024', LocalDate, 'd MMMM yyyy', null, null, swedish)
+    )
   }
 
   @Test

--- a/matrix-core/src/test/groovy/ValueConverterTest.groovy
+++ b/matrix-core/src/test/groovy/ValueConverterTest.groovy
@@ -203,7 +203,7 @@ class ValueConverterTest {
     assertEquals(Time.valueOf('12:34:56'), ValueConverter.asSqlTime('12:34:56'))
     assertEquals(Time.valueOf('00:00:00'), ValueConverter.asSqlTime('00:00:00'))
     assertNull(ValueConverter.asSqlTime(null))
-    assertEquals(Time.valueOf('12:34:56'), ValueConverter.asSqlTIme('12:34:56'))
+    assertEquals(Time.valueOf('12:34:56'), ValueConverter.asSqlTime('12:34:56'))
   }
 
   @Test

--- a/matrix-core/src/test/groovy/ValueConverterTest.groovy
+++ b/matrix-core/src/test/groovy/ValueConverterTest.groovy
@@ -65,8 +65,8 @@ class ValueConverterTest {
 
     assertEquals(
         '2024-10-27',
-        new SimpleDateFormat('yyyy-MM-dd').format(
-            ValueConverter.convert('27 oktober 2024', java.util.Date, 'd MMMM yyyy', null, null, swedish)
+        new SimpleDateFormat('yyyy-MM-dd', Locale.US).format(
+            ValueConverter.convert('27 oktober 2024', Date, 'd MMMM yyyy', null, null, swedish)
         )
     )
   }

--- a/matrix-examples/whiskey/src/main/groovy/WhiskeyAnalysis.groovy
+++ b/matrix-examples/whiskey/src/main/groovy/WhiskeyAnalysis.groovy
@@ -67,7 +67,7 @@ println result
 println Matrix.builder('Cluster allocation').ginqResult(result).build().content()
 
 //assert m.rows().countBy{ it.Cluster } == [0:51, 1:23, 2:12]
-data = m.selectColumns(features) as double[][]
+data = m.select(features) as double[][]
 pca = PCA.fit(data)
 projected = pca.getProjection(2).apply(data)
 m['X'] = projected*.getAt(0)

--- a/matrix-examples/whiskey/src/main/groovy/WhiskeyAnalysis.groovy
+++ b/matrix-examples/whiskey/src/main/groovy/WhiskeyAnalysis.groovy
@@ -19,7 +19,7 @@ import se.alipsa.matrix.stats.Correlation
 import se.alipsa.matrix.xchart.*
 
 m = CsvImporter.importCsv('https://www.niss.org/sites/default/files/ScotchWhisky01.txt')
-    .dropColumns('RowID')
+    .drop('RowID')
 println m.dimensions()
 
 features = m.columnNames() - 'Distillery'

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeans.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeans.groovy
@@ -122,7 +122,7 @@ class KMeans {
       throw new IllegalArgumentException("The following columns does not exist in the matrix: ${missingItems.join(', ')}")
     }
 
-    Matrix m = matrix.selectColumns(columnNames)
+    Matrix m = matrix.select(columnNames)
     double[][] points = new double[m.rowCount()][m.columnCount()]
     m.eachWithIndex { row, i ->
       points[i] = ListConverter.toDoubleArray(row as List<? extends Number>)

--- a/matrix-stats/src/test/groovy/KMeansTest.groovy
+++ b/matrix-stats/src/test/groovy/KMeansTest.groovy
@@ -86,7 +86,7 @@ class KMeansTest {
     def m = Matrix.builder()
         .data('https://www.niss.org/sites/default/files/ScotchWhisky01.txt')
         .build()
-        .dropColumns('RowID')
+        .drop('RowID')
 
     List<String> features = m.columnNames() - 'Distillery'
     features.each {

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
@@ -56,7 +56,7 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
     if (columnNames.isEmpty()) {
       throw new IllegalArgumentException("At least one column name must be provided for the correlation heatmap series.")
     }
-    Matrix data = matrix.selectColumns(columnNames)
+    Matrix data = matrix.select(columnNames)
     int size = columnNames.size()
     List<BigDecimal> corr = ((size - 1)..0).collectMany { int i ->
       (0..<size).collect { int j ->


### PR DESCRIPTION
## Summary

This branch consolidates all matrix-core 3.8.0 work: new features, bug fixes, API improvements, and cleanup of deprecated methods.

### Highlights

**Security & correctness**
- `toHtml()` now escapes HTML special characters (`<`, `>`, `&`, `'`, `"`) in column names and cell values, preventing injectable HTML output
- `diff()` returns empty string when equal, matching its GroovyDoc contract
- `Matrix.equals()` uses `BigDecimal` arithmetic for tolerance comparisons (eliminates `double`/`NaN` imprecision), checks row counts before values, and correctly detects null-vs-numeric differences
- Typed `Grid` mutators now reject values that don't match the grid element type

**New features**
- `top(n)`, `bottom(n)`, `info()`, `sample(n)`, `sampleFraction(fraction)` on Matrix
- `merge()` instance methods, `crossJoin()`, `rename(Map)` on Matrix
- `hasNulls()`, `countNulls()` on Column
- Full Joiner rewrite with `JoinType` enum (INNER, LEFT, RIGHT, FULL, CROSS, SEMI, ANTI), composite keys, type preservation

**API improvements**
- Column arithmetic (`+`, `-`, `*`, `/`, `**`) and `withColumn`/`withColumns` now return `Column` instead of `List`, preserving name/type for fluent chaining
- Added `select(String...)` as shorter alias for `selectColumns(...)` (deprecated)
- Added `dropExcept(List<String>)` overload
- `removeNulls()` and `unique()` on Column now preserve name/type

**Deprecation cleanup (breaking)**
- Removed 7 deprecated methods from Matrix (`dropColumnsExcept` x2, `dropColumns` x4, `removeEmptyColumns`) and `ValueConverter.asSqlTIme` (typo) — all deprecated since 3.7.0
- Callers updated across matrix-core tests, matrix-stats, and matrix-examples

**Bug fixes**
- `Stat.sd()`, `Stat.mean()`, `Stat.medians()`, `Stat.min/max` fixes
- `ValueConverter.asLong()` precision, locale-aware date parsing
- MatrixBuilder: ragged row rejection, stable row width, quoted delimiter handling
- Groovy version guard accepts qualified versions (e.g. `6.0.0-alpha-1`)

**Cleanup**
- Removed redundant `@CompileStatic` (compiler config handles it globally)
- Removed dead `columns != null` null check in constructor
- Removed unused `List<String> names` variable in `addColumns`
- CodeNarc violations fixed across 5 files

### Modules touched
- `matrix-core` (main + test)
- `matrix-stats` (test only)
- `matrix-examples/whiskey` (caller update)
- `AGENTS.md` (instructions update)

## Test plan
- [x] `./gradlew :matrix-core:codenarcMain` — passes
- [x] `./gradlew :matrix-core:spotlessCheck` — passes
- [x] `./gradlew :matrix-core:test` — 524 tests pass
- [x] `./gradlew :matrix-stats:test` — 969 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)