### PR TITLE
[codex] Implement matrix-charts 0.5.0-r3 phase 6

### DIFF
--- a/matrix-charts/build.gradle
+++ b/matrix-charts/build.gradle
@@ -28,16 +28,6 @@ compileGroovy {
   options.deprecation = true
 }
 
-// we should consider using monocle to allow this to work for back-end headless apps:
-// https://wiki.openjdk.org/display/OpenJFX/Monocle
-/*
-this makes the javafx dependencies added to the pom
-javafx {
-  version = "19.0.2.1"
-  modules = ['javafx.controls', 'javafx.swing']
-}
- */
-
 dependencies {
   OperatingSystem os = OperatingSystem.current()
 
@@ -55,7 +45,6 @@ dependencies {
   compileOnly libs.groovy
   compileOnly project(':matrix-core')
   compileOnly project(':matrix-stats')
-  //compileOnly project(':matrix-groovy-ext')
   api libs.gsvg
   api libs.gsvg.export
   implementation libs.commons.text
@@ -71,13 +60,10 @@ dependencies {
 
   testImplementation libs.groovy
   testImplementation libs.groovy.xml
-  //testImplementation "org.testfx:openjfx-monocle:jdk-11+26"
-
   testImplementation project(':matrix-core')
   testImplementation project(':matrix-stats')
   testImplementation project(':matrix-datasets')
   testImplementation project(':matrix-ggplot')
-  //testImplementation project(':matrix-groovy-ext')
   testImplementation "org.openjfx:javafx-graphics:${javaFxVersion}:$qualifier"
   testImplementation "org.openjfx:javafx-base:${javaFxVersion}:$qualifier"
   testImplementation "org.openjfx:javafx-controls:${javaFxVersion}:$qualifier"

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/PlotGrid.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/PlotGrid.groovy
@@ -63,7 +63,7 @@ class PlotGrid {
     if (spacing < 0) {
       throw new IllegalArgumentException("spacing must be >= 0, got $spacing")
     }
-    int minRows = Math.ceil(charts.size() / (double) ncol) as int
+    int minRows = (charts.size() / ncol).ceil() as int
     if (nrow != null && nrow < 1) {
       throw new IllegalArgumentException("nrow must be >= 1, got $nrow")
     }

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/scale/ContinuousCharmScale.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/scale/ContinuousCharmScale.groovy
@@ -242,9 +242,9 @@ class ContinuousCharmScale extends CharmScale {
       return bd.toBigInteger().toString()
     }
     if (bd < BigDecimal.ONE) {
-      return String.format('%.2g', bd as double)
+      return String.format('%.2g', bd)
     }
-    String.format('%.0f', bd as double)
+    String.format('%.0f', bd)
   }
 
   private List<Object> resolveConfiguredBreaks() {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/util/ColorUtil.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/util/ColorUtil.groovy
@@ -1,6 +1,7 @@
 package se.alipsa.matrix.charm.util
 
 import java.awt.Color
+import java.math.RoundingMode
 
 /** Utility methods for color conversion and parsing. */
 @SuppressWarnings('DuplicateNumberLiteral')
@@ -60,7 +61,7 @@ class ColorUtil {
         if (matcher.matches()) {
             int pct = Integer.parseInt(matcher.group(1))
             pct = 0.max(pct.min(100)) as int
-            int value = (255 * (pct / 100.0f)).round() as int
+            int value = (255 * pct / 100).setScale(0, RoundingMode.HALF_UP) as int
             String hex = pad(Integer.toHexString(value))
             return "#${hex}${hex}${hex}"
         }


### PR DESCRIPTION
## Summary

Implements Phase 6 of `matrix-charts/req/0.5.0-r3-plan.md` for low-risk code quality cleanup.

- Preserves gray-percent rounding behavior in `ColorUtil` while removing float arithmetic.
- Removes redundant `as double` casts from log-axis number formatting.
- Uses Groovy GDK `.ceil()` in `PlotGrid` row calculation.
- Removes stale commented-out blocks from `matrix-charts/build.gradle`.

## Impact

No intended behavior changes. The gray-percent conversion keeps half-up rounding semantics, including `gray67` mapping through rounded `170.85 -> 171` behavior.

## Validation

- `./gradlew :matrix-charts:codenarcMain`
- `./gradlew :matrix-charts:spotlessCheck`
- `./gradlew :matrix-charts:test -Pheadless=true`