### PR TITLE
[codex] Add chart render and write conveniences

### DIFF
--- a/matrix-charts/req/0.5.0-r2-plan.md
+++ b/matrix-charts/req/0.5.0-r2-plan.md
@@ -172,7 +172,7 @@ concrete types actually passed by callers (e.g. `CoordType` enum, `String`,
 
 ## Phase 4 — Usability: Convenience Methods on `PlotSpec` and `Chart`
 
-### 4.1 [ ] Add `PlotSpec.render()` convenience method
+### 4.1 [x] Add `PlotSpec.render()` convenience method
 
 **File:** `matrix-charts/src/main/groovy/se/alipsa/matrix/charm/PlotSpec.groovy`
 
@@ -200,7 +200,7 @@ Charts.plot(data) { mapping { x = 'a'; y = 'b' }; layers { geomPoint() } }.build
 Charts.plot(data) { mapping { x = 'a'; y = 'b' }; layers { geomPoint() } }.render()
 ```
 
-### 4.2 [ ] Add `PlotSpec.writeTo()` convenience methods
+### 4.2 [x] Add `PlotSpec.writeTo()` convenience methods
 
 **File:** `PlotSpec.groovy`
 
@@ -217,7 +217,7 @@ void writeTo(File targetFile) {
 }
 ```
 
-### 4.3 [ ] Add `Chart.writeTo(File, int, int)` overload with dimensions
+### 4.3 [x] Add `Chart.writeTo(File, int, int)` overload with dimensions
 
 **File:** `matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Chart.groovy`
 
@@ -242,8 +242,11 @@ void writeTo(String targetPath, int width, int height) {
 }
 ```
 
-**Test:** Add tests verifying writeTo with custom dimensions produces output
-files of the expected dimensions.
+**Test:** Passed:
+- `./gradlew :matrix-charts:test --tests "export.WriteToAndPlotGridExportTest"`
+- `./gradlew :matrix-charts:codenarcMain`
+- `./gradlew :matrix-charts:spotlessCheck`
+- `./gradlew :matrix-charts:test`
 
 ---
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Chart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Chart.groovy
@@ -4,6 +4,8 @@ import se.alipsa.groovy.svg.Svg
 import se.alipsa.groovy.svg.io.SvgWriter
 import se.alipsa.matrix.charm.render.CharmRenderer
 import se.alipsa.matrix.charm.render.RenderBuilder
+import se.alipsa.matrix.chartexport.ChartToJpeg
+import se.alipsa.matrix.chartexport.ChartToPng
 import se.alipsa.matrix.chartexport.ExportFormat
 import se.alipsa.matrix.core.Matrix
 
@@ -371,9 +373,43 @@ class Chart {
       throw new IllegalArgumentException('targetFile cannot be null')
     }
     switch (ExportFormat.fromFile(targetFile)) {
-      case ExportFormat.PNG -> se.alipsa.matrix.chartexport.ChartToPng.export(this, targetFile)
-      case ExportFormat.JPEG -> se.alipsa.matrix.chartexport.ChartToJpeg.export(this, targetFile)
+      case ExportFormat.PNG -> ChartToPng.export(this, targetFile)
+      case ExportFormat.JPEG -> ChartToJpeg.export(this, targetFile)
       default -> targetFile.text = SvgWriter.toXmlPretty(render())
+    }
+  }
+
+  /**
+   * Writes the chart to a target file path using custom render dimensions.
+   *
+   * @param targetPath output file path
+   * @param width render width in pixels
+   * @param height render height in pixels
+   */
+  void writeTo(String targetPath, int width, int height) {
+    if (targetPath == null || targetPath.trim().isEmpty()) {
+      throw new IllegalArgumentException('targetPath cannot be blank')
+    }
+    writeTo(new File(targetPath), width, height)
+  }
+
+  /**
+   * Writes the chart to a target file using custom render dimensions.
+   * Supported extensions: {@code .png}, {@code .jpg}/{@code .jpeg}, and {@code .svg} (default).
+   *
+   * @param targetFile output file
+   * @param width render width in pixels
+   * @param height render height in pixels
+   */
+  void writeTo(File targetFile, int width, int height) {
+    if (targetFile == null) {
+      throw new IllegalArgumentException('targetFile cannot be null')
+    }
+    Svg svg = render(width, height)
+    switch (ExportFormat.fromFile(targetFile)) {
+      case ExportFormat.PNG -> ChartToPng.export(svg, targetFile)
+      case ExportFormat.JPEG -> ChartToJpeg.export(svg, targetFile)
+      default -> targetFile.text = SvgWriter.toXmlPretty(svg)
     }
   }
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/PlotSpec.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/PlotSpec.groovy
@@ -5,6 +5,7 @@ import groovy.transform.stc.SimpleType
 
 import org.apache.commons.text.similarity.LevenshteinDistance
 
+import se.alipsa.groovy.svg.Svg
 import se.alipsa.matrix.charm.facet.Labeller
 import se.alipsa.matrix.charm.theme.CharmThemes
 import se.alipsa.matrix.core.Matrix
@@ -523,6 +524,44 @@ class PlotSpec {
     } catch (Exception e) {
       throw new CharmCompilationException("Failed to compile plot specification: ${e.message}", e)
     }
+  }
+
+  /**
+   * Compiles and renders this plot using default dimensions (800x600).
+   *
+   * @return SVG model object
+   */
+  Svg render() {
+    build().render()
+  }
+
+  /**
+   * Compiles and renders this plot at the given dimensions.
+   *
+   * @param width SVG width in pixels
+   * @param height SVG height in pixels
+   * @return SVG model object
+   */
+  Svg render(int width, int height) {
+    build().render(width, height)
+  }
+
+  /**
+   * Compiles and writes this plot to the target file path.
+   *
+   * @param targetPath output file path
+   */
+  void writeTo(String targetPath) {
+    build().writeTo(targetPath)
+  }
+
+  /**
+   * Compiles and writes this plot to the target file.
+   *
+   * @param targetFile output file
+   */
+  void writeTo(File targetFile) {
+    build().writeTo(targetFile)
   }
 
   private void validate() {

--- a/matrix-charts/src/test/groovy/export/WriteToAndPlotGridExportTest.groovy
+++ b/matrix-charts/src/test/groovy/export/WriteToAndPlotGridExportTest.groovy
@@ -10,6 +10,7 @@ import testutil.Slow
 
 import se.alipsa.matrix.charm.Chart
 import se.alipsa.matrix.charm.PlotGrid
+import se.alipsa.matrix.charm.PlotSpec
 import se.alipsa.matrix.chartexport.ChartToImage
 import se.alipsa.matrix.chartexport.ChartToJpeg
 import se.alipsa.matrix.chartexport.ChartToPng
@@ -91,6 +92,70 @@ class WriteToAndPlotGridExportTest {
     assertTrue(file.exists())
     String content = file.text
     assertTrue(content.contains('<svg'))
+  }
+
+  @Test
+  void testChartWriteToSvgWithDimensions(@TempDir Path tempDir) {
+    Chart chart = buildChart()
+    File file = tempDir.resolve('chart-sized.svg').toFile()
+    chart.writeTo(file, 320, 240)
+    assertTrue(file.exists())
+    String content = file.text
+    assertTrue(content.contains('<svg'))
+    assertTrue(content.contains('width="320"'))
+    assertTrue(content.contains('height="240"'))
+  }
+
+  @Test
+  void testChartWriteToPngWithDimensions(@TempDir Path tempDir) {
+    Chart chart = buildChart()
+    File file = tempDir.resolve('chart-sized.png').toFile()
+    chart.writeTo(file, 320, 240)
+    assertTrue(file.exists())
+    assertTrue(file.length() > 0)
+    BufferedImage image = ImageIO.read(file)
+    assertNotNull(image)
+    assertEquals(320, image.width)
+    assertEquals(240, image.height)
+  }
+
+  @Test
+  void testChartWriteToJpegStringPathWithDimensions(@TempDir Path tempDir) {
+    Chart chart = buildChart()
+    String path = tempDir.resolve('chart-sized.jpg') as String
+    chart.writeTo(path, 320, 240)
+    File file = new File(path)
+    assertTrue(file.exists())
+    assertTrue(file.length() > 0)
+    BufferedImage image = ImageIO.read(file)
+    assertNotNull(image)
+    assertEquals(320, image.width)
+    assertEquals(240, image.height)
+  }
+
+  @Test
+  void testPlotSpecRenderConvenienceMethods() {
+    PlotSpec spec = buildPlotSpec()
+    assertEquals('800', spec.render().width.toString())
+    assertEquals('600', spec.render().height.toString())
+    assertEquals('320', spec.render(320, 240).width.toString())
+    assertEquals('240', spec.render(320, 240).height.toString())
+  }
+
+  @Test
+  void testPlotSpecWriteToConvenienceMethods(@TempDir Path tempDir) {
+    PlotSpec spec = buildPlotSpec()
+    File fileTarget = tempDir.resolve('plot-spec-file.svg').toFile()
+    String pathTarget = tempDir.resolve('plot-spec-path.svg') as String
+
+    spec.writeTo(fileTarget)
+    spec.writeTo(pathTarget)
+
+    assertTrue(fileTarget.exists())
+    assertTrue(fileTarget.text.contains('<svg'))
+    File pathFile = new File(pathTarget)
+    assertTrue(pathFile.exists())
+    assertTrue(pathFile.text.contains('<svg'))
   }
 
   // ---- PlotGrid.writeTo ----
@@ -236,6 +301,10 @@ class WriteToAndPlotGridExportTest {
   }
 
   private static Chart buildChart() {
+    buildPlotSpec().build()
+  }
+
+  private static PlotSpec buildPlotSpec() {
     Matrix data = Matrix.builder()
         .columnNames('x', 'y')
         .rows([[1, 2], [2, 4], [3, 6]])
@@ -243,7 +312,7 @@ class WriteToAndPlotGridExportTest {
     plot(data) {
       mapping { x = 'x'; y = 'y' }
       layers { geomPoint() }
-    }.build()
+    }
   }
 
   private static PlotGrid buildGrid() {


### PR DESCRIPTION
## Summary

Implement phase 4 of the matrix-charts 0.5.0 review round 2 plan.

This adds `PlotSpec.render()` and `PlotSpec.writeTo(...)` convenience methods so callers can render or export directly from a plot spec, plus `Chart.writeTo(..., width, height)` overloads for custom export dimensions.

## Modules touched

- `matrix-charts`

## Validation

- `./gradlew :matrix-charts:test --tests "export.WriteToAndPlotGridExportTest"`
- `./gradlew :matrix-charts:codenarcMain`
- `./gradlew :matrix-charts:spotlessCheck`
- `./gradlew :matrix-charts:test`