### PR TITLE
fix: remove null-returning LineChart stub and add builder validation

### DIFF
--- a/matrix-charts/req/0.5.0-r2-plan.md
+++ b/matrix-charts/req/0.5.0-r2-plan.md
@@ -1,0 +1,324 @@
+# matrix-charts 0.5.0 Review Round 2 — Issues & Enhancements
+
+Findings from a full review of the matrix-charts module. Organized by priority
+and grouped into implementable phases. Each phase is one PR.
+
+---
+
+## Phase 1 — Bug Fixes
+
+Critical correctness issues that could cause runtime failures.
+
+### 1.1 [x] Remove or implement `LineChart.create(LinearRegression)` stub
+
+**File:** `matrix-charts/src/main/groovy/se/alipsa/matrix/pict/LineChart.groovy:11-13`
+
+```groovy
+@SuppressWarnings('UnusedMethodParameter')
+static LineChart create(LinearRegression model) {
+    null
+}
+```
+
+This stub silently returns `null`, guaranteeing an NPE for any caller. The
+`@SuppressWarnings('UnusedMethodParameter')` confirms it's a known placeholder.
+
+**Action:** Remove the method entirely. If regression-line charting from a
+`LinearRegression` model is desired, file a separate issue and implement it
+properly — a null-returning factory method is never acceptable.
+
+**Test:** Verify `LineChart` still compiles and all existing `LineChart` tests
+pass after removal.
+
+### 1.2 [x] Add input validation to legacy chart builder `build()` methods
+
+**Files:**
+- `BarChart.Builder.build()` — `matrix-charts/src/main/groovy/se/alipsa/matrix/pict/BarChart.groovy:127`
+- `LineChart.Builder.build()` — `LineChart.groovy:59`
+- `ScatterChart.Builder.build()` — `ScatterChart.groovy:47`
+- `AreaChart.Builder.build()` — `AreaChart.groovy:69`
+- `PieChart.Builder.build()` — `PieChart.groovy:54`
+- `BoxChart.Builder.build()` — `BoxChart.groovy:87`
+
+Most subclass `build()` methods will NPE if `x()` was never called (e.g.
+`data.column(xCol)` where `xCol` is `null`). Only `BubbleChart.Builder`
+validates its inputs.
+
+**Action:** Add validation at the start of each `build()`:
+```groovy
+if (xCol == null) {
+    throw new IllegalStateException('x(...) must be called before build()')
+}
+if (yCols == null || yCols.isEmpty()) {
+    throw new IllegalStateException('y(...) must be called before build()')
+}
+```
+
+Adapt per chart type (e.g. `Histogram` only needs `xCol`, `BoxChart` with
+`columns()` mode doesn't need `xCol`).
+
+**Test:** Add a test per chart type verifying a clear error on missing x/y.
+
+---
+
+## Phase 2 — Dead Code Removal
+
+### 2.1 [ ] Delete `InitializationException`
+
+**File:** `matrix-charts/src/main/groovy/se/alipsa/matrix/pict/InitializationException.groovy`
+
+Not referenced anywhere in the codebase — not in production code, not in tests,
+not in other modules. Pure dead code.
+
+**Action:** Delete the file.
+
+**Test:** `./gradlew :matrix-charts:build` — confirm no compilation errors.
+
+---
+
+## Phase 3 — Type Safety: Replace `Object` Parameters
+
+Addresses the AGENTS.md "Avoid Object Parameters" rule on `Scale`.
+
+### 3.1 [ ] Replace `Scale.setTransform(Object)` with typed overloads
+
+**File:** `matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Scale.groovy:145`
+
+Current: `void setTransform(Object transform)`
+
+**Note:** `Scale.setTransformStrategy(ScaleTransform)` already exists at line
+170 and accepts a `ScaleTransform` to set the same backing field. The proposed
+`setTransform(ScaleTransform)` overload would overlap with it. The
+implementation should reconcile these — e.g. `setTransform(ScaleTransform)` can
+delegate to `setTransformStrategy()`, or `setTransformStrategy` can be
+deprecated.
+
+**Action:** Replace with:
+```groovy
+void setTransform(String transformName) { ... }
+void setTransform(ScaleTransform transform) { ... }
+```
+
+Internal callers that pass `Object` should be updated to call the appropriate
+overload. `ScaleTransforms.resolve(Object)` at `ScaleTransforms.groovy:230`
+should also get typed overloads since `setTransform` delegates to it.
+
+### 3.2 [ ] Replace `Scale.manual(Object)` with typed overloads
+
+**File:** `Scale.groovy:241`
+
+Current: `static Scale manual(Object values)`
+
+**Action:** Replace with:
+```groovy
+static Scale manual(Map<String, String> namedValues) { ... }
+static Scale manual(List<String> values) { ... }
+```
+
+### 3.3 [ ] Replace `Scale.guide(Object)` with typed overloads
+
+**File:** `Scale.groovy:498`
+
+Current: `Scale guide(Object value)`
+
+**Action:** Replace with:
+```groovy
+Scale guide(GuideSpec value) { ... }
+Scale guide(GuideType value) { ... }
+Scale guide(String value) { ... }
+Scale guide(boolean value) { ... }  // false -> NONE
+```
+
+### 3.4 [ ] Replace `ScaleDsl.manual(Object)` with typed overloads
+
+**File:** `PlotSpec.groovy:867`
+
+Current: `Scale manual(Object values)` — delegates to `Scale.manual(Object)`.
+
+**Action:** Match the overloads added to `Scale` in 3.2.
+
+**Test:** Existing scale tests should continue to pass. Add a test verifying
+each typed overload compiles and works.
+
+### 3.5 [ ] Replace `Object` parameters in `Coord` and `CoordSpec`
+
+Per AGENTS.md "Avoid Object Parameters", these should be replaced with typed
+overloads:
+
+**Files:**
+- `Coord.setType(Object)` — `matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Coord.groovy:27`
+- `CoordSpec.type(Object)` — `matrix-charts/src/main/groovy/se/alipsa/matrix/charm/CoordSpec.groovy:14`
+- `CoordSpec.setRatio(Object)` — `CoordSpec.groovy:54`
+- `CoordSpec.setStart(Object)` — `CoordSpec.groovy:80`
+
+**Action:** Replace each `Object` parameter with typed overloads using the
+concrete types actually passed by callers (e.g. `CoordType` enum, `String`,
+`Number`).
+
+**Test:** Existing coord tests should continue to pass. Add tests verifying
+each typed overload compiles and works.
+
+---
+
+## Phase 4 — Usability: Convenience Methods on `PlotSpec` and `Chart`
+
+### 4.1 [ ] Add `PlotSpec.render()` convenience method
+
+**File:** `matrix-charts/src/main/groovy/se/alipsa/matrix/charm/PlotSpec.groovy`
+
+Users must currently call `plot(...).build().render()` — two steps. A shortcut
+that calls `build().render()` internally would be more ergonomic.
+
+**Action:** Add:
+```groovy
+Svg render() {
+    build().render()
+}
+
+Svg render(int width, int height) {
+    build().render(width, height)
+}
+```
+
+**Before:**
+```groovy
+Charts.plot(data) { mapping { x = 'a'; y = 'b' }; layers { geomPoint() } }.build().render()
+```
+
+**After:**
+```groovy
+Charts.plot(data) { mapping { x = 'a'; y = 'b' }; layers { geomPoint() } }.render()
+```
+
+### 4.2 [ ] Add `PlotSpec.writeTo()` convenience methods
+
+**File:** `PlotSpec.groovy`
+
+Same ergonomic improvement for file output.
+
+**Action:** Add:
+```groovy
+void writeTo(String targetPath) {
+    build().writeTo(targetPath)
+}
+
+void writeTo(File targetFile) {
+    build().writeTo(targetFile)
+}
+```
+
+### 4.3 [ ] Add `Chart.writeTo(File, int, int)` overload with dimensions
+
+**File:** `matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Chart.groovy`
+
+`writeTo(File)` always renders at default 800x600. Users wanting a different
+size must manually render and write.
+
+**Action:** Add:
+```groovy
+void writeTo(File targetFile, int width, int height) {
+    if (targetFile == null) {
+        throw new IllegalArgumentException('targetFile cannot be null')
+    }
+    switch (ExportFormat.fromFile(targetFile)) {
+        case ExportFormat.PNG -> ChartToPng.export(render(width, height), targetFile)
+        case ExportFormat.JPEG -> ChartToJpeg.export(render(width, height), targetFile)
+        default -> targetFile.text = SvgWriter.toXmlPretty(render(width, height))
+    }
+}
+
+void writeTo(String targetPath, int width, int height) {
+    writeTo(new File(targetPath), width, height)
+}
+```
+
+**Test:** Add tests verifying writeTo with custom dimensions produces output
+files of the expected dimensions.
+
+---
+
+## Phase 5 — Legacy API Fixes
+
+Lower priority since the pict API is deprecated, but still affects users of the
+builder API (which is not itself deprecated).
+
+### 5.1 [ ] Handle `ChartType.GROUPED` in `CharmBridge`
+
+**File:** `matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy:87`
+
+`BarChart` accepts `ChartType.BASIC`, `STACKED`, and presumably `GROUPED`, but
+`CharmBridge.buildBarSpec` currently uses `chart.stacked` (a boolean shorthand
+for `chartType == STACKED`) to decide positioning. This replaces the boolean
+check with a direct switch on `chart.chartType` to support all chart types.
+
+**Action:** Replace the `chart.stacked` boolean check with a switch on
+`chart.chartType`:
+```groovy
+PositionSpec position = switch (chart.chartType) {
+    case ChartType.STACKED -> PositionSpec.of(CharmPositionType.STACK)
+    case ChartType.GROUPED -> PositionSpec.of(CharmPositionType.DODGE)
+    default -> PositionSpec.of(CharmPositionType.IDENTITY)
+}
+```
+
+This works because `BarChart.chartType` is accessible (protected field with
+getter). The switch replaces the `chart.stacked` boolean check, not augments it.
+
+**Test:** Verify `ChartType` actually has a `GROUPED` value. If not, skip this
+item. If yes, add a test rendering a grouped bar chart through the bridge.
+
+### 5.2 [ ] Deprecate legacy chart factory methods in favor of builders
+
+**Files:** All pict chart classes (`BarChart`, `LineChart`, `ScatterChart`,
+`AreaChart`, `PieChart`, `BoxChart`, `Histogram`, `BubbleChart`)
+
+The static `create(...)` factory methods use positional parameters and explicit
+`return` statements. The builder pattern is already in place and is cleaner.
+
+**Action:** Add `@Deprecated` to all `create(...)` methods with a GroovyDoc
+pointer to the builder.
+
+This is a documentation-only change — no code removal.
+
+---
+
+## Phase 6 — Naming / API Clarity (Discussion Items)
+
+These are longer-term suggestions that may warrant discussion before acting on.
+
+### 6.1 [ ] Consider renaming `charm.Chart` or `pict.Chart` to resolve name collision
+
+Every export class uses `import se.alipsa.matrix.charm.Chart as CharmChart` to
+disambiguate. Users writing import-heavy code face the same confusion. Options:
+
+- Rename `pict.Chart` to `pict.LegacyChart` (breaking change for deprecated API)
+- Rename `charm.Chart` to `charm.CharmChart` (breaking change for new API)
+- Accept the status quo since `Charts.chart()` alias already exists for the
+  common DSL entry point
+
+**Action:** Discuss and decide. If the pict API is removed in a future major
+version, this resolves itself.
+
+### 6.2 [ ] Consider adding PDF export format
+
+`ExportFormat` currently supports PNG, JPEG, and SVG. PDF output would be
+valuable for reports and dashboards. This would require an additional dependency
+(e.g. Apache Batik or Flying Saucer).
+
+**Action:** Evaluate dependency weight and add if feasible.
+
+---
+
+## Verification
+
+After each phase, run:
+```bash
+./gradlew :matrix-charts:codenarcMain
+./gradlew :matrix-charts:spotlessCheck
+./gradlew :matrix-charts:test -Pheadless=true
+```
+
+Before final merge, run the full suite:
+```bash
+./gradlew test
+```

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/AreaChart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/AreaChart.groovy
@@ -67,6 +67,12 @@ class AreaChart extends Chart<AreaChart> {
      * @return the area chart
      */
     AreaChart build() {
+      if (xCol == null) {
+        throw new IllegalStateException('x(...) must be called before build()')
+      }
+      if (yCols == null || yCols.isEmpty()) {
+        throw new IllegalStateException('y(...) must be called before build()')
+      }
       AreaChart chart = new AreaChart()
       applyTo(chart)
       chart.categorySeries = data.column(xCol) as List<?>

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/BarChart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/BarChart.groovy
@@ -125,6 +125,12 @@ class BarChart extends Chart<BarChart> {
      * @return the bar chart
      */
     BarChart build() {
+      if (xCol == null) {
+        throw new IllegalStateException('x(...) must be called before build()')
+      }
+      if (yCols == null || yCols.isEmpty()) {
+        throw new IllegalStateException('y(...) must be called before build()')
+      }
       BarChart chart = new BarChart()
       applyTo(chart)
       chart.chartType = chartType

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/BoxChart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/BoxChart.groovy
@@ -85,6 +85,14 @@ class BoxChart extends Chart<BoxChart> {
      * @return the box chart
      */
     BoxChart build() {
+      if (!columnNames) {
+        if (xCol == null) {
+          throw new IllegalStateException('x(...) or columns(...) must be called before build()')
+        }
+        if (yCols == null || yCols.isEmpty()) {
+          throw new IllegalStateException('y(...) or columns(...) must be called before build()')
+        }
+      }
       String chartTitle = this.@title
       BoxChart chart
       if (columnNames) {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
@@ -136,6 +136,9 @@ class Histogram extends Chart<Histogram> {
      * @return the histogram
      */
     Histogram build() {
+      if (xCol == null) {
+        throw new IllegalStateException('x(...) must be called before build()')
+      }
       Histogram chart = Histogram.create(this.@title, data, xCol, bins, binDecimals)
       applyTo(chart)
       chart

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/LineChart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/LineChart.groovy
@@ -1,16 +1,10 @@
 package se.alipsa.matrix.pict
 
 import se.alipsa.matrix.core.Matrix
-import se.alipsa.matrix.stats.regression.LinearRegression
 
 /** Line chart for visualizing data trends over a continuous axis. */
 @SuppressWarnings('UnnecessaryObjectReferences')
 class LineChart extends Chart<LineChart> {
-
-  @SuppressWarnings('UnusedMethodParameter')
-  static LineChart create(LinearRegression model) {
-    null
-  }
 
   static LineChart create(Matrix data, String xAxis, String... valueColumns) {
     create(data.matrixName, data, xAxis, valueColumns)
@@ -57,6 +51,12 @@ class LineChart extends Chart<LineChart> {
      * @return the line chart
      */
     LineChart build() {
+      if (xCol == null) {
+        throw new IllegalStateException('x(...) must be called before build()')
+      }
+      if (yCols == null || yCols.isEmpty()) {
+        throw new IllegalStateException('y(...) must be called before build()')
+      }
       LineChart chart = new LineChart()
       applyTo(chart)
       chart.categorySeries = data.column(xCol) as List<?>

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/PieChart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/PieChart.groovy
@@ -52,6 +52,12 @@ class PieChart extends Chart<PieChart> {
      * @return the pie chart
      */
     PieChart build() {
+      if (xCol == null) {
+        throw new IllegalStateException('x(...) must be called before build()')
+      }
+      if (yCols == null || yCols.isEmpty()) {
+        throw new IllegalStateException('y(...) must be called before build()')
+      }
       PieChart chart = new PieChart()
       applyTo(chart)
       chart.categorySeries = data.column(xCol) as List<?>

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/ScatterChart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/ScatterChart.groovy
@@ -45,6 +45,12 @@ class ScatterChart extends Chart<ScatterChart> {
      * @return the scatter chart
      */
     ScatterChart build() {
+      if (xCol == null) {
+        throw new IllegalStateException('x(...) must be called before build()')
+      }
+      if (yCols == null || yCols.isEmpty()) {
+        throw new IllegalStateException('y(...) must be called before build()')
+      }
       ScatterChart chart = new ScatterChart()
       applyTo(chart)
       chart.categorySeries = data.column(xCol) as List<?>

--- a/matrix-charts/src/test/groovy/chart/ChartBuilderTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/ChartBuilderTest.groovy
@@ -394,6 +394,105 @@ class ChartBuilderTest {
   }
 
   @Test
+  void testBuilderValidationMissingX() {
+    def data = Matrix.builder()
+        .columnNames(['x', 'y'])
+        .rows([[1, 10], [2, 20]])
+        .types([int, int])
+        .build()
+
+    def ex = assertThrows(IllegalStateException) {
+      AreaChart.builder(data).y('y').build()
+    }
+    assertTrue(ex.message.contains('x(...)'))
+
+    ex = assertThrows(IllegalStateException) {
+      BarChart.builder(data).y('y').build()
+    }
+    assertTrue(ex.message.contains('x(...)'))
+
+    ex = assertThrows(IllegalStateException) {
+      LineChart.builder(data).y('y').build()
+    }
+    assertTrue(ex.message.contains('x(...)'))
+
+    ex = assertThrows(IllegalStateException) {
+      ScatterChart.builder(data).y('y').build()
+    }
+    assertTrue(ex.message.contains('x(...)'))
+
+    ex = assertThrows(IllegalStateException) {
+      PieChart.builder(data).y('y').build()
+    }
+    assertTrue(ex.message.contains('x(...)'))
+
+    ex = assertThrows(IllegalStateException) {
+      Histogram.builder(data).build()
+    }
+    assertTrue(ex.message.contains('x(...)'))
+  }
+
+  @Test
+  void testBuilderValidationMissingY() {
+    def data = Matrix.builder()
+        .columnNames(['x', 'y'])
+        .rows([[1, 10], [2, 20]])
+        .types([int, int])
+        .build()
+
+    def ex = assertThrows(IllegalStateException) {
+      AreaChart.builder(data).x('x').build()
+    }
+    assertTrue(ex.message.contains('y(...)'))
+
+    ex = assertThrows(IllegalStateException) {
+      BarChart.builder(data).x('x').build()
+    }
+    assertTrue(ex.message.contains('y(...)'))
+
+    ex = assertThrows(IllegalStateException) {
+      LineChart.builder(data).x('x').build()
+    }
+    assertTrue(ex.message.contains('y(...)'))
+
+    ex = assertThrows(IllegalStateException) {
+      ScatterChart.builder(data).x('x').build()
+    }
+    assertTrue(ex.message.contains('y(...)'))
+
+    ex = assertThrows(IllegalStateException) {
+      PieChart.builder(data).x('x').build()
+    }
+    assertTrue(ex.message.contains('y(...)'))
+  }
+
+  @Test
+  void testBoxChartBuilderValidationMissingXAndColumns() {
+    def data = Matrix.builder()
+        .columnNames(['dept', 'salary'])
+        .rows([['HR', 50000], ['IT', 70000]])
+        .types([String, int])
+        .build()
+
+    def ex = assertThrows(IllegalStateException) {
+      BoxChart.builder(data).y('salary').build()
+    }
+    assertTrue(ex.message.contains('x(...)') || ex.message.contains('columns(...)'))
+
+    ex = assertThrows(IllegalStateException) {
+      BoxChart.builder(data).x('dept').build()
+    }
+    assertTrue(ex.message.contains('y(...)') || ex.message.contains('columns(...)'))
+
+    // columns() mode should work without x/y
+    def chart = BoxChart.builder(data)
+        .title('Test')
+        .columns(['dept', 'salary'])
+        .build()
+    assertNotNull(chart)
+  }
+
+  @Test
   void testBuilderFluentStyleMethods() {
     def data = Matrix.builder()
         .columnNames(['x', 'y'])


### PR DESCRIPTION
## Summary
- Removed `LineChart.create(LinearRegression)` stub that silently returned `null`, guaranteeing NPE for any caller
- Added input validation to all 7 legacy chart builder `build()` methods (`BarChart`, `LineChart`, `ScatterChart`, `AreaChart`, `PieChart`, `BoxChart`, `Histogram`) — missing `x()`/`y()` calls now throw a clear `IllegalStateException` instead of NPE
- `BoxChart` validates contextually: requires `x()`+`y()` OR `columns()`, not both
- `Histogram` only requires `x()` (no y-axis needed)
- `BubbleChart` already had validation — unchanged
- Added the `0.5.0-r2-plan.md` review plan document (Phase 1 of 6)

## Modules touched
- `matrix-charts`

## Test plan
- [x] `./gradlew :matrix-charts:codenarcMain` — clean
- [x] `./gradlew :matrix-charts:spotlessCheck` — clean
- [x] `./gradlew :matrix-charts:test -Pheadless=true` — 710 tests passed
- [x] 3 new test methods in `ChartBuilderTest`: `testBuilderValidationMissingX`, `testBuilderValidationMissingY`, `testBoxChartBuilderValidationMissingXAndColumns`

🤖 Generated with [Claude Code](https://claude.com/claude-code)