### PR TITLE
[codex] Implement matrix-charts 0.5.0-r3 phase 5

### DIFF
--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
@@ -6,6 +6,7 @@ import se.alipsa.matrix.charm.LegendDirection
 import se.alipsa.matrix.charm.LegendPosition
 import se.alipsa.matrix.charm.PlotSpec
 import se.alipsa.matrix.charm.PositionSpec
+import se.alipsa.matrix.charm.Scale
 import se.alipsa.matrix.charm.geom.AreaBuilder
 import se.alipsa.matrix.charm.geom.BarBuilder
 import se.alipsa.matrix.charm.geom.BoxplotBuilder
@@ -267,6 +268,7 @@ class CharmBridge {
     if (chart.yAxisTitle) {
       labels.y = chart.yAxisTitle
     }
+    applyAxisScales(spec, chart)
 
     se.alipsa.matrix.charm.ThemeSpec theme = spec.theme as se.alipsa.matrix.charm.ThemeSpec
     if (chart.style?.plotBackgroundColor) {
@@ -318,6 +320,52 @@ class CharmBridge {
         labels.guides['fill'] = legend.title
       }
     }
+  }
+
+  private static void applyAxisScales(PlotSpec spec, Chart chart) {
+    if (chart.xAxisScale != null) {
+      spec.scale.x(scaleFromAxisScale(chart.xAxisScale))
+    }
+
+    Scale yScale = chart.yAxisScale != null ? scaleFromAxisScale(chart.yAxisScale) : null
+    if (chart.style?.yLabels) {
+      yScale = yScale ?: Scale.continuous()
+      applyYLabels(yScale, chart.style.yLabels)
+    }
+    if (yScale != null) {
+      spec.scale.y(yScale)
+    }
+  }
+
+  private static Scale scaleFromAxisScale(AxisScale axisScale) {
+    Scale scale = Scale.continuous()
+    scale.params['limits'] = [axisScale.start, axisScale.end]
+    scale.breaks = axisBreaks(axisScale)
+    scale
+  }
+
+  private static List<BigDecimal> axisBreaks(AxisScale axisScale) {
+    List<BigDecimal> breaks = []
+    BigDecimal current = axisScale.start
+    while (current <= axisScale.end) {
+      breaks << current
+      current += axisScale.step
+    }
+    if (breaks.last() != axisScale.end) {
+      breaks << axisScale.end
+    }
+    breaks
+  }
+
+  private static void applyYLabels(Scale scale, Map<String, String> yLabels) {
+    List<BigDecimal> breaks = []
+    List<String> labels = []
+    yLabels.each { String value, String label ->
+      breaks << new BigDecimal(value)
+      labels << label
+    }
+    scale.breaks = breaks
+    scale.labels = labels
   }
 
   /**

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
@@ -348,6 +348,9 @@ class CharmBridge {
     if (axisScale.step <= 0) {
       throw new IllegalArgumentException("AxisScale step must be positive, got ${axisScale.step}")
     }
+    if (axisScale.start > axisScale.end) {
+      throw new IllegalArgumentException("AxisScale start (${axisScale.start}) must be <= end (${axisScale.end})")
+    }
     List<BigDecimal> breaks = []
     BigDecimal current = axisScale.start
     while (current <= axisScale.end) {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
@@ -345,6 +345,9 @@ class CharmBridge {
   }
 
   private static List<BigDecimal> axisBreaks(AxisScale axisScale) {
+    if (axisScale.step <= 0) {
+      throw new IllegalArgumentException("AxisScale step must be positive, got ${axisScale.step}")
+    }
     List<BigDecimal> breaks = []
     BigDecimal current = axisScale.start
     while (current <= axisScale.end) {
@@ -358,14 +361,14 @@ class CharmBridge {
   }
 
   private static void applyYLabels(Scale scale, Map<String, String> yLabels) {
-    List<BigDecimal> breaks = []
-    List<String> labels = []
-    yLabels.each { String value, String label ->
-      breaks << new BigDecimal(value)
-      labels << label
+    List<AbstractMap.SimpleEntry<BigDecimal, String>> entries = yLabels.collect { String value, String label ->
+      new AbstractMap.SimpleEntry<BigDecimal, String>(new BigDecimal(value), label)
     }
-    scale.breaks = breaks
-    scale.labels = labels
+    entries.sort { AbstractMap.SimpleEntry<BigDecimal, String> entry ->
+      entry.key
+    }
+    scale.breaks = entries*.key
+    scale.labels = entries*.value
   }
 
   /**

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Chart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Chart.groovy
@@ -285,7 +285,14 @@ abstract class Chart<T extends Chart> {
     /** Sets y-axis visibility. */
     B yAxisVisible(boolean visible) { ensureStyle(); style.yAxisVisible = visible; this as B }
 
-    /** Sets custom CSS. */
+    /**
+     * Sets legacy raw CSS text.
+     *
+     * @param css raw CSS text
+     * @return this builder
+     * @deprecated Raw CSS is not applied by the Charm bridge; use Charm theme settings instead.
+     */
+    @Deprecated
     B css(String css) { ensureStyle(); style.css = css; this as B }
 
     private void ensureStyle() {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
@@ -182,15 +182,21 @@ class MinMax {
 
   BigDecimal minValue
   BigDecimal maxValue
+  private final int binDecimals
 
   MinMax(BigDecimal minValue, BigDecimal maxValue, int binDecimals = 1) {
-    this.minValue = minValue.setScale(binDecimals, RoundingMode.HALF_EVEN)
-    this.maxValue = maxValue.setScale(binDecimals, RoundingMode.HALF_EVEN)
+    this.minValue = minValue
+    this.maxValue = maxValue
+    this.binDecimals = binDecimals
   }
 
   @Override
   String toString() {
-    return minValue + '-' + maxValue
+    return "${format(minValue)}-${format(maxValue)}"
+  }
+
+  private String format(BigDecimal value) {
+    value.setScale(binDecimals, RoundingMode.HALF_EVEN).toString()
   }
 
 }

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Style.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Style.groovy
@@ -51,6 +51,15 @@ import java.awt.Color
  */
 class Style {
 
+  /**
+   * Legacy raw CSS text retained for source compatibility.
+   *
+   * <p>The Charm bridge does not inject arbitrary stylesheet text. Prefer Charm theme
+   * settings and CSS attribute APIs for new code.</p>
+   *
+   * @deprecated Raw CSS is not applied by the Charm bridge.
+   */
+  @Deprecated
   String css
 
   /** The back ground color of the plot area (where the actual chart is drawn) */
@@ -65,12 +74,27 @@ class Style {
   Boolean xAxisVisible
   Boolean yAxisVisible
 
+  /** Maps numeric y-axis break values to custom display labels. */
   Map<String, String> yLabels = [:]
 
+  /**
+   * Sets legacy raw CSS text.
+   *
+   * @param css raw CSS text
+   * @deprecated Raw CSS is not applied by the Charm bridge; use Charm theme settings instead.
+   */
+  @Deprecated
   void setCss(String css) {
     this.css = css
   }
 
+  /**
+   * Returns legacy raw CSS text.
+   *
+   * @return raw CSS text
+   * @deprecated Raw CSS is not applied by the Charm bridge; use Charm theme settings instead.
+   */
+  @Deprecated
   String getCss() {
     return css
   }

--- a/matrix-charts/src/test/groovy/chart/HistogramTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/HistogramTest.groovy
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*
 
 import org.junit.jupiter.api.Test
 
+import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.datasets.Dataset
 import se.alipsa.matrix.pict.Histogram
 
@@ -32,6 +33,19 @@ class HistogramTest {
       assertEquals(expected[i], it.value)
       i++
     }
+  }
+
+  @Test
+  void testRoundedBinLabelsDoNotDropValuesAtExactMax() {
+    Matrix data = Matrix.builder()
+        .matrixName('RoundedHistogram')
+        .columns([value: [0.0, 3.4, 6.8, 10.4]])
+        .types([Number])
+        .build()
+    def chart = Histogram.create('Rounded Histogram', data, 'value', 3, 0)
+
+    assertEquals(4, chart.ranges.values().sum())
+    assertEquals(['0-3', '3-7', '7-10'], chart.ranges.keySet()*.toString())
   }
 
 }

--- a/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
@@ -5,12 +5,16 @@ import static org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
 
+import se.alipsa.groovy.svg.Svg
+import se.alipsa.groovy.svg.Text
+import se.alipsa.groovy.svg.io.SvgWriter
 import se.alipsa.matrix.chartexport.ChartToImage
 import se.alipsa.matrix.chartexport.ChartToJfx
 import se.alipsa.matrix.chartexport.ChartToPng
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.pict.AreaChart
 import se.alipsa.matrix.pict.BarChart
+import se.alipsa.matrix.pict.CharmBridge
 import se.alipsa.matrix.pict.ChartType
 import se.alipsa.matrix.pict.Histogram
 import se.alipsa.matrix.pict.LineChart
@@ -172,6 +176,67 @@ class PlotCompatibilityTest {
   }
 
   @Test
+  void testLegacyAxisScaleAppliesToCharmBridge() {
+    Matrix data = Matrix.builder()
+        .matrixName('AxisScaleData')
+        .columns([
+            x: [0, 1, 2, 3, 4, 5],
+            y: [0, 10, 20, 30, 40, 50]
+        ])
+        .types([Number, Number])
+        .build()
+    LineChart chart = LineChart.builder(data)
+        .title('Axis Scale')
+        .x('x')
+        .y('y')
+        .xAxisScale(0, 5, 1)
+        .yAxisScale(0, 50, 10)
+        .build()
+
+    List<String> labels = textContent(CharmBridge.renderSvg(chart, 800, 600))
+
+    assertTrue(labels.containsAll(['0', '1', '2', '3', '4', '5']))
+    assertTrue(labels.containsAll(['10', '20', '30', '40', '50']))
+  }
+
+  @Test
+  void testLegacyYLabelsApplyToCharmBridge() {
+    Matrix data = Matrix.builder()
+        .matrixName('YLabelData')
+        .columns([
+            x: [1, 2, 3],
+            y: [10, 20, 30]
+        ])
+        .types([Number, Number])
+        .build()
+    LineChart chart = LineChart.builder(data)
+        .title('Y Labels')
+        .x('x')
+        .y('y')
+        .build()
+    chart.style.yLabels = ['10': 'Low', '20': 'Middle', '30': 'High']
+
+    List<String> labels = textContent(CharmBridge.renderSvg(chart, 800, 600))
+
+    assertTrue(labels.containsAll(['Low', 'Middle', 'High']))
+  }
+
+  @Test
+  @SuppressWarnings('GrDeprecatedAPIUsage')
+  void testLegacyCssApiRemainsCallableWithoutRawCharmCssInjection() {
+    Matrix data = sampleData()
+    BarChart chart = BarChart.builder(data)
+        .title('CSS Compatibility')
+        .x('category')
+        .y('value')
+        .css('.legacy-custom { fill: red; }')
+        .build()
+
+    assertEquals('.legacy-custom { fill: red; }', chart.style.css)
+    assertFalse(SvgWriter.toXml(CharmBridge.renderSvg(chart, 800, 600)).contains('.legacy-custom'))
+  }
+
+  @Test
   void testJfxReturnsJavafxNode() {
     Assumptions.assumeTrue(
         System.getenv('DISPLAY') != null || 'true' == System.getProperty('headless'),
@@ -192,6 +257,10 @@ class PlotCompatibilityTest {
     for (int i = 0; i < PNG_HEADER.length; i++) {
       assertEquals(PNG_HEADER[i], header[i], "PNG header byte ${i} should match")
     }
+  }
+
+  private static List<String> textContent(Svg svg) {
+    svg.descendants().findAll { it instanceof Text }*.content
   }
 
 }

--- a/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
@@ -214,11 +214,14 @@ class PlotCompatibilityTest {
         .x('x')
         .y('y')
         .build()
-    chart.style.yLabels = ['10': 'Low', '20': 'Middle', '30': 'High']
+    chart.style.yLabels = ['30': 'High', '10': 'Low', '20': 'Middle']
 
     List<String> labels = textContent(CharmBridge.renderSvg(chart, 800, 600))
+    se.alipsa.matrix.charm.Chart charmChart = CharmBridge.convert(chart)
 
     assertTrue(labels.containsAll(['Low', 'Middle', 'High']))
+    assertEquals(['10', '20', '30'], charmChart.scale.y.breaks*.toString())
+    assertEquals(['Low', 'Middle', 'High'], charmChart.scale.y.labels)
   }
 
   @Test

--- a/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
@@ -213,6 +213,7 @@ class PlotCompatibilityTest {
         .title('Y Labels')
         .x('x')
         .y('y')
+        .xAxisVisible(true)
         .build()
     chart.style.yLabels = ['30': 'High', '10': 'Low', '20': 'Middle']
 


### PR DESCRIPTION
## Summary

Implements Phase 5 of `matrix-charts/req/0.5.0-r3-plan.md` for legacy `pict` bridge compatibility.

- Maps legacy `AxisScale` settings to Charm continuous scale limits and breaks in `CharmBridge`.
- Applies numeric legacy `Style.yLabels` as Charm y-axis breaks and display labels.
- Preserves exact histogram bin boundaries internally and rounds only the displayed bin labels.
- Deprecates legacy raw `Style.css` and builder `.css(...)` as source-compatible but not injected by the Charm bridge.
- Adds regression coverage for axis scales, y labels, CSS compatibility, and histogram rounded-label edge cases.

## Impact

Legacy `pict` charts regain axis-scale and y-label behavior after conversion through Charm. Raw CSS remains callable for source compatibility, but the API is now documented as deprecated because there is no clean Charm equivalent for injecting arbitrary stylesheet text.

## Validation

- `./gradlew :matrix-charts:codenarcMain`
- `./gradlew :matrix-charts:codenarcTest`
- `./gradlew :matrix-charts:spotlessCheck`
- `./gradlew :matrix-charts:test --tests "chart.PlotCompatibilityTest" --tests "chart.HistogramTest" --tests "chart.ChartBuilderTest" -Pheadless=true`
- `./gradlew :matrix-charts:test -Pheadless=true`