### PR TITLE
refactor: migrate tests from deprecated Plot to current export API

### DIFF
--- a/matrix-charts/src/test/groovy/PngTest.groovy
+++ b/matrix-charts/src/test/groovy/PngTest.groovy
@@ -1,26 +1,16 @@
 import static org.junit.jupiter.api.Assertions.*
 import static se.alipsa.matrix.core.ListConverter.*
 
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 
+import se.alipsa.matrix.chartexport.ChartToImage
+import se.alipsa.matrix.chartexport.ChartToPng
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.pict.*
 
 import java.time.LocalDate
 
 class PngTest {
-
-    @BeforeAll
-    static void init() {
-        if ('true' == System.getProperty('headless')) {
-            println('Enable monocle for headless testing')
-            System.setProperty('testfx.robot', 'glass')
-            System.setProperty('testfx.headless', 'true')
-            System.setProperty('prism.order', 'sw')
-            System.setProperty('prism.text', 't2k')
-        }
-    }
 
     def empData = Matrix.builder().data(
             emp_id: 1..5,
@@ -35,26 +25,19 @@ class PngTest {
         def file = File.createTempFile('barchart', '.png')
         BarChart chart = BarChart.createVertical('Salaries', empData, 'emp_name', ChartType.BASIC, 'salary')
         try {
-            Plot.png(chart, file, 600, 400)
-            //println("Wrote $file")
+            ChartToPng.export(chart, file)
             assertTrue(file.exists())
+        } finally {
             file.delete()
-        } catch (UnsatisfiedLinkError | NoClassDefFoundError e) {
-            println "No graphics environment available: $e, skipping test"
         }
     }
 
     @Test
     void testBarchartToBase64() {
         BarChart chart = BarChart.createVertical('Salaries', empData, 'emp_name', ChartType.BASIC, 'salary')
-        try {
-            def base64 = Plot.base64(chart, 600, 400)
-            // println(base64)
-            assertNotNull(base64)
-            assertTrue(base64.startsWith('data:image/png;base64,'))
-        } catch (UnsatisfiedLinkError | NoClassDefFoundError e) {
-            println "No graphics environment available: $e, skipping test"
-        }
+        def base64 = ChartToImage.base64(chart)
+        assertNotNull(base64)
+        assertTrue(base64.startsWith('data:image/png;base64,'))
     }
 
     @Test
@@ -62,12 +45,10 @@ class PngTest {
         def file = File.createTempFile('areaChart', '.png')
         AreaChart chart = AreaChart.create('Salaries', empData, 'emp_name', 'salary')
         try {
-            Plot.png(chart, file, 1024, 768)
-            //println("Wrote $file")
+            ChartToPng.export(chart, file)
             assertTrue(file.exists())
+        } finally {
             file.delete()
-        } catch (UnsatisfiedLinkError | NoClassDefFoundError e) {
-            println "No graphics environment available: $e, skipping test"
         }
     }
 

--- a/matrix-charts/src/test/groovy/chart/BoxChartTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/BoxChartTest.groovy
@@ -5,9 +5,10 @@ import static org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
 
+import se.alipsa.matrix.chartexport.ChartToJfx
+import se.alipsa.matrix.chartexport.ChartToPng
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.pict.BoxChart
-import se.alipsa.matrix.pict.Plot
 
 class BoxChartTest {
 
@@ -56,7 +57,7 @@ class BoxChartTest {
     ]).types([String, int]).build()
 
     def chart = BoxChart.create('JFX Box Chart', data, 'group', 'value')
-    def jfxNode = Plot.jfx(chart)
+    def jfxNode = ChartToJfx.export(chart)
     assertNotNull(jfxNode)
     assertTrue(jfxNode instanceof javafx.scene.Node, "Expected javafx.scene.Node but got ${jfxNode.getClass().name}")
   }
@@ -74,10 +75,13 @@ class BoxChartTest {
 
     def chart = BoxChart.create('PNG Box Chart', data, 'group', 'value')
     File file = File.createTempFile('BoxChart', '.png')
-    Plot.png(chart, file)
-    assertTrue(file.exists(), 'PNG file should exist')
-    assertTrue(file.length() > 0, 'PNG file should not be empty')
-    file.delete()
+    try {
+      ChartToPng.export(chart, file)
+      assertTrue(file.exists(), 'PNG file should exist')
+      assertTrue(file.length() > 0, 'PNG file should not be empty')
+    } finally {
+      file.delete()
+    }
   }
 
 }

--- a/matrix-charts/src/test/groovy/chart/LineChartTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/LineChartTest.groovy
@@ -4,9 +4,9 @@ import static org.junit.jupiter.api.Assertions.*
 
 import org.junit.jupiter.api.Test
 
+import se.alipsa.matrix.chartexport.ChartToPng
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.pict.LineChart
-import se.alipsa.matrix.pict.Plot
 
 import java.time.YearMonth
 
@@ -28,7 +28,6 @@ class LineChartTest {
     def salesData = Matrix.builder().matrixName('Salesdata').columns(
         [
             yearMonth: [202301, 202302, 202303, 202304, 202305, 202306, 202307, 202308, 202309, 202310, 202311, 202312],
-            // yearMonth: [1,2,3,4,5,6,7,8,9,10,11,12],
             sales    : [23, 14, 15, 24, 34, 36, 22, 45, 43, 17, 29, 25]
         ])
     .types([YearMonth, int])
@@ -40,10 +39,12 @@ class LineChartTest {
     assertEquals(12, chart.categorySeries.size(), 'Number of elements in x')
     assertEquals(12, chart.valueSeries[0].size(), 'Number of elements in y')
     File file = File.createTempFile('JfxLineChart', '.png')
-    Plot.png(chart, file)
-    //println("Wrote ${file.getAbsolutePath()}")
-    assertTrue(file.exists())
-    file.delete()
+    try {
+      ChartToPng.export(chart, file)
+      assertTrue(file.exists())
+    } finally {
+      file.delete()
+    }
   }
 
 }

--- a/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
 
+import se.alipsa.matrix.chartexport.ChartToImage
+import se.alipsa.matrix.chartexport.ChartToJfx
+import se.alipsa.matrix.chartexport.ChartToPng
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.pict.AreaChart
 import se.alipsa.matrix.pict.BarChart
@@ -12,12 +15,11 @@ import se.alipsa.matrix.pict.ChartType
 import se.alipsa.matrix.pict.Histogram
 import se.alipsa.matrix.pict.LineChart
 import se.alipsa.matrix.pict.PieChart
-import se.alipsa.matrix.pict.Plot
 import se.alipsa.matrix.pict.ScatterChart
 
 /**
- * Compatibility tests verifying that {@link Plot} methods produce valid
- * output for each chart type after the Charm rewiring.
+ * Tests verifying that legacy chart types produce valid export output
+ * through the current export API (ChartToPng, ChartToImage, ChartToJfx).
  */
 class PlotCompatibilityTest {
 
@@ -40,7 +42,7 @@ class PlotCompatibilityTest {
     AreaChart chart = AreaChart.create('Area PNG', data, 'category', 'value')
     File file = File.createTempFile('AreaChart', '.png')
     try {
-      Plot.png(chart, file)
+      ChartToPng.export(chart, file)
       assertTrue(file.exists(), 'PNG file should exist')
       assertTrue(file.length() > 100, 'PNG file should have content')
       assertPngHeader(file)
@@ -55,7 +57,7 @@ class PlotCompatibilityTest {
     BarChart chart = BarChart.createVertical('Bar PNG', data, 'category', ChartType.BASIC, 'value')
     File file = File.createTempFile('BarChart', '.png')
     try {
-      Plot.png(chart, file)
+      ChartToPng.export(chart, file)
       assertTrue(file.exists(), 'PNG file should exist')
       assertTrue(file.length() > 100, 'PNG file should have content')
       assertPngHeader(file)
@@ -77,7 +79,7 @@ class PlotCompatibilityTest {
     LineChart chart = LineChart.create('Line PNG', data, 'x', 'y')
     File file = File.createTempFile('LineChart', '.png')
     try {
-      Plot.png(chart, file)
+      ChartToPng.export(chart, file)
       assertTrue(file.exists(), 'PNG file should exist')
       assertTrue(file.length() > 100, 'PNG file should have content')
       assertPngHeader(file)
@@ -92,7 +94,7 @@ class PlotCompatibilityTest {
     PieChart chart = PieChart.create('Pie PNG', data, 'category', 'value')
     File file = File.createTempFile('PieChart', '.png')
     try {
-      Plot.png(chart, file)
+      ChartToPng.export(chart, file)
       assertTrue(file.exists(), 'PNG file should exist')
       assertTrue(file.length() > 100, 'PNG file should have content')
       assertPngHeader(file)
@@ -114,7 +116,7 @@ class PlotCompatibilityTest {
     ScatterChart chart = ScatterChart.create('Scatter PNG', data, 'x', 'y')
     File file = File.createTempFile('ScatterChart', '.png')
     try {
-      Plot.png(chart, file)
+      ChartToPng.export(chart, file)
       assertTrue(file.exists(), 'PNG file should exist')
       assertTrue(file.length() > 100, 'PNG file should have content')
       assertPngHeader(file)
@@ -133,7 +135,7 @@ class PlotCompatibilityTest {
     Histogram chart = Histogram.create('Hist PNG', data, 'score', 4)
     File file = File.createTempFile('Histogram', '.png')
     try {
-      Plot.png(chart, file)
+      ChartToPng.export(chart, file)
       assertTrue(file.exists(), 'PNG file should exist')
       assertTrue(file.length() > 100, 'PNG file should have content')
       assertPngHeader(file)
@@ -147,7 +149,7 @@ class PlotCompatibilityTest {
     Matrix data = sampleData()
     BarChart chart = BarChart.createVertical('Bar OS', data, 'category', ChartType.BASIC, 'value')
     ByteArrayOutputStream baos = new ByteArrayOutputStream()
-    Plot.png(chart, baos)
+    ChartToPng.export(chart, baos)
     byte[] bytes = baos.toByteArray()
     assertTrue(bytes.length > 100, 'PNG output should have content')
     for (int i = 0; i < PNG_HEADER.length; i++) {
@@ -159,7 +161,7 @@ class PlotCompatibilityTest {
   void testBase64ReturnsValidDataUri() {
     Matrix data = sampleData()
     PieChart chart = PieChart.create('Pie Base64', data, 'category', 'value')
-    String uri = Plot.base64(chart)
+    String uri = ChartToImage.base64(chart)
     assertTrue(uri.startsWith('data:image/png;base64,'), 'Should start with data URI prefix')
     String base64Part = uri.substring('data:image/png;base64,'.length())
     byte[] decoded = Base64.decoder.decode(base64Part)
@@ -177,8 +179,8 @@ class PlotCompatibilityTest {
     )
     Matrix data = sampleData()
     ScatterChart chart = ScatterChart.create('JFX Test', data, 'category', 'value')
-    javafx.scene.Node node = Plot.jfx(chart)
-    assertNotNull(node, 'jfx() should return a non-null Node')
+    javafx.scene.Node node = ChartToJfx.export(chart)
+    assertNotNull(node, 'export() should return a non-null Node')
     assertTrue(node instanceof javafx.scene.Node, 'Result should be a javafx.scene.Node')
   }
 


### PR DESCRIPTION
## Summary
- **PngTest**: `Plot.png()` → `ChartToPng.export()`, `Plot.base64()` → `ChartToImage.base64()`
- **LineChartTest**: `Plot.png()` → `ChartToPng.export()`
- **BoxChartTest**: `Plot.png()` → `ChartToPng.export()`, `Plot.jfx()` → `ChartToJfx.export()`
- **PlotCompatibilityTest**: `Plot.png()` → `ChartToPng.export()`, `Plot.base64()` → `ChartToImage.base64()`, `Plot.jfx()` → `ChartToJfx.export()`

After this change, the deprecated `Plot` class has zero test references and can be removed in a future release.

## Test plan
- [x] All 694 matrix-charts tests pass (`-Pheadless=true`)
- [x] CodeNarc and Spotless checks pass
- [x] `grep -rn 'import.*\.Plot\b' src/test/` returns zero hits for the deprecated class

🤖 Generated with [Claude Code](https://claude.com/claude-code)