### PR TITLE
[codex] Replace chart scale and coord object overloads

### DIFF
--- a/matrix-charts/req/0.5.0-r2-plan.md
+++ b/matrix-charts/req/0.5.0-r2-plan.md
@@ -84,7 +84,7 @@ not in other modules. Pure dead code.
 
 Addresses the AGENTS.md "Avoid Object Parameters" rule on `Scale`.
 
-### 3.1 [ ] Replace `Scale.setTransform(Object)` with typed overloads
+### 3.1 [x] Replace `Scale.setTransform(Object)` with typed overloads
 
 **File:** `matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Scale.groovy:145`
 
@@ -107,7 +107,7 @@ Internal callers that pass `Object` should be updated to call the appropriate
 overload. `ScaleTransforms.resolve(Object)` at `ScaleTransforms.groovy:230`
 should also get typed overloads since `setTransform` delegates to it.
 
-### 3.2 [ ] Replace `Scale.manual(Object)` with typed overloads
+### 3.2 [x] Replace `Scale.manual(Object)` with typed overloads
 
 **File:** `Scale.groovy:241`
 
@@ -119,7 +119,7 @@ static Scale manual(Map<String, String> namedValues) { ... }
 static Scale manual(List<String> values) { ... }
 ```
 
-### 3.3 [ ] Replace `Scale.guide(Object)` with typed overloads
+### 3.3 [x] Replace `Scale.guide(Object)` with typed overloads
 
 **File:** `Scale.groovy:498`
 
@@ -133,7 +133,7 @@ Scale guide(String value) { ... }
 Scale guide(boolean value) { ... }  // false -> NONE
 ```
 
-### 3.4 [ ] Replace `ScaleDsl.manual(Object)` with typed overloads
+### 3.4 [x] Replace `ScaleDsl.manual(Object)` with typed overloads
 
 **File:** `PlotSpec.groovy:867`
 
@@ -141,10 +141,13 @@ Current: `Scale manual(Object values)` — delegates to `Scale.manual(Object)`.
 
 **Action:** Match the overloads added to `Scale` in 3.2.
 
-**Test:** Existing scale tests should continue to pass. Add a test verifying
-each typed overload compiles and works.
+**Test:** Passed:
+- `./gradlew :matrix-charts:test --tests "charm.core.CharmTypedOverloadApiTest"`
+- `./gradlew :matrix-charts:codenarcMain`
+- `./gradlew :matrix-charts:spotlessCheck`
+- `./gradlew :matrix-charts:test`
 
-### 3.5 [ ] Replace `Object` parameters in `Coord` and `CoordSpec`
+### 3.5 [x] Replace `Object` parameters in `Coord` and `CoordSpec`
 
 Per AGENTS.md "Avoid Object Parameters", these should be replaced with typed
 overloads:
@@ -159,8 +162,11 @@ overloads:
 concrete types actually passed by callers (e.g. `CoordType` enum, `String`,
 `Number`).
 
-**Test:** Existing coord tests should continue to pass. Add tests verifying
-each typed overload compiles and works.
+**Test:** Passed:
+- `./gradlew :matrix-charts:test --tests "charm.core.CharmTypedOverloadApiTest"`
+- `./gradlew :matrix-charts:codenarcMain`
+- `./gradlew :matrix-charts:spotlessCheck`
+- `./gradlew :matrix-charts:test`
 
 ---
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Coord.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Coord.groovy
@@ -22,33 +22,48 @@ class Coord {
   /**
    * Sets coordinate system type.
    *
-   * @param value CharmCoordType or string value
+   * @param value coord type value
    */
-  void setType(Object value) {
+  void setType(CharmCoordType value) {
     if (value == null) {
       type = CharmCoordType.CARTESIAN
       return
     }
-    if (value instanceof CharmCoordType) {
-      type = value as CharmCoordType
+    type = value
+  }
+
+  /**
+   * Sets coordinate system type.
+   *
+   * @param value coord type name
+   */
+  void setType(String value) {
+    if (value == null) {
+      type = CharmCoordType.CARTESIAN
       return
     }
-    if (value instanceof CharSequence) {
-      switch (value.toString().trim().toLowerCase(Locale.ROOT)) {
-        case 'cartesian' -> type = CharmCoordType.CARTESIAN
-        case 'polar' -> type = CharmCoordType.POLAR
-        case 'flip' -> type = CharmCoordType.FLIP
-        case 'fixed' -> type = CharmCoordType.FIXED
-        case 'trans' -> type = CharmCoordType.TRANS
-        case 'radial' -> type = CharmCoordType.RADIAL
-        case 'map' -> type = CharmCoordType.MAP
-        case 'quickmap' -> type = CharmCoordType.QUICKMAP
-        case 'sf' -> type = CharmCoordType.SF
-        default -> throw new CharmValidationException("Unsupported coord type '${value}'")
-      }
-      return
+    switch (value.trim().toLowerCase(Locale.ROOT)) {
+      case 'cartesian' -> type = CharmCoordType.CARTESIAN
+      case 'polar' -> type = CharmCoordType.POLAR
+      case 'flip' -> type = CharmCoordType.FLIP
+      case 'fixed' -> type = CharmCoordType.FIXED
+      case 'trans' -> type = CharmCoordType.TRANS
+      case 'radial' -> type = CharmCoordType.RADIAL
+      case 'map' -> type = CharmCoordType.MAP
+      case 'quickmap' -> type = CharmCoordType.QUICKMAP
+      case 'sf' -> type = CharmCoordType.SF
+      default -> throw new CharmValidationException("Unsupported coord type '${value}'")
     }
-    throw new CharmValidationException("Unsupported coord type input '${value.getClass().name}'")
+  }
+
+  /**
+   * Resets coordinate system type to cartesian.
+   *
+   * @param value null coord type value
+   */
+  @SuppressWarnings('UnusedMethodParameter')
+  void setType(Void value) {
+    type = CharmCoordType.CARTESIAN
   }
 
   /**

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/CoordSpec.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/CoordSpec.groovy
@@ -11,7 +11,30 @@ class CoordSpec extends Coord {
    * @param value coord type value
    * @return this spec
    */
-  CoordSpec type(Object value) {
+  CoordSpec type(CharmCoordType value) {
+    setType(value)
+    this
+  }
+
+  /**
+   * Builder-style coordinate type setter.
+   *
+   * @param value coord type name
+   * @return this spec
+   */
+  CoordSpec type(String value) {
+    setType(value)
+    this
+  }
+
+  /**
+   * Builder-style coordinate type reset.
+   *
+   * @param value null coord type value
+   * @return this spec
+   */
+  @SuppressWarnings('UnusedMethodParameter')
+  CoordSpec type(Void value) {
     setType(value)
     this
   }
@@ -51,8 +74,8 @@ class CoordSpec extends Coord {
     params.ratio as BigDecimal
   }
 
-  void setRatio(Object value) {
-    params.ratio = value
+  void setRatio(Number value) {
+    params.ratio = value == null ? null : value as BigDecimal
   }
 
   /**
@@ -77,8 +100,8 @@ class CoordSpec extends Coord {
     params.start as BigDecimal
   }
 
-  void setStart(Object value) {
-    params.start = value
+  void setStart(Number value) {
+    params.start = value == null ? null : value as BigDecimal
   }
 
   /**

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/PlotSpec.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/PlotSpec.groovy
@@ -859,12 +859,22 @@ class PlotSpec {
     }
 
     /**
-     * Creates a manual color scale from a list of colors or a named map.
+     * Creates a manual color scale from a named map.
      *
-     * @param values color list or named map (e.g. {@code ['below': '#e74c3c', 'above': '#2ecc71']})
+     * @param namedValues named color map (e.g. {@code ['below': '#e74c3c', 'above': '#2ecc71']})
      * @return scale object
      */
-    Scale manual(Object values) {
+    Scale manual(Map<String, String> namedValues) {
+      Scale.manual(namedValues)
+    }
+
+    /**
+     * Creates a manual color scale from a list of colors.
+     *
+     * @param values color list
+     * @return scale object
+     */
+    Scale manual(List<String> values) {
       Scale.manual(values)
     }
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Scale.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Scale.groovy
@@ -137,13 +137,8 @@ class Scale {
     transformStrategy?.id()
   }
 
-  /**
-   * Sets transform name.
-   *
-   * @param transform transform name
-   */
-  void setTransform(Object transform) {
-    this.transformStrategy = ScaleTransforms.resolve(transform)
+  private void applyTransformStrategy(ScaleTransform transform) {
+    this.transformStrategy = transform
     if (this.transformStrategy == null) {
       if (type == ScaleType.TRANSFORM) {
         type = ScaleType.CONTINUOUS
@@ -151,6 +146,34 @@ class Scale {
       return
     }
     type = ScaleType.TRANSFORM
+  }
+
+  /**
+   * Sets transform name.
+   *
+   * @param transformName transform name
+   */
+  void setTransform(String transformName) {
+    applyTransformStrategy(ScaleTransforms.resolve(transformName))
+  }
+
+  /**
+   * Sets transform strategy object.
+   *
+   * @param transform transform strategy object
+   */
+  void setTransform(ScaleTransform transform) {
+    applyTransformStrategy(ScaleTransforms.resolve(transform))
+  }
+
+  /**
+   * Clears transform strategy.
+   *
+   * @param transform null transform value
+   */
+  @SuppressWarnings('UnusedMethodParameter')
+  void setTransform(Void transform) {
+    applyTransformStrategy(null)
   }
 
   /**
@@ -168,14 +191,7 @@ class Scale {
    * @param transformStrategy strategy object
    */
   void setTransformStrategy(ScaleTransform transformStrategy) {
-    this.transformStrategy = transformStrategy
-    if (transformStrategy == null) {
-      if (type == ScaleType.TRANSFORM) {
-        type = ScaleType.CONTINUOUS
-      }
-      return
-    }
-    type = ScaleType.TRANSFORM
+    applyTransformStrategy(transformStrategy)
   }
 
   /**
@@ -235,17 +251,26 @@ class Scale {
   /**
    * Creates a manual color scale.
    *
-   * @param values color list or named map
+   * @param namedValues named color map
    * @return scale instance
    */
-  static Scale manual(Object values) {
+  static Scale manual(Map<String, String> namedValues) {
     Scale s = new Scale(type: ScaleType.DISCRETE)
     s.params['colorType'] = 'manual'
-    if (values instanceof Map) {
-      s.params['namedValues'] = values
-    } else if (values instanceof List) {
-      s.params['values'] = values
-    }
+    s.params['namedValues'] = namedValues == null ? [:] : new LinkedHashMap<String, String>(namedValues)
+    s
+  }
+
+  /**
+   * Creates a manual color scale.
+   *
+   * @param values color list
+   * @return scale instance
+   */
+  static Scale manual(List<String> values) {
+    Scale s = new Scale(type: ScaleType.DISCRETE)
+    s.params['colorType'] = 'manual'
+    s.params['values'] = values == null ? [] : new ArrayList<String>(values)
     s
   }
 
@@ -492,11 +517,58 @@ class Scale {
    * (for example {@code 'legend'} or {@code 'colorbar'}), or {@code false} for
    * {@link GuideType#NONE}. Passing {@code null} removes any attached guide.</p>
    *
-   * @param value guide value
+   * @param value guide spec
    * @return this scale
    */
-  Scale guide(Object value) {
-    GuideSpec guideSpec = GuideUtils.coerceGuide(value, 'scale')
+  Scale guide(GuideSpec value) {
+    setGuideSpec(value?.copy())
+  }
+
+  /**
+   * Attaches a guide configuration to this scale.
+   *
+   * @param value guide type
+   * @return this scale
+   */
+  Scale guide(GuideType value) {
+    setGuideSpec(value == null ? null : new GuideSpec(value))
+  }
+
+  /**
+   * Attaches a guide configuration to this scale.
+   *
+   * @param value guide type name
+   * @return this scale
+   */
+  Scale guide(String value) {
+    setGuideSpec(GuideUtils.coerceGuide(value, 'scale'))
+  }
+
+  /**
+   * Attaches a guide configuration to this scale.
+   *
+   * @param value false suppresses guide rendering
+   * @return this scale
+   */
+  Scale guide(boolean value) {
+    if (value) {
+      throw new CharmValidationException('Cannot set scale guide to true — use a GuideSpec, GuideType, or guide type name')
+    }
+    setGuideSpec(GuideSpec.none())
+  }
+
+  /**
+   * Removes any attached guide configuration.
+   *
+   * @param value null guide value
+   * @return this scale
+   */
+  @SuppressWarnings('UnusedMethodParameter')
+  Scale guide(Void value) {
+    setGuideSpec(null)
+  }
+
+  private Scale setGuideSpec(GuideSpec guideSpec) {
     if (guideSpec == null) {
       params.remove('guide')
     } else {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/ScaleTransform.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/ScaleTransform.groovy
@@ -209,7 +209,6 @@ class CustomScaleTransform extends BaseScaleTransform {
 /**
  * Registry and factory methods for transform strategies.
  */
-@SuppressWarnings('Instanceof')
 class ScaleTransforms {
 
   private static final Map<String, ScaleTransform> BUILTIN = [
@@ -222,22 +221,34 @@ class ScaleTransforms {
   ]
 
   /**
-   * Resolves a transform from object input.
+   * Resolves a transform from a transform id.
    *
-   * @param value transform instance or transform id
+   * @param value transform id
    * @return transform strategy
    */
-  static ScaleTransform resolve(Object value) {
-    if (value == null) {
-      return null
-    }
-    if (value instanceof ScaleTransform) {
-      return value as ScaleTransform
-    }
-    if (value instanceof CharSequence) {
-      return named(value.toString())
-    }
-    throw new CharmValidationException("Unsupported transform input: ${value.getClass().name}")
+  static ScaleTransform resolve(String value) {
+    value == null ? null : named(value)
+  }
+
+  /**
+   * Resolves a transform strategy.
+   *
+   * @param value transform strategy
+   * @return transform strategy
+   */
+  static ScaleTransform resolve(ScaleTransform value) {
+    value
+  }
+
+  /**
+   * Resolves a null transform value.
+   *
+   * @param value null transform value
+   * @return null
+   */
+  @SuppressWarnings('UnusedMethodParameter')
+  static ScaleTransform resolve(Void value) {
+    null
   }
 
   /**

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/coord/TransCoord.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/coord/TransCoord.groovy
@@ -1,5 +1,6 @@
 package se.alipsa.matrix.charm.render.coord
 
+import se.alipsa.matrix.charm.CharmValidationException
 import se.alipsa.matrix.charm.CoordSpec
 import se.alipsa.matrix.charm.ScaleTransform
 import se.alipsa.matrix.charm.ScaleTransforms
@@ -10,6 +11,7 @@ import se.alipsa.matrix.core.ValueConverter
 /**
  * Coordinate transform applying named transforms to x/y.
  */
+@SuppressWarnings('Instanceof')
 class TransCoord {
 
   static List<LayerData> compute(CoordSpec coordSpec, List<LayerData> data) {
@@ -48,8 +50,14 @@ class TransCoord {
       return null
     }
     try {
-      ScaleTransforms.resolve(value)
-    } catch (Exception ignored) {
+      if (value instanceof ScaleTransform) {
+        return ScaleTransforms.resolve(value as ScaleTransform)
+      }
+      if (value instanceof CharSequence) {
+        return ScaleTransforms.resolve(value.toString())
+      }
+      null
+    } catch (CharmValidationException ignored) {
       null
     }
   }

--- a/matrix-charts/src/test/groovy/charm/core/CharmTypedOverloadApiTest.groovy
+++ b/matrix-charts/src/test/groovy/charm/core/CharmTypedOverloadApiTest.groovy
@@ -1,0 +1,108 @@
+package charm.core
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+import org.junit.jupiter.api.Test
+
+import se.alipsa.matrix.charm.CharmCoordType
+import se.alipsa.matrix.charm.Coord
+import se.alipsa.matrix.charm.CoordSpec
+import se.alipsa.matrix.charm.GuideSpec
+import se.alipsa.matrix.charm.GuideType
+import se.alipsa.matrix.charm.ReverseScaleTransform
+import se.alipsa.matrix.charm.Scale
+import se.alipsa.matrix.charm.ScaleTransform
+import se.alipsa.matrix.charm.ScaleTransforms
+import se.alipsa.matrix.charm.ScaleType
+
+/**
+ * Verifies callers can use typed scale and coord overloads.
+ */
+class CharmTypedOverloadApiTest {
+
+  @Test
+  void testScaleTransformTypedOverloads() {
+    Scale scale = Scale.continuous()
+    scale.transform = 'log10'
+
+    assertEquals(ScaleType.TRANSFORM, scale.type)
+    assertEquals('log10', scale.transform)
+
+    ScaleTransform reverse = new ReverseScaleTransform()
+    scale.transform = reverse
+
+    assertEquals(ScaleType.TRANSFORM, scale.type)
+    assertEquals('reverse', scale.transform)
+
+    scale.transform = (Void) null
+
+    assertEquals(ScaleType.CONTINUOUS, scale.type)
+    assertNull(scale.transformStrategy)
+    assertEquals('sqrt', ScaleTransforms.resolve('sqrt').id())
+    assertEquals(reverse, ScaleTransforms.resolve(reverse))
+    assertNull(ScaleTransforms.resolve((Void) null))
+  }
+
+  @Test
+  void testManualScaleTypedOverloads() {
+    Map<String, String> namedValues = [A: '#ff0000', B: '#00ff00']
+    List<String> values = ['#ff0000', '#00ff00']
+
+    Scale named = Scale.manual(namedValues)
+    Scale ordered = Scale.manual(values)
+
+    assertEquals('manual', named.params['colorType'])
+    assertEquals(namedValues, named.params['namedValues'])
+    assertFalse(named.params.containsKey('values'))
+
+    assertEquals('manual', ordered.params['colorType'])
+    assertEquals(values, ordered.params['values'])
+    assertFalse(ordered.params.containsKey('namedValues'))
+  }
+
+  @Test
+  void testScaleGuideTypedOverloads() {
+    GuideSpec legend = GuideSpec.legend([title: 'Class'])
+    Scale bySpec = Scale.continuous().guide(legend)
+    Scale byType = Scale.continuous().guide(GuideType.COLORBAR)
+    Scale byString = Scale.continuous().guide('none')
+    Scale byBoolean = Scale.continuous().guide(false)
+
+    assertEquals(GuideType.LEGEND, (bySpec.params['guide'] as GuideSpec).type)
+    assertEquals('Class', ((bySpec.params['guide'] as GuideSpec).params['title']))
+    assertEquals(GuideType.COLORBAR, (byType.params['guide'] as GuideSpec).type)
+    assertEquals(GuideType.NONE, (byString.params['guide'] as GuideSpec).type)
+    assertEquals(GuideType.NONE, (byBoolean.params['guide'] as GuideSpec).type)
+
+    bySpec.guide((Void) null)
+    assertFalse(bySpec.params.containsKey('guide'))
+  }
+
+  @Test
+  void testCoordTypedOverloads() {
+    Coord coord = new Coord()
+    coord.type = CharmCoordType.POLAR
+    assertEquals(CharmCoordType.POLAR, coord.type)
+
+    coord.type = 'flip'
+    assertEquals(CharmCoordType.FLIP, coord.type)
+
+    coord.setType((Void) null)
+    assertEquals(CharmCoordType.CARTESIAN, coord.type)
+
+    CoordSpec spec = new CoordSpec()
+        .type(CharmCoordType.FIXED)
+        .type('polar')
+        .type((Void) null)
+    spec.ratio = 1.5
+    spec.start = 0
+
+    assertEquals(CharmCoordType.CARTESIAN, spec.type)
+    assertEquals(0, spec.ratio.compareTo(1.5 as BigDecimal))
+    assertEquals(0, spec.start.compareTo(0 as BigDecimal))
+  }
+
+}


### PR DESCRIPTION
## Summary

Implement phase 3 of the matrix-charts 0.5.0 review round 2 plan by replacing targeted `Object` parameters with typed overloads.

This updates `Scale`, `ScaleTransforms`, `ScaleDsl`, `Coord`, and `CoordSpec`, plus the internal `TransCoord` transform resolution path. The phase plan is marked complete with the validation commands that passed.

## Modules touched

- `matrix-charts`

## Validation

- `./gradlew :matrix-charts:test --tests "charm.core.CharmCoreModelTest.testClearingTransformResetsScaleTypeConsistency" --tests "charm.core.CharmTypedOverloadApiTest"`
- `./gradlew :matrix-charts:spotlessCheck`
- `./gradlew :matrix-charts:codenarcMain`
- `./gradlew :matrix-charts:test`