### PR TITLE
[codex] Implement matrix-charts PDF export phase 1

### DIFF
--- a/matrix-charts/req/0.5.0-r3-plan.md
+++ b/matrix-charts/req/0.5.0-r3-plan.md
@@ -2,11 +2,131 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Fix a PDDocument resource leak and a double-wrapped exception in `Chart.render()`, add missing `String`-SVG overloads for API parity with `ChartToPng`, add dimension-aware `writeTo` overloads to `PlotGrid`, fill the OutputStream test coverage gap, add warn logging to silent configuration fallbacks, and replace `Object` parameters on public builder APIs to comply with AGENTS.md.
+**Goal:** Fix a PDDocument resource leak and a double-wrapped exception in `Chart.render()`, add missing `String`-SVG overloads for API parity with `ChartToPng`, add dimension-aware `writeTo` overloads to `PlotGrid`, fill the OutputStream test coverage gap, add warn logging to silent configuration fallbacks, replace `Object` parameters on public builder APIs to comply with AGENTS.md, and close legacy `pict` usability gaps exposed by the Charm bridge migration.
 
-**Architecture:** All changes are confined to the `matrix-charts` module. `ChartToPdf` gets resource-safe document creation and two new `String`-SVG entry-point overloads. `PlotGrid` gets `writeTo(File, int, int)` and `writeTo(String, int, int)` following the identical pattern already present on `Chart`. `Chart.render()` gets the same `CharmRenderException` pass-through guard already present in `RenderBuilder.render()`. Silent configuration fallbacks in `TemporalScaleUtil` and geometry stat classes get `log.warn`/`log.debug` calls. Builder `Object` parameters are replaced with typed overloads throughout the `geom` package and `MappingSpec`.
+**Architecture:** All changes are confined to the `matrix-charts` module. `ChartToPdf` gets resource-safe document creation and two new `String`-SVG entry-point overloads. `PlotGrid` gets `writeTo(File, int, int)` and `writeTo(String, int, int)` following the identical pattern already present on `Chart`. `Chart.render()` gets the same `CharmRenderException` pass-through guard already present in `RenderBuilder.render()`. Silent configuration fallbacks in `TemporalScaleUtil` and geometry stat classes get `log.warn`/`log.debug` calls. Builder `Object` parameters are replaced with typed overloads throughout the `geom` package and `MappingSpec`. Legacy `pict` chart settings are either mapped through `CharmBridge` or explicitly deprecated when no equivalent Charm behavior exists.
 
 **Tech Stack:** Groovy 5 / Java 21, Apache PDFBox 3.0.x, JUnit 5, Gradle
+
+---
+
+## Implementation Phases
+
+Each phase is sized as one focused PR. Implement phases in order because later phases build on export and compatibility coverage added earlier.
+
+### Phase 1: PDF export correctness and API parity
+
+**PR scope:** Fix the PDF resource leak and page sizing, add missing SVG-string PDF overloads, and cover the missing CharmChart OutputStream path.
+
+**Implementation note:** Task 1 and Task 9 both modify `ChartToPdf.createDocument`. Implement Task 1 first to isolate the resource-safety fix, then Task 9 supersedes that method with the combined resource-safe + DPI-scaled version. This is intentional.
+
+**Tasks:**
+- Task 1: Fix PDDocument resource leak in `createDocument`
+- Task 2: Add `String`-SVG overloads to `ChartToPdf`
+- Task 4: Add missing `ChartToPdf.export(CharmChart, OutputStream)` test coverage
+- Task 9: Fix PDF page dimensions — scale pixels to PDF points at 96 DPI
+
+**Verification:**
+```bash
+./gradlew :matrix-charts:codenarcMain
+./gradlew :matrix-charts:spotlessCheck
+./gradlew :matrix-charts:test --tests "export.WriteToAndPlotGridExportTest" -Pheadless=true
+```
+
+### Phase 2: PlotGrid export parity
+
+**PR scope:** Add dimension-aware `PlotGrid.writeTo` overloads after the PDF export paths are corrected and tested.
+
+**Tasks:**
+- Task 3: Add dimension overloads to `PlotGrid.writeTo`
+
+**Verification:**
+```bash
+./gradlew :matrix-charts:codenarcMain
+./gradlew :matrix-charts:spotlessCheck
+./gradlew :matrix-charts:test --tests "export.WriteToAndPlotGridExportTest" -Pheadless=true
+```
+
+### Phase 3: Render error and fallback diagnostics
+
+**PR scope:** Improve failure diagnostics without changing chart output semantics.
+
+**Tasks:**
+- Task 5: Fix `Chart.render()` double-wrapping of `CharmRenderException`
+- Task 6: Add warn/debug logging to silent configuration fallbacks
+
+**Verification:**
+```bash
+./gradlew :matrix-charts:codenarcMain
+./gradlew :matrix-charts:spotlessCheck
+./gradlew :matrix-charts:test -Pheadless=true
+```
+
+### Phase 4: Typed public API cleanup
+
+**PR scope:** Replace avoidable public `Object` parameters with typed overloads while keeping DSL property assignment compatibility.
+
+**Tasks:**
+- Task 7: Replace `Object` parameters with typed overloads in builder APIs
+- Task 14: Replace public `ChartToSwing.export(Object)` with typed overloads
+
+**Verification:**
+```bash
+./gradlew :matrix-charts:codenarcMain
+./gradlew :matrix-charts:codenarcTest
+./gradlew :matrix-charts:spotlessCheck
+./gradlew :matrix-charts:test --tests "*CharmTypedOverloadApiTest" --tests "export.*" -Pheadless=true
+```
+
+### Phase 5: Legacy `pict` bridge compatibility
+
+**PR scope:** Fix user-visible legacy chart behavior that was lost or weakened by the Charm bridge migration.
+
+**Implementation note:** Tasks 10, 12, and 13 require judgment after inspecting the current Charm API. Prefer applying legacy settings through `CharmBridge` when there is a clean equivalent; otherwise keep source compatibility and deprecate the legacy no-op with clear GroovyDoc.
+
+**Tasks:**
+- Task 10: Apply legacy `AxisScale` settings in `CharmBridge`
+- Task 11: Preserve exact histogram bin boundaries while rounding labels only
+- Task 12: Either apply or deprecate legacy `Style.css`
+- Task 13: Apply or deprecate legacy `Style.yLabels`
+
+**Verification:**
+```bash
+./gradlew :matrix-charts:codenarcMain
+./gradlew :matrix-charts:spotlessCheck
+./gradlew :matrix-charts:test --tests "chart.PlotCompatibilityTest" --tests "chart.HistogramTest" --tests "chart.ChartBuilderTest" -Pheadless=true
+```
+
+### Phase 6: Low-risk code quality cleanup
+
+**PR scope:** Apply small arithmetic, formatting, and stale-comment cleanup after behavioral changes are merged.
+
+**Tasks:**
+- Task 8: Minor code quality fixes
+
+**Verification:**
+```bash
+./gradlew :matrix-charts:codenarcMain
+./gradlew :matrix-charts:spotlessCheck
+./gradlew :matrix-charts:test -Pheadless=true
+```
+
+### Final Verification
+
+After Phase 6 is merged, run the full module checks:
+
+```bash
+./gradlew :matrix-charts:codenarcMain
+./gradlew :matrix-charts:codenarcTest
+./gradlew :matrix-charts:spotlessCheck
+./gradlew :matrix-charts:test -Pheadless=true
+```
+
+### General Execution Notes
+
+- Implement phases in order: 1 → 2 → 3 → 4 → 5 → 6.
+- Within each task, follow the local TDD flow in the task body: write the failing test, implement, then verify passing.
+- `ChartToPdf.export(CharmChart, File)` is already covered through `chart.writeTo(file)` in the existing PDF tests, so no extra task is needed for that path.
 
 ---
 
@@ -28,9 +148,14 @@
 | `matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/ColorUtil.groovy` | Fix float arithmetic in gray-color conversion (line 63) |
 | `matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/scale/ContinuousCharmScale.groovy` | Remove redundant `as double` cast in `String.format` (lines 245, 247) |
 | `matrix-charts/src/main/groovy/se/alipsa/matrix/charm/PlotGrid.groovy` | Replace `Math.ceil(... / (double) ncol)` with GDK `.ceil()` (line 66) |
+| `matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy` | Apply legacy axis scale limits/breaks, custom y labels, and legacy CSS during Charm conversion |
+| `matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy` | Preserve exact internal bin boundaries and round only display labels |
+| `matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToSwing.groovy` | Replace public `export(Object)` with typed overloads/private dynamic dispatch helper |
 | `matrix-charts/build.gradle` | Remove commented-out code blocks |
 | `matrix-charts/src/test/groovy/export/WriteToAndPlotGridExportTest.groovy` | Add tests for String overloads, PlotGrid dimension overloads, CharmChart OutputStream |
 | `matrix-charts/src/test/groovy/charm/core/CharmTypedOverloadApiTest.groovy` | Add tests for new typed overloads on MappingSpec and builders |
+| `matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy` | Add legacy `pict` bridge tests for axis scales, CSS, custom y labels, and histogram edge bins |
+| `matrix-charts/src/test/groovy/export/CharmExportTest.groovy` | Add Swing typed dispatch tests |
 
 ---
 
@@ -461,6 +586,8 @@ The implementation follows the identical pattern as `Chart.writeTo(File, int, in
   ```
 
   **Note:** If clearing the x mapping does not trigger a CharmRenderException from the renderer with the chart's current validation, adjust the chart configuration to one that is known to fail (e.g., refer to other failure-mode tests in the file for the correct pattern). The assertion structure remains the same.
+
+  **Implementation concern:** This setup is intentionally provisional. It depends on `plotSpec` accessibility and on `setX(null)` producing a `CharmRenderException` instead of an NPE or silent render. If it does not compile or does not produce the right exception type, use another existing invalid-chart pattern that reliably enters `Chart.render()` and throws `CharmRenderException`.
 
 - [ ] **Step 2: Run the test to confirm the current double-wrap behaviour**
 
@@ -943,10 +1070,10 @@ log.warn("message")
   int value = (255 * (pct / 100.0f)).round() as int
 
   // After:
-  int value = (255 * pct).intdiv(100)
+  int value = (255 * pct / 100).setScale(0, RoundingMode.HALF_UP) as int
   ```
 
-  `intdiv` is integer division — no rounding needed since `255 * pct` is always divisible cleanly enough for an 8-bit color channel.
+  Keep the existing round-to-nearest behavior. Do not use `intdiv` here unless the truncation is explicitly accepted as a behavior change. For example, `pct = 67` should remain `171` (`170.85` rounded), not `170`.
 
 - [ ] **Step 2: Remove redundant `as double` cast in `ContinuousCharmScale`**
 
@@ -1121,6 +1248,222 @@ The embedded image itself is still `image.width × image.height` pixels; PDFBox 
   git add matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToPdf.groovy
   git add matrix-charts/src/test/groovy/export/WriteToAndPlotGridExportTest.groovy
   git commit -m "Fix PDF page size: scale pixel dimensions to PDF points at 96 DPI"
+  ```
+
+---
+
+## Task 10: Apply legacy `AxisScale` settings in `CharmBridge`
+
+**Background:** The legacy `pict.Chart` API exposes `xAxisScale` and `yAxisScale` through setters and builders, and `ChartBuilderTest` verifies these values are stored. `CharmBridge` does not apply them when converting legacy charts to Charm, so rendered output ignores configured axis ranges and steps.
+
+**Files:**
+- Modify: `matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy`
+- Test: `matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy` or `ChartBuilderTest.groovy`
+
+- [ ] **Step 1: Add a failing render-level test for legacy axis scales**
+
+  Build a legacy chart with explicit x/y axis scales, render it through `CharmBridge.renderSvg`, and assert the generated axis labels reflect configured limits and steps rather than auto-trained ticks.
+
+  Example target behavior:
+
+  ```groovy
+  def chart = LineChart.builder(data)
+      .title('Scaled')
+      .x('x')
+      .y('y')
+      .xAxisScale(0.0, 5.0, 1.0)
+      .yAxisScale(0.0, 50.0, 10.0)
+      .build()
+
+  def svg = CharmBridge.renderSvg(chart, 800, 600)
+  def labels = svg.descendants().findAll { it instanceof Text }*.text
+  assertTrue(labels.contains('0'))
+  assertTrue(labels.contains('5'))
+  assertTrue(labels.contains('50'))
+  ```
+
+- [ ] **Step 2: Map `AxisScale` to Charm scale limits and breaks**
+
+  Add helper methods in `CharmBridge` to convert an `AxisScale` to:
+
+  - `limits: [start, end]`
+  - `breaks: [start, start + step, ..., end]`
+
+  Apply them after each spec mapping is created and before `applyLabelsAndTheme` returns.
+
+- [ ] **Step 3: Run verification**
+
+  ```bash
+  ./gradlew :matrix-charts:codenarcMain
+  ./gradlew :matrix-charts:spotlessCheck
+  ./gradlew :matrix-charts:test --tests "chart.PlotCompatibilityTest" -Pheadless=true
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
+  git add matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
+  git commit -m "Apply legacy pict axis scales in CharmBridge"
+  ```
+
+---
+
+## Task 11: Preserve exact histogram bin boundaries while rounding labels only
+
+**Background:** `Histogram.MinMax` rounds `minValue` and `maxValue` in the constructor. `Histogram.createRanges` then counts data against those rounded boundaries. With low `binDecimals`, the rounded final `maxValue` can be lower than the actual maximum and the largest values can be silently dropped from all bins.
+
+**Files:**
+- Modify: `matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy`
+- Test: `matrix-charts/src/test/groovy/chart/HistogramTest.groovy` or `ChartBuilderTest.groovy`
+
+- [ ] **Step 1: Add a failing test for values near rounded bin edges**
+
+  Use data where `binDecimals` rounds a final boundary below the true maximum. Assert the sum of all bin counts equals the original data size.
+
+  ```groovy
+  def chart = Histogram.create('edge bins', matrix, 'value', 3, 0)
+  assertEquals(matrix.rowCount(), chart.ranges.values().sum())
+  ```
+
+- [ ] **Step 2: Keep internal bounds exact**
+
+  Change `MinMax` so `minValue` and `maxValue` retain the exact computed `BigDecimal` values. Store `binDecimals` separately and apply rounding only in `toString()` or a dedicated label method.
+
+- [ ] **Step 3: Verify existing histogram expectations**
+
+  Existing tests that compare `ranges.keySet().first().toString()` should continue to pass if display labels are preserved.
+
+  ```bash
+  ./gradlew :matrix-charts:codenarcMain
+  ./gradlew :matrix-charts:spotlessCheck
+  ./gradlew :matrix-charts:test --tests "chart.HistogramTest" --tests "chart.ChartBuilderTest.testHistogramBuilder*" -Pheadless=true
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
+  git add matrix-charts/src/test/groovy/chart/HistogramTest.groovy
+  git commit -m "Fix histogram bin counting with rounded labels"
+  ```
+
+---
+
+## Task 12: Either apply or deprecate legacy `Style.css`
+
+**Background:** `Style.css` and `ChartBuilder.css(String)` are public API, but `CharmBridge` does not consume the value. Legacy callers can set custom CSS without any effect after conversion to Charm.
+
+**Files:**
+- Modify: `matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy`
+- Modify if deprecating: `matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Style.groovy`
+- Test: `matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy`
+
+- [ ] **Step 1: Decide implementation path**
+
+  Prefer applying `Style.css` if Charm supports injecting raw SVG/CSS styles safely. If there is no suitable Charm API for raw stylesheet injection, mark `Style.css`, `setCss`, `getCss`, and `ChartBuilder.css(String)` as deprecated with GroovyDoc that explains it is retained only for source compatibility.
+
+- [ ] **Step 2: Add a test for the chosen behavior**
+
+  If applying CSS, render a legacy chart with `.css(...)` and assert the SVG contains the stylesheet or equivalent style attributes.
+
+  If deprecating, add an API test that verifies the methods remain callable and document that they intentionally do not alter Charm rendering.
+
+- [ ] **Step 3: Run verification**
+
+  ```bash
+  ./gradlew :matrix-charts:codenarcMain
+  ./gradlew :matrix-charts:spotlessCheck
+  ./gradlew :matrix-charts:test --tests "chart.PlotCompatibilityTest" -Pheadless=true
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
+  git add matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Style.groovy
+  git add matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
+  git commit -m "Clarify legacy Style.css behavior in Charm bridge"
+  ```
+
+---
+
+## Task 13: Apply or deprecate legacy `Style.yLabels`
+
+**Background:** `Style.yLabels` is exposed on the legacy style object but is not read anywhere in main code. If callers use it for custom y-axis labels, the Charm bridge migration drops that behavior.
+
+**Files:**
+- Modify: `matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy`
+- Modify if deprecating: `matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Style.groovy`
+- Test: `matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy`
+
+- [ ] **Step 1: Decide implementation path**
+
+  Prefer mapping `yLabels` to the y scale's configured `breaks` and `labels` if the map keys can be coerced to numeric break values. If the legacy semantics are unclear or undocumented, deprecate `yLabels` and document that Charm scale labels should be used for new code.
+
+- [ ] **Step 2: Add a render-level test**
+
+  If applying labels, create a legacy chart with `style.yLabels = ['10': 'low', '20': 'high']`, render through `CharmBridge`, and assert the SVG text contains `low` and `high`.
+
+  If deprecating, add a source-compatibility test and update GroovyDoc.
+
+- [ ] **Step 3: Run verification**
+
+  ```bash
+  ./gradlew :matrix-charts:codenarcMain
+  ./gradlew :matrix-charts:spotlessCheck
+  ./gradlew :matrix-charts:test --tests "chart.PlotCompatibilityTest" -Pheadless=true
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
+  git add matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Style.groovy
+  git add matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
+  git commit -m "Clarify legacy yLabels behavior in Charm bridge"
+  ```
+
+---
+
+## Task 14: Replace public `ChartToSwing.export(Object)` with typed overloads
+
+**Background:** `ChartToSwing` already has typed overloads for `String`, `Svg`, Charm `Chart`, legacy `pict.Chart`, and `PlotGrid`, but also exposes a public `export(Object)` dynamic-dispatch method. This conflicts with the repository's typed-overload API rule and weakens IDE/static-compilation feedback.
+
+**Files:**
+- Modify: `matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToSwing.groovy`
+- Test: `matrix-charts/src/test/groovy/export/CharmExportTest.groovy` or `WriteToAndPlotGridExportTest.groovy`
+
+- [ ] **Step 1: Add typed-dispatch tests**
+
+  Add `@CompileStatic` tests that call `ChartToSwing.export` with each supported concrete type. Include a `CharSequence`/`GString` case only if a dedicated typed overload is added for it.
+
+- [ ] **Step 2: Remove or hide the public `Object` overload**
+
+  Prefer adding:
+
+  ```groovy
+  static SvgPanel export(CharSequence svgChart) {
+    export(svgChart?.toString())
+  }
+  ```
+
+  Then remove the public `export(Object)` overload. If dynamic dispatch is still needed internally, make it private and do not expose it as public API.
+
+- [ ] **Step 3: Run verification**
+
+  ```bash
+  ./gradlew :matrix-charts:codenarcMain
+  ./gradlew :matrix-charts:spotlessCheck
+  ./gradlew :matrix-charts:test --tests "export.*" -Pheadless=true
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToSwing.groovy
+  git add matrix-charts/src/test/groovy/export/CharmExportTest.groovy
+  git commit -m "Replace ChartToSwing Object export overload with typed API"
   ```
 
 ---

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToPdf.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToPdf.groovy
@@ -27,8 +27,8 @@ import java.awt.image.BufferedImage
 @SuppressWarnings('DuplicateStringLiteral')
 class ChartToPdf {
 
-  private static final float SCREEN_DPI = 96.0f
-  private static final float PDF_DPI = 72.0f
+  private static final float SCREEN_DPI = 96.0f  // standard screen resolution
+  private static final float PDF_DPI = 72.0f      // 1 pt = 1/72 inch
 
   /**
    * Export an {@link Svg} chart as a PDF file.

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToPdf.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToPdf.groovy
@@ -8,6 +8,7 @@ import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject
 
 import se.alipsa.groovy.svg.Svg
+import se.alipsa.groovy.svg.io.SvgReader
 import se.alipsa.matrix.charm.Chart as CharmChart
 import se.alipsa.matrix.charm.PlotGrid
 import se.alipsa.matrix.pict.Chart
@@ -19,9 +20,15 @@ import java.awt.image.BufferedImage
  *
  * <p>The current implementation renders the chart through the existing SVG-to-image
  * pipeline and embeds the resulting image on a single PDF page.</p>
+ *
+ * <p>Accepts SVG strings, {@link Svg} objects, {@link CharmChart} instances,
+ * legacy {@link Chart} instances, and {@link PlotGrid} grids.</p>
  */
 @SuppressWarnings('DuplicateStringLiteral')
 class ChartToPdf {
+
+  private static final float SCREEN_DPI = 96.0f
+  private static final float PDF_DPI = 72.0f
 
   /**
    * Export an {@link Svg} chart as a PDF file.
@@ -47,6 +54,32 @@ class ChartToPdf {
       throw new IllegalArgumentException('svgChart cannot be null')
     }
     writePdf(ChartToImage.export(svgChart), os)
+  }
+
+  /**
+   * Export an SVG string as a PDF file.
+   *
+   * @param svgChart the SVG content as a {@link String}
+   * @param targetFile the PDF file to write
+   */
+  static void export(String svgChart, File targetFile) throws IOException {
+    if (svgChart == null || svgChart.isEmpty()) {
+      throw new IllegalArgumentException('svgChart cannot be null or empty')
+    }
+    export(SvgReader.parse(svgChart), targetFile)
+  }
+
+  /**
+   * Export an SVG string as PDF to an {@link OutputStream}.
+   *
+   * @param svgChart the SVG content as a {@link String}
+   * @param os the output stream to write
+   */
+  static void export(String svgChart, OutputStream os) throws IOException {
+    if (svgChart == null || svgChart.isEmpty()) {
+      throw new IllegalArgumentException('svgChart cannot be null or empty')
+    }
+    export(SvgReader.parse(svgChart), os)
   }
 
   /**
@@ -159,15 +192,26 @@ class ChartToPdf {
     if (image == null) {
       throw new IllegalArgumentException('image cannot be null')
     }
+    float pageWidth = (image.width * PDF_DPI / SCREEN_DPI) as float
+    float pageHeight = (image.height * PDF_DPI / SCREEN_DPI) as float
     PDDocument document = new PDDocument()
-    PDPage page = new PDPage(new PDRectangle(image.width as float, image.height as float))
-    document.addPage(page)
-    PDImageXObject pdfImage = LosslessFactory.createFromImage(document, image)
-    PDPageContentStream contentStream = new PDPageContentStream(document, page)
     try {
-      contentStream.drawImage(pdfImage, 0, 0, image.width as float, image.height as float)
-    } finally {
-      contentStream.close()
+      PDPage page = new PDPage(new PDRectangle(pageWidth, pageHeight))
+      document.addPage(page)
+      PDImageXObject pdfImage = LosslessFactory.createFromImage(document, image)
+      PDPageContentStream contentStream = new PDPageContentStream(document, page)
+      try {
+        contentStream.drawImage(pdfImage, 0, 0, pageWidth, pageHeight)
+      } finally {
+        contentStream.close()
+      }
+    } catch (IOException e) {
+      try {
+        document.close()
+      } catch (IOException closeEx) {
+        e.addSuppressed(closeEx)
+      }
+      throw e
     }
     document
   }

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToPdf.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToPdf.groovy
@@ -27,8 +27,7 @@ import java.awt.image.BufferedImage
 @SuppressWarnings('DuplicateStringLiteral')
 class ChartToPdf {
 
-  private static final float SCREEN_DPI = 96.0f  // standard screen resolution
-  private static final float PDF_DPI = 72.0f      // 1 pt = 1/72 inch
+  private static final float PDF_POINT_SCALE = 0.75f  // 72 PDF points / 96 screen pixels
 
   /**
    * Export an {@link Svg} chart as a PDF file.
@@ -192,8 +191,8 @@ class ChartToPdf {
     if (image == null) {
       throw new IllegalArgumentException('image cannot be null')
     }
-    float pageWidth = (image.width * PDF_DPI / SCREEN_DPI) as float
-    float pageHeight = (image.height * PDF_DPI / SCREEN_DPI) as float
+    float pageWidth = image.width * PDF_POINT_SCALE
+    float pageHeight = image.height * PDF_POINT_SCALE
     PDDocument document = new PDDocument()
     try {
       PDPage page = new PDPage(new PDRectangle(pageWidth, pageHeight))

--- a/matrix-charts/src/test/groovy/export/WriteToAndPlotGridExportTest.groovy
+++ b/matrix-charts/src/test/groovy/export/WriteToAndPlotGridExportTest.groovy
@@ -403,8 +403,8 @@ class WriteToAndPlotGridExportTest {
     try {
       assertEquals(1, document.numberOfPages)
       PDRectangle mediaBox = document.getPage(0).mediaBox
-      assertEquals(expectedPtWidth, mediaBox.width, 0.5f)
-      assertEquals(expectedPtHeight, mediaBox.height, 0.5f)
+      assertEquals(expectedPtWidth, mediaBox.width, 0.1f)
+      assertEquals(expectedPtHeight, mediaBox.height, 0.1f)
     } finally {
       document.close()
     }

--- a/matrix-charts/src/test/groovy/export/WriteToAndPlotGridExportTest.groovy
+++ b/matrix-charts/src/test/groovy/export/WriteToAndPlotGridExportTest.groovy
@@ -87,6 +87,24 @@ class WriteToAndPlotGridExportTest {
   }
 
   @Test
+  void testExportSvgStringToPdfFile(@TempDir Path tempDir) {
+    Chart chart = buildChart()
+    String svgString = chart.render().toXml()
+    File file = tempDir.resolve('svg-string.pdf').toFile()
+    ChartToPdf.export(svgString, file)
+    assertPdfDimensions(file, 800, 600)
+  }
+
+  @Test
+  void testExportSvgStringToPdfOutputStream() {
+    Chart chart = buildChart()
+    String svgString = chart.render().toXml()
+    ByteArrayOutputStream baos = new ByteArrayOutputStream()
+    ChartToPdf.export(svgString, baos)
+    assertPdfHeader(baos.toByteArray())
+  }
+
+  @Test
   void testWriteToStringPath(@TempDir Path tempDir) {
     Chart chart = buildChart()
     String path = tempDir.resolve('chart.png') as String
@@ -151,6 +169,14 @@ class WriteToAndPlotGridExportTest {
     File file = tempDir.resolve('chart-sized.pdf').toFile()
     chart.writeTo(file, 320, 240)
     assertPdfDimensions(file, 320, 240)
+  }
+
+  @Test
+  void testCharmChartExportToPdfOutputStream() {
+    Chart chart = buildChart()
+    ByteArrayOutputStream baos = new ByteArrayOutputStream()
+    ChartToPdf.export(chart, baos)
+    assertPdfHeader(baos.toByteArray())
   }
 
   @Test
@@ -288,12 +314,7 @@ class WriteToAndPlotGridExportTest {
     PlotGrid grid = buildGrid()
     ByteArrayOutputStream baos = new ByteArrayOutputStream()
     ChartToPdf.export(grid, baos)
-    byte[] bytes = baos.toByteArray()
-    assertTrue(bytes.length > 0)
-    assertEquals((byte) 0x25, bytes[0])
-    assertEquals((byte) 0x50, bytes[1])
-    assertEquals((byte) 0x44, bytes[2])
-    assertEquals((byte) 0x46, bytes[3])
+    assertPdfHeader(baos.toByteArray())
   }
 
   @Test
@@ -373,18 +394,28 @@ class WriteToAndPlotGridExportTest {
     }
   }
 
-  private static void assertPdfDimensions(File file, int width, int height) {
+  private static void assertPdfDimensions(File file, int pixelWidth, int pixelHeight) {
     assertTrue(file.exists())
     assertTrue(file.length() > 0)
+    float expectedPtWidth = pixelWidth * 72f / 96f
+    float expectedPtHeight = pixelHeight * 72f / 96f
     PDDocument document = Loader.loadPDF(file)
     try {
       assertEquals(1, document.numberOfPages)
       PDRectangle mediaBox = document.getPage(0).mediaBox
-      assertEquals(width as float, mediaBox.width, 0.01f)
-      assertEquals(height as float, mediaBox.height, 0.01f)
+      assertEquals(expectedPtWidth, mediaBox.width, 0.5f)
+      assertEquals(expectedPtHeight, mediaBox.height, 0.5f)
     } finally {
       document.close()
     }
+  }
+
+  private static void assertPdfHeader(byte[] bytes) {
+    assertTrue(bytes.length >= 4)
+    assertEquals((byte) 0x25, bytes[0])
+    assertEquals((byte) 0x50, bytes[1])
+    assertEquals((byte) 0x44, bytes[2])
+    assertEquals((byte) 0x46, bytes[3])
   }
 
 }


### PR DESCRIPTION
## Summary

Implements Phase 1 from `matrix-charts/req/0.5.0-r3-plan.md`.

- Adds `ChartToPdf.export(String, File)` and `ChartToPdf.export(String, OutputStream)` for SVG-string PDF export parity.
- Makes PDF document creation resource-safe if page/image setup fails.
- Converts chart pixel dimensions to PDF points at 96 DPI so exported PDF page sizes are print-friendly.
- Adds PDF export coverage for SVG strings and `ChartToPdf.export(CharmChart, OutputStream)`.
- Organizes the r3 plan into PR-sized phases and records implementation concerns.

## Modules touched

- `matrix-charts`

## Validation

- `./gradlew :matrix-charts:codenarcMain`
- `./gradlew :matrix-charts:codenarcTest`
- `./gradlew :matrix-charts:spotlessCheck`
- `./gradlew :matrix-charts:test --tests "export.WriteToAndPlotGridExportTest" -Pheadless=true`
- `./gradlew :matrix-charts:test -Pheadless=true` (`728 tests, 728 passed`)
