### PR TITLE
[codex] Fix xchart histogram and heatmap validation

### DIFF
--- a/matrix-xchart/release.md
+++ b/matrix-xchart/release.md
@@ -1,5 +1,10 @@
 # Matrix XChart release history
 
+## v0.3.0, unreleased
+- fix histogram default bin calculation so Scott's rule is treated as a bin width and converted to a bucket count from the data range
+- add clear validation for invalid histogram input and invalid heatmap shapes
+- breaking: vector heatmap input whose value count is not evenly divisible by the requested column count now throws `IllegalArgumentException` instead of dropping trailing values
+
 ## v0.2.3, 2026-01-31
 - add @CompileStatic to all 17 classes for performance and type safety (100% static compilation, no @CompileDynamic needed)
 - complete empty test methods in HistogramChartTest (testDensityHistogram, testFrequencyHistogramCustom)

--- a/matrix-xchart/req/0.3.0-plan.md
+++ b/matrix-xchart/req/0.3.0-plan.md
@@ -1,0 +1,89 @@
+# matrix-xchart 0.3.0 Plan
+
+## Scope
+
+Improve `matrix-xchart` correctness, API consistency, and quality-gate reliability based on the module review. Each phase is intended to be a separate PR. A task is only complete when its checkbox is marked `[x]` and the exact verification command used is recorded under that task.
+
+## Phase 1: Histogram and Heatmap Correctness
+
+Scope: Fix silent data-shape bugs in chart generation and add focused tests for invalid inputs.
+
+1.1 [x] Update `HistogramChart.addSeries(String columnName)` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HistogramChart.groovy` so Scott's rule is treated as a bin width, not a bucket count.
+
+1.2 [x] Add a small helper for converting a positive bin width to a bucket count, using the column range and rounding up to avoid losing the right edge.
+
+1.3 [x] Validate degenerate histogram input clearly: empty columns, all-null columns, zero-width data, and non-positive bucket counts should throw `IllegalArgumentException` with useful messages.
+
+1.4 [x] Add tests in `matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/HistogramChartTest.groovy` covering the default overload, custom bucket count, and invalid inputs.
+
+1.5 [x] Update `HeatmapChart.addSeries(String seriesName, Column col, Integer columns = null)` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy` to reject `null`, empty, or non-positive column counts.
+
+1.6 [x] Reject vector heatmap input where `col.size()` is not evenly divisible by the requested column count, instead of silently dropping trailing values. This is a breaking behavior change for callers relying on truncation; call it out in `matrix-xchart/release.md`.
+
+1.7 [x] Update `HeatmapChart.addSeries(String seriesName, List<Column> columns)` and the label overload to reject empty column lists and mismatched column lengths with clear `IllegalArgumentException` messages.
+
+1.8 [x] Guard `HeatmapChart.addAllToSeriesBy` against a null `matrix.matrixName`: throw `IllegalArgumentException` with a clear message asking the caller to name the matrix before charting, so XChart never receives a null or duplicated fallback series name.
+
+1.9 [x] Add tests in `matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/HeatmapChartTest.groovy` for uneven vector input, empty column lists, mismatched column lengths, and unnamed-matrix input to `addAllToSeriesBy`.
+
+1.10 [x] Verify Phase 1 with `./gradlew :matrix-xchart:codenarcMain :matrix-xchart:codenarcTest :matrix-xchart:spotlessCheck :matrix-xchart:test --tests 'test.alipsa.matrix.xchart.HistogramChartTest' --tests 'test.alipsa.matrix.xchart.HeatmapChartTest' -Pheadless=true`.
+
+## Phase 2: OHLC and Correlation Input Validation
+
+Scope: Align public API types with documented usage and fail fast for invalid matrix columns.
+
+2.1 [ ] Change `OhlcChart.addSeries(String name, List<Number> xData, List<Number> open, List<Number> high, List<Number> low, List<Number> close)` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy` to `OhlcChart addSeries(String name, List<Date> xData, List<Number> open, List<Number> high, List<Number> low, List<Number> close)`, matching XChart's OHLC API and the existing GroovyDoc example that uses a `Date` column.
+
+2.2 [ ] Keep the OHLC value columns typed as numeric lists and validate all five input lists have equal length before delegating to XChart.
+
+2.3 [ ] Add or update tests in `matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/OhlcChartTest.groovy` to cover date x-axis input and mismatched list lengths.
+
+2.4 [ ] In `CorrelationHeatmapChart.addSeries(String title, List<String> columnNames)` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy`, keep the existing empty-list guard and add the remaining validation immediately after it: validate column existence and numeric column types before `matrix.select(columnNames)` and `ListConverter.toBigDecimals(...)`.
+
+2.5 [ ] Verify that every requested correlation column exists and has a type assignable to `Number`. Throw `IllegalArgumentException` naming the missing or non-numeric column.
+
+2.6 [ ] Add tests in `matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/CorrelationHeatmapChartTest.groovy` covering a String column input, an unknown column name, and a valid numeric heatmap.
+
+2.7 [ ] Verify Phase 2 with `./gradlew :matrix-xchart:codenarcMain :matrix-xchart:codenarcTest :matrix-xchart:spotlessCheck :matrix-xchart:test --tests 'test.alipsa.matrix.xchart.OhlcChartTest' --tests 'test.alipsa.matrix.xchart.CorrelationHeatmapChartTest' -Pheadless=true`.
+
+## Phase 3: API Ergonomics and Swing Display Safety
+
+Scope: Improve public factory consistency and guard Swing display behavior without changing chart output.
+
+3.1 [ ] Add default-width/default-height factory support to `LineChart.create` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/LineChart.groovy`.
+
+3.2 [ ] Add default-width/default-height factory support to `AreaChart.create` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/AreaChart.groovy`.
+
+3.3 [ ] Review factory signatures across `LineChart`, `AreaChart`, `ScatterChart`, `BarChart`, `PieChart`, `HistogramChart`, `BoxChart`, `BubbleChart`, `HeatmapChart`, `RadarChart`, `StickChart`, and `OhlcChart` for consistent `Integer width = null, Integer height = null` behavior.
+
+3.4 [ ] Add explicit return types to all `create()` factory methods that currently return `def` or are missing a return type declaration, specifically `StickChart.create()`, `HeatmapChart.create()`, and `CorrelationHeatmapChart.create()`.
+
+3.5 [ ] Add API consistency tests for no-size creation of line and area charts.
+
+3.6 [ ] In `AbstractChart.display()` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/AbstractChart.groovy`, check `SwingUtilities.isEventDispatchThread()` before calling `SwingUtilities.invokeAndWait`. When already on the EDT, run the block directly or via `SwingUtilities.invokeLater`.
+
+3.7 [ ] Add an executable regression test for the EDT path where feasible. The test should call the display-window creation path from the EDT without opening a real window in headless mode; if Swing/XChart cannot support that safely in CI, extract a small package-visible helper for the EDT dispatch branch and test that helper directly.
+
+3.8 [ ] If a fully automated EDT regression test is not feasible, record an explicit manual headed verification command. This is the one Phase 3 task that may not be CI-verifiable; it requires a deliberate out-of-band headed check before the Phase 3 PR is merged.
+
+3.9 [ ] Verify Phase 3 with `./gradlew :matrix-xchart:codenarcMain :matrix-xchart:codenarcTest :matrix-xchart:spotlessCheck :matrix-xchart:test --tests 'test.alipsa.matrix.xchart.XyChartTest' --tests 'test.alipsa.matrix.xchart.CategoryChartTest' --tests 'test.alipsa.matrix.xchart.HeatmapChartTest' --tests 'test.alipsa.matrix.xchart.CorrelationHeatmapChartTest' -Pheadless=true`.
+
+## Phase 4: CodeNarc Enforcement and Final Verification
+
+Scope: Clean existing static-analysis debt, make CodeNarc blocking, and perform final module validation.
+
+4.1 [ ] Remove `codenarc { ignoreFailures = true }` from `matrix-xchart/build.gradle` after existing main and test violations have been fixed.
+
+4.2 [ ] Fix main-source CodeNarc violations without changing behavior: unused imports, spacing, unnecessary semicolons, string literal style, public constructor visibility on abstract classes, and duplicate literal warnings where appropriate.
+
+4.3 [ ] Fix test-source CodeNarc violations without weakening tests: method naming, string literal style, spacing, blank lines, and repeated style warnings.
+
+4.4 [ ] Add a short note to `matrix-xchart/release.md` that CodeNarc is now enforced for the module.
+
+4.5 [ ] Verify CodeNarc enforcement with `./gradlew :matrix-xchart:codenarcMain :matrix-xchart:codenarcTest :matrix-xchart:spotlessCheck`.
+
+4.6 [ ] Run the full matrix-xchart verification sequence: `./gradlew :matrix-xchart:codenarcMain :matrix-xchart:codenarcTest :matrix-xchart:spotlessCheck :matrix-xchart:test -Pheadless=true`.
+
+4.7 [ ] Confirm `matrix-xchart/build/reports/codenarc/main.html` and `matrix-xchart/build/reports/codenarc/test.html` report zero violations.
+
+4.8 [ ] Record all final verification commands and outcomes in the PR description or release notes before merge.

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
@@ -137,7 +137,7 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
     if (col == null || col.isEmpty()) {
       throw new IllegalArgumentException('Heatmap column must contain at least one value')
     }
-    int nCols = columns == null ? col.size().sqrt() as int : columns
+    int nCols = columns == null ? autoColumnCount(col) : columns
     if (nCols <= 0) {
       throw new IllegalArgumentException("Heatmap column count must be positive, got $nCols")
     }
@@ -151,14 +151,24 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
     if (columns == null || columns.isEmpty()) {
       throw new IllegalArgumentException('Heatmap column list must contain at least one column')
     }
-    int expectedSize = columns[0].size()
     columns.each { Column column ->
       if (column == null) {
         throw new IllegalArgumentException('Heatmap column list must not contain null columns')
       }
+    }
+    int expectedSize = columns[0].size()
+    columns.each { Column column ->
       if (column.size() != expectedSize) {
         throw new IllegalArgumentException("Heatmap columns must have equal lengths; expected $expectedSize values but column '${column.name}' has ${column.size()}")
       }
     }
+  }
+
+  private static int autoColumnCount(Column col) {
+    int nCols = col.size().sqrt() as int
+    if (nCols * nCols != col.size()) {
+      throw new IllegalArgumentException("Heatmap column '${col.name}' with ${col.size()} values has no integer square root; pass an explicit column count instead of relying on auto-detection")
+    }
+    nCols
   }
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
@@ -151,13 +151,12 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
     if (columns == null || columns.isEmpty()) {
       throw new IllegalArgumentException('Heatmap column list must contain at least one column')
     }
+    Integer expectedSize = null
     columns.each { Column column ->
       if (column == null) {
         throw new IllegalArgumentException('Heatmap column list must not contain null columns')
       }
-    }
-    int expectedSize = columns[0].size()
-    columns.each { Column column ->
+      expectedSize = expectedSize ?: column.size()
       if (column.size() != expectedSize) {
         throw new IllegalArgumentException("Heatmap columns must have equal lengths; expected $expectedSize values but column '${column.name}' has ${column.size()}")
       }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
@@ -61,8 +61,8 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
   }
 
   HeatmapChart addSeries(String seriesName, Column col, Integer columns = null) {
-    int nCols = columns ?: col.size().sqrt() as int
-    int nRows = (int) (col.size() / nCols)
+    int nCols = validateVectorColumn(col, columns)
+    int nRows = (col.size() / nCols) as int
     List<Number[]> heatData = []
     Number[] numberArray = new Number[]{}
     List<List> tmpRows = []
@@ -82,12 +82,14 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
   }
 
   HeatmapChart addSeries(String seriesName, List<Column> columns) {
+    validateColumns(columns)
     int nCols = columns.size()
     int nRows = columns[0].size()
     addSeries(seriesName, 1..nRows, 1..nCols, columns)
   }
 
   HeatmapChart addSeries(String seriesName, List columnLabels, List rowLabels, List<Column> columns) {
+    validateColumns(columns)
     int nCols = columns.size()
     int nRows = columns[0].size()
     List<Number[]> heatData = []
@@ -107,6 +109,9 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
   }
 
   HeatmapChart addAllToSeriesBy(String columnName) {
+    if (matrix.matrixName == null || matrix.matrixName.isBlank()) {
+      throw new IllegalArgumentException('Matrix must have a name before charting all columns as a heatmap series')
+    }
     int byIdx = matrix.columnIndex(columnName)
     List<Number[]> heatData = []
     List<List> tmpRows = []
@@ -126,5 +131,34 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
     List<String> colNames = matrix.columnNames() - columnName
     xchart.addSeries(matrix.matrixName, colNames, matrix[columnName], heatData)
     this
+  }
+
+  private static int validateVectorColumn(Column col, Integer columns) {
+    if (col == null || col.isEmpty()) {
+      throw new IllegalArgumentException('Heatmap column must contain at least one value')
+    }
+    int nCols = columns == null ? col.size().sqrt() as int : columns
+    if (nCols <= 0) {
+      throw new IllegalArgumentException("Heatmap column count must be positive, got $nCols")
+    }
+    if (col.size() % nCols != 0) {
+      throw new IllegalArgumentException("Heatmap column '${col.name}' with ${col.size()} values cannot be evenly divided into $nCols columns")
+    }
+    nCols
+  }
+
+  private static void validateColumns(List<Column> columns) {
+    if (columns == null || columns.isEmpty()) {
+      throw new IllegalArgumentException('Heatmap column list must contain at least one column')
+    }
+    int expectedSize = columns[0].size()
+    columns.each { Column column ->
+      if (column == null) {
+        throw new IllegalArgumentException('Heatmap column list must not contain null columns')
+      }
+      if (column.size() != expectedSize) {
+        throw new IllegalArgumentException("Heatmap columns must have equal lengths; expected $expectedSize values but column '${column.name}' has ${column.size()}")
+      }
+    }
   }
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HistogramChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HistogramChart.groovy
@@ -52,7 +52,8 @@ class HistogramChart extends AbstractChart<HistogramChart, CategoryChart, Catego
   HistogramChart addSeries(String columnName) {
     Column c = matrix.column(columnName)
     List<Number> values = validatedValues(c)
-    addSeries(c.name, values, bucketCount(values, scottsRule(values)))
+    BigDecimal range = validateRange(values)
+    addSeries(c.name, values, bucketCount(range, scottsRule(values)), false)
   }
 
   HistogramChart addSeries(String columnName, int numBuckets) {
@@ -63,11 +64,13 @@ class HistogramChart extends AbstractChart<HistogramChart, CategoryChart, Catego
     addSeries(column.name, validatedValues(column), numBuckets)
   }
 
-  private HistogramChart addSeries(String seriesName, List<Number> values, int numBuckets) {
+  private HistogramChart addSeries(String seriesName, List<Number> values, int numBuckets, boolean validateDataRange = true) {
     if (numBuckets <= 0) {
       throw new IllegalArgumentException("Histogram bucket count must be positive, got $numBuckets")
     }
-    validateRange(values)
+    if (validateDataRange) {
+      validateRange(values)
+    }
     Histogram h = new Histogram(values, numBuckets)
     xchart.addSeries(seriesName, h.xAxisData, h.yAxisData)
     this
@@ -86,11 +89,10 @@ class HistogramChart extends AbstractChart<HistogramChart, CategoryChart, Catego
     3.49 * s / n**(1/3)
   }
 
-  private static int bucketCount(List<Number> values, BigDecimal binWidth) {
+  private static int bucketCount(BigDecimal range, BigDecimal binWidth) {
     if (binWidth == null || binWidth <= 0) {
       throw new IllegalArgumentException("Histogram bin width must be positive, got $binWidth")
     }
-    BigDecimal range = validateRange(values)
     (range / binWidth).ceil() as int
   }
 

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HistogramChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HistogramChart.groovy
@@ -51,7 +51,8 @@ class HistogramChart extends AbstractChart<HistogramChart, CategoryChart, Catego
 
   HistogramChart addSeries(String columnName) {
     Column c = matrix.column(columnName)
-    addSeries(c, scottsRule(c).round() as int)
+    List<Number> values = validatedValues(c)
+    addSeries(c.name, values, bucketCount(values, scottsRule(values)))
   }
 
   HistogramChart addSeries(String columnName, int numBuckets) {
@@ -59,8 +60,16 @@ class HistogramChart extends AbstractChart<HistogramChart, CategoryChart, Catego
   }
 
   HistogramChart addSeries(Column column, int numBuckets) {
-    Histogram h = new Histogram(column, numBuckets)
-    xchart.addSeries(column.name, h.xAxisData, h.yAxisData)
+    addSeries(column.name, validatedValues(column), numBuckets)
+  }
+
+  private HistogramChart addSeries(String seriesName, List<Number> values, int numBuckets) {
+    if (numBuckets <= 0) {
+      throw new IllegalArgumentException("Histogram bucket count must be positive, got $numBuckets")
+    }
+    validateRange(values)
+    Histogram h = new Histogram(values, numBuckets)
+    xchart.addSeries(seriesName, h.xAxisData, h.yAxisData)
     this
   }
 
@@ -75,6 +84,49 @@ class HistogramChart extends AbstractChart<HistogramChart, CategoryChart, Catego
     def s = Stat.sd(data)
     def n = data.size()
     3.49 * s / n**(1/3)
+  }
+
+  private static int bucketCount(List<Number> values, BigDecimal binWidth) {
+    if (binWidth == null || binWidth <= 0) {
+      throw new IllegalArgumentException("Histogram bin width must be positive, got $binWidth")
+    }
+    BigDecimal range = validateRange(values)
+    (range / binWidth).ceil() as int
+  }
+
+  private static List<Number> validatedValues(Column column) {
+    if (column == null || column.isEmpty()) {
+      throw new IllegalArgumentException('Histogram column must contain at least one value')
+    }
+    List<Number> values = []
+    column.each { value ->
+      if (value instanceof Number) {
+        values << value
+      }
+    }
+    if (values.isEmpty()) {
+      throw new IllegalArgumentException("Histogram column '$column.name' must contain at least one non-null numeric value")
+    }
+    values
+  }
+
+  private static BigDecimal validateRange(List<Number> values) {
+    BigDecimal min = values[0] as BigDecimal
+    BigDecimal max = values[0] as BigDecimal
+    values.each { Number value ->
+      BigDecimal number = value as BigDecimal
+      if (number < min) {
+        min = number
+      }
+      if (number > max) {
+        max = number
+      }
+    }
+    BigDecimal range = max - min
+    if (range <= 0) {
+      throw new IllegalArgumentException('Histogram data must span more than one distinct value')
+    }
+    range
   }
 
   /**

--- a/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/HeatmapChartTest.groovy
+++ b/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/HeatmapChartTest.groovy
@@ -122,6 +122,20 @@ class HeatmapChartTest {
   }
 
   @Test
+  void testVectorHeatmapRejectsAutoDetectionWithoutSquareInput() {
+    Matrix matrix = Matrix.builder()
+        .data(c: [1, 2, 3, 4, 5])
+        .types(Number)
+        .build()
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      HeatmapChart.create(matrix).addSeries('Auto', 'c')
+    }
+
+    assertTrue(exception.message.contains('no integer square root'))
+  }
+
+  @Test
   void testHeatmapRejectsEmptyColumnLists() {
     Matrix matrix = Matrix.builder().data(c: [1, 2]).types(Number).build()
 
@@ -131,6 +145,10 @@ class HeatmapChartTest {
 
     assertThrows(IllegalArgumentException) {
       HeatmapChart.create(matrix).addSeries('Empty', [], [], [])
+    }
+
+    assertThrows(IllegalArgumentException) {
+      HeatmapChart.create(matrix).addSeries('Null', [null, matrix['c']])
     }
   }
 

--- a/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/HeatmapChartTest.groovy
+++ b/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/HeatmapChartTest.groovy
@@ -1,12 +1,13 @@
 package test.alipsa.matrix.xchart
 
-import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assertions.*
 
 import org.junit.jupiter.api.Test
 import org.knowm.xchart.BitmapEncoder
 import org.knowm.xchart.HeatMapChart
 import org.knowm.xchart.HeatMapChartBuilder
 
+import se.alipsa.matrix.core.Column
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.datasets.Dataset
 import se.alipsa.matrix.stats.Normalize
@@ -90,6 +91,75 @@ class HeatmapChartTest {
     File file = new File("build/testVerifyDistribution.png")
     hmc.exportPng(file)
     assertTrue(file.exists())
+  }
+
+  @Test
+  void testVectorHeatmapRejectsUnevenInput() {
+    Matrix matrix = Matrix.builder()
+        .data(c: [1, 2, 3, 4, 5])
+        .types(Number)
+        .build()
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      HeatmapChart.create(matrix).addSeries('Uneven', 'c', 2)
+    }
+
+    assertTrue(exception.message.contains('cannot be evenly divided'))
+  }
+
+  @Test
+  void testVectorHeatmapRejectsInvalidColumnCount() {
+    Matrix matrix = Matrix.builder()
+        .data(c: [1, 2, 3, 4])
+        .types(Number)
+        .build()
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      HeatmapChart.create(matrix).addSeries('Invalid', 'c', 0)
+    }
+
+    assertTrue(exception.message.contains('column count'))
+  }
+
+  @Test
+  void testHeatmapRejectsEmptyColumnLists() {
+    Matrix matrix = Matrix.builder().data(c: [1, 2]).types(Number).build()
+
+    assertThrows(IllegalArgumentException) {
+      HeatmapChart.create(matrix).addSeries('Empty', [])
+    }
+
+    assertThrows(IllegalArgumentException) {
+      HeatmapChart.create(matrix).addSeries('Empty', [], [], [])
+    }
+  }
+
+  @Test
+  void testHeatmapRejectsMismatchedColumnLengths() {
+    Matrix matrix = Matrix.builder()
+        .data(a: [1, 2, 3], b: [4, 5, 6])
+        .types([Number, Number])
+        .build()
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      HeatmapChart.create(matrix).addSeries('Mismatch', [matrix['a'], new Column('short', [4, 5], Number)])
+    }
+
+    assertTrue(exception.message.contains('equal lengths'))
+  }
+
+  @Test
+  void testAddAllToSeriesByRejectsUnnamedMatrix() {
+    Matrix matrix = Matrix.builder()
+        .data(model: ['a', 'b'], value: [1, 2])
+        .types([String, Number])
+        .build()
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      HeatmapChart.create(matrix).addAllToSeriesBy('model')
+    }
+
+    assertTrue(exception.message.contains('name'))
   }
 
   /**

--- a/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/HeatmapChartTest.groovy
+++ b/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/HeatmapChartTest.groovy
@@ -146,6 +146,11 @@ class HeatmapChartTest {
     assertThrows(IllegalArgumentException) {
       HeatmapChart.create(matrix).addSeries('Empty', [], [], [])
     }
+  }
+
+  @Test
+  void testHeatmapRejectsNullColumnInList() {
+    Matrix matrix = Matrix.builder().data(c: [1, 2]).types(Number).build()
 
     assertThrows(IllegalArgumentException) {
       HeatmapChart.create(matrix).addSeries('Null', [null, matrix['c']])

--- a/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/HistogramChartTest.groovy
+++ b/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/HistogramChartTest.groovy
@@ -1,9 +1,11 @@
 package test.alipsa.matrix.xchart
 
-import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assertions.*
 
 import org.junit.jupiter.api.Test
 
+import se.alipsa.matrix.core.Column
+import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.datasets.Dataset
 import se.alipsa.matrix.xchart.HistogramChart
 
@@ -11,6 +13,55 @@ import java.math.RoundingMode
 
 class HistogramChartTest {
 
+  @Test
+  void testDefaultHistogramUsesScottBinWidth() {
+    Matrix matrix = Matrix.builder()
+        .data(values: (1..100).toList())
+        .types(Number)
+        .build()
+
+    HistogramChart chart = HistogramChart.create(matrix).addSeries('values')
+
+    assertNotNull(chart.getSeries('values'))
+    assertTrue(chart.getSeries('values').getYData().size() > 1)
+  }
+
+  @Test
+  void testCustomBucketCount() {
+    Matrix matrix = Matrix.builder()
+        .data(values: [1, 2, 3, 4, 5, 6])
+        .types(Number)
+        .build()
+
+    HistogramChart chart = HistogramChart.create(matrix).addSeries('values', 3)
+
+    assertNotNull(chart.getSeries('values'))
+    assertEquals(3, chart.getSeries('values').getYData().size())
+  }
+
+  @Test
+  void testHistogramRejectsInvalidInputs() {
+    assertThrows(IllegalArgumentException) {
+      HistogramChart.create(Matrix.builder().data(values: []).types(Number).build()).addSeries('values')
+    }
+
+    assertThrows(IllegalArgumentException) {
+      HistogramChart.create(Matrix.builder().data(values: [null, null]).types(Number).build()).addSeries('values')
+    }
+
+    assertThrows(IllegalArgumentException) {
+      HistogramChart.create(Matrix.builder().data(values: [7, 7, 7]).types(Number).build()).addSeries('values')
+    }
+
+    IllegalArgumentException bucketException = assertThrows(IllegalArgumentException) {
+      HistogramChart.create(Matrix.builder().data(values: [1, 2, 3]).types(Number).build()).addSeries('values', 0)
+    }
+    assertTrue(bucketException.message.contains('bucket count'))
+
+    assertThrows(IllegalArgumentException) {
+      HistogramChart.create(Dataset.airquality()).addSeries(new Column('empty', [], Number), 5)
+    }
+  }
 
   /**
    * Equivalent to the following R code


### PR DESCRIPTION
## Summary
- Fix `HistogramChart.addSeries(String)` so Scott's rule is treated as a bin width and converted to a bucket count from the data range.
- Add histogram validation for empty, all-null, zero-width, and non-positive bucket inputs.
- Add heatmap validation for invalid vector shapes, empty or mismatched column lists, and unnamed matrices in `addAllToSeriesBy`.
- Document the vector heatmap breaking change in `matrix-xchart/release.md` and mark Phase 1 complete in the 0.3.0 plan.

## Modules touched
- `matrix-xchart`

## Validation
- `./gradlew :matrix-xchart:codenarcMain :matrix-xchart:codenarcTest :matrix-xchart:spotlessCheck :matrix-xchart:test --tests 'test.alipsa.matrix.xchart.HistogramChartTest' --tests 'test.alipsa.matrix.xchart.HeatmapChartTest' -Pheadless=true`

Note: CodeNarc reports existing module violations under the current `ignoreFailures` configuration; the command exits successfully. Phase 4 covers CodeNarc cleanup/enforcement.