### PR TITLE
[codex] Replace chart Object overloads with typed APIs

### DIFF
--- a/matrix-charts/req/0.5.0-r3-plan.md
+++ b/matrix-charts/req/0.5.0-r3-plan.md
@@ -785,7 +785,7 @@ log.warn("message")
 - Modify: `matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/LayerBuilder.groovy`
 - Test: `matrix-charts/src/test/groovy/charm/api/CharmTypedOverloadApiTest.groovy`
 
-- [ ] **Step 1: Write failing tests for the new typed overloads**
+- [x] **Step 1: Write failing tests for the new typed overloads**
 
   Add a new test class or extend `CharmTypedOverloadApiTest.groovy`. The tests should call the typed methods and verify they compile and produce correct results under `@CompileStatic`:
 
@@ -851,15 +851,15 @@ log.warn("message")
   }
   ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
   ```bash
   ./gradlew :matrix-charts:test --tests "*CharmTypedOverloadApiTest" -Pheadless=true
   ```
 
-  Expected: compile failures — `x(String)`, `fontface(int)`, `bins(int)`, etc. do not yet exist.
+  Result: Existing `Object` overloads allowed typed calls to pass, so reflection assertions were added to verify the targeted public `Object` overloads are absent.
 
-- [ ] **Step 3: Replace `Object` methods in `MappingSpec.groovy`**
+- [x] **Step 3: Replace `Object` methods in `MappingSpec.groovy`**
 
   For each of the 13 aesthetic methods, replace the single `Object` overload with `String` and `ColumnExpr` overloads. Example for `x` — repeat this pattern for `y`, `color`, `fill`, `size`, `shape`, `group`, `xend`, `yend`, `xmin`, `xmax`, `ymin`, `ymax`, `alpha`, `linetype`, `label`, `tooltip`, `weight`:
 
@@ -889,7 +889,7 @@ log.warn("message")
 
   Remove the original `MappingSpec x(Object value)` method. `Mapping.setX(Object value)` in the base class is unchanged — it handles the property-assignment DSL path and coercion.
 
-- [ ] **Step 4: Replace `fontface(Object)` in `TextBuilder` and `LabelBuilder`**
+- [x] **Step 4: Replace `fontface(Object)` in `TextBuilder` and `LabelBuilder`**
 
   In `TextBuilder.groovy` (line 93) and `LabelBuilder.groovy` (line 94), replace `fontface(Object value)` with:
 
@@ -919,7 +919,7 @@ log.warn("message")
 
   Use `LabelBuilder` as the return type in `LabelBuilder.groovy`.
 
-- [ ] **Step 5: Replace `bins(Object)` in `Bin2dBuilder`**
+- [x] **Step 5: Replace `bins(Object)` in `Bin2dBuilder`**
 
   ```groovy
   /**
@@ -945,7 +945,7 @@ log.warn("message")
   }
   ```
 
-- [ ] **Step 6: Replace `stat(Object)` in `LayerBuilder`**
+- [x] **Step 6: Replace `stat(Object)` in `LayerBuilder`**
 
   Replace the single `stat(Object stat)` method with three typed overloads. The private `parseStatType(Object)` method is unchanged — it is still used internally for String parsing:
 
@@ -990,7 +990,7 @@ log.warn("message")
   }
   ```
 
-- [ ] **Step 7: Replace `position(Object)` in `LayerBuilder`**
+- [x] **Step 7: Replace `position(Object)` in `LayerBuilder`**
 
   `LayerDsl.parsePosition(Object)` handles the coercion logic. Route each typed overload through it to avoid duplication:
 
@@ -1029,16 +1029,17 @@ log.warn("message")
   }
   ```
 
-- [ ] **Step 8: Run CodeNarc, Spotless, and tests**
+- [x] **Step 8: Run CodeNarc, Spotless, and tests**
 
   ```bash
   ./gradlew :matrix-charts:codenarcMain
   ./gradlew :matrix-charts:codenarcTest
   ./gradlew :matrix-charts:spotlessCheck
+  ./gradlew :matrix-charts:test --tests "*CharmTypedOverloadApiTest" --tests "export.*" -Pheadless=true
   ./gradlew :matrix-charts:test -Pheadless=true
   ```
 
-  Expected: all pass. If any test that previously passed `Object` args now fails to compile, it reveals a usage that must be updated.
+  Result: PASS. Full chart suite result was 744 tests passed. `SampleStatTest` was updated so unsupported `stat([:])` now expects Groovy's missing-method error from the typed API.
 
 - [ ] **Step 9: Commit**
 
@@ -1049,6 +1050,7 @@ log.warn("message")
   git add matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/Bin2dBuilder.groovy
   git add matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/LayerBuilder.groovy
   git add matrix-charts/src/test/groovy/charm/api/CharmTypedOverloadApiTest.groovy
+  git add matrix-charts/src/test/groovy/charm/render/stat/SampleStatTest.groovy
   git commit -m "Replace Object params with typed overloads in MappingSpec and builder APIs"
   ```
 
@@ -1442,11 +1444,11 @@ The embedded image itself is still `image.width × image.height` pixels; PDFBox 
 - Modify: `matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToSwing.groovy`
 - Test: `matrix-charts/src/test/groovy/export/CharmExportTest.groovy` or `WriteToAndPlotGridExportTest.groovy`
 
-- [ ] **Step 1: Add typed-dispatch tests**
+- [x] **Step 1: Add typed-dispatch tests**
 
   Add `@CompileStatic` tests that call `ChartToSwing.export` with each supported concrete type. Include a `CharSequence`/`GString` case only if a dedicated typed overload is added for it.
 
-- [ ] **Step 2: Remove or hide the public `Object` overload**
+- [x] **Step 2: Remove or hide the public `Object` overload**
 
   Prefer adding:
 
@@ -1458,13 +1460,17 @@ The embedded image itself is still `image.width × image.height` pixels; PDFBox 
 
   Then remove the public `export(Object)` overload. If dynamic dispatch is still needed internally, make it private and do not expose it as public API.
 
-- [ ] **Step 3: Run verification**
+- [x] **Step 3: Run verification**
 
   ```bash
   ./gradlew :matrix-charts:codenarcMain
+  ./gradlew :matrix-charts:codenarcTest
   ./gradlew :matrix-charts:spotlessCheck
   ./gradlew :matrix-charts:test --tests "export.*" -Pheadless=true
+  ./gradlew :matrix-charts:test -Pheadless=true
   ```
+
+  Result: PASS. Full chart suite result was 744 tests passed.
 
 - [ ] **Step 4: Commit**
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/MappingSpec.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/MappingSpec.groovy
@@ -6,191 +6,292 @@ package se.alipsa.matrix.charm
 class MappingSpec extends Mapping {
 
   /**
-   * Builder-style x mapping assignment.
+   * Builder-style x mapping assignment from a column name.
    *
-   * @param value mapping value
+   * @param value column name
    * @return this spec
    */
-  MappingSpec x(Object value) {
-    setX(value)
-    this
-  }
+  MappingSpec x(String value) { setX(value); this }
 
   /**
-   * Builder-style y mapping assignment.
+   * Builder-style x mapping assignment from a column expression.
    *
-   * @param value mapping value
+   * @param value column expression
    * @return this spec
    */
-  MappingSpec y(Object value) {
-    setY(value)
-    this
-  }
+  MappingSpec x(ColumnExpr value) { setX(value); this }
 
   /**
-   * Builder-style color mapping assignment.
+   * Builder-style y mapping assignment from a column name.
    *
-   * @param value mapping value
+   * @param value column name
    * @return this spec
    */
-  MappingSpec color(Object value) {
-    setColor(value)
-    this
-  }
+  MappingSpec y(String value) { setY(value); this }
 
   /**
-   * Builder-style fill mapping assignment.
+   * Builder-style y mapping assignment from a column expression.
    *
-   * @param value mapping value
+   * @param value column expression
    * @return this spec
    */
-  MappingSpec fill(Object value) {
-    setFill(value)
-    this
-  }
+  MappingSpec y(ColumnExpr value) { setY(value); this }
 
   /**
-   * Builder-style size mapping assignment.
+   * Builder-style color mapping assignment from a column name.
    *
-   * @param value mapping value
+   * @param value column name
    * @return this spec
    */
-  MappingSpec size(Object value) {
-    setSize(value)
-    this
-  }
+  MappingSpec color(String value) { setColor(value); this }
 
   /**
-   * Builder-style shape mapping assignment.
+   * Builder-style color mapping assignment from a column expression.
    *
-   * @param value mapping value
+   * @param value column expression
    * @return this spec
    */
-  MappingSpec shape(Object value) {
-    setShape(value)
-    this
-  }
+  MappingSpec color(ColumnExpr value) { setColor(value); this }
 
   /**
-   * Builder-style group mapping assignment.
+   * Builder-style fill mapping assignment from a column name.
    *
-   * @param value mapping value
+   * @param value column name
    * @return this spec
    */
-  MappingSpec group(Object value) {
-    setGroup(value)
-    this
-  }
+  MappingSpec fill(String value) { setFill(value); this }
 
   /**
-   * Builder-style xend mapping assignment.
+   * Builder-style fill mapping assignment from a column expression.
    *
-   * @param value mapping value
+   * @param value column expression
    * @return this spec
    */
-  MappingSpec xend(Object value) {
-    setXend(value)
-    this
-  }
+  MappingSpec fill(ColumnExpr value) { setFill(value); this }
 
   /**
-   * Builder-style yend mapping assignment.
+   * Builder-style size mapping assignment from a column name.
    *
-   * @param value mapping value
+   * @param value column name
    * @return this spec
    */
-  MappingSpec yend(Object value) {
-    setYend(value)
-    this
-  }
+  MappingSpec size(String value) { setSize(value); this }
 
   /**
-   * Builder-style xmin mapping assignment.
+   * Builder-style size mapping assignment from a column expression.
    *
-   * @param value mapping value
+   * @param value column expression
    * @return this spec
    */
-  MappingSpec xmin(Object value) {
-    setXmin(value)
-    this
-  }
+  MappingSpec size(ColumnExpr value) { setSize(value); this }
 
   /**
-   * Builder-style xmax mapping assignment.
+   * Builder-style shape mapping assignment from a column name.
    *
-   * @param value mapping value
+   * @param value column name
    * @return this spec
    */
-  MappingSpec xmax(Object value) {
-    setXmax(value)
-    this
-  }
+  MappingSpec shape(String value) { setShape(value); this }
 
   /**
-   * Builder-style ymin mapping assignment.
+   * Builder-style shape mapping assignment from a column expression.
    *
-   * @param value mapping value
+   * @param value column expression
    * @return this spec
    */
-  MappingSpec ymin(Object value) {
-    setYmin(value)
-    this
-  }
+  MappingSpec shape(ColumnExpr value) { setShape(value); this }
 
   /**
-   * Builder-style ymax mapping assignment.
+   * Builder-style group mapping assignment from a column name.
    *
-   * @param value mapping value
+   * @param value column name
    * @return this spec
    */
-  MappingSpec ymax(Object value) {
-    setYmax(value)
-    this
-  }
+  MappingSpec group(String value) { setGroup(value); this }
 
   /**
-   * Builder-style alpha mapping assignment.
+   * Builder-style group mapping assignment from a column expression.
    *
-   * @param value mapping value
+   * @param value column expression
    * @return this spec
    */
-  MappingSpec alpha(Object value) {
-    setAlpha(value)
-    this
-  }
+  MappingSpec group(ColumnExpr value) { setGroup(value); this }
 
   /**
-   * Builder-style linetype mapping assignment.
+   * Builder-style xend mapping assignment from a column name.
    *
-   * @param value mapping value
+   * @param value column name
    * @return this spec
    */
-  MappingSpec linetype(Object value) {
-    setLinetype(value)
-    this
-  }
+  MappingSpec xend(String value) { setXend(value); this }
 
   /**
-   * Builder-style label mapping assignment.
+   * Builder-style xend mapping assignment from a column expression.
    *
-   * @param value mapping value
+   * @param value column expression
    * @return this spec
    */
-  MappingSpec label(Object value) {
-    setLabel(value)
-    this
-  }
+  MappingSpec xend(ColumnExpr value) { setXend(value); this }
 
   /**
-   * Builder-style weight mapping assignment.
+   * Builder-style yend mapping assignment from a column name.
    *
-   * @param value mapping value
+   * @param value column name
    * @return this spec
    */
-  MappingSpec weight(Object value) {
-    setWeight(value)
-    this
-  }
+  MappingSpec yend(String value) { setYend(value); this }
+
+  /**
+   * Builder-style yend mapping assignment from a column expression.
+   *
+   * @param value column expression
+   * @return this spec
+   */
+  MappingSpec yend(ColumnExpr value) { setYend(value); this }
+
+  /**
+   * Builder-style xmin mapping assignment from a column name.
+   *
+   * @param value column name
+   * @return this spec
+   */
+  MappingSpec xmin(String value) { setXmin(value); this }
+
+  /**
+   * Builder-style xmin mapping assignment from a column expression.
+   *
+   * @param value column expression
+   * @return this spec
+   */
+  MappingSpec xmin(ColumnExpr value) { setXmin(value); this }
+
+  /**
+   * Builder-style xmax mapping assignment from a column name.
+   *
+   * @param value column name
+   * @return this spec
+   */
+  MappingSpec xmax(String value) { setXmax(value); this }
+
+  /**
+   * Builder-style xmax mapping assignment from a column expression.
+   *
+   * @param value column expression
+   * @return this spec
+   */
+  MappingSpec xmax(ColumnExpr value) { setXmax(value); this }
+
+  /**
+   * Builder-style ymin mapping assignment from a column name.
+   *
+   * @param value column name
+   * @return this spec
+   */
+  MappingSpec ymin(String value) { setYmin(value); this }
+
+  /**
+   * Builder-style ymin mapping assignment from a column expression.
+   *
+   * @param value column expression
+   * @return this spec
+   */
+  MappingSpec ymin(ColumnExpr value) { setYmin(value); this }
+
+  /**
+   * Builder-style ymax mapping assignment from a column name.
+   *
+   * @param value column name
+   * @return this spec
+   */
+  MappingSpec ymax(String value) { setYmax(value); this }
+
+  /**
+   * Builder-style ymax mapping assignment from a column expression.
+   *
+   * @param value column expression
+   * @return this spec
+   */
+  MappingSpec ymax(ColumnExpr value) { setYmax(value); this }
+
+  /**
+   * Builder-style alpha mapping assignment from a column name.
+   *
+   * @param value column name
+   * @return this spec
+   */
+  MappingSpec alpha(String value) { setAlpha(value); this }
+
+  /**
+   * Builder-style alpha mapping assignment from a column expression.
+   *
+   * @param value column expression
+   * @return this spec
+   */
+  MappingSpec alpha(ColumnExpr value) { setAlpha(value); this }
+
+  /**
+   * Builder-style linetype mapping assignment from a column name.
+   *
+   * @param value column name
+   * @return this spec
+   */
+  MappingSpec linetype(String value) { setLinetype(value); this }
+
+  /**
+   * Builder-style linetype mapping assignment from a column expression.
+   *
+   * @param value column expression
+   * @return this spec
+   */
+  MappingSpec linetype(ColumnExpr value) { setLinetype(value); this }
+
+  /**
+   * Builder-style label mapping assignment from a column name.
+   *
+   * @param value column name
+   * @return this spec
+   */
+  MappingSpec label(String value) { setLabel(value); this }
+
+  /**
+   * Builder-style label mapping assignment from a column expression.
+   *
+   * @param value column expression
+   * @return this spec
+   */
+  MappingSpec label(ColumnExpr value) { setLabel(value); this }
+
+  /**
+   * Builder-style tooltip mapping assignment from a column name.
+   *
+   * @param value column name
+   * @return this spec
+   */
+  MappingSpec tooltip(String value) { setTooltip(value); this }
+
+  /**
+   * Builder-style tooltip mapping assignment from a column expression.
+   *
+   * @param value column expression
+   * @return this spec
+   */
+  MappingSpec tooltip(ColumnExpr value) { setTooltip(value); this }
+
+  /**
+   * Builder-style weight mapping assignment from a column name.
+   *
+   * @param value column name
+   * @return this spec
+   */
+  MappingSpec weight(String value) { setWeight(value); this }
+
+  /**
+   * Builder-style weight mapping assignment from a column expression.
+   *
+   * @param value column expression
+   * @return this spec
+   */
+  MappingSpec weight(ColumnExpr value) { setWeight(value); this }
 
   /**
    * Builder-style named mapping apply.

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/Bin2dBuilder.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/Bin2dBuilder.groovy
@@ -19,6 +19,8 @@ import se.alipsa.matrix.charm.CharmStatType
  */
 class Bin2dBuilder extends LayerBuilder {
 
+  private static final String BINS = 'bins'
+
   /**
    * Sets bin fill colour.
    *
@@ -52,13 +54,24 @@ class Bin2dBuilder extends LayerBuilder {
   }
 
   /**
-   * Sets bin count (integer or list of two integers for x/y).
+   * Sets bin count (same for x and y).
    *
    * @param value bin count
    * @return this builder
    */
-  Bin2dBuilder bins(Object value) {
-    params['bins'] = value
+  Bin2dBuilder bins(int value) {
+    params[BINS] = value
+    this
+  }
+
+  /**
+   * Sets bin counts for x and y separately.
+   *
+   * @param value list of [xBins, yBins]
+   * @return this builder
+   */
+  Bin2dBuilder bins(List<Integer> value) {
+    params[BINS] = value
     this
   }
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/LabelBuilder.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/LabelBuilder.groovy
@@ -20,6 +20,8 @@ import se.alipsa.matrix.charm.CharmStatType
  */
 class LabelBuilder extends LayerBuilder {
 
+  private static final String FONTFACE = 'fontface'
+
   /**
    * Sets label text size.
    *
@@ -86,13 +88,24 @@ class LabelBuilder extends LayerBuilder {
   }
 
   /**
-   * Sets font face (e.g. bold, italic).
+   * Sets font face by name (e.g. 'bold', 'italic').
    *
-   * @param value fontface name or integer code
+   * @param value fontface name
    * @return this builder
    */
-  LabelBuilder fontface(Object value) {
-    params['fontface'] = value
+  LabelBuilder fontface(String value) {
+    params[FONTFACE] = value
+    this
+  }
+
+  /**
+   * Sets font face by integer code (1 = plain, 2 = bold, 3 = italic, 4 = bold-italic).
+   *
+   * @param value fontface integer code
+   * @return this builder
+   */
+  LabelBuilder fontface(int value) {
+    params[FONTFACE] = value
     this
   }
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/LayerBuilder.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/LayerBuilder.groovy
@@ -77,32 +77,73 @@ abstract class LayerBuilder {
   }
 
   /**
-   * Sets the position adjustment for this layer.
+   * Sets the position adjustment from a type enum.
    *
-   * @param value position type, spec, or string name
+   * @param value position type
    * @return this builder
    */
-  LayerBuilder position(Object value) {
+  LayerBuilder position(CharmPositionType value) {
     this.positionSpec = LayerDsl.parsePosition(value)
     this
   }
 
   /**
-   * Sets the statistical transformation for this layer.
+   * Sets the position adjustment from a spec.
    *
-   * @param stat stat value as enum, spec, or string name
+   * @param value position spec
    * @return this builder
    */
-  LayerBuilder stat(Object stat) {
+  LayerBuilder position(PositionSpec value) {
+    this.positionSpec = LayerDsl.parsePosition(value)
+    this
+  }
+
+  /**
+   * Sets the position adjustment by name (case-insensitive).
+   *
+   * @param value position name (e.g. 'dodge', 'stack', 'jitter')
+   * @return this builder
+   */
+  LayerBuilder position(String value) {
+    this.positionSpec = LayerDsl.parsePosition(value)
+    this
+  }
+
+  /**
+   * Sets the statistical transformation from a type enum.
+   *
+   * @param stat stat type
+   * @return this builder
+   */
+  LayerBuilder stat(CharmStatType stat) {
     statParams.clear()
-    if (stat instanceof StatSpec) {
-      StatSpec statSpec = stat as StatSpec
-      this.statType = statSpec.type
-      if (statSpec.params != null) {
-        this.statParams.putAll(statSpec.params)
-      }
-      return this
+    this.statType = stat
+    this
+  }
+
+  /**
+   * Sets the statistical transformation from a spec (includes params).
+   *
+   * @param stat stat spec
+   * @return this builder
+   */
+  LayerBuilder stat(StatSpec stat) {
+    statParams.clear()
+    this.statType = stat.type
+    if (stat.params != null) {
+      this.statParams.putAll(stat.params)
     }
+    this
+  }
+
+  /**
+   * Sets the statistical transformation by name (case-insensitive).
+   *
+   * @param stat stat name (e.g. 'count', 'bin', 'identity')
+   * @return this builder
+   */
+  LayerBuilder stat(String stat) {
+    statParams.clear()
     this.statType = parseStatType(stat)
     this
   }
@@ -286,25 +327,19 @@ abstract class LayerBuilder {
     )
   }
 
-  private static CharmStatType parseStatType(Object stat) {
+  private static CharmStatType parseStatType(String stat) {
     if (stat == null) {
       return null
     }
-    if (stat instanceof CharmStatType) {
-      return stat as CharmStatType
+    String normalized = stat.trim()
+    if (normalized.isEmpty()) {
+      return null
     }
-    if (stat instanceof CharSequence) {
-      String normalized = stat.toString().trim()
-      if (normalized.isEmpty()) {
-        return null
-      }
-      try {
-        return CharmStatType.valueOf(normalized.toUpperCase(Locale.ROOT))
-      } catch (IllegalArgumentException e) {
-        throw new CharmValidationException("Unsupported stat '${stat}'", e)
-      }
+    try {
+      return CharmStatType.valueOf(normalized.toUpperCase(Locale.ROOT))
+    } catch (IllegalArgumentException e) {
+      throw new CharmValidationException("Unsupported stat '${stat}'", e)
     }
-    throw new CharmValidationException("Unsupported stat type '${stat.getClass().name}'")
   }
 
   /**

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/TextBuilder.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/TextBuilder.groovy
@@ -19,6 +19,8 @@ import se.alipsa.matrix.charm.CharmStatType
  */
 class TextBuilder extends LayerBuilder {
 
+  private static final String FONTFACE = 'fontface'
+
   /**
    * Sets the label text content.
    *
@@ -85,13 +87,24 @@ class TextBuilder extends LayerBuilder {
   }
 
   /**
-   * Sets font face (e.g. bold, italic).
+   * Sets font face by name (e.g. 'bold', 'italic').
    *
-   * @param value fontface name or integer code
+   * @param value fontface name
    * @return this builder
    */
-  TextBuilder fontface(Object value) {
-    params['fontface'] = value
+  TextBuilder fontface(String value) {
+    params[FONTFACE] = value
+    this
+  }
+
+  /**
+   * Sets font face by integer code (1 = plain, 2 = bold, 3 = italic, 4 = bold-italic).
+   *
+   * @param value fontface integer code
+   * @return this builder
+   */
+  TextBuilder fontface(int value) {
+    params[FONTFACE] = value
     this
   }
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToSwing.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToSwing.groovy
@@ -32,6 +32,19 @@ class ChartToSwing {
   }
 
   /**
+   * Create a {@link SvgPanel} from an SVG document represented as a character sequence.
+   *
+   * @param svgChart the SVG content
+   * @return a {@link SvgPanel} displaying the provided SVG content
+   */
+  static SvgPanel export(CharSequence svgChart) {
+    if (svgChart == null) {
+      throw new IllegalArgumentException('svgChart must not be null')
+    }
+    export(svgChart.toString())
+  }
+
+  /**
    * Create a {@link SvgPanel} from an {@link Svg} instance.
    *
    * @param svgChart the {@link Svg} chart to render
@@ -58,13 +71,6 @@ class ChartToSwing {
   }
 
   /**
-   * Dynamic dispatch overload for untyped chart objects.
-   *
-   * @param svgChart an SVG string, {@link Svg}, or {@link CharmChart}
-   * @return a {@link SvgPanel} displaying the rendered chart
-   * @throws IllegalArgumentException if svgChart is null or an unsupported type
-   */
-  /**
    * Create a {@link SvgPanel} from a legacy {@link Chart} (e.g. BarChart, ScatterChart).
    *
    * @param chart the legacy chart to render
@@ -88,32 +94,6 @@ class ChartToSwing {
       throw new IllegalArgumentException('grid cannot be null')
     }
     export(grid.render())
-  }
-
-  /**
-   * Dynamic dispatch overload for untyped chart objects.
-   *
-   * @param svgChart an SVG string, {@link Svg}, {@link CharmChart}, or legacy {@link Chart}
-   * @return a {@link SvgPanel} displaying the rendered chart
-   * @throws IllegalArgumentException if svgChart is null or an unsupported type
-   */
-  static SvgPanel export(Object svgChart) {
-    if (svgChart == null) {
-      throw new IllegalArgumentException('svgChart must not be null')
-    }
-    if (svgChart instanceof CharSequence) {
-      return export(String.valueOf(svgChart))
-    }
-    if (svgChart instanceof Svg) {
-      return export((Svg) svgChart)
-    }
-    if (svgChart instanceof CharmChart) {
-      return export((CharmChart) svgChart)
-    }
-    if (svgChart instanceof Chart) {
-      return export((Chart) svgChart)
-    }
-    throw new IllegalArgumentException("Unsupported chart type: ${svgChart.getClass().name}")
   }
 
 }

--- a/matrix-charts/src/test/groovy/charm/api/CharmTypedOverloadApiTest.groovy
+++ b/matrix-charts/src/test/groovy/charm/api/CharmTypedOverloadApiTest.groovy
@@ -21,6 +21,7 @@ import se.alipsa.matrix.charm.geom.PointBuilder
 import se.alipsa.matrix.charm.geom.TextBuilder
 
 import java.lang.reflect.Method
+import java.lang.reflect.Modifier
 
 @CompileStatic
 class CharmTypedOverloadApiTest {
@@ -48,8 +49,7 @@ class CharmTypedOverloadApiTest {
   void testMappingSpecFluentApiDoesNotExposeObjectOverloads() {
     List<Method> objectOverloads = MappingSpec.declaredMethods.findAll { Method method ->
       MAPPING_FLUENT_METHODS.contains(method.name) &&
-          method.parameterTypes.length == 1 &&
-          method.parameterTypes[0] == Object
+          isPublicSingleObjectParameter(method)
     }
     assertTrue(objectOverloads.isEmpty(), "Unexpected Object overloads: ${objectOverloads*.name}")
   }
@@ -124,11 +124,15 @@ class CharmTypedOverloadApiTest {
 
   private static void assertNoPublicObjectOverload(Class<?> type, String methodName) {
     List<Method> objectOverloads = type.declaredMethods.findAll { Method method ->
-      method.name == methodName &&
-          method.parameterTypes.length == 1 &&
-          method.parameterTypes[0] == Object
+      method.name == methodName && isPublicSingleObjectParameter(method)
     }
     assertTrue(objectOverloads.isEmpty(), "${type.simpleName}.${methodName}(Object) should not be public API")
+  }
+
+  private static boolean isPublicSingleObjectParameter(Method method) {
+    Modifier.isPublic(method.modifiers) &&
+        method.parameterTypes.length == 1 &&
+        method.parameterTypes[0] == Object
   }
 
 }

--- a/matrix-charts/src/test/groovy/charm/api/CharmTypedOverloadApiTest.groovy
+++ b/matrix-charts/src/test/groovy/charm/api/CharmTypedOverloadApiTest.groovy
@@ -1,0 +1,134 @@
+package charm.api
+
+import static org.junit.jupiter.api.Assertions.*
+
+import groovy.transform.CompileStatic
+
+import org.junit.jupiter.api.Test
+
+import se.alipsa.matrix.charm.CharmPositionType
+import se.alipsa.matrix.charm.CharmStatType
+import se.alipsa.matrix.charm.ColumnExpr
+import se.alipsa.matrix.charm.ColumnRef
+import se.alipsa.matrix.charm.LayerSpec
+import se.alipsa.matrix.charm.MappingSpec
+import se.alipsa.matrix.charm.PositionSpec
+import se.alipsa.matrix.charm.StatSpec
+import se.alipsa.matrix.charm.geom.Bin2dBuilder
+import se.alipsa.matrix.charm.geom.LabelBuilder
+import se.alipsa.matrix.charm.geom.LayerBuilder
+import se.alipsa.matrix.charm.geom.PointBuilder
+import se.alipsa.matrix.charm.geom.TextBuilder
+
+import java.lang.reflect.Method
+
+@CompileStatic
+class CharmTypedOverloadApiTest {
+
+  private static final Set<String> MAPPING_FLUENT_METHODS = [
+      'x', 'y', 'color', 'fill', 'size', 'shape', 'group', 'xend', 'yend',
+      'xmin', 'xmax', 'ymin', 'ymax', 'alpha', 'linetype', 'label', 'tooltip', 'weight'
+  ] as Set<String>
+
+  @Test
+  void testMappingSpecTypedOverloads() {
+    MappingSpec spec = new MappingSpec()
+    spec.x('column_name')
+    assertNotNull(spec.x)
+    assertTrue(spec.x instanceof ColumnRef)
+    assertEquals('column_name', spec.x.columnName())
+
+    ColumnExpr expr = new ColumnRef('other')
+    spec.y(expr)
+    assertNotNull(spec.y)
+    assertSame(expr, spec.y)
+  }
+
+  @Test
+  void testMappingSpecFluentApiDoesNotExposeObjectOverloads() {
+    List<Method> objectOverloads = MappingSpec.declaredMethods.findAll { Method method ->
+      MAPPING_FLUENT_METHODS.contains(method.name) &&
+          method.parameterTypes.length == 1 &&
+          method.parameterTypes[0] == Object
+    }
+    assertTrue(objectOverloads.isEmpty(), "Unexpected Object overloads: ${objectOverloads*.name}")
+  }
+
+  @Test
+  void testTextBuilderFontfaceTypedOverloads() {
+    TextBuilder builder = new TextBuilder()
+    builder.fontface('bold')
+    assertEquals('bold', builder.build().params['fontface'])
+
+    builder.fontface(2)
+    assertEquals(2, builder.build().params['fontface'])
+  }
+
+  @Test
+  void testLabelBuilderFontfaceTypedOverloads() {
+    LabelBuilder builder = new LabelBuilder()
+    builder.fontface('italic')
+    assertEquals('italic', builder.build().params['fontface'])
+
+    builder.fontface(3)
+    assertEquals(3, builder.build().params['fontface'])
+  }
+
+  @Test
+  void testBin2dBuilderBinsTypedOverloads() {
+    Bin2dBuilder builder = new Bin2dBuilder()
+    builder.bins(10)
+    assertEquals(10, builder.build().params['bins'])
+
+    builder.bins([5, 8])
+    assertEquals([5, 8], builder.build().params['bins'])
+  }
+
+  @Test
+  void testLayerBuilderStatTypedOverloads() {
+    LayerBuilder builder = new PointBuilder()
+    builder.stat(CharmStatType.IDENTITY)
+    assertEquals(CharmStatType.IDENTITY, builder.build().statType)
+
+    builder.stat('count')
+    assertEquals(CharmStatType.COUNT, builder.build().statType)
+
+    builder.stat(StatSpec.of(CharmStatType.BIN))
+    assertEquals(CharmStatType.BIN, builder.build().statType)
+  }
+
+  @Test
+  void testLayerBuilderPositionTypedOverloads() {
+    LayerBuilder builder = new PointBuilder()
+    builder.position(CharmPositionType.DODGE)
+    LayerSpec layer = builder.build()
+    assertEquals(CharmPositionType.DODGE, layer.positionSpec.type)
+
+    builder.position(PositionSpec.of(CharmPositionType.STACK))
+    layer = builder.build()
+    assertEquals(CharmPositionType.STACK, layer.positionSpec.type)
+
+    builder.position('jitter')
+    layer = builder.build()
+    assertEquals(CharmPositionType.JITTER, layer.positionSpec.type)
+  }
+
+  @Test
+  void testBuilderApisDoNotExposeTargetedObjectOverloads() {
+    assertNoPublicObjectOverload(TextBuilder, 'fontface')
+    assertNoPublicObjectOverload(LabelBuilder, 'fontface')
+    assertNoPublicObjectOverload(Bin2dBuilder, 'bins')
+    assertNoPublicObjectOverload(LayerBuilder, 'stat')
+    assertNoPublicObjectOverload(LayerBuilder, 'position')
+  }
+
+  private static void assertNoPublicObjectOverload(Class<?> type, String methodName) {
+    List<Method> objectOverloads = type.declaredMethods.findAll { Method method ->
+      method.name == methodName &&
+          method.parameterTypes.length == 1 &&
+          method.parameterTypes[0] == Object
+    }
+    assertTrue(objectOverloads.isEmpty(), "${type.simpleName}.${methodName}(Object) should not be public API")
+  }
+
+}

--- a/matrix-charts/src/test/groovy/charm/render/stat/SampleStatTest.groovy
+++ b/matrix-charts/src/test/groovy/charm/render/stat/SampleStatTest.groovy
@@ -71,12 +71,12 @@ class SampleStatTest {
   }
 
   @Test
-  void testLayerBuilderRejectsUnsupportedStatTypeWithValidationError() {
-    CharmValidationException e = assertThrows(CharmValidationException) {
+  void testLayerBuilderRejectsUnsupportedStatTypeWithMissingMethodError() {
+    MissingMethodException e = assertThrows(MissingMethodException) {
       new PointBuilder().stat([:])
     }
 
-    assertTrue(e.message.contains('Unsupported stat type'))
+    assertTrue(e.message.contains('No signature of method: stat'))
   }
 
   @Test

--- a/matrix-charts/src/test/groovy/export/CharmExportTest.groovy
+++ b/matrix-charts/src/test/groovy/export/CharmExportTest.groovy
@@ -2,12 +2,16 @@ package export
 
 import static org.junit.jupiter.api.Assertions.*
 
+import groovy.transform.CompileStatic
+
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import testutil.Slow
 
+import se.alipsa.groovy.svg.Svg
 import se.alipsa.matrix.charm.Chart as CharmChart
 import se.alipsa.matrix.charm.Charts
+import se.alipsa.matrix.charm.PlotGrid
 import se.alipsa.matrix.charm.geom.PointBuilder
 import se.alipsa.matrix.chartexport.ChartToImage
 import se.alipsa.matrix.chartexport.ChartToJpeg
@@ -20,6 +24,7 @@ import se.alipsa.matrix.pict.Chart
 import se.alipsa.matrix.pict.ScatterChart
 
 import java.awt.image.BufferedImage
+import java.lang.reflect.Method
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -82,6 +87,34 @@ class CharmExportTest {
     assertNotNull(panel.getPreferredSize(), 'Panel should have preferred size')
     assertTrue(panel.getPreferredSize().width > 0)
     assertTrue(panel.getPreferredSize().height > 0)
+  }
+
+  @Test
+  @CompileStatic
+  void testChartToSwingTypedOverloads() {
+    CharmChart charmChart = buildCharmChart()
+    Svg svg = charmChart.render()
+    String svgText = svg.toXml()
+    CharSequence svgSequence = new StringBuilder(svgText)
+    Chart legacyChart = buildLegacyChart()
+    PlotGrid grid = Charts.plotGrid([charmChart], 1)
+
+    assertNotNull(ChartToSwing.export(svgText))
+    assertNotNull(ChartToSwing.export(svgSequence))
+    assertNotNull(ChartToSwing.export(svg))
+    assertNotNull(ChartToSwing.export(charmChart))
+    assertNotNull(ChartToSwing.export(legacyChart))
+    assertNotNull(ChartToSwing.export(grid))
+  }
+
+  @Test
+  void testChartToSwingDoesNotExposeObjectExportOverload() {
+    List<Method> objectOverloads = ChartToSwing.declaredMethods.findAll { Method method ->
+      method.name == 'export' &&
+          method.parameterTypes.length == 1 &&
+          method.parameterTypes[0] == Object
+    }
+    assertTrue(objectOverloads.isEmpty(), 'ChartToSwing.export(Object) should not be public API')
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Replace targeted public builder `Object` overloads with typed overloads in `MappingSpec`, `TextBuilder`, `LabelBuilder`, `Bin2dBuilder`, and `LayerBuilder`.
- Remove public `ChartToSwing.export(Object)` and add typed `CharSequence` support.
- Add `@CompileStatic` typed API/export coverage and reflection assertions that targeted public `Object` overloads are absent.
- Update `SampleStatTest` for the new typed API behavior when unsupported `stat([:])` is passed.
- Record completed Phase 4 steps and validation in `matrix-charts/req/0.5.0-r3-plan.md`.

## Breaking behavior change

- Unsupported argument types passed to typed builder methods now fail at Groovy method dispatch instead of entering an `Object` catch-all. In particular, `new PointBuilder().stat([:])` now throws `MissingMethodException` rather than `CharmValidationException("Unsupported stat type ...")`. Valid `stat(String)`, `stat(CharmStatType)`, and `stat(StatSpec)` calls are unchanged.

## Modules touched

- `matrix-charts`

## Validation

- `./gradlew :matrix-charts:codenarcMain`
- `./gradlew :matrix-charts:codenarcTest`
- `./gradlew :matrix-charts:spotlessCheck`
- `./gradlew :matrix-charts:test --tests "*CharmTypedOverloadApiTest" --tests "export.*" -Pheadless=true`
- `./gradlew :matrix-charts:test -Pheadless=true` (`744 tests passed`)
- Follow-up: `./gradlew :matrix-charts:test --tests "*CharmTypedOverloadApiTest" -Pheadless=true`
- Follow-up: `./gradlew :matrix-charts:codenarcTest`
- Follow-up: `./gradlew :matrix-charts:spotlessCheck`