### PR TITLE
[codex] Improve xchart factories and display dispatch

### DIFF
--- a/matrix-xchart/req/0.3.0-plan.md
+++ b/matrix-xchart/req/0.3.0-plan.md
@@ -50,23 +50,23 @@ Scope: Align public API types with documented usage and fail fast for invalid ma
 
 Scope: Improve public factory consistency and guard Swing display behavior without changing chart output.
 
-3.1 [ ] Add default-width/default-height factory support to `LineChart.create` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/LineChart.groovy`.
+3.1 [x] Add default-width/default-height factory support to `LineChart.create` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/LineChart.groovy`.
 
-3.2 [ ] Add default-width/default-height factory support to `AreaChart.create` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/AreaChart.groovy`.
+3.2 [x] Add default-width/default-height factory support to `AreaChart.create` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/AreaChart.groovy`.
 
-3.3 [ ] Review factory signatures across `LineChart`, `AreaChart`, `ScatterChart`, `BarChart`, `PieChart`, `HistogramChart`, `BoxChart`, `BubbleChart`, `HeatmapChart`, `RadarChart`, `StickChart`, and `OhlcChart` for consistent `Integer width = null, Integer height = null` behavior.
+3.3 [x] Review factory signatures across `LineChart`, `AreaChart`, `ScatterChart`, `BarChart`, `PieChart`, `HistogramChart`, `BoxChart`, `BubbleChart`, `HeatmapChart`, `RadarChart`, `StickChart`, and `OhlcChart` for consistent `Integer width = null, Integer height = null` behavior.
 
-3.4 [ ] Add explicit return types to all `create()` factory methods that currently return `def` or are missing a return type declaration, specifically `StickChart.create()`, `HeatmapChart.create()`, and `CorrelationHeatmapChart.create()`.
+3.4 [x] Add explicit return types to all `create()` factory methods that currently return `def` or are missing a return type declaration, specifically `StickChart.create()`, `HeatmapChart.create()`, and `CorrelationHeatmapChart.create()`.
 
-3.5 [ ] Add API consistency tests for no-size creation of line and area charts.
+3.5 [x] Add API consistency tests for no-size creation of line and area charts.
 
-3.6 [ ] In `AbstractChart.display()` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/AbstractChart.groovy`, check `SwingUtilities.isEventDispatchThread()` before calling `SwingUtilities.invokeAndWait`. When already on the EDT, run the block directly or via `SwingUtilities.invokeLater`.
+3.6 [x] In `AbstractChart.display()` in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/AbstractChart.groovy`, check `SwingUtilities.isEventDispatchThread()` before calling `SwingUtilities.invokeAndWait`. When already on the EDT, run the block directly or via `SwingUtilities.invokeLater`.
 
-3.7 [ ] Add an executable regression test for the EDT path where feasible. The test should call the display-window creation path from the EDT without opening a real window in headless mode; if Swing/XChart cannot support that safely in CI, extract a small package-visible helper for the EDT dispatch branch and test that helper directly.
+3.7 [x] Add an executable regression test for the EDT path where feasible. The test should call the display-window creation path from the EDT without opening a real window in headless mode; if Swing/XChart cannot support that safely in CI, extract a small package-visible helper for the EDT dispatch branch and test that helper directly.
 
-3.8 [ ] If a fully automated EDT regression test is not feasible, record an explicit manual headed verification command. This is the one Phase 3 task that may not be CI-verifiable; it requires a deliberate out-of-band headed check before the Phase 3 PR is merged.
+3.8 [x] If a fully automated EDT regression test is not feasible, record an explicit manual headed verification command. This is the one Phase 3 task that may not be CI-verifiable; it requires a deliberate out-of-band headed check before the Phase 3 PR is merged. Automated helper regression was feasible, so no manual headed command is required.
 
-3.9 [ ] Verify Phase 3 with `./gradlew :matrix-xchart:codenarcMain :matrix-xchart:codenarcTest :matrix-xchart:spotlessCheck :matrix-xchart:test --tests 'test.alipsa.matrix.xchart.XyChartTest' --tests 'test.alipsa.matrix.xchart.CategoryChartTest' --tests 'test.alipsa.matrix.xchart.HeatmapChartTest' --tests 'test.alipsa.matrix.xchart.CorrelationHeatmapChartTest' -Pheadless=true`.
+3.9 [x] Verify Phase 3 with `./gradlew :matrix-xchart:codenarcMain :matrix-xchart:codenarcTest :matrix-xchart:spotlessCheck :matrix-xchart:test --tests 'test.alipsa.matrix.xchart.XyChartTest' --tests 'test.alipsa.matrix.xchart.CategoryChartTest' --tests 'test.alipsa.matrix.xchart.HeatmapChartTest' --tests 'test.alipsa.matrix.xchart.CorrelationHeatmapChartTest' -Pheadless=true`.
 
 ## Phase 4: CodeNarc Enforcement and Final Verification
 

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/AreaChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/AreaChart.groovy
@@ -23,11 +23,11 @@ import se.alipsa.matrix.xchart.abstractions.AbstractXYChart
 @CompileStatic
 class AreaChart extends AbstractXYChart<AreaChart> {
 
-  private AreaChart(Matrix matrix, int width, int height) {
+  private AreaChart(Matrix matrix, Integer width = null, Integer height = null) {
     super(matrix, width, height, XYSeries.XYSeriesRenderStyle.Area)
   }
 
-  static AreaChart create(Matrix matrix, int width, int height) {
+  static AreaChart create(Matrix matrix, Integer width = null, Integer height = null) {
     return new AreaChart(matrix, width, height)
   }
 

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
@@ -48,7 +48,7 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
     }
   }
 
-  static create(Matrix matrix, Integer width = null, Integer height = null) {
+  static CorrelationHeatmapChart create(Matrix matrix, Integer width = null, Integer height = null) {
     new CorrelationHeatmapChart(matrix, width, height)
   }
 

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
@@ -52,7 +52,7 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
     }
   }
 
-  static create(Matrix matrix, Integer width = null, Integer height = null) {
+  static HeatmapChart create(Matrix matrix, Integer width = null, Integer height = null) {
     new HeatmapChart(matrix, width, height)
   }
 

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/LineChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/LineChart.groovy
@@ -27,11 +27,11 @@ import se.alipsa.matrix.xchart.abstractions.AbstractXYChart
 @CompileStatic
 class LineChart extends AbstractXYChart<LineChart> {
 
-  private LineChart(Matrix matrix, int width, int height) {
+  private LineChart(Matrix matrix, Integer width = null, Integer height = null) {
     super(matrix, width, height, XYSeries.XYSeriesRenderStyle.Line)
   }
 
-  static LineChart create(Matrix matrix, int width, int height) {
+  static LineChart create(Matrix matrix, Integer width = null, Integer height = null) {
     return new LineChart(matrix, width, height)
   }
 

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/StickChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/StickChart.groovy
@@ -33,7 +33,7 @@ class StickChart extends AbstractCategoryChart<StickChart> {
     super(matrix, width, height, CategorySeries.CategorySeriesRenderStyle.Stick)
   }
 
-  static create(Matrix matrix, Integer width = null, Integer height = null) {
+  static StickChart create(Matrix matrix, Integer width = null, Integer height = null) {
     new StickChart(matrix, width, height)
   }
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/AbstractChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/AbstractChart.groovy
@@ -216,9 +216,9 @@ abstract class AbstractChart<T extends AbstractChart, C extends Chart, ST extend
   @Override
   void display() {
     String windowTitle = xchart.title ?: matrix.getMatrixName() ?: "Matrix XChart"
-    final JFrame frame = new JFrame(windowTitle)
 
     runOnEventDispatchThread(() -> {
+      JFrame frame = new JFrame(windowTitle)
       frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE)
       frame.add(exportSwing())
       frame.pack()

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/AbstractChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/AbstractChart.groovy
@@ -216,17 +216,25 @@ abstract class AbstractChart<T extends AbstractChart, C extends Chart, ST extend
   @Override
   void display() {
     String windowTitle = xchart.title ?: matrix.getMatrixName() ?: "Matrix XChart"
-    final JFrame frame = new JFrame(windowTitle);
+    final JFrame frame = new JFrame(windowTitle)
 
+    runOnEventDispatchThread(() -> {
+      frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE)
+      frame.add(exportSwing())
+      frame.pack()
+      frame.setVisible(true)
+    })
+  }
+
+  protected static void runOnEventDispatchThread(Runnable action) {
+    if (SwingUtilities.isEventDispatchThread()) {
+      action.run()
+      return
+    }
     try {
-      SwingUtilities.invokeAndWait(() -> {
-        frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE)
-        frame.add(exportSwing())
-        frame.pack()
-        frame.setVisible(true)
-      })
+      SwingUtilities.invokeAndWait(action)
     } catch (InterruptedException | InvocationTargetException e) {
-      throw new RuntimeException("Error displaying chart", e)
+      throw new RuntimeException('Error displaying chart', e)
     }
   }
 }

--- a/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/XyChartTest.groovy
+++ b/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/XyChartTest.groovy
@@ -1,22 +1,56 @@
 package test.alipsa.matrix.xchart
 
-import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assertions.*
 import static org.knowm.xchart.XYSeries.XYSeriesRenderStyle.*
 
 import org.junit.jupiter.api.Test
 import org.knowm.xchart.VectorGraphicsEncoder
+import org.knowm.xchart.XYChart
+import org.knowm.xchart.XYSeries
 import org.knowm.xchart.style.AxesChartStyler
 import org.knowm.xchart.style.Styler
+import org.knowm.xchart.style.XYStyler
 import org.knowm.xchart.style.markers.SeriesMarkers
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.xchart.AreaChart
 import se.alipsa.matrix.xchart.LineChart
 import se.alipsa.matrix.xchart.ScatterChart
+import se.alipsa.matrix.xchart.abstractions.AbstractChart
 
 import java.awt.Color
+import java.util.concurrent.atomic.AtomicBoolean
+
+import javax.swing.SwingUtilities
 
 class XyChartTest {
+
+  @Test
+  void testLineAndAreaChartsCanBeCreatedWithoutExplicitSize() {
+    Matrix matrix = Matrix.builder()
+        .data(x: [1, 2, 3], y: [1, 4, 9])
+        .types([Number] * 2)
+        .build()
+
+    assertNotNull(LineChart.create(matrix).addSeries('x', 'y'))
+    assertNotNull(AreaChart.create(matrix).addSeries('x', 'y'))
+  }
+
+  @Test
+  void testEventDispatchHelperRunsDirectlyOnEventDispatchThread() {
+    AtomicBoolean ran = new AtomicBoolean(false)
+    AtomicBoolean ranOnEdt = new AtomicBoolean(false)
+
+    SwingUtilities.invokeAndWait {
+      DispatchProbe.run {
+        ran.set(true)
+        ranOnEdt.set(SwingUtilities.isEventDispatchThread())
+      }
+    }
+
+    assertTrue(ran.get())
+    assertTrue(ranOnEdt.get())
+  }
 
   @Test
   void testLineChart() {
@@ -222,5 +256,12 @@ class XyChartTest {
       sc.exportPng(fos)
     }
     assertTrue(file.exists())
+  }
+
+  private static class DispatchProbe extends AbstractChart<DispatchProbe, XYChart, XYStyler, XYSeries> {
+
+    static void run(Runnable action) {
+      runOnEventDispatchThread(action)
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add omitted-width/height support to `LineChart.create` and `AreaChart.create`.
- Add explicit return types for `StickChart.create`, `HeatmapChart.create`, and `CorrelationHeatmapChart.create`.
- Guard `AbstractChart.display()` against calling `SwingUtilities.invokeAndWait` from the Swing event dispatch thread.
- Add API consistency tests for no-size line/area creation and an executable EDT dispatch regression test.
- Mark Phase 3 complete in `matrix-xchart/req/0.3.0-plan.md`.

## Modules touched
- `matrix-xchart`

## Validation
- `./gradlew :matrix-xchart:codenarcMain :matrix-xchart:codenarcTest :matrix-xchart:spotlessCheck :matrix-xchart:test --tests 'test.alipsa.matrix.xchart.XyChartTest' --tests 'test.alipsa.matrix.xchart.CategoryChartTest' --tests 'test.alipsa.matrix.xchart.HeatmapChartTest' --tests 'test.alipsa.matrix.xchart.CorrelationHeatmapChartTest' -Pheadless=true`

Note: CodeNarc reports existing module violations under the current `ignoreFailures` configuration; the command exits successfully. Phase 4 covers CodeNarc cleanup/enforcement.