### PR TITLE
fix: strip animation CSS in ChartToImage and simplify ChartToJpeg

### DIFF
--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToImage.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToImage.groovy
@@ -30,7 +30,7 @@ class ChartToImage {
     if (svgChart == null) {
       throw new IllegalArgumentException('svgChart must not be null')
     }
-    return SvgRenderer.toBufferedImage(svgChart)
+    return SvgRenderer.toBufferedImage(AnimationCssStripper.stripFromSvg(svgChart))
   }
 
   /**

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToJpeg.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToJpeg.groovy
@@ -50,12 +50,7 @@ class ChartToJpeg {
     if (targetFile == null) {
       throw new IllegalArgumentException('targetFile cannot be null')
     }
-    Svg rendered = chart.render()
-    if (!hasActiveAnimation(chart)) {
-      SvgRenderer.toJpeg(rendered, targetFile, [quality: quality])
-      return
-    }
-    SvgRenderer.toJpeg(stripAnimationCss(rendered), targetFile, [quality: quality])
+    SvgRenderer.toJpeg(stripAnimationCss(chart.render()), targetFile, [quality: quality])
   }
 
   /**
@@ -110,12 +105,7 @@ class ChartToJpeg {
     if (os == null) {
       throw new IllegalArgumentException('outputStream cannot be null')
     }
-    Svg rendered = chart.render()
-    if (!hasActiveAnimation(chart)) {
-      SvgRenderer.toJpeg(rendered, os, [quality: quality])
-      return
-    }
-    SvgRenderer.toJpeg(stripAnimationCss(rendered), os, [quality: quality])
+    SvgRenderer.toJpeg(stripAnimationCss(chart.render()), os, [quality: quality])
   }
 
   /**
@@ -139,14 +129,6 @@ class ChartToJpeg {
 
   private static Svg stripAnimationCss(Svg svgChart) {
     AnimationCssStripper.stripFromSvg(svgChart)
-  }
-
-  private static String stripAnimationCss(String svgXml) {
-    AnimationCssStripper.stripFromXml(svgXml)
-  }
-
-  private static boolean hasActiveAnimation(CharmChart chart) {
-    chart.animation?.isActive() ?: false
   }
 
 }

--- a/matrix-charts/src/test/groovy/charm/render/AnimationTest.groovy
+++ b/matrix-charts/src/test/groovy/charm/render/AnimationTest.groovy
@@ -1,6 +1,7 @@
 package charm.render
 
 import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertSame
 import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.junit.jupiter.api.Assertions.assertTrue
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test
 import se.alipsa.groovy.svg.io.SvgWriter
 import se.alipsa.matrix.charm.CharmRenderException
 import se.alipsa.matrix.chartexport.AnimationCssStripper
+import se.alipsa.matrix.chartexport.ChartToImage
 import se.alipsa.matrix.chartexport.ChartToJpeg
 import se.alipsa.matrix.chartexport.ChartToPng
 import se.alipsa.matrix.core.Matrix
@@ -72,6 +74,10 @@ class AnimationTest {
       ChartToJpeg.export(chart, jpeg)
       assertTrue(png.exists() && png.length() > 0)
       assertTrue(jpeg.exists() && jpeg.length() > 0)
+
+      def img = ChartToImage.export(chart)
+      assertNotNull(img)
+      assertTrue(img.width > 0 && img.height > 0)
     } finally {
       png.delete()
       jpeg.delete()

--- a/matrix-charts/src/test/groovy/charm/render/AnimationTest.groovy
+++ b/matrix-charts/src/test/groovy/charm/render/AnimationTest.groovy
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test
 
 import se.alipsa.groovy.svg.io.SvgWriter
 import se.alipsa.matrix.charm.CharmRenderException
+import se.alipsa.matrix.chartexport.AnimationCssStripper
 import se.alipsa.matrix.chartexport.ChartToJpeg
 import se.alipsa.matrix.chartexport.ChartToPng
 import se.alipsa.matrix.core.Matrix
@@ -104,12 +105,12 @@ class AnimationTest {
 </svg>'''
 
     String pngSanitized = invokeStrip(ChartToPng, svg)
-    String jpegSanitized = invokeStrip(ChartToJpeg, svg)
+    String stripperSanitized = AnimationCssStripper.stripFromXml(svg)
 
     assertFalse(pngSanitized.contains('charm-animation'))
-    assertFalse(jpegSanitized.contains('charm-animation'))
+    assertFalse(stripperSanitized.contains('charm-animation'))
     assertTrue(pngSanitized.contains('<circle'))
-    assertTrue(jpegSanitized.contains('<circle'))
+    assertTrue(stripperSanitized.contains('<circle'))
   }
 
   @Test
@@ -117,10 +118,10 @@ class AnimationTest {
     String svg = '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><circle cx="5" cy="5" r="3"/></svg>'
 
     String pngSanitized = invokeStrip(ChartToPng, svg)
-    String jpegSanitized = invokeStrip(ChartToJpeg, svg)
+    String stripperSanitized = AnimationCssStripper.stripFromXml(svg)
 
     assertSame(svg, pngSanitized)
-    assertSame(svg, jpegSanitized)
+    assertSame(svg, stripperSanitized)
   }
 
   private static Matrix sampleData() {


### PR DESCRIPTION
## Summary
- **ChartToImage**: `export(Svg)` now strips animation CSS via `AnimationCssStripper` before rendering to `BufferedImage`, matching `ChartToPng` behaviour (plan issue #2)
- **ChartToJpeg**: Always strip animation CSS unconditionally — removed `hasActiveAnimation()` check and dead `stripAnimationCss(String)` overload (plan issue #7)
- **AnimationTest**: Updated to call `AnimationCssStripper.stripFromXml()` directly instead of reflective access to the removed private method

## Test plan
- [x] All 674 matrix-charts tests pass (`-Pheadless=true`)
- [x] CodeNarc and Spotless checks pass
- [x] Verify raster exports (PNG, JPEG, BufferedImage) of animated charts produce valid images without animation artefacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)