### PR TITLE
[codex] Fix grouped legacy bar chart bridge

### DIFF
--- a/matrix-charts/req/0.5.0-r2-plan.md
+++ b/matrix-charts/req/0.5.0-r2-plan.md
@@ -255,7 +255,7 @@ void writeTo(String targetPath, int width, int height) {
 Lower priority since the pict API is deprecated, but still affects users of the
 builder API (which is not itself deprecated).
 
-### 5.1 [ ] Handle `ChartType.GROUPED` in `CharmBridge`
+### 5.1 [x] Handle `ChartType.GROUPED` in `CharmBridge`
 
 **File:** `matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy:87`
 
@@ -277,10 +277,14 @@ PositionSpec position = switch (chart.chartType) {
 This works because `BarChart.chartType` is accessible (protected field with
 getter). The switch replaces the `chart.stacked` boolean check, not augments it.
 
-**Test:** Verify `ChartType` actually has a `GROUPED` value. If not, skip this
-item. If yes, add a test rendering a grouped bar chart through the bridge.
+**Test:** Passed:
+- `./gradlew :matrix-charts:test --tests "chart.ChartsCharmIntegrationTest.testGroupedBarChartUsesDodgePosition"`
+- `./gradlew :matrix-charts:codenarcMain`
+- `./gradlew :matrix-charts:spotlessCheck`
+- `./gradlew :matrix-charts:test`
+- `./gradlew :matrix-charts:test -Pheadless=true`
 
-### 5.2 [ ] Deprecate legacy chart factory methods in favor of builders
+### 5.2 [x] Deprecate legacy chart factory methods in favor of builders
 
 **Files:** All pict chart classes (`BarChart`, `LineChart`, `ScatterChart`,
 `AreaChart`, `PieChart`, `BoxChart`, `Histogram`, `BubbleChart`)
@@ -292,6 +296,12 @@ The static `create(...)` factory methods use positional parameters and explicit
 pointer to the builder.
 
 This is a documentation-only change — no code removal.
+
+**Test:** Passed:
+- `./gradlew :matrix-charts:codenarcMain`
+- `./gradlew :matrix-charts:spotlessCheck`
+- `./gradlew :matrix-charts:test`
+- `./gradlew :matrix-charts:test -Pheadless=true`
 
 ---
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/AreaChart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/AreaChart.groovy
@@ -5,6 +5,14 @@ import se.alipsa.matrix.core.Matrix
 /** Area chart for visualizing data as filled regions between lines and an axis. */
 class AreaChart extends Chart<AreaChart> {
 
+  /**
+   * Creates an area chart from a two-column matrix.
+   *
+   * @param data chart data
+   * @return area chart
+   * @deprecated Use {@link #builder(Matrix)} for new code.
+   */
+  @Deprecated
   static AreaChart create(Matrix data) {
     if (data.columnCount() != 2) {
       throw new IllegalArgumentException('Table ' + data.matrixName + ' does not contain 2 columns.')
@@ -17,6 +25,16 @@ class AreaChart extends Chart<AreaChart> {
     return chart
   }
 
+  /**
+   * Creates an area chart from positional series.
+   *
+   * @param title chart title
+   * @param groupColumn x-axis values
+   * @param valueColumn y-axis series
+   * @return area chart
+   * @deprecated Use {@link #builder(Matrix)} for new code.
+   */
+  @Deprecated
   static AreaChart create(String title, List<?> groupColumn, List<?>... valueColumn) {
     AreaChart chart = new AreaChart()
     chart.title = title
@@ -26,9 +44,16 @@ class AreaChart extends Chart<AreaChart> {
   }
 
   /**
-   * AreaPlot.create(
-   *         "Boston Robberies by month: Jan 1966-Oct 1975", robberies, "Record", "Robberies")
+   * Creates an area chart from matrix columns.
+   *
+   * @param title chart title
+   * @param data chart data
+   * @param xCol x-axis column name
+   * @param yCol y-axis column name
+   * @return area chart
+   * @deprecated Use {@link #builder(Matrix)} for new code.
    */
+  @Deprecated
   static AreaChart create(String title, Matrix data, String xCol, String yCol) {
     List<?> xColumn = data.column(xCol) as List<?>
     List<?> yColumn = data.column(yCol) as List<?>

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/BarChart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/BarChart.groovy
@@ -17,6 +17,18 @@ class BarChart extends Chart<BarChart> {
     return direction
   }
 
+  /**
+   * Creates a bar chart from positional series.
+   *
+   * @param title chart title
+   * @param chartType bar chart type
+   * @param direction bar direction
+   * @param groupColumn category values
+   * @param valueColumn value series
+   * @return bar chart
+   * @deprecated Use {@link #builder(Matrix)} for new code.
+   */
+  @Deprecated
   static BarChart create(String title, ChartType chartType, ChartDirection direction, List<?> groupColumn, List<?>... valueColumn) {
     BarChart chart = new BarChart()
     chart.title = title
@@ -28,6 +40,19 @@ class BarChart extends Chart<BarChart> {
     return chart
   }
 
+  /**
+   * Creates a bar chart from matrix columns.
+   *
+   * @param title chart title
+   * @param chartType bar chart type
+   * @param data chart data
+   * @param categoryColumnName category column name
+   * @param direction bar direction
+   * @param valueColumn value column names
+   * @return bar chart
+   * @deprecated Use {@link #builder(Matrix)} for new code.
+   */
+  @Deprecated
   static BarChart create(String title, ChartType chartType, Matrix data, String categoryColumnName, ChartDirection direction, String... valueColumn) {
     List<?> groupColumn = data.column(categoryColumnName) as List<?>
     List<List<?>> valueColumns = data.columns(valueColumn.toList()) as List<List<?>>

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/BoxChart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/BoxChart.groovy
@@ -7,6 +7,17 @@ import se.alipsa.matrix.core.Matrix
 @SuppressWarnings('UnnecessaryObjectReferences')
 class BoxChart extends Chart<BoxChart> {
 
+  /**
+   * Creates a box chart from category and value columns.
+   *
+   * @param title chart title
+   * @param data chart data
+   * @param categoryColumnName category column name
+   * @param valueColumn value column name
+   * @return box chart
+   * @deprecated Use {@link #builder(Matrix)} for new code.
+   */
+  @Deprecated
   static BoxChart create(String title, Matrix data, String categoryColumnName, String valueColumn) {
     Map<String, Matrix> groups = data.split(categoryColumnName).sort() as Map<String, Matrix>
     BoxChart chart = new BoxChart()
@@ -19,6 +30,16 @@ class BoxChart extends Chart<BoxChart> {
     return chart
   }
 
+  /**
+   * Creates a box chart from multiple value columns.
+   *
+   * @param title chart title
+   * @param data chart data
+   * @param columnNames value column names
+   * @return box chart
+   * @deprecated Use {@link #builder(Matrix)} for new code.
+   */
+  @Deprecated
   static BoxChart create(String title, Matrix data, List<String> columnNames) {
     BoxChart chart = new BoxChart()
     chart.title = title

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/BubbleChart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/BubbleChart.groovy
@@ -46,7 +46,9 @@ class BubbleChart extends Chart<BubbleChart> {
    * @param yCol column name for y-axis values
    * @param sizeCol column name for size values
    * @return a configured BubbleChart
+   * @deprecated Use {@link #builder(Matrix)} for new code.
    */
+  @Deprecated
   static BubbleChart create(String title, Matrix data, String xCol, String yCol, String sizeCol) {
     BubbleChart chart = new BubbleChart()
     chart.title = title
@@ -69,7 +71,9 @@ class BubbleChart extends Chart<BubbleChart> {
    * @param sizeCol column name for size values
    * @param groupCol column name for grouping (colour aesthetic)
    * @return a configured BubbleChart with group data
+   * @deprecated Use {@link #builder(Matrix)} for new code.
    */
+  @Deprecated
   static BubbleChart create(String title, Matrix data, String xCol, String yCol, String sizeCol, String groupCol) {
     BubbleChart chart = create(title, data, xCol, yCol, sizeCol)
     chart.groupColumn = groupCol

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
@@ -84,7 +84,11 @@ class CharmBridge {
     Matrix data = buildLongFormatMatrix(chart)
     boolean multiSeries = chart.valueSeries.size() > 1
     boolean horizontal = chart.direction == ChartDirection.HORIZONTAL
-    PositionSpec position = chart.stacked ? PositionSpec.of(CharmPositionType.STACK) : PositionSpec.of(CharmPositionType.IDENTITY)
+    PositionSpec position = switch (chart.chartType) {
+      case ChartType.STACKED -> PositionSpec.of(CharmPositionType.STACK)
+      case ChartType.GROUPED -> PositionSpec.of(CharmPositionType.DODGE)
+      default -> PositionSpec.of(CharmPositionType.IDENTITY)
+    }
 
     PlotSpec spec = Charts.plot(data)
     if (horizontal) {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
@@ -16,6 +16,14 @@ class Histogram extends Chart<Histogram> {
   Map<MinMax, Integer> ranges
   Integer numberOfBins = 9
 
+  /**
+   * Creates a histogram from named parameters.
+   *
+   * @param params named parameters: title, data, columnName, bins, binDecimals
+   * @return histogram
+   * @deprecated Use {@link #builder(Matrix)} for new code.
+   */
+  @Deprecated
   static Histogram create(Map params) {
     String title = params.title as String
     Matrix data = params.data as Matrix
@@ -25,6 +33,18 @@ class Histogram extends Chart<Histogram> {
     return create(title, data, columnName, bins, binDecimals)
   }
 
+  /**
+   * Creates a histogram from a matrix column.
+   *
+   * @param title chart title
+   * @param data chart data
+   * @param columnName numeric column name
+   * @param bins number of bins
+   * @param binDecimals number of decimals for bin boundaries
+   * @return histogram
+   * @deprecated Use {@link #builder(Matrix)} for new code.
+   */
+  @Deprecated
   static Histogram create(String title, Matrix data, String columnName, Integer bins = 9, int binDecimals = 1) {
     Histogram chart = new Histogram()
     chart.title = title
@@ -38,6 +58,15 @@ class Histogram extends Chart<Histogram> {
     return chart
   }
 
+  /**
+   * Creates a histogram from numeric values.
+   *
+   * @param column numeric values
+   * @param bins number of bins
+   * @return histogram
+   * @deprecated Use {@link #builder(Matrix)} for new code.
+   */
+  @Deprecated
   static Histogram create(List<? extends Number> column, Integer bins = 9) {
     Histogram chart = new Histogram()
     chart.originalData = column

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
@@ -21,7 +21,8 @@ class Histogram extends Chart<Histogram> {
    *
    * @param params named parameters: title, data, columnName, bins, binDecimals
    * @return histogram
-   * @deprecated Use {@link #builder(Matrix)} for new code.
+   * @deprecated Use {@link #builder(Matrix)} with {@code title(...)}, {@code x(...)},
+   * {@code bins(...)}, and {@code binDecimals(...)} for new code.
    */
   @Deprecated
   static Histogram create(Map params) {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/LineChart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/LineChart.groovy
@@ -6,10 +6,31 @@ import se.alipsa.matrix.core.Matrix
 @SuppressWarnings('UnnecessaryObjectReferences')
 class LineChart extends Chart<LineChart> {
 
+  /**
+   * Creates a line chart from matrix columns.
+   *
+   * @param data chart data
+   * @param xAxis x-axis column name
+   * @param valueColumns y-axis column names
+   * @return line chart
+   * @deprecated Use {@link #builder(Matrix)} for new code.
+   */
+  @Deprecated
   static LineChart create(Matrix data, String xAxis, String... valueColumns) {
     create(data.matrixName, data, xAxis, valueColumns)
   }
 
+  /**
+   * Creates a line chart from matrix columns.
+   *
+   * @param title chart title
+   * @param data chart data
+   * @param xAxis x-axis column name
+   * @param valueColumns y-axis column names
+   * @return line chart
+   * @deprecated Use {@link #builder(Matrix)} for new code.
+   */
+  @Deprecated
   static LineChart create(String title, Matrix data, String xAxis, String... valueColumns) {
     LineChart chart = new LineChart()
     chart.title = title

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/PieChart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/PieChart.groovy
@@ -5,6 +5,16 @@ import se.alipsa.matrix.core.Matrix
 /** Pie chart for visualizing proportional data as circular segments. */
 class PieChart extends Chart<PieChart> {
 
+  /**
+   * Creates a pie chart from positional series.
+   *
+   * @param title chart title
+   * @param groupCol category values
+   * @param numberCol numeric values
+   * @return pie chart
+   * @deprecated Use {@link #builder(Matrix)} for new code.
+   */
+  @Deprecated
   static PieChart create(String title, List<?> groupCol, List<?> numberCol) {
     PieChart chart = new PieChart()
     chart.categorySeries = groupCol
@@ -13,10 +23,31 @@ class PieChart extends Chart<PieChart> {
     return chart
   }
 
+  /**
+   * Creates a pie chart from matrix columns.
+   *
+   * @param table chart data
+   * @param groupColName category column name
+   * @param numberColName numeric column name
+   * @return pie chart
+   * @deprecated Use {@link #builder(Matrix)} for new code.
+   */
+  @Deprecated
   static PieChart create(Matrix table, String groupColName, String numberColName) {
     return create(table.matrixName, table, groupColName, numberColName)
   }
 
+  /**
+   * Creates a pie chart from matrix columns.
+   *
+   * @param title chart title
+   * @param table chart data
+   * @param groupColName category column name
+   * @param numberColName numeric column name
+   * @return pie chart
+   * @deprecated Use {@link #builder(Matrix)} for new code.
+   */
+  @Deprecated
   static PieChart create(String title, Matrix table, String groupColName, String numberColName) {
     return create(title, table.column(groupColName) as List<?>, table.column(numberColName) as List<?>)
   }

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/ScatterChart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/ScatterChart.groovy
@@ -5,6 +5,17 @@ import se.alipsa.matrix.core.Matrix
 /** Scatter chart for visualizing relationships between two numerical variables. */
 class ScatterChart extends Chart<ScatterChart> {
 
+  /**
+   * Creates a scatter chart from matrix columns.
+   *
+   * @param title chart title
+   * @param data chart data
+   * @param xAxis x-axis column name
+   * @param yAxis y-axis column name
+   * @return scatter chart
+   * @deprecated Use {@link #builder(Matrix)} for new code.
+   */
+  @Deprecated
   static ScatterChart create(String title, Matrix data, String xAxis, String yAxis) {
     ScatterChart chart = new ScatterChart()
     chart.title = title

--- a/matrix-charts/src/test/groovy/chart/ChartsCharmIntegrationTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/ChartsCharmIntegrationTest.groovy
@@ -10,6 +10,7 @@ import se.alipsa.groovy.svg.Path
 import se.alipsa.groovy.svg.Rect
 import se.alipsa.groovy.svg.Svg
 import se.alipsa.groovy.svg.Text
+import se.alipsa.matrix.charm.CharmPositionType
 import se.alipsa.matrix.charm.LegendDirection
 import se.alipsa.matrix.charm.LegendPosition
 import se.alipsa.matrix.core.Matrix
@@ -110,6 +111,28 @@ class ChartsCharmIntegrationTest {
     def rects = svg.descendants().findAll { it instanceof Rect }
     // 6 bars (3 categories x 2 series) + background rects; in long format these become 6 data rects
     assertTrue(rects.size() >= 3, "Stacked bar should render multiple rects, got ${rects.size()}")
+  }
+
+  @Test
+  void testGroupedBarChartUsesDodgePosition() {
+    Matrix data = Matrix.builder()
+        .matrixName('GroupedBar')
+        .columns([
+            region: ['North', 'South', 'East'],
+            q1    : [50, 60, 40],
+            q2    : [70, 55, 80]
+        ])
+        .types([String, Number, Number])
+        .build()
+
+    BarChart chart = BarChart.createVertical('Revenue', data, 'region', ChartType.GROUPED, 'q1', 'q2')
+    se.alipsa.matrix.charm.Chart charmChart = CharmBridge.convert(chart)
+    assertEquals(CharmPositionType.DODGE, charmChart.layers.first().positionType)
+
+    Svg svg = charmChart.render()
+    assertNotNull(svg)
+    def rects = svg.descendants().findAll { it instanceof Rect }
+    assertTrue(rects.size() >= 6, "Grouped bar should render multiple rects, got ${rects.size()}")
   }
 
   @Test


### PR DESCRIPTION
## Summary

Implement phase 5 of the matrix-charts 0.5.0 review round 2 plan.

This updates the legacy `CharmBridge` bar chart conversion to map `ChartType.GROUPED` to dodge positioning, adds a regression test, and deprecates legacy pict `create(...)` factory methods in favor of builders.

## Modules touched

- `matrix-charts`

## Validation

- `./gradlew :matrix-charts:test --tests "chart.ChartsCharmIntegrationTest.testGroupedBarChartUsesDodgePosition"`
- `./gradlew :matrix-charts:codenarcMain`
- `./gradlew :matrix-charts:spotlessCheck`
- `./gradlew :matrix-charts:test`
- `./gradlew :matrix-charts:test -Pheadless=true`