### PR TITLE
feat: + operator composition for PlotSpec

### DIFF
--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/PlotSpec.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/PlotSpec.groovy
@@ -260,6 +260,71 @@ class PlotSpec {
     this
   }
 
+  // ---- Operator composition (ggplot2-style + chaining) ----
+
+  /**
+   * Adds a layer via the {@code +} operator.
+   *
+   * @param builder configured layer builder
+   * @return this plot spec
+   */
+  PlotSpec plus(se.alipsa.matrix.charm.geom.LayerBuilder builder) {
+    addLayer(builder)
+  }
+
+  /**
+   * Merges a theme via the {@code +} operator.
+   *
+   * @param other theme to merge
+   * @return this plot spec
+   */
+  PlotSpec plus(Theme other) {
+    if (other == null) {
+      return this
+    }
+    Theme merged = theme.plus(other)
+    merged.properties.each { key, val ->
+      String k = key as String
+      if (k != 'class' && theme.hasProperty(k)) {
+        theme.setProperty(k, val)
+      }
+    }
+    this
+  }
+
+  /**
+   * Replaces labels via the {@code +} operator.
+   *
+   * @param other labels to apply
+   * @return this plot spec
+   */
+  PlotSpec plus(LabelsSpec other) {
+    if (other == null) {
+      return this
+    }
+    if (other.title != null) { labels.title = other.title }
+    if (other.subtitle != null) { labels.subtitle = other.subtitle }
+    if (other.caption != null) { labels.caption = other.caption }
+    if (other.x != null) { labels.x = other.x }
+    if (other.y != null) { labels.y = other.y }
+    this
+  }
+
+  /**
+   * Applies a coord spec via the {@code +} operator.
+   *
+   * @param other coord to apply
+   * @return this plot spec
+   */
+  PlotSpec plus(CoordSpec other) {
+    if (other == null) {
+      return this
+    }
+    coord.type = other.type
+    other.params.each { String k, Object v -> coord.params[k] = v }
+    this
+  }
+
   /**
    * Configures scales using closure syntax.
    *

--- a/matrix-charts/src/test/groovy/charm/api/DslErgonomicsTest.groovy
+++ b/matrix-charts/src/test/groovy/charm/api/DslErgonomicsTest.groovy
@@ -5,13 +5,19 @@ import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static se.alipsa.matrix.charm.Charts.plot
+import static se.alipsa.matrix.charm.geom.Geoms.geomLine
+import static se.alipsa.matrix.charm.geom.Geoms.geomPoint
 
 import org.junit.jupiter.api.Test
 
 import se.alipsa.matrix.charm.CharmCoordType
+import se.alipsa.matrix.charm.CharmGeomType
 import se.alipsa.matrix.charm.CharmValidationException
 import se.alipsa.matrix.charm.Chart
+import se.alipsa.matrix.charm.CoordSpec
+import se.alipsa.matrix.charm.LabelsSpec
 import se.alipsa.matrix.charm.PlotSpec
+import se.alipsa.matrix.charm.theme.CharmThemes
 import se.alipsa.matrix.datasets.Dataset
 
 class DslErgonomicsTest {
@@ -102,6 +108,84 @@ class DslErgonomicsTest {
     Chart chart = spec.build()
     assertNotNull(chart.cssAttributes)
     assertEquals(false, chart.cssAttributes.enabled)
+  }
+
+  // ---- Phase 7: + operator composition ----
+
+  @Test
+  void testPlusLayerBuilder() {
+    PlotSpec spec = plot(Dataset.mpg()) {
+      mapping { x = 'cty'; y = 'hwy' }
+    }
+    spec = spec + geomPoint().size(3)
+    Chart chart = spec.build()
+    assertEquals(1, chart.layers.size())
+    assertEquals(CharmGeomType.POINT, chart.layers[0].geomType)
+  }
+
+  @Test
+  void testPlusMultipleLayers() {
+    PlotSpec spec = plot(Dataset.mpg()) {
+      mapping { x = 'cty'; y = 'hwy' }
+    }
+    spec = spec + geomPoint() + geomLine()
+    Chart chart = spec.build()
+    assertEquals(2, chart.layers.size())
+    assertEquals(CharmGeomType.POINT, chart.layers[0].geomType)
+    assertEquals(CharmGeomType.LINE, chart.layers[1].geomType)
+  }
+
+  @Test
+  void testPlusTheme() {
+    PlotSpec spec = plot(Dataset.mpg()) {
+      mapping { x = 'cty'; y = 'hwy' }
+      layers { geomPoint() }
+    }
+    spec = spec + CharmThemes.dark()
+    Chart chart = spec.build()
+    assertNotNull(chart.theme)
+    assertEquals('dark', chart.theme.themeName)
+  }
+
+  @Test
+  void testPlusLabels() {
+    PlotSpec spec = plot(Dataset.mpg()) {
+      mapping { x = 'cty'; y = 'hwy' }
+      layers { geomPoint() }
+    }
+    LabelsSpec lbl = new LabelsSpec()
+    lbl.title = 'MPG Plot'
+    lbl.x = 'City'
+    lbl.y = 'Highway'
+    spec = spec + lbl
+    Chart chart = spec.build()
+    assertEquals('MPG Plot', chart.labels.title)
+    assertEquals('City', chart.labels.x)
+    assertEquals('Highway', chart.labels.y)
+  }
+
+  @Test
+  void testPlusCoordSpec() {
+    PlotSpec spec = plot(Dataset.mpg()) {
+      mapping { x = 'cty'; y = 'hwy' }
+      layers { geomPoint() }
+    }
+    CoordSpec flip = new CoordSpec()
+    flip.type = CharmCoordType.FLIP
+    spec = spec + flip
+    Chart chart = spec.build()
+    assertEquals(CharmCoordType.FLIP, chart.coord.type)
+  }
+
+  @Test
+  void testPlusChainCombination() {
+    PlotSpec spec = plot(Dataset.mpg()) {
+      mapping { x = 'cty'; y = 'hwy' }
+    }
+    spec = spec + geomPoint().size(2) + CharmThemes.minimal()
+    Chart chart = spec.build()
+    assertEquals(1, chart.layers.size())
+    assertEquals('minimal', chart.theme.themeName)
   }
 
 }


### PR DESCRIPTION
## Summary
- **`PlotSpec plus(LayerBuilder)`** — adds a layer: `plot(data) + geomPoint().size(3)`
- **`PlotSpec plus(Theme)`** — deep-merges theme via `Theme.plus()`: `spec + CharmThemes.dark()`
- **`PlotSpec plus(LabelsSpec)`** — applies non-null label fields
- **`PlotSpec plus(CoordSpec)`** — applies coord type and params

Enables ggplot2-style `+` chaining: `Charts.plot(data) + geomPoint() + CharmThemes.minimal()`

Phase 7 of `matrix-charts/req/0.5.0-plan.md`.

## Test plan
- [x] `+ geomPoint()` adds a single layer with correct geom type
- [x] `+ geomPoint() + geomLine()` chains multiple layers in order
- [x] `+ CharmThemes.dark()` deep-merges theme (verifies themeName)
- [x] `+ LabelsSpec` applies title, x, y labels
- [x] `+ CoordSpec(FLIP)` applies coord type
- [x] Combined chain `+ geomPoint() + CharmThemes.minimal()` works end-to-end
- [x] All 707 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)