### PR TITLE
Fix issues and add usability enhancements to matrix-xchart

### DIFF
--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/AreaChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/AreaChart.groovy
@@ -24,8 +24,31 @@ class AreaChart extends AbstractXYChart<AreaChart> {
     super(matrix, width, height, XYSeries.XYSeriesRenderStyle.Area)
   }
 
+  /**
+   * Create a new area chart with optional dimensions.
+   *
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new AreaChart instance
+   */
   static AreaChart create(Matrix matrix, Integer width = null, Integer height = null) {
-    return new AreaChart(matrix, width, height)
+    new AreaChart(matrix, width, height)
+  }
+
+  /**
+   * Create a new area chart with a title and optional dimensions.
+   *
+   * @param title the chart title
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new AreaChart instance
+   */
+  static AreaChart create(String title, Matrix matrix, Integer width = null, Integer height = null) {
+    def chart = new AreaChart(matrix, width, height)
+    chart.title = title
+    chart
   }
 
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BarChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BarChart.groovy
@@ -29,10 +29,41 @@ class BarChart extends AbstractCategoryChart<BarChart> {
     super(matrix, width, height, type)
   }
 
+  /**
+   * Create a new bar chart with optional dimensions.
+   *
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new BarChart instance
+   */
   static BarChart create(Matrix matrix, Integer width = null, Integer height = null) {
     new BarChart(matrix, width, height, CategorySeries.CategorySeriesRenderStyle.Bar)
   }
 
+  /**
+   * Create a new bar chart with a title and optional dimensions.
+   *
+   * @param title the chart title
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new BarChart instance
+   */
+  static BarChart create(String title, Matrix matrix, Integer width = null, Integer height = null) {
+    def chart = new BarChart(matrix, width, height, CategorySeries.CategorySeriesRenderStyle.Bar)
+    chart.title = title
+    chart
+  }
+
+  /**
+   * Create a new stacked bar chart with optional dimensions.
+   *
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new stacked BarChart instance
+   */
   static BarChart createStacked(Matrix matrix, Integer width = null, Integer height = null) {
     def bc = new BarChart(matrix, width, height, CategorySeries.CategorySeriesRenderStyle.Bar)
     bc.style.setStacked(true)

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BoxChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BoxChart.groovy
@@ -34,7 +34,6 @@ import se.alipsa.matrix.xchart.abstractions.AbstractChart
 class BoxChart extends AbstractChart<BoxChart, org.knowm.xchart.BoxChart, BoxStyler, BoxSeries> {
 
   private BoxChart(Matrix matrix, Integer width = null, Integer height = null) {
-    super.matrix = matrix
     def builder = new BoxChartBuilder()
     if (width != null) {
       builder.width(width)
@@ -42,35 +41,97 @@ class BoxChart extends AbstractChart<BoxChart, org.knowm.xchart.BoxChart, BoxSty
     if (height != null) {
       builder.height(height)
     }
-    xchart = builder.build()
-    style.theme = new MatrixTheme()
-    def matrixName = matrix.matrixName
-    if (matrixName != null && !matrixName.isBlank()) {
-      title = matrix.matrixName
-    }
+    initChart(builder.build(), matrix)
   }
 
+  /**
+   * Create a new box chart with optional dimensions.
+   *
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new BoxChart instance
+   */
   static BoxChart create(Matrix matrix, Integer width = null, Integer height = null) {
     new BoxChart(matrix, width, height)
   }
 
+  /**
+   * Create a new box chart with a title and optional dimensions.
+   *
+   * @param title the chart title
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new BoxChart instance
+   */
+  static BoxChart create(String title, Matrix matrix, Integer width = null, Integer height = null) {
+    def chart = new BoxChart(matrix, width, height)
+    chart.title = title
+    chart
+  }
+
+  /**
+   * Add a box plot series using a column name from the source Matrix.
+   * The series will be named after the column.
+   *
+   * @param valueCol the name of the numeric column to plot
+   * @return this chart for method chaining
+   */
   BoxChart addSeries(String valueCol) {
     addSeries(matrix.column(valueCol))
   }
 
+  /**
+   * Add a named box plot series using a column name from the source Matrix.
+   *
+   * @param seriesName the name for this series (displayed in legend)
+   * @param valueCol the name of the numeric column to plot
+   * @return this chart for method chaining
+   */
   BoxChart addSeries(String seriesName, String valueCol) {
     addSeries(seriesName, matrix.column(valueCol))
   }
 
+  /**
+   * Add a box plot series using a Column object.
+   * The series will be named after the column.
+   *
+   * @param valueCol the Column containing numeric values to plot
+   * @return this chart for method chaining
+   */
   BoxChart addSeries(Column valueCol) {
     addSeries(valueCol.name, valueCol)
   }
 
+  /**
+   * Add a named box plot series using a Column object.
+   *
+   * @param seriesName the name for this series (displayed in legend)
+   * @param valueCol the Column containing numeric values to plot
+   * @return this chart for method chaining
+   * @throws IllegalArgumentException if valueCol is null
+   */
   BoxChart addSeries(String seriesName, Column valueCol) {
     if (valueCol == null) {
       throw new IllegalArgumentException('The valueCol is null, cannot add series')
     }
     xchart.addSeries(seriesName, valueCol)
+    this
+  }
+
+  /**
+   * Add all numeric columns from the source Matrix as individual box plot series.
+   * Each numeric column becomes a series named after the column.
+   *
+   * @return this chart for method chaining
+   */
+  BoxChart addAllSeries() {
+    matrix.columnNames().each { String colName ->
+      if (Number.isAssignableFrom(matrix.type(colName))) {
+        addSeries(colName)
+      }
+    }
     this
   }
 

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BubbleChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BubbleChart.groovy
@@ -31,10 +31,9 @@ import se.alipsa.matrix.xchart.abstractions.AbstractChart
  */
 class BubbleChart extends AbstractChart<BubbleChart, org.knowm.xchart.BubbleChart, BubbleStyler, BubbleSeries> {
 
-  int numSeries = 0
+  private int numSeries = 0
 
   private BubbleChart(Matrix matrix, Integer width = null, Integer height = null) {
-    super.matrix = matrix
     def builder = new BubbleChartBuilder()
     if (width != null) {
       builder.width(width)
@@ -42,30 +41,89 @@ class BubbleChart extends AbstractChart<BubbleChart, org.knowm.xchart.BubbleChar
     if (height != null) {
       builder.height(height)
     }
-    xchart = builder.build()
-    style.theme = new MatrixTheme()
-    def matrixName = matrix.matrixName
-    if (matrixName != null && !matrixName.isBlank()) {
-      title = matrix.matrixName
-    }
+    initChart(builder.build(), matrix)
   }
 
+  /**
+   * Create a new bubble chart with optional dimensions.
+   *
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new BubbleChart instance
+   */
   static BubbleChart create(Matrix matrix, Integer width = null, Integer height = null) {
     new BubbleChart(matrix, width, height)
   }
 
+  /**
+   * Create a new bubble chart with a title and optional dimensions.
+   *
+   * @param title the chart title
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new BubbleChart instance
+   */
+  static BubbleChart create(String title, Matrix matrix, Integer width = null, Integer height = null) {
+    def chart = new BubbleChart(matrix, width, height)
+    chart.title = title
+    chart
+  }
+
+  /**
+   * Add a bubble series using column names from the source Matrix.
+   * The series will be named after the value column.
+   *
+   * @param xCol the name of the column containing X-axis values
+   * @param yCol the name of the column containing Y-axis values
+   * @param valueCol the name of the column containing bubble size values
+   * @param transparency the fill alpha value (0 = fully transparent, 255 = fully opaque); defaults to 185
+   * @return this chart for method chaining
+   */
   BubbleChart addSeries(String xCol, String yCol, String valueCol, Integer transparency = 185) {
     addSeries(matrix.column(xCol), matrix.column(yCol), matrix.column(valueCol), transparency)
   }
 
+  /**
+   * Add a named bubble series using column names from the source Matrix.
+   *
+   * @param seriesName the name for this series (displayed in legend)
+   * @param xCol the name of the column containing X-axis values
+   * @param yCol the name of the column containing Y-axis values
+   * @param valueCol the name of the column containing bubble size values
+   * @param transparency the fill alpha value (0 = fully transparent, 255 = fully opaque); defaults to 185
+   * @return this chart for method chaining
+   */
   BubbleChart addSeries(String seriesName, String xCol, String yCol, String valueCol, Integer transparency = 185) {
     addSeries(seriesName, matrix.column(xCol), matrix.column(yCol), matrix.column(valueCol), transparency)
   }
 
+  /**
+   * Add a bubble series using Column objects.
+   * The series will be named after the value column.
+   *
+   * @param xCol the column containing X-axis values
+   * @param yCol the column containing Y-axis values
+   * @param valueCol the column containing bubble size values
+   * @param transparency the fill alpha value (0 = fully transparent, 255 = fully opaque); defaults to 185
+   * @return this chart for method chaining
+   */
   BubbleChart addSeries(Column xCol, Column yCol, Column valueCol, Integer transparency = 185) {
     addSeries(valueCol.name, xCol, yCol, valueCol, transparency)
   }
 
+  /**
+   * Add a named bubble series using Column objects.
+   *
+   * @param seriesName the name for this series (displayed in legend)
+   * @param xCol the column containing X-axis values
+   * @param yCol the column containing Y-axis values
+   * @param valueCol the column containing bubble size values
+   * @param transparency the fill alpha value (0 = fully transparent, 255 = fully opaque); defaults to 185
+   * @return this chart for method chaining
+   * @throws IllegalArgumentException if valueCol is null
+   */
   BubbleChart addSeries(String seriesName, Column xCol, Column yCol, Column valueCol, Integer transparency = 185) {
     if (valueCol == null) {
       throw new IllegalArgumentException('The valueCol is null, cannot add series')

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
@@ -112,7 +112,7 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
    * @param columns the correlation data organized as a list of column lists
    * @return this chart for method chaining
    */
-  CorrelationHeatmapChart addSeries(String seriesName, List<String> columnLabels, List<String> rowLabels, List<List> columns) {
+  CorrelationHeatmapChart addSeries(String seriesName, List<String> columnLabels, List<String> rowLabels, List<List<Number>> columns) {
     int nCols = columns.size()
     int nRows = columns[0].size()
     List<Number[]> heatData = []

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
@@ -29,7 +29,6 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
   final Number[] numberArray = new Number[]{}
 
   private CorrelationHeatmapChart(Matrix matrix, Integer width = null, Integer height = null) {
-    super.matrix = matrix
     def builder = new HeatMapChartBuilder()
     if (width != null) {
       builder.width(width)
@@ -37,20 +36,47 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
     if (height != null) {
       builder.height(height)
     }
-    xchart = builder.build()
-    style.theme = new MatrixTheme()
+    initChart(builder.build(), matrix)
     style.setPlotContentSize(1)
     style.setShowValue(true)
-    def matrixName = matrix.matrixName
-    if (matrixName != null && !matrixName.isBlank()) {
-      title = matrix.matrixName
-    }
   }
 
+  /**
+   * Create a new correlation heatmap chart with optional dimensions.
+   *
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new CorrelationHeatmapChart instance
+   */
   static CorrelationHeatmapChart create(Matrix matrix, Integer width = null, Integer height = null) {
     new CorrelationHeatmapChart(matrix, width, height)
   }
 
+  /**
+   * Create a new correlation heatmap chart with a title and optional dimensions.
+   *
+   * @param title the chart title
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new CorrelationHeatmapChart instance
+   */
+  static CorrelationHeatmapChart create(String title, Matrix matrix, Integer width = null, Integer height = null) {
+    def chart = new CorrelationHeatmapChart(matrix, width, height)
+    chart.title = title
+    chart
+  }
+
+  /**
+   * Add a correlation heatmap series computed from the specified numeric columns.
+   * The correlation matrix is calculated using Pearson correlation coefficients.
+   *
+   * @param title the name for this series (displayed in legend)
+   * @param columnNames the names of the numeric columns to compute correlations for
+   * @return this chart for method chaining
+   * @throws IllegalArgumentException if columnNames is empty, or any column is missing or non-numeric
+   */
   CorrelationHeatmapChart addSeries(String title, List<String> columnNames) {
     if (columnNames.isEmpty()) {
       throw new IllegalArgumentException('At least one column name must be provided for the correlation heatmap series.')
@@ -77,7 +103,16 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
     )
   }
 
-  CorrelationHeatmapChart addSeries(String seriesName, List columnLabels, List rowLabels, List<List> columns) {
+  /**
+   * Add a correlation heatmap series with pre-computed data and custom labels.
+   *
+   * @param seriesName the name for this series
+   * @param columnLabels labels for the X-axis
+   * @param rowLabels labels for the Y-axis
+   * @param columns the correlation data organized as a list of column lists
+   * @return this chart for method chaining
+   */
+  CorrelationHeatmapChart addSeries(String seriesName, List<String> columnLabels, List<String> rowLabels, List<List> columns) {
     int nCols = columns.size()
     int nRows = columns[0].size()
     List<Number[]> heatData = []

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
@@ -31,7 +31,6 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
   Matrix heatMapMatrix
 
   private HeatmapChart(Matrix matrix, Integer width = null, Integer height = null) {
-    super.matrix = matrix
     def builder = new HeatMapChartBuilder()
     if (width != null) {
       builder.width(width)
@@ -39,29 +38,62 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
     if (height != null) {
       builder.height(height)
     }
-    xchart = builder.build()
-    style.theme = new MatrixTheme()
+    initChart(builder.build(), matrix)
     style.setPlotContentSize(1)
     style.setShowValue(true)
-    def matrixName = matrix.matrixName
-    if (matrixName != null && !matrixName.isBlank()) {
-      title = matrix.matrixName
-    }
   }
 
+  /**
+   * Create a new heatmap chart with optional dimensions.
+   *
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new HeatmapChart instance
+   */
   static HeatmapChart create(Matrix matrix, Integer width = null, Integer height = null) {
     new HeatmapChart(matrix, width, height)
   }
 
+  /**
+   * Create a new heatmap chart with a title and optional dimensions.
+   *
+   * @param title the chart title
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new HeatmapChart instance
+   */
+  static HeatmapChart create(String title, Matrix matrix, Integer width = null, Integer height = null) {
+    def chart = new HeatmapChart(matrix, width, height)
+    chart.title = title
+    chart
+  }
+
+  /**
+   * Add a heatmap series from a single column, reshaping it into a grid.
+   *
+   * @param seriesName the name for this series
+   * @param colName the name of the column containing values
+   * @param columns the number of grid columns; if null, auto-detected from the square root of the column size
+   * @return this chart for method chaining
+   */
   HeatmapChart addSeries(String seriesName, String colName, Integer columns = null) {
     addSeries(seriesName, matrix.column(colName), columns)
   }
 
+  /**
+   * Add a heatmap series from a single Column, reshaping it into a grid.
+   *
+   * @param seriesName the name for this series
+   * @param col the Column containing values
+   * @param columns the number of grid columns; if null, auto-detected from the square root of the column size
+   * @return this chart for method chaining
+   */
   HeatmapChart addSeries(String seriesName, Column col, Integer columns = null) {
     int nCols = validateVectorColumn(col, columns)
     int nRows = (col.size() / nCols) as int
     List<Number[]> heatData = []
-    Number[] numberArray = new Number[]{}
     List<List> tmpRows = []
     int idx = 0
     (0..<nRows).each { int r ->
@@ -78,6 +110,13 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
     this
   }
 
+  /**
+   * Add a heatmap series from a list of Columns with auto-generated labels.
+   *
+   * @param seriesName the name for this series
+   * @param columns the list of Columns, each representing a column in the heatmap grid
+   * @return this chart for method chaining
+   */
   HeatmapChart addSeries(String seriesName, List<Column> columns) {
     validateColumns(columns)
     int nCols = columns.size()
@@ -85,7 +124,16 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
     addSeries(seriesName, 1..nRows, 1..nCols, columns)
   }
 
-  HeatmapChart addSeries(String seriesName, List columnLabels, List rowLabels, List<Column> columns) {
+  /**
+   * Add a heatmap series from a list of Columns with custom axis labels.
+   *
+   * @param seriesName the name for this series
+   * @param columnLabels labels for the X-axis (columns)
+   * @param rowLabels labels for the Y-axis (rows)
+   * @param columns the list of Columns, each representing a column in the heatmap grid
+   * @return this chart for method chaining
+   */
+  HeatmapChart addSeries(String seriesName, List<?> columnLabels, List<?> rowLabels, List<Column> columns) {
     validateColumns(columns)
     int nCols = columns.size()
     int nRows = columns[0].size()
@@ -105,6 +153,14 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
     this
   }
 
+  /**
+   * Add all columns (except the specified one) as a heatmap series, using the specified column for row labels.
+   * The Matrix must have a name set before calling this method.
+   *
+   * @param columnName the name of the column to use as row labels (excluded from heatmap values)
+   * @return this chart for method chaining
+   * @throws IllegalArgumentException if the Matrix has no name
+   */
   HeatmapChart addAllToSeriesBy(String columnName) {
     if (matrix.matrixName == null || matrix.matrixName.isBlank()) {
       throw new IllegalArgumentException('Matrix must have a name before charting all columns as a heatmap series')

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HistogramChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HistogramChart.groovy
@@ -1,15 +1,12 @@
 package se.alipsa.matrix.xchart
 
-import org.knowm.xchart.CategoryChart
-import org.knowm.xchart.CategoryChartBuilder
 import org.knowm.xchart.CategorySeries
 import org.knowm.xchart.Histogram
-import org.knowm.xchart.style.CategoryStyler
 
 import se.alipsa.matrix.core.Column
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Stat
-import se.alipsa.matrix.xchart.abstractions.AbstractChart
+import se.alipsa.matrix.xchart.abstractions.AbstractCategoryChart
 
 /**
  * A HistogramChart is a visual representation of the distribution of quantitative data.
@@ -22,50 +19,79 @@ import se.alipsa.matrix.xchart.abstractions.AbstractChart
  * hc.exportPng(file)
  * </code></pre>
  */
-class HistogramChart extends AbstractChart<HistogramChart, CategoryChart, CategoryStyler, CategorySeries> {
+class HistogramChart extends AbstractCategoryChart<HistogramChart> {
 
   private static final BigDecimal SCOTT_FACTOR = 3.49
   private static final int CUBE_ROOT_DENOMINATOR = 3
   private static final int FREEDMAN_DIACONIS_FACTOR = 2
 
-  private HistogramChart(Matrix matrix, Integer width = null, Integer height = null, CategorySeries.CategorySeriesRenderStyle type) {
-    this.matrix = matrix
-    CategoryChartBuilder builder = new CategoryChartBuilder()
-    if (width != null) {
-      builder.width = width
-    }
-    if (height != null) {
-      builder.height = height
-    }
-    xchart = builder.build()
-    style.theme = new MatrixTheme()
-    def matrixName = matrix.matrixName
-    if (matrixName != null && !matrixName.isBlank()) {
-      title = matrix.matrixName
-    }
-    style.defaultSeriesRenderStyle = type
+  private HistogramChart(Matrix matrix, Integer width = null, Integer height = null) {
+    super(matrix, width, height, CategorySeries.CategorySeriesRenderStyle.Bar)
   }
 
+  /**
+   * Create a new histogram chart with optional dimensions.
+   *
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new HistogramChart instance
+   */
   static HistogramChart create(Matrix matrix, Integer width = null, Integer height = null) {
-    new HistogramChart(matrix, width, height, CategorySeries.CategorySeriesRenderStyle.Bar)
+    new HistogramChart(matrix, width, height)
   }
 
+  /**
+   * Create a new histogram chart with a title and optional dimensions.
+   *
+   * @param title the chart title
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new HistogramChart instance
+   */
+  static HistogramChart create(String title, Matrix matrix, Integer width = null, Integer height = null) {
+    def chart = new HistogramChart(matrix, width, height)
+    chart.title = title
+    chart
+  }
+
+  /**
+   * Add a histogram series using automatic bin count determined by Scott's rule.
+   *
+   * @param columnName the name of the numeric column to create the histogram from
+   * @return this chart for method chaining
+   */
   HistogramChart addSeries(String columnName) {
     Column c = matrix.column(columnName)
     List<Number> values = validatedValues(c)
     BigDecimal range = validateRange(values)
-    addSeries(c.name, values, bucketCount(range, scottsRule(values)), false)
+    addHistogramSeries(c.name, values, bucketCount(range, scottsRule(values)), false)
   }
 
+  /**
+   * Add a histogram series with a specified number of bins.
+   *
+   * @param columnName the name of the numeric column to create the histogram from
+   * @param numBuckets the number of bins to group the data into
+   * @return this chart for method chaining
+   */
   HistogramChart addSeries(String columnName, int numBuckets) {
     addSeries(matrix.column(columnName), numBuckets)
   }
 
+  /**
+   * Add a histogram series from a Column with a specified number of bins.
+   *
+   * @param column the Column containing numeric values
+   * @param numBuckets the number of bins to group the data into
+   * @return this chart for method chaining
+   */
   HistogramChart addSeries(Column column, int numBuckets) {
-    addSeries(column.name, validatedValues(column), numBuckets)
+    addHistogramSeries(column.name, validatedValues(column), numBuckets)
   }
 
-  private HistogramChart addSeries(String seriesName, List<Number> values, int numBuckets, boolean validateDataRange = true) {
+  private HistogramChart addHistogramSeries(String seriesName, List<Number> values, int numBuckets, boolean validateDataRange = true) {
     if (numBuckets <= 0) {
       throw new IllegalArgumentException("Histogram bucket count must be positive, got $numBuckets")
     }
@@ -78,11 +104,13 @@ class HistogramChart extends AbstractChart<HistogramChart, CategoryChart, Catego
   }
 
   /**
-   * Calculate the bin width using Scott's rule
+   * Calculate the bin width using Scott's rule.
    * The formula is:
    * <code>3.49 * s / n^(1/3)</code>
-   * where s is the standard deviation and n the number of data points
-   * @return the suggested number of bins as per the Scott's rule
+   * where s is the standard deviation and n the number of data points.
+   *
+   * @param data the data values to inspect
+   * @return the suggested bin width as per Scott's rule
    */
   static BigDecimal scottsRule(List data) {
     def s = Stat.sd(data)
@@ -129,11 +157,12 @@ class HistogramChart extends AbstractChart<HistogramChart, CategoryChart, Catego
   }
 
   /**
-   * Calculate the bin width using Freedman-Diaconis rule
+   * Calculate the bin width using Freedman-Diaconis rule.
    * The formula is:
    * <code>2 * IQR / n^(1/3)</code>
-   * where IQR is a measure of the spread of the data (1st quartile - 3:rd quartile)
+   * where IQR is a measure of the spread of the data (1st quartile - 3rd quartile)
    * and n is the number of data points.
+   *
    * @param data the data values to inspect
    * @return the suggested bin width as per the Freedman-Diaconis rule
    */

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/LineChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/LineChart.groovy
@@ -28,8 +28,31 @@ class LineChart extends AbstractXYChart<LineChart> {
     super(matrix, width, height, XYSeries.XYSeriesRenderStyle.Line)
   }
 
+  /**
+   * Create a new line chart with optional dimensions.
+   *
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new LineChart instance
+   */
   static LineChart create(Matrix matrix, Integer width = null, Integer height = null) {
-    return new LineChart(matrix, width, height)
+    new LineChart(matrix, width, height)
+  }
+
+  /**
+   * Create a new line chart with a title and optional dimensions.
+   *
+   * @param title the chart title
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new LineChart instance
+   */
+  static LineChart create(String title, Matrix matrix, Integer width = null, Integer height = null) {
+    def chart = new LineChart(matrix, width, height)
+    chart.title = title
+    chart
   }
 
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy
@@ -43,7 +43,6 @@ import se.alipsa.matrix.xchart.abstractions.AbstractChart
 class OhlcChart extends AbstractChart<OhlcChart, OHLCChart, OHLCStyler, OHLCSeries> {
 
   private OhlcChart(Matrix matrix, Integer width = null, Integer height = null) {
-    super.matrix = matrix
     def builder = new OHLCChartBuilder()
     if (width != null) {
       builder.width(width)
@@ -51,22 +50,63 @@ class OhlcChart extends AbstractChart<OhlcChart, OHLCChart, OHLCStyler, OHLCSeri
     if (height != null) {
       builder.height(height)
     }
-    xchart = builder.build()
-    style.theme = new MatrixTheme()
-    def matrixName = matrix.matrixName
-    if (matrixName != null && !matrixName.isBlank()) {
-      title = matrix.matrixName
-    }
+    initChart(builder.build(), matrix)
   }
 
-  static OhlcChart create(Matrix table, Integer width = null, Integer height = null) {
-    new OhlcChart(table, width, height)
+  /**
+   * Create a new OHLC chart with optional dimensions.
+   *
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new OhlcChart instance
+   */
+  static OhlcChart create(Matrix matrix, Integer width = null, Integer height = null) {
+    new OhlcChart(matrix, width, height)
   }
 
+  /**
+   * Create a new OHLC chart with a title and optional dimensions.
+   *
+   * @param title the chart title
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new OhlcChart instance
+   */
+  static OhlcChart create(String title, Matrix matrix, Integer width = null, Integer height = null) {
+    def chart = new OhlcChart(matrix, width, height)
+    chart.title = title
+    chart
+  }
+
+  /**
+   * Add an OHLC series using column names from the source Matrix.
+   *
+   * @param name the name for this series (displayed in legend)
+   * @param xData the name of the column containing date/time values
+   * @param open the name of the column containing opening prices
+   * @param high the name of the column containing high prices
+   * @param low the name of the column containing low prices
+   * @param close the name of the column containing closing prices
+   * @return this chart for method chaining
+   */
   OhlcChart addSeries(String name, String xData, String open, String high, String low, String close) {
     addSeries(name, matrix[xData] as List<Date>, matrix[open] as List<Number>, matrix[high] as List<Number>, matrix[low] as List<Number>, matrix[close] as List<Number>)
   }
 
+  /**
+   * Add an OHLC series using lists of values.
+   *
+   * @param name the name for this series (displayed in legend)
+   * @param xData the date/time values for the X-axis
+   * @param open the opening price values
+   * @param high the high price values
+   * @param low the low price values
+   * @param close the closing price values
+   * @return this chart for method chaining
+   * @throws IllegalArgumentException if any list is null or lists have unequal lengths
+   */
   OhlcChart addSeries(String name, List<Date> xData, List<Number> open, List<Number> high, List<Number> low, List<Number> close) {
     validateEqualLengths(xData, open, high, low, close)
     xchart.addSeries(name, xData, open, high, low, close)

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/PieChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/PieChart.groovy
@@ -29,8 +29,6 @@ import se.alipsa.matrix.xchart.abstractions.AbstractChart
 class PieChart extends AbstractChart<PieChart, org.knowm.xchart.PieChart, PieStyler, PieSeries> {
 
   private PieChart(Matrix matrix, Integer width = null, Integer height = null) {
-    super()
-    super.matrix = matrix
     PieChartBuilder builder = new PieChartBuilder()
     if (width != null) {
       builder.width(width)
@@ -38,18 +36,44 @@ class PieChart extends AbstractChart<PieChart, org.knowm.xchart.PieChart, PieSty
     if (height != null) {
       builder.height(height)
     }
-    xchart = builder.build()
-    getStyle().setTheme(new MatrixTheme())
-    def matrixName = matrix.matrixName
-    if (matrixName != null && !matrixName.isBlank()) {
-      title = matrix.matrixName
-    }
+    initChart(builder.build(), matrix)
   }
 
+  /**
+   * Create a new pie chart with optional dimensions.
+   *
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new PieChart instance
+   */
   static PieChart create(Matrix matrix, Integer width = null, Integer height = null) {
     new PieChart(matrix, width, height)
   }
 
+  /**
+   * Create a new pie chart with a title and optional dimensions.
+   *
+   * @param title the chart title
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new PieChart instance
+   */
+  static PieChart create(String title, Matrix matrix, Integer width = null, Integer height = null) {
+    def chart = new PieChart(matrix, width, height)
+    chart.title = title
+    chart
+  }
+
+  /**
+   * Create a new donut chart with default styling.
+   *
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new PieChart configured as a donut
+   */
   static PieChart createDonut(Matrix matrix, Integer width = null, Integer height = null) {
     def chart = new PieChart(matrix, width, height)
     chart.style.setDefaultSeriesRenderStyle(PieSeries.PieSeriesRenderStyle.Donut)
@@ -60,14 +84,50 @@ class PieChart extends AbstractChart<PieChart, org.knowm.xchart.PieChart, PieSty
     chart
   }
 
-  org.knowm.xchart.PieChart getXchart() {
-    return super.xchart as org.knowm.xchart.PieChart
+  /**
+   * Create a new donut chart with custom styling applied via a closure.
+   * The closure receives the {@link PieStyler} for additional configuration.
+   * <pre><code>
+   * def dc = PieChart.createDonut(matrix) { style ->
+   *     style.labelsDistance = 0.85
+   *     style.plotContentSize = 0.95
+   * }
+   * </code></pre>
+   *
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @param config a closure receiving the PieStyler for custom configuration
+   * @return a new PieChart configured as a donut with custom styling
+   */
+  static PieChart createDonut(Matrix matrix, Integer width = null, Integer height = null,
+                              @DelegatesTo(PieStyler) Closure config) {
+    def chart = createDonut(matrix, width, height)
+    config.delegate = chart.style
+    config.resolveStrategy = Closure.DELEGATE_FIRST
+    config.call(chart.style)
+    chart
   }
 
+  /**
+   * Add pie slices using column names from the source Matrix.
+   *
+   * @param xValueCol the name of the column containing slice labels
+   * @param yValueCol the name of the column containing slice values
+   * @return this chart for method chaining
+   */
   PieChart addSeries(String xValueCol, String yValueCol) {
     addSeries(matrix.column(xValueCol), matrix.column(yValueCol))
   }
 
+  /**
+   * Add pie slices using Column objects.
+   *
+   * @param xCol the column containing slice labels
+   * @param yCol the column containing slice values
+   * @return this chart for method chaining
+   * @throws IllegalArgumentException if xCol or yCol is null, or if they have different sizes
+   */
   PieChart addSeries(Column xCol, Column yCol) {
     if (xCol == null) {
       throw new IllegalArgumentException('The xCol is null, cannot add series')

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/RadarChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/RadarChart.groovy
@@ -29,10 +29,9 @@ import se.alipsa.matrix.xchart.abstractions.AbstractChart
  */
 class RadarChart extends AbstractChart<RadarChart, org.knowm.xchart.RadarChart, RadarStyler, RadarSeries> {
 
-  int numSeries = 0
+  private int numSeries = 0
 
   private RadarChart(Matrix matrix, Integer width = null, Integer height = null) {
-    super.matrix = matrix
     def builder = new RadarChartBuilder()
     if (width != null) {
       builder.width(width)
@@ -40,18 +39,44 @@ class RadarChart extends AbstractChart<RadarChart, org.knowm.xchart.RadarChart, 
     if (height != null) {
       builder.height(height)
     }
-    xchart = builder.build()
-    style.theme = new MatrixTheme()
-    def matrixName = matrix.matrixName
-    if (matrixName != null && !matrixName.isBlank()) {
-      title = matrix.matrixName
-    }
+    initChart(builder.build(), matrix)
   }
 
-  static RadarChart create(Matrix matrix,  Integer width = null, Integer height = null) {
+  /**
+   * Create a new radar chart with optional dimensions.
+   *
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new RadarChart instance
+   */
+  static RadarChart create(Matrix matrix, Integer width = null, Integer height = null) {
     new RadarChart(matrix, width, height)
   }
 
+  /**
+   * Create a new radar chart with a title and optional dimensions.
+   *
+   * @param title the chart title
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new RadarChart instance
+   */
+  static RadarChart create(String title, Matrix matrix, Integer width = null, Integer height = null) {
+    def chart = new RadarChart(matrix, width, height)
+    chart.title = title
+    chart
+  }
+
+  /**
+   * Add all rows of the Matrix as radar series, using the specified column for series labels.
+   * All other columns become radar axes (radii). Values should be normalized to [0, 1].
+   *
+   * @param seriesNameColumn the name of the column containing series labels (one series per row)
+   * @param transparency the fill alpha value (0 = fully transparent, 255 = fully opaque); defaults to 150
+   * @return this chart for method chaining
+   */
   RadarChart addSeries(String seriesNameColumn, Integer transparency = 150) {
     def labels = matrix.columnNames() - seriesNameColumn
     xchart.radiiLabels = labels as String[]

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/ScatterChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/ScatterChart.groovy
@@ -25,16 +25,44 @@ class ScatterChart extends AbstractXYChart<ScatterChart> {
     style.seriesMarkers = MatrixTheme.MARKERS as org.knowm.xchart.style.markers.Marker[]
   }
 
+  /**
+   * Create a new scatter chart with a title and optional dimensions.
+   *
+   * @param title the chart title
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new ScatterChart instance
+   */
   static ScatterChart create(String title, Matrix matrix, Integer width = null, Integer height = null) {
     def chart = new ScatterChart(matrix, width, height)
     chart.title = title
     chart
   }
 
+  /**
+   * Create a new scatter chart with optional dimensions.
+   *
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new ScatterChart instance
+   */
   static ScatterChart create(Matrix matrix, Integer width = null, Integer height = null) {
     new ScatterChart(matrix, width, height)
   }
 
+  /**
+   * Create a new scatter chart with a title, pre-configured with a single X/Y series.
+   *
+   * @param title the chart title
+   * @param matrix the source Matrix data
+   * @param xAxis the name of the column containing X values
+   * @param yAxis the name of the column containing Y values
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new ScatterChart instance with one series added
+   */
   static ScatterChart create(String title, Matrix matrix, String xAxis, String yAxis, Integer width = null, Integer height = null) {
     def chart = new ScatterChart(matrix, width, height)
     chart.title = title
@@ -42,6 +70,19 @@ class ScatterChart extends AbstractXYChart<ScatterChart> {
     chart
   }
 
+  /**
+   * Create a new scatter chart with a title, splitting data into multiple series by a grouping column.
+   * Each unique value in the series column becomes a separate scatter series.
+   *
+   * @param title the chart title
+   * @param matrix the source Matrix data
+   * @param xAxis the name of the column containing X values
+   * @param yAxis the name of the column containing Y values
+   * @param seriesCol the name of the column used to group data into separate series
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new ScatterChart instance with one series per unique value in seriesCol
+   */
   static ScatterChart create(String title, Matrix matrix, String xAxis, String yAxis, String seriesCol, Integer width = null, Integer height = null) {
     def chart = new ScatterChart(matrix, width, height)
     chart.title = title

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/ScatterChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/ScatterChart.groovy
@@ -6,7 +6,7 @@ import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.xchart.abstractions.AbstractXYChart
 
 /**
- * A ChatterChart uses dots to represent values for two different numeric variables.
+ * A ScatterChart uses dots to represent values for two different numeric variables.
  * The position of each dot on the horizontal and vertical axis indicates values for an individual data point.
  * Scatter charts are used to observe relationships between variables.
  * Sample usage:

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/StickChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/StickChart.groovy
@@ -30,8 +30,31 @@ class StickChart extends AbstractCategoryChart<StickChart> {
     super(matrix, width, height, CategorySeries.CategorySeriesRenderStyle.Stick)
   }
 
+  /**
+   * Create a new stick chart with optional dimensions.
+   *
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new StickChart instance
+   */
   static StickChart create(Matrix matrix, Integer width = null, Integer height = null) {
     new StickChart(matrix, width, height)
+  }
+
+  /**
+   * Create a new stick chart with a title and optional dimensions.
+   *
+   * @param title the chart title
+   * @param matrix the source Matrix data
+   * @param width optional chart width in pixels
+   * @param height optional chart height in pixels
+   * @return a new StickChart instance
+   */
+  static StickChart create(String title, Matrix matrix, Integer width = null, Integer height = null) {
+    def chart = new StickChart(matrix, width, height)
+    chart.title = title
+    chart
   }
 
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/AbstractCategoryChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/AbstractCategoryChart.groovy
@@ -7,7 +7,6 @@ import org.knowm.xchart.style.CategoryStyler
 
 import se.alipsa.matrix.core.Column
 import se.alipsa.matrix.core.Matrix
-import se.alipsa.matrix.xchart.MatrixTheme
 
 /**
  * Base class for category chart types (Bar, Stick, Histogram).
@@ -27,7 +26,6 @@ import se.alipsa.matrix.xchart.MatrixTheme
 class AbstractCategoryChart<T extends AbstractCategoryChart> extends AbstractChart<T, CategoryChart, CategoryStyler, CategorySeries> {
 
   AbstractCategoryChart(Matrix matrix, Integer width = null, Integer height = null, CategorySeries.CategorySeriesRenderStyle chartType) {
-    this.matrix = matrix
     CategoryChartBuilder builder = new CategoryChartBuilder()
     if (width != null) {
       builder.width = width
@@ -35,12 +33,7 @@ class AbstractCategoryChart<T extends AbstractCategoryChart> extends AbstractCha
     if (height != null) {
       builder.height = height
     }
-    xchart = builder.build()
-    style.theme = new MatrixTheme()
-    def matrixName = matrix.matrixName
-    if (matrixName != null && !matrixName.isBlank()) {
-      title = matrix.matrixName
-    }
+    initChart(builder.build(), matrix)
     style.defaultSeriesRenderStyle = chartType
   }
 
@@ -97,6 +90,22 @@ class AbstractCategoryChart<T extends AbstractCategoryChart> extends AbstractCha
     CategorySeries series = xchart.addSeries(name, xCol, yCol)
     if (renderStyle != null) {
       series.setChartCategorySeriesRenderStyle(renderStyle)
+    }
+    this as T
+  }
+
+  /**
+   * Add multiple Y-axis data series against a shared X-axis (category) column.
+   * Each Y column becomes a separate series named after the column.
+   *
+   * @param xCol the name of the column containing shared category (X-axis) values
+   * @param yCols the names of the columns containing numeric (Y-axis) values
+   * @param renderStyle optional render style override for all series (null to use chart default)
+   * @return this chart for method chaining
+   */
+  T addAllSeries(String xCol, List<String> yCols, CategorySeries.CategorySeriesRenderStyle renderStyle = null) {
+    yCols.each { String yCol ->
+      addSeries(xCol, yCol, renderStyle)
     }
     this as T
   }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/AbstractChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/AbstractChart.groovy
@@ -8,6 +8,7 @@ import org.knowm.xchart.internal.series.Series
 import org.knowm.xchart.style.Styler
 
 import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.xchart.MatrixTheme
 
 import java.awt.Color
 import java.lang.reflect.InvocationTargetException
@@ -49,6 +50,15 @@ abstract class AbstractChart<T extends AbstractChart, C extends Chart, ST extend
    */
   Matrix getMatrix() {
     return matrix
+  }
+
+  /**
+   * Get the chart title.
+   *
+   * @return the chart title text
+   */
+  String getTitle() {
+    xchart.title
   }
 
   /**
@@ -106,6 +116,24 @@ abstract class AbstractChart<T extends AbstractChart, C extends Chart, ST extend
    */
   void exportSvg(File file) {
     VectorGraphicsEncoder.saveVectorGraphic(xchart, file.absolutePath, VectorGraphicsEncoder.VectorGraphicsFormat.SVG)
+  }
+
+  /**
+   * Export the chart to a PDF document stream.
+   *
+   * @param os the output stream to write the PDF data to
+   */
+  void exportPdf(OutputStream os) {
+    VectorGraphicsEncoder.saveVectorGraphic(xchart, os, VectorGraphicsEncoder.VectorGraphicsFormat.PDF)
+  }
+
+  /**
+   * Export the chart to a PDF document file.
+   *
+   * @param file the file to write the PDF document to (will be created or overwritten)
+   */
+  void exportPdf(File file) {
+    VectorGraphicsEncoder.saveVectorGraphic(xchart, file.absolutePath, VectorGraphicsEncoder.VectorGraphicsFormat.PDF)
   }
 
   /**
@@ -190,6 +218,30 @@ abstract class AbstractChart<T extends AbstractChart, C extends Chart, ST extend
     xchart.YAxisTitle
   }
 
+  /**
+   * Initialize common chart properties: sets the matrix reference, XChart instance, theme, and title.
+   * Subclasses should call this after building the XChart instance.
+   *
+   * @param chart the XChart instance to wrap
+   * @param matrix the source Matrix data
+   */
+  protected void initChart(C chart, Matrix matrix) {
+    this.xchart = chart
+    this.matrix = matrix
+    style.theme = new MatrixTheme()
+    def matrixName = matrix.matrixName
+    if (matrixName != null && !matrixName.isBlank()) {
+      title = matrix.matrixName
+    }
+  }
+
+  /**
+   * Make the fill color of a series semi-transparent so overlapping areas remain visible.
+   *
+   * @param s the series whose fill color to adjust
+   * @param numSeries the zero-based index of this series, used to select the color from the theme palette
+   * @param transparency the alpha value (0 = fully transparent, 255 = fully opaque); defaults to 185
+   */
   void makeFillTransparent(Series s, int numSeries, Integer transparency = 185) {
     // Make the fill transparent so that overlaps are visible
     Color[] colors = style.theme.seriesColors

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/AbstractXYChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/AbstractXYChart.groovy
@@ -7,7 +7,6 @@ import org.knowm.xchart.style.XYStyler
 
 import se.alipsa.matrix.core.Column
 import se.alipsa.matrix.core.Matrix
-import se.alipsa.matrix.xchart.MatrixTheme
 
 /**
  * Base class for XY chart types (Line, Area, Scatter).
@@ -28,7 +27,6 @@ abstract class AbstractXYChart<T extends AbstractXYChart> extends AbstractChart<
 
   protected AbstractXYChart(Matrix matrix, Integer width = null, Integer height = null,
                             XYSeries.XYSeriesRenderStyle chartType) {
-    this.matrix = matrix
     XYChartBuilder builder = new XYChartBuilder()
     if (width != null) {
       builder.width = width
@@ -36,12 +34,7 @@ abstract class AbstractXYChart<T extends AbstractXYChart> extends AbstractChart<
     if (height != null) {
       builder.height = height
     }
-    xchart = builder.build()
-    style.theme = new MatrixTheme()
-    def matrixName = matrix.matrixName
-    if (matrixName != null && !matrixName.isBlank()) {
-      title = matrix.matrixName
-    }
+    initChart(builder.build(), matrix)
     style.defaultSeriesRenderStyle = chartType
   }
 
@@ -87,7 +80,7 @@ abstract class AbstractXYChart<T extends AbstractXYChart> extends AbstractChart<
 
   /**
    * Add a data series to the chart using Column objects.
-   * The series will be named using the X column name.
+   * The series will be named using the Y column name.
    *
    * @param xCol the column containing X values
    * @param yCol the column containing Y values
@@ -95,12 +88,12 @@ abstract class AbstractXYChart<T extends AbstractXYChart> extends AbstractChart<
    * @return this chart for method chaining
    */
   T addSeries(Column xCol, Column yCol, XYSeries.XYSeriesRenderStyle renderStyle = null) {
-    addSeries(xCol.name, xCol, yCol, renderStyle)
+    addSeries(yCol.name, xCol, yCol, renderStyle)
   }
 
   /**
    * Add a data series with error bars to the chart using Column objects.
-   * The series will be named using the X column name.
+   * The series will be named using the Y column name.
    *
    * @param xCol the column containing X values
    * @param yCol the column containing Y values
@@ -109,7 +102,7 @@ abstract class AbstractXYChart<T extends AbstractXYChart> extends AbstractChart<
    * @return this chart for method chaining
    */
   T addSeries(Column xCol, Column yCol, Column errorCol, XYSeries.XYSeriesRenderStyle renderStyle = null) {
-    addSeries(xCol.name, xCol, yCol, errorCol, renderStyle)
+    addSeries(yCol.name, xCol, yCol, errorCol, renderStyle)
   }
 
   /**
@@ -145,6 +138,22 @@ abstract class AbstractXYChart<T extends AbstractXYChart> extends AbstractChart<
     XYSeries xySeries = xchart.addSeries(name, xCol, yCol)
     if (renderStyle != null) {
       xySeries.setXYSeriesRenderStyle(renderStyle)
+    }
+    this as T
+  }
+
+  /**
+   * Add multiple Y-axis data series against a shared X-axis column.
+   * Each Y column becomes a separate series named after the column.
+   *
+   * @param xCol the name of the column containing shared X values
+   * @param yCols the names of the columns containing Y values
+   * @param renderStyle optional render style override for all series (null to use chart default)
+   * @return this chart for method chaining
+   */
+  T addAllSeries(String xCol, List<String> yCols, XYSeries.XYSeriesRenderStyle renderStyle = null) {
+    yCols.each { String yCol ->
+      addSeries(xCol, yCol, renderStyle)
     }
     this as T
   }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/MatrixXChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/MatrixXChart.groovy
@@ -45,6 +45,20 @@ interface MatrixXChart<C extends Chart> {
   void exportSvg(File file)
 
   /**
+   * Export the chart to a PDF document stream.
+   *
+   * @param os the output stream to write the PDF data to
+   */
+  void exportPdf(OutputStream os)
+
+  /**
+   * Export the chart to a PDF document file.
+   *
+   * @param file the file to write the PDF document to (will be created or overwritten)
+   */
+  void exportPdf(File file)
+
+  /**
    * Export the chart as a Swing component panel.
    * This creates a displayable panel that can be embedded in Swing applications.
    *

--- a/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/XyChartTest.groovy
+++ b/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/XyChartTest.groovy
@@ -161,7 +161,7 @@ class XyChartTest {
     ac.style.setPlotMargin(0)
     ac.style.setPlotContentSize(.95)
 
-    ac.series.ages.setMarker(SeriesMarkers.DIAMOND)
+    ac.series.liability.setMarker(SeriesMarkers.DIAMOND)
 
     File file = new File('build/testAreaAndLineCombo.svg')
     ac.exportSvg(file)


### PR DESCRIPTION
## Summary
- **8 bug fixes**: ScatterChart GroovyDoc typo, inconsistent default series naming (XY charts now use yCol.name like category charts), PieChart shadowing `getXchart()` method, HeatmapChart `numberArray` field shadowing, exposed `numSeries` fields made private, added missing `getTitle()` getter, added GroovyDoc to all undocumented public methods, fixed raw `List` types in method signatures
- **7 usability enhancements**: `exportPdf(File/OutputStream)` on all charts, `addAllSeries(xCol, yCols)` bulk methods on XY and category charts, `addAllSeries()` on BoxChart, extracted `initChart()` helper to eliminate ~12 lines of duplication from 10 chart classes, HistogramChart now extends AbstractCategoryChart, `create(String title, Matrix, ...)` factory methods on all 12 chart types, closure-based `createDonut` for PieChart

## Modules touched
- `matrix-xchart`

## Test plan
- [x] `./gradlew :matrix-xchart:codenarcMain` — passes
- [x] `./gradlew :matrix-xchart:codenarcTest` — passes
- [x] `./gradlew :matrix-xchart:spotlessCheck` — passes
- [x] `./gradlew :matrix-xchart:test -Pheadless=true` — 60/60 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)