### PR TITLE
[codex] Improve chart render diagnostics

### DIFF
--- a/matrix-charts/req/0.5.0-r3-plan.md
+++ b/matrix-charts/req/0.5.0-r3-plan.md
@@ -564,7 +564,7 @@ The implementation follows the identical pattern as `Chart.writeTo(File, int, in
 - Modify: `matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Chart.groovy:335-341`
 - Test: `matrix-charts/src/test/groovy/chart/ChartBuilderTest.groovy` (or nearest chart test)
 
-- [ ] **Step 1: Write a failing test for the double-wrap**
+- [x] **Step 1: Write a failing test for the double-wrap**
 
   Find an existing test file that exercises `Chart.render()`. Add this test to `matrix-charts/src/test/groovy/chart/ChartBuilderTest.groovy` or `ChartFactoryBaselineTest.groovy`:
 
@@ -589,15 +589,15 @@ The implementation follows the identical pattern as `Chart.writeTo(File, int, in
 
   **Implementation concern:** This setup is intentionally provisional. It depends on `plotSpec` accessibility and on `setX(null)` producing a `CharmRenderException` instead of an NPE or silent render. If it does not compile or does not produce the right exception type, use another existing invalid-chart pattern that reliably enters `Chart.render()` and throws `CharmRenderException`.
 
-- [ ] **Step 2: Run the test to confirm the current double-wrap behaviour**
+- [x] **Step 2: Run the test to confirm the current double-wrap behaviour**
 
   ```bash
-  ./gradlew :matrix-charts:test --tests "*ChartBuilderTest.testRenderExceptionIsNotDoubleWrapped" -Pheadless=true
+  ./gradlew :matrix-charts:test --tests "charm.render.CharmRendererTest.testRenderExceptionIsNotDoubleWrapped" -Pheadless=true
   ```
 
-  Expected: FAIL — `ex.cause instanceof CharmRenderException` is `true` (the double-wrap is present).
+  Result: FAIL — `ex.cause instanceof CharmRenderException` was `true` (the double-wrap was present).
 
-- [ ] **Step 3: Fix `Chart.render()` to mirror `RenderBuilder.render()`**
+- [x] **Step 3: Fix `Chart.render()` to mirror `RenderBuilder.render()`**
 
   Replace lines 335–341 in `Chart.groovy`:
 
@@ -613,20 +613,24 @@ The implementation follows the identical pattern as `Chart.writeTo(File, int, in
   }
   ```
 
-- [ ] **Step 4: Run the test to confirm it passes**
+- [x] **Step 4: Run the test to confirm it passes**
 
   ```bash
-  ./gradlew :matrix-charts:test --tests "*ChartBuilderTest.testRenderExceptionIsNotDoubleWrapped" -Pheadless=true
+  ./gradlew :matrix-charts:test --tests "charm.render.CharmRendererTest.testRenderExceptionIsNotDoubleWrapped" -Pheadless=true
   ```
 
-  Expected: PASS.
+  Result: PASS.
 
-- [ ] **Step 5: Run CodeNarc and full test suite**
+- [x] **Step 5: Run CodeNarc and full test suite**
 
   ```bash
   ./gradlew :matrix-charts:codenarcMain
+  ./gradlew :matrix-charts:spotlessCheck
   ./gradlew :matrix-charts:test -Pheadless=true
+  ./gradlew :matrix-charts:codenarcTest
   ```
+
+  Result: PASS. Full chart suite result was 734 tests passed.
 
 - [ ] **Step 6: Commit**
 
@@ -660,7 +664,7 @@ log.warn("message")
 - Modify: `matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/SfStat.groovy` (line 30)
 - Modify: `matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/SfCoordinatesStat.groovy` (line 31)
 
-- [ ] **Step 1: Add Logger to `TemporalScaleUtil` and fix `resolveZoneId`**
+- [x] **Step 1: Add Logger to `TemporalScaleUtil` and fix `resolveZoneId`**
 
   `TemporalScaleUtil` currently has no `log` field. Add the import and field alongside the existing imports/constants at the top of the class:
 
@@ -681,7 +685,7 @@ log.warn("message")
   }
   ```
 
-- [ ] **Step 2: Fix the silent catch in `formatter`**
+- [x] **Step 2: Fix the silent catch in `formatter`**
 
   Locate the `formatter(String pattern, String fallback)` private method (around line 783–793). Replace the silent catch:
 
@@ -694,7 +698,7 @@ log.warn("message")
   }
   ```
 
-- [ ] **Step 3: Add Logger to `SfStat` and fix the silent catch**
+- [x] **Step 3: Add Logger to `SfStat` and fix the silent catch**
 
   `SfStat.groovy` currently has no `log` field. Add the import and field:
 
@@ -714,7 +718,7 @@ log.warn("message")
   }
   ```
 
-- [ ] **Step 4: Add Logger to `SfCoordinatesStat` and fix the silent catch**
+- [x] **Step 4: Add Logger to `SfCoordinatesStat` and fix the silent catch**
 
   Same pattern as `SfStat`:
 
@@ -734,12 +738,16 @@ log.warn("message")
   }
   ```
 
-- [ ] **Step 5: Run CodeNarc and full test suite**
+- [x] **Step 5: Run CodeNarc and full test suite**
 
   ```bash
   ./gradlew :matrix-charts:codenarcMain
+  ./gradlew :matrix-charts:spotlessCheck
   ./gradlew :matrix-charts:test -Pheadless=true
+  ./gradlew :matrix-charts:codenarcTest
   ```
+
+  Result: PASS. Full chart suite result was 734 tests passed.
 
 - [ ] **Step 6: Commit**
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Chart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Chart.groovy
@@ -335,6 +335,8 @@ class Chart {
   Svg render() {
     try {
       new CharmRenderer().render(this)
+    } catch (CharmRenderException e) {
+      throw e
     } catch (Exception e) {
       throw new CharmRenderException("Failed to render Charm chart: ${e.message}", e)
     }

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/scale/TemporalScaleUtil.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/scale/TemporalScaleUtil.groovy
@@ -62,7 +62,7 @@ class TemporalScaleUtil {
     try {
       return ZoneId.of(configured)
     } catch (Exception ignored) {
-      log.warn("Invalid zoneId '${configured}', falling back to ${DEFAULT_ZONE}; check the 'zoneId' scale parameter")
+      log.warn("Invalid zoneId '${configured}', falling back to ${DEFAULT_ZONE.id}; check the 'zoneId' scale parameter")
       return DEFAULT_ZONE
     }
   }

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/scale/TemporalScaleUtil.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/scale/TemporalScaleUtil.groovy
@@ -2,6 +2,7 @@ package se.alipsa.matrix.charm.render.scale
 
 import se.alipsa.matrix.charm.ScaleTransform
 import se.alipsa.matrix.core.ValueConverter
+import se.alipsa.matrix.core.util.Logger
 
 import java.time.Duration
 import java.time.Instant
@@ -29,6 +30,7 @@ class TemporalScaleUtil {
 
   static final ZoneId DEFAULT_ZONE = ZoneOffset.UTC
 
+  private static final Logger log = Logger.getLogger(TemporalScaleUtil)
   private static final BigDecimal MILLIS_PER_DAY = 86_400_000
   private static final String DATE_TRANSFORM = 'date'
   private static final String TIME_TRANSFORM = 'time'
@@ -60,6 +62,7 @@ class TemporalScaleUtil {
     try {
       return ZoneId.of(configured)
     } catch (Exception ignored) {
+      log.warn("Invalid zoneId '${configured}', falling back to ${DEFAULT_ZONE}; check the 'zoneId' scale parameter")
       return DEFAULT_ZONE
     }
   }
@@ -788,6 +791,7 @@ class TemporalScaleUtil {
     try {
       DateTimeFormatter.ofPattern(resolved)
     } catch (Exception ignored) {
+      log.warn("Invalid date/time format pattern '${resolved}', falling back to '${fallback}'")
       DateTimeFormatter.ofPattern(fallback)
     }
   }

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/SfCoordinatesStat.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/SfCoordinatesStat.groovy
@@ -4,12 +4,15 @@ import se.alipsa.matrix.charm.LayerSpec
 import se.alipsa.matrix.charm.render.LayerData
 import se.alipsa.matrix.charm.sf.SfGeometry
 import se.alipsa.matrix.charm.sf.SfGeometryUtils
+import se.alipsa.matrix.core.util.Logger
 
 /**
  * Computes representative label points for simple-feature geometries.
  */
 @SuppressWarnings('ReturnNullFromCatchBlock')
 class SfCoordinatesStat {
+
+  private static final Logger log = Logger.getLogger(SfCoordinatesStat)
 
   static List<LayerData> compute(LayerSpec layer, List<LayerData> data) {
     if (data == null || data.isEmpty()) {
@@ -28,7 +31,8 @@ class SfCoordinatesStat {
       SfGeometry geometry
       try {
         geometry = SfStatSupport.toGeometry(geometryValue)
-      } catch (Exception ignored) {
+      } catch (Exception e) {
+        log.debug("SfCoordinatesStat: skipping row - cannot parse geometry from '${geometryValue}': ${e.message}")
         return
       }
       if (geometry == null || geometry.empty) {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/SfStat.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/SfStat.groovy
@@ -3,12 +3,15 @@ package se.alipsa.matrix.charm.render.stat
 import se.alipsa.matrix.charm.LayerSpec
 import se.alipsa.matrix.charm.render.LayerData
 import se.alipsa.matrix.charm.sf.SfGeometry
+import se.alipsa.matrix.core.util.Logger
 
 /**
  * Expands simple-feature geometries into x/y rows for rendering.
  */
 @SuppressWarnings('ReturnNullFromCatchBlock')
 class SfStat {
+
+  private static final Logger log = Logger.getLogger(SfStat)
 
   static List<LayerData> compute(LayerSpec layer, List<LayerData> data) {
     if (data == null || data.isEmpty()) {
@@ -27,7 +30,8 @@ class SfStat {
       SfGeometry geometry
       try {
         geometry = SfStatSupport.toGeometry(geometryValue)
-      } catch (Exception ignored) {
+      } catch (Exception e) {
+        log.debug("SfStat: skipping row - cannot parse geometry from '${geometryValue}': ${e.message}")
         return
       }
       if (geometry == null || geometry.empty) {

--- a/matrix-charts/src/test/groovy/charm/render/CharmRendererTest.groovy
+++ b/matrix-charts/src/test/groovy/charm/render/CharmRendererTest.groovy
@@ -1,6 +1,7 @@
 package charm.render
 
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
 import static org.junit.jupiter.api.Assertions.assertNotEquals
 import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.junit.jupiter.api.Assertions.assertTrue
@@ -12,13 +13,48 @@ import se.alipsa.groovy.svg.Circle
 import se.alipsa.groovy.svg.Line
 import se.alipsa.groovy.svg.Rect
 import se.alipsa.groovy.svg.Svg
+import se.alipsa.matrix.charm.CharmRenderException
 import se.alipsa.matrix.charm.Chart
 import se.alipsa.matrix.charm.Charts
 import se.alipsa.matrix.charm.render.CharmRenderer
 import se.alipsa.matrix.charm.render.RenderConfig
 import se.alipsa.matrix.core.Matrix
 
+import java.lang.reflect.Field
+
 class CharmRendererTest {
+
+  @Test
+  void testRenderExceptionIsNotDoubleWrapped() {
+    Matrix data = Matrix.builder()
+        .columnNames('x', 'y')
+        .rows([[1, 2]])
+        .build()
+
+    Chart chart = plot(data) {
+      mapping {
+        x = 'x'
+        y = 'y'
+      }
+      layers { geomPoint() }
+    }.build()
+
+    setField(chart.layers[0].geomSpec, 'type', null)
+
+    CharmRenderException ex = assertThrows(CharmRenderException) {
+      chart.render()
+    }
+    assertFalse(
+        ex.cause instanceof CharmRenderException,
+        "render() must not double-wrap CharmRenderException; cause was: ${ex.cause?.getClass()?.name}"
+    )
+  }
+
+  private static void setField(Object target, String name, Object value) {
+    Field field = target.class.getDeclaredField(name)
+    field.accessible = true
+    field.set(target, value)
+  }
 
   @Test
   void testPointLayerRendersCirclesAxesAndClipPath() {

--- a/matrix-charts/src/test/groovy/charm/render/CharmRendererTest.groovy
+++ b/matrix-charts/src/test/groovy/charm/render/CharmRendererTest.groovy
@@ -39,6 +39,7 @@ class CharmRendererTest {
       layers { geomPoint() }
     }.build()
 
+    // GeomSpec.type is final; reflection is needed to force this renderer-only failure path.
     setField(chart.layers[0].geomSpec, 'type', null)
 
     CharmRenderException ex = assertThrows(CharmRenderException) {


### PR DESCRIPTION
## Summary

- Re-throw existing `CharmRenderException` instances from `Chart.render()` instead of wrapping them again.
- Add regression coverage for the double-wrap case in `CharmRendererTest`.
- Add warning logs for invalid temporal `zoneId` and date/time format fallback.
- Add debug logs when simple-feature geometry parsing fails and rows are skipped.
- Record completed Phase 3 steps and verification in `matrix-charts/req/0.5.0-r3-plan.md`.

## Modules touched

- `matrix-charts`

## Validation

- `./gradlew :matrix-charts:test --tests "charm.render.CharmRendererTest.testRenderExceptionIsNotDoubleWrapped" -Pheadless=true`
- `./gradlew :matrix-charts:codenarcMain`
- `./gradlew :matrix-charts:spotlessCheck`
- `./gradlew :matrix-charts:test -Pheadless=true` (`734 tests passed`)
- `./gradlew :matrix-charts:codenarcTest`