### PR TITLE
[codex] Add PlotGrid dimension writeTo overloads

### DIFF
--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/PlotGrid.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/PlotGrid.groovy
@@ -185,6 +185,22 @@ class PlotGrid {
   }
 
   /**
+   * Writes the grid to a target file path using custom render dimensions,
+   * auto-detecting the format from the file extension.
+   * Supported extensions: {@code .png}, {@code .jpg}/{@code .jpeg}, {@code .pdf}, and {@code .svg} (default).
+   *
+   * @param targetPath path to output file
+   * @param width render width in pixels
+   * @param height render height in pixels
+   */
+  void writeTo(String targetPath, int width, int height) {
+    if (targetPath == null || targetPath.trim().isEmpty()) {
+      throw new IllegalArgumentException('targetPath cannot be blank')
+    }
+    writeTo(new File(targetPath), width, height)
+  }
+
+  /**
    * Writes the grid to a target file, auto-detecting the format from the file extension.
    * Supported extensions: {@code .png}, {@code .jpg}/{@code .jpeg}, {@code .pdf}, and {@code .svg} (default).
    *
@@ -199,6 +215,28 @@ class PlotGrid {
       case ExportFormat.JPEG -> ChartToJpeg.export(this, targetFile)
       case ExportFormat.PDF -> ChartToPdf.export(this, targetFile)
       default -> targetFile.text = SvgWriter.toXmlPretty(render())
+    }
+  }
+
+  /**
+   * Writes the grid to a target file using custom render dimensions,
+   * auto-detecting the format from the file extension.
+   * Supported extensions: {@code .png}, {@code .jpg}/{@code .jpeg}, {@code .pdf}, and {@code .svg} (default).
+   *
+   * @param targetFile output file
+   * @param width render width in pixels
+   * @param height render height in pixels
+   */
+  void writeTo(File targetFile, int width, int height) {
+    if (targetFile == null) {
+      throw new IllegalArgumentException('targetFile cannot be null')
+    }
+    Svg svg = render(width, height)
+    switch (ExportFormat.fromFile(targetFile)) {
+      case ExportFormat.PNG -> ChartToPng.export(svg, targetFile)
+      case ExportFormat.JPEG -> ChartToJpeg.export(svg, targetFile)
+      case ExportFormat.PDF -> ChartToPdf.export(svg, targetFile)
+      default -> targetFile.text = SvgWriter.toXmlPretty(svg)
     }
   }
 

--- a/matrix-charts/src/test/groovy/export/WriteToAndPlotGridExportTest.groovy
+++ b/matrix-charts/src/test/groovy/export/WriteToAndPlotGridExportTest.groovy
@@ -262,6 +262,17 @@ class WriteToAndPlotGridExportTest {
   }
 
   @Test
+  void testPlotGridWriteToJpegWithDimensions(@TempDir Path tempDir) {
+    PlotGrid grid = buildSingleGrid()
+    File file = tempDir.resolve('grid-sized.jpg').toFile()
+    grid.writeTo(file, 320, 240)
+    BufferedImage image = ImageIO.read(file)
+    assertNotNull(image)
+    assertEquals(320, image.width)
+    assertEquals(240, image.height)
+  }
+
+  @Test
   void testPlotGridWriteToSvgWithDimensions(@TempDir Path tempDir) {
     PlotGrid grid = buildSingleGrid()
     File file = tempDir.resolve('grid-sized.svg').toFile()
@@ -281,6 +292,10 @@ class WriteToAndPlotGridExportTest {
     File file = new File(path)
     assertTrue(file.exists())
     assertTrue(file.length() > 0)
+    BufferedImage image = ImageIO.read(file)
+    assertNotNull(image)
+    assertEquals(320, image.width)
+    assertEquals(240, image.height)
   }
 
   @Test

--- a/matrix-charts/src/test/groovy/export/WriteToAndPlotGridExportTest.groovy
+++ b/matrix-charts/src/test/groovy/export/WriteToAndPlotGridExportTest.groovy
@@ -241,6 +241,49 @@ class WriteToAndPlotGridExportTest {
   }
 
   @Test
+  void testPlotGridWriteToPdfWithDimensions(@TempDir Path tempDir) {
+    PlotGrid grid = buildSingleGrid()
+    File file = tempDir.resolve('grid-sized.pdf').toFile()
+    grid.writeTo(file, 320, 240)
+    assertPdfDimensions(file, 320, 240)
+  }
+
+  @Test
+  void testPlotGridWriteToPngWithDimensions(@TempDir Path tempDir) {
+    PlotGrid grid = buildSingleGrid()
+    File file = tempDir.resolve('grid-sized.png').toFile()
+    grid.writeTo(file, 320, 240)
+    assertTrue(file.exists())
+    assertTrue(file.length() > 0)
+    BufferedImage image = ImageIO.read(file)
+    assertNotNull(image)
+    assertEquals(320, image.width)
+    assertEquals(240, image.height)
+  }
+
+  @Test
+  void testPlotGridWriteToSvgWithDimensions(@TempDir Path tempDir) {
+    PlotGrid grid = buildSingleGrid()
+    File file = tempDir.resolve('grid-sized.svg').toFile()
+    grid.writeTo(file, 320, 240)
+    assertTrue(file.exists())
+    String content = file.text
+    assertTrue(content.contains('<svg'))
+    assertTrue(content.contains('width="320"'))
+    assertTrue(content.contains('height="240"'))
+  }
+
+  @Test
+  void testPlotGridWriteToStringPathWithDimensions(@TempDir Path tempDir) {
+    PlotGrid grid = buildSingleGrid()
+    String path = tempDir.resolve('grid-sized.png') as String
+    grid.writeTo(path, 320, 240)
+    File file = new File(path)
+    assertTrue(file.exists())
+    assertTrue(file.length() > 0)
+  }
+
+  @Test
   void testPlotGridWriteToPdf(@TempDir Path tempDir) {
     PlotGrid grid = buildGrid()
     File file = tempDir.resolve('grid.pdf').toFile()
@@ -391,6 +434,14 @@ class WriteToAndPlotGridExportTest {
     plotGrid {
       add c1, c2
       ncol 2
+    }
+  }
+
+  private static PlotGrid buildSingleGrid() {
+    Chart chart = buildChart()
+    plotGrid {
+      add chart
+      ncol 1
     }
   }
 


### PR DESCRIPTION
## Summary

Implements Phase 2 from `matrix-charts/req/0.5.0-r3-plan.md`.

- Adds `PlotGrid.writeTo(String, int, int)` and `PlotGrid.writeTo(File, int, int)`.
- Routes custom-dimension PlotGrid export through `render(width, height)` before dispatching by file extension.
- Adds coverage for custom-size PlotGrid PDF, PNG, SVG, and String path exports.

## Modules touched

- `matrix-charts`

## Validation

- `./gradlew :matrix-charts:test --tests "export.WriteToAndPlotGridExportTest" -Pheadless=true` (`37 tests, 37 passed`)
- `./gradlew :matrix-charts:codenarcMain`
- `./gradlew :matrix-charts:spotlessCheck`
- `./gradlew :matrix-charts:test -Pheadless=true` (`732 tests, 732 passed`)
- `./gradlew :matrix-charts:codenarcTest`
