### PR TITLE
[codex] Validate xchart OHLC and correlation inputs

### DIFF
--- a/matrix-xchart/req/0.3.0-plan.md
+++ b/matrix-xchart/req/0.3.0-plan.md
@@ -32,19 +32,19 @@ Scope: Fix silent data-shape bugs in chart generation and add focused tests for 
 
 Scope: Align public API types with documented usage and fail fast for invalid matrix columns.
 
-2.1 [ ] Change `OhlcChart.addSeries(String name, List<Number> xData, List<Number> open, List<Number> high, List<Number> low, List<Number> close)` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy` to `OhlcChart addSeries(String name, List<Date> xData, List<Number> open, List<Number> high, List<Number> low, List<Number> close)`, matching XChart's OHLC API and the existing GroovyDoc example that uses a `Date` column.
+2.1 [x] Change `OhlcChart.addSeries(String name, List<Number> xData, List<Number> open, List<Number> high, List<Number> low, List<Number> close)` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy` to `OhlcChart addSeries(String name, List<Date> xData, List<Number> open, List<Number> high, List<Number> low, List<Number> close)`, matching XChart's OHLC API and the existing GroovyDoc example that uses a `Date` column.
 
-2.2 [ ] Keep the OHLC value columns typed as numeric lists and validate all five input lists have equal length before delegating to XChart.
+2.2 [x] Keep the OHLC value columns typed as numeric lists and validate all five input lists have equal length before delegating to XChart.
 
-2.3 [ ] Add or update tests in `matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/OhlcChartTest.groovy` to cover date x-axis input and mismatched list lengths.
+2.3 [x] Add or update tests in `matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/OhlcChartTest.groovy` to cover date x-axis input and mismatched list lengths.
 
-2.4 [ ] In `CorrelationHeatmapChart.addSeries(String title, List<String> columnNames)` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy`, keep the existing empty-list guard and add the remaining validation immediately after it: validate column existence and numeric column types before `matrix.select(columnNames)` and `ListConverter.toBigDecimals(...)`.
+2.4 [x] In `CorrelationHeatmapChart.addSeries(String title, List<String> columnNames)` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy`, keep the existing empty-list guard and add the remaining validation immediately after it: validate column existence and numeric column types before `matrix.select(columnNames)` and `ListConverter.toBigDecimals(...)`.
 
-2.5 [ ] Verify that every requested correlation column exists and has a type assignable to `Number`. Throw `IllegalArgumentException` naming the missing or non-numeric column.
+2.5 [x] Verify that every requested correlation column exists and has a type assignable to `Number`. Throw `IllegalArgumentException` naming the missing or non-numeric column.
 
-2.6 [ ] Add tests in `matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/CorrelationHeatmapChartTest.groovy` covering a String column input, an unknown column name, and a valid numeric heatmap.
+2.6 [x] Add tests in `matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/CorrelationHeatmapChartTest.groovy` covering a String column input, an unknown column name, and a valid numeric heatmap.
 
-2.7 [ ] Verify Phase 2 with `./gradlew :matrix-xchart:codenarcMain :matrix-xchart:codenarcTest :matrix-xchart:spotlessCheck :matrix-xchart:test --tests 'test.alipsa.matrix.xchart.OhlcChartTest' --tests 'test.alipsa.matrix.xchart.CorrelationHeatmapChartTest' -Pheadless=true`.
+2.7 [x] Verify Phase 2 with `./gradlew :matrix-xchart:codenarcMain :matrix-xchart:codenarcTest :matrix-xchart:spotlessCheck :matrix-xchart:test --tests 'test.alipsa.matrix.xchart.OhlcChartTest' --tests 'test.alipsa.matrix.xchart.CorrelationHeatmapChartTest' -Pheadless=true`.
 
 ## Phase 3: API Ergonomics and Swing Display Safety
 

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
@@ -102,8 +102,8 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
         throw new IllegalArgumentException("Correlation heatmap column '$columnName' does not exist")
       }
       Class columnType = matrix.type(columnName)
-      if (!Number.isAssignableFrom(columnType)) {
-        throw new IllegalArgumentException("Correlation heatmap column '$columnName' must be numeric, got ${columnType.simpleName}")
+      if (columnType == null || !Number.isAssignableFrom(columnType)) {
+        throw new IllegalArgumentException("Correlation heatmap column '$columnName' must be numeric, got ${columnType?.simpleName ?: 'null'}")
       }
     }
   }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
@@ -56,6 +56,7 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
     if (columnNames.isEmpty()) {
       throw new IllegalArgumentException("At least one column name must be provided for the correlation heatmap series.")
     }
+    validateColumns(columnNames)
     Matrix data = matrix.select(columnNames)
     int size = columnNames.size()
     List<BigDecimal> corr = ((size - 1)..0).collectMany { int i ->
@@ -93,5 +94,17 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
     }
     xchart.addSeries(seriesName, rowLabels, columnLabels, heatData)
     this
+  }
+
+  private void validateColumns(List<String> columnNames) {
+    columnNames.each { String columnName ->
+      if (matrix.columnIndex(columnName) == -1) {
+        throw new IllegalArgumentException("Correlation heatmap column '$columnName' does not exist")
+      }
+      Class columnType = matrix.type(columnName)
+      if (!Number.isAssignableFrom(columnType)) {
+        throw new IllegalArgumentException("Correlation heatmap column '$columnName' must be numeric, got ${columnType.simpleName}")
+      }
+    }
   }
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy
@@ -89,11 +89,8 @@ class OhlcChart extends AbstractChart<OhlcChart, OHLCChart, OHLCStyler, OHLCSeri
       if (values == null) {
         throw new IllegalArgumentException("OHLC $columnName data must not be null")
       }
-    }
-    int expectedSize = xData.size()
-    data.each { String columnName, List values ->
-      if (values.size() != expectedSize) {
-        throw new IllegalArgumentException("OHLC series lists must have equal lengths; expected $expectedSize values but $columnName has ${values.size()}")
+      if (values.size() != xData.size()) {
+        throw new IllegalArgumentException("OHLC series lists must have equal lengths; expected ${xData.size()} values but $columnName has ${values.size()}")
       }
     }
   }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy
@@ -68,11 +68,33 @@ class OhlcChart extends AbstractChart<OhlcChart, OHLCChart, OHLCStyler, OHLCSeri
   }
 
   OhlcChart addSeries(String name, String xData, String open, String high, String low, String close) {
-    addSeries(name, matrix[xData], matrix[open], matrix[high], matrix[low], matrix[close])
+    addSeries(name, matrix[xData] as List<Date>, matrix[open] as List<Number>, matrix[high] as List<Number>, matrix[low] as List<Number>, matrix[close] as List<Number>)
   }
 
-  OhlcChart addSeries(String name, List<Number> xData, List<Number> open, List<Number> high, List<Number> low, List<Number> close) {
+  OhlcChart addSeries(String name, List<Date> xData, List<Number> open, List<Number> high, List<Number> low, List<Number> close) {
+    validateEqualLengths(xData, open, high, low, close)
     xchart.addSeries(name, xData, open, high, low, close)
     this
+  }
+
+  private static void validateEqualLengths(List<Date> xData, List<Number> open, List<Number> high, List<Number> low, List<Number> close) {
+    Map<String, List> data = [
+        xData: xData,
+        open: open,
+        high: high,
+        low: low,
+        close: close
+    ]
+    data.each { String columnName, List values ->
+      if (values == null) {
+        throw new IllegalArgumentException("OHLC $columnName data must not be null")
+      }
+    }
+    int expectedSize = xData.size()
+    data.each { String columnName, List values ->
+      if (values.size() != expectedSize) {
+        throw new IllegalArgumentException("OHLC series lists must have equal lengths; expected $expectedSize values but $columnName has ${values.size()}")
+      }
+    }
   }
 }

--- a/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/CorrelationHeatmapChartTest.groovy
+++ b/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/CorrelationHeatmapChartTest.groovy
@@ -52,6 +52,19 @@ class CorrelationHeatmapChartTest {
   }
 
   @Test
+  void testCorrelationHeatmapRejectsUntypedColumn() {
+    Matrix matrix = Matrix.builder()
+        .data(x: [1, 2, 3], y: [1, 4, 9])
+        .build()
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      CorrelationHeatmapChart.create(matrix).addSeries('Correlation', ['x', 'y'])
+    }
+
+    assertTrue(exception.message.contains("'x' must be numeric"))
+  }
+
+  @Test
   void testCorrelationHeatmapAcceptsNumericColumns() {
     Matrix matrix = Matrix.builder()
         .data(x: [1, 2, 3], y: [1, 4, 9])

--- a/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/CorrelationHeatmapChartTest.groovy
+++ b/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/CorrelationHeatmapChartTest.groovy
@@ -1,7 +1,6 @@
 package test.alipsa.matrix.xchart
 
-import static org.junit.jupiter.api.Assertions.assertNotNull
-import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assertions.*
 
 import org.junit.jupiter.api.Test
 
@@ -14,11 +13,53 @@ class CorrelationHeatmapChartTest {
   void testCorrelationHeatmap() {
     Matrix whisky = Matrix.builder().data(this.class.getResource('/ScotchWhisky01.csv')).build()
     assertNotNull(whisky, "Failed to load csv file")
+    List<String> numericColumns = whisky.columnNames() - 'Distillery' as List<String>
+    whisky = whisky.convert(numericColumns.collectEntries { String columnName -> [(columnName): Number] })
     File chartFile = new File("build/correlationHeatmap.svg")
     def chart = CorrelationHeatmapChart.create(whisky, 800, 600)
         .setTitle("Correlation Heatmap of Scotch Whisky Data")
-        .addSeries("Correlation", whisky.columnNames() - 'Distillery' as List<String>)
+        .addSeries("Correlation", numericColumns)
     chart.exportSvg(chartFile)
     assertTrue(chartFile.exists(), "SVG file should be created")
+  }
+
+  @Test
+  void testCorrelationHeatmapRejectsStringColumn() {
+    Matrix matrix = Matrix.builder()
+        .data(name: ['a', 'b', 'c'], value: [1, 2, 3])
+        .types([String, Number])
+        .build()
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      CorrelationHeatmapChart.create(matrix).addSeries('Correlation', ['name', 'value'])
+    }
+
+    assertTrue(exception.message.contains("'name' must be numeric"))
+  }
+
+  @Test
+  void testCorrelationHeatmapRejectsUnknownColumn() {
+    Matrix matrix = Matrix.builder()
+        .data(x: [1, 2, 3], y: [1, 4, 9])
+        .types([Number, Number])
+        .build()
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      CorrelationHeatmapChart.create(matrix).addSeries('Correlation', ['x', 'missing'])
+    }
+
+    assertTrue(exception.message.contains("'missing' does not exist"))
+  }
+
+  @Test
+  void testCorrelationHeatmapAcceptsNumericColumns() {
+    Matrix matrix = Matrix.builder()
+        .data(x: [1, 2, 3], y: [1, 4, 9])
+        .types([Number, Number])
+        .build()
+
+    def chart = CorrelationHeatmapChart.create(matrix).addSeries('Correlation', ['x', 'y'])
+
+    assertNotNull(chart.getSeries('Correlation'))
   }
 }

--- a/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/OhlcChartTest.groovy
+++ b/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/OhlcChartTest.groovy
@@ -1,6 +1,6 @@
 package test.alipsa.matrix.xchart
 
-import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assertions.*
 
 import org.apache.commons.csv.CSVFormat
 import org.junit.jupiter.api.Test
@@ -12,9 +12,6 @@ import org.knowm.xchart.OHLCSeries
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.csv.CsvImporter
 import se.alipsa.matrix.xchart.OhlcChart
-
-import java.awt.Color
-import java.time.LocalDate
 
 class OhlcChartTest {
 
@@ -43,5 +40,24 @@ class OhlcChartTest {
     def file2 = new File("build/testXChartOhlcChart2.png")
     ohlcChart.exportPng(file2)
     assertTrue(file2.exists())
+    assertNotNull(ohlcChart.getSeries("GSPC"))
+  }
+
+  @Test
+  void testOhlcChartRejectsMismatchedListLengths() {
+    Matrix matrix = Matrix.builder().data(Date: [new Date(), new Date()]).types(Date).build()
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      OhlcChart.create(matrix).addSeries(
+          'Mismatch',
+          matrix.Date,
+          [1, 2],
+          [2, 3],
+          [0],
+          [1, 2]
+      )
+    }
+
+    assertTrue(exception.message.contains('equal lengths'))
   }
 }


### PR DESCRIPTION
## Summary
- Change `OhlcChart.addSeries(...)` to use `List<Date>` x-axis data and validate all OHLC input lists have equal length before delegating to XChart.
- Validate correlation heatmap column existence and numeric types before selecting/converting matrix data.
- Add focused tests for OHLC date-axis input, OHLC length mismatch, correlation string-column rejection, unknown-column rejection, and valid numeric heatmaps.
- Mark Phase 2 complete in `matrix-xchart/req/0.3.0-plan.md`.

## Modules touched
- `matrix-xchart`

## Validation
- `./gradlew :matrix-xchart:codenarcMain :matrix-xchart:codenarcTest :matrix-xchart:spotlessCheck :matrix-xchart:test --tests 'test.alipsa.matrix.xchart.OhlcChartTest' --tests 'test.alipsa.matrix.xchart.CorrelationHeatmapChartTest' -Pheadless=true`

Note: CodeNarc reports existing module violations under the current `ignoreFailures` configuration; the command exits successfully. Phase 4 covers CodeNarc cleanup/enforcement.