### PR TITLE
[codex] Implement deferred matrix-charts builder and arrow cleanup

### DIFF
--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/ArrowEnds.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/ArrowEnds.groovy
@@ -1,0 +1,17 @@
+package se.alipsa.matrix.charm
+
+/**
+ * Endpoint selection for segment and curve arrows.
+ */
+enum ArrowEnds {
+
+  /** Render an arrow at the start of the line or curve. */
+  START,
+
+  /** Render an arrow at the end of the line or curve. */
+  END,
+
+  /** Render arrows at both ends of the line or curve. */
+  BOTH
+
+}

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/ArrowSpec.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/ArrowSpec.groovy
@@ -1,0 +1,111 @@
+package se.alipsa.matrix.charm
+
+/**
+ * Arrow marker specification for segment and curve geoms.
+ */
+class ArrowSpec {
+
+  private final BigDecimal length
+  private final BigDecimal width
+  private final ArrowEnds ends
+  private final boolean closed
+
+  /**
+   * Creates an arrow specification.
+   *
+   * @param length marker length in pixels
+   * @param width marker width in pixels
+   * @param ends endpoints where arrows are rendered
+   * @param closed true to render a filled triangular arrowhead, false for an open arrowhead
+   */
+  ArrowSpec(Number length = 6, Number width = 6, ArrowEnds ends = ArrowEnds.END, boolean closed = true) {
+    this.length = coercePositive(length, 'length')
+    this.width = coercePositive(width, 'width')
+    this.ends = ends ?: ArrowEnds.END
+    this.closed = closed
+  }
+
+  /**
+   * Creates an arrow rendered at the end of the line or curve.
+   *
+   * @param length marker length in pixels
+   * @param width marker width in pixels
+   * @param closed true for a filled triangular arrowhead
+   * @return arrow specification
+   */
+  static ArrowSpec end(Number length = 6, Number width = 6, boolean closed = true) {
+    new ArrowSpec(length, width, ArrowEnds.END, closed)
+  }
+
+  /**
+   * Creates an arrow rendered at the start of the line or curve.
+   *
+   * @param length marker length in pixels
+   * @param width marker width in pixels
+   * @param closed true for a filled triangular arrowhead
+   * @return arrow specification
+   */
+  static ArrowSpec start(Number length = 6, Number width = 6, boolean closed = true) {
+    new ArrowSpec(length, width, ArrowEnds.START, closed)
+  }
+
+  /**
+   * Creates arrows rendered at both ends of the line or curve.
+   *
+   * @param length marker length in pixels
+   * @param width marker width in pixels
+   * @param closed true for filled triangular arrowheads
+   * @return arrow specification
+   */
+  static ArrowSpec both(Number length = 6, Number width = 6, boolean closed = true) {
+    new ArrowSpec(length, width, ArrowEnds.BOTH, closed)
+  }
+
+  /**
+   * Returns marker length in pixels.
+   *
+   * @return marker length
+   */
+  BigDecimal getLength() {
+    length
+  }
+
+  /**
+   * Returns marker width in pixels.
+   *
+   * @return marker width
+   */
+  BigDecimal getWidth() {
+    width
+  }
+
+  /**
+   * Returns endpoints where arrows are rendered.
+   *
+   * @return endpoint selection
+   */
+  ArrowEnds getEnds() {
+    ends
+  }
+
+  /**
+   * Returns true for a filled triangular arrowhead.
+   *
+   * @return closed arrowhead flag
+   */
+  boolean isClosed() {
+    closed
+  }
+
+  private static BigDecimal coercePositive(Number value, String name) {
+    if (value == null) {
+      throw new IllegalArgumentException("${name} must not be null")
+    }
+    BigDecimal resolved = value as BigDecimal
+    if (resolved <= 0) {
+      throw new IllegalArgumentException("${name} must be > 0, got ${value}")
+    }
+    resolved
+  }
+
+}

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/CurveBuilder.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/CurveBuilder.groovy
@@ -2,7 +2,6 @@ package se.alipsa.matrix.charm.geom
 
 import se.alipsa.matrix.charm.CharmGeomType
 import se.alipsa.matrix.charm.CharmStatType
-import se.alipsa.matrix.charm.LinetypeName
 
 /**
  * Fluent builder for curve layers.
@@ -18,50 +17,7 @@ import se.alipsa.matrix.charm.LinetypeName
  * }
  * }</pre>
  */
-class CurveBuilder extends LayerBuilder {
-
-  /**
-   * Sets curve colour.
-   *
-   * @param value colour value
-   * @return this builder
-   */
-  CurveBuilder color(String value) {
-    params['color'] = value
-    this
-  }
-
-  /**
-   * Sets curve colour (British spelling alias).
-   *
-   * @param value colour value
-   * @return this builder
-   */
-  CurveBuilder colour(String value) {
-    color(value)
-  }
-
-  /**
-   * Sets curve line width.
-   *
-   * @param value size value
-   * @return this builder
-   */
-  CurveBuilder size(Number value) {
-    params['size'] = value
-    this
-  }
-
-  /**
-   * Sets line type.
-   *
-   * @param value linetype name
-   * @return this builder
-   */
-  CurveBuilder linetype(LinetypeName value) {
-    params['linetype'] = value
-    this
-  }
+class CurveBuilder extends LineEndpointBuilder<CurveBuilder> {
 
   /**
    * Sets the amount of curvature. Negative values produce left-hand curves,
@@ -94,17 +50,6 @@ class CurveBuilder extends LayerBuilder {
    */
   CurveBuilder ncp(Integer value) {
     params['ncp'] = value
-    this
-  }
-
-  /**
-   * Sets arrow specification for curve endpoints.
-   *
-   * @param value arrow specification
-   * @return this builder
-   */
-  CurveBuilder arrow(Object value) {
-    params['arrow'] = value
     this
   }
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/LabelBuilder.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/LabelBuilder.groovy
@@ -18,41 +18,7 @@ import se.alipsa.matrix.charm.CharmStatType
  * }
  * }</pre>
  */
-class LabelBuilder extends LayerBuilder {
-
-  private static final String FONTFACE = 'fontface'
-
-  /**
-   * Sets label text size.
-   *
-   * @param value size value
-   * @return this builder
-   */
-  LabelBuilder size(Number value) {
-    params['size'] = value
-    this
-  }
-
-  /**
-   * Sets label text colour.
-   *
-   * @param value colour value
-   * @return this builder
-   */
-  LabelBuilder color(String value) {
-    params['color'] = value
-    this
-  }
-
-  /**
-   * Sets label text colour (British spelling alias).
-   *
-   * @param value colour value
-   * @return this builder
-   */
-  LabelBuilder colour(String value) {
-    color(value)
-  }
+class LabelBuilder extends TextLayerBuilder<LabelBuilder> {
 
   /**
    * Sets label background fill colour.
@@ -62,72 +28,6 @@ class LabelBuilder extends LayerBuilder {
    */
   LabelBuilder fill(String value) {
     params['fill'] = value
-    this
-  }
-
-  /**
-   * Sets label rotation angle in degrees.
-   *
-   * @param value angle in degrees
-   * @return this builder
-   */
-  LabelBuilder angle(Number value) {
-    params['angle'] = value
-    this
-  }
-
-  /**
-   * Sets font family.
-   *
-   * @param value font family name
-   * @return this builder
-   */
-  LabelBuilder family(String value) {
-    params['family'] = value
-    this
-  }
-
-  /**
-   * Sets font face by name (e.g. 'bold', 'italic').
-   *
-   * @param value fontface name
-   * @return this builder
-   */
-  LabelBuilder fontface(String value) {
-    params[FONTFACE] = value
-    this
-  }
-
-  /**
-   * Sets font face by integer code (1 = plain, 2 = bold, 3 = italic, 4 = bold-italic).
-   *
-   * @param value fontface integer code
-   * @return this builder
-   */
-  LabelBuilder fontface(int value) {
-    params[FONTFACE] = value
-    this
-  }
-
-  /**
-   * Sets horizontal justification (0 = left, 0.5 = centre, 1 = right).
-   *
-   * @param value horizontal justification
-   * @return this builder
-   */
-  LabelBuilder hjust(Number value) {
-    params['hjust'] = value
-    this
-  }
-
-  /**
-   * Sets vertical justification (0 = bottom, 0.5 = middle, 1 = top).
-   *
-   * @param value vertical justification
-   * @return this builder
-   */
-  LabelBuilder vjust(Number value) {
-    params['vjust'] = value
     this
   }
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/LineEndpointBuilder.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/LineEndpointBuilder.groovy
@@ -1,0 +1,71 @@
+package se.alipsa.matrix.charm.geom
+
+import se.alipsa.matrix.charm.ArrowSpec
+import se.alipsa.matrix.charm.LinetypeName
+
+/**
+ * Shared fluent API for line-like geoms with start and end points.
+ *
+ * @param <T> concrete builder type
+ */
+abstract class LineEndpointBuilder<T extends LineEndpointBuilder<T>> extends LayerBuilder {
+
+  /**
+   * Sets line colour.
+   *
+   * @param value colour value
+   * @return this builder
+   */
+  T color(String value) {
+    params['color'] = value
+    self()
+  }
+
+  /**
+   * Sets line colour (British spelling alias).
+   *
+   * @param value colour value
+   * @return this builder
+   */
+  T colour(String value) {
+    color(value)
+  }
+
+  /**
+   * Sets line width.
+   *
+   * @param value size value
+   * @return this builder
+   */
+  T size(Number value) {
+    params['size'] = value
+    self()
+  }
+
+  /**
+   * Sets line type.
+   *
+   * @param value linetype name
+   * @return this builder
+   */
+  T linetype(LinetypeName value) {
+    params['linetype'] = value
+    self()
+  }
+
+  /**
+   * Sets arrow specification for line endpoints.
+   *
+   * @param value arrow specification
+   * @return this builder
+   */
+  T arrow(ArrowSpec value) {
+    params['arrow'] = value
+    self()
+  }
+
+  protected T self() {
+    this as T
+  }
+
+}

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/SegmentBuilder.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/SegmentBuilder.groovy
@@ -2,7 +2,6 @@ package se.alipsa.matrix.charm.geom
 
 import se.alipsa.matrix.charm.CharmGeomType
 import se.alipsa.matrix.charm.CharmStatType
-import se.alipsa.matrix.charm.LinetypeName
 
 /**
  * Fluent builder for segment layers.
@@ -18,61 +17,7 @@ import se.alipsa.matrix.charm.LinetypeName
  * }
  * }</pre>
  */
-class SegmentBuilder extends LayerBuilder {
-
-  /**
-   * Sets segment colour.
-   *
-   * @param value colour value
-   * @return this builder
-   */
-  SegmentBuilder color(String value) {
-    params['color'] = value
-    this
-  }
-
-  /**
-   * Sets segment colour (British spelling alias).
-   *
-   * @param value colour value
-   * @return this builder
-   */
-  SegmentBuilder colour(String value) {
-    color(value)
-  }
-
-  /**
-   * Sets segment line width.
-   *
-   * @param value size value
-   * @return this builder
-   */
-  SegmentBuilder size(Number value) {
-    params['size'] = value
-    this
-  }
-
-  /**
-   * Sets line type.
-   *
-   * @param value linetype name
-   * @return this builder
-   */
-  SegmentBuilder linetype(LinetypeName value) {
-    params['linetype'] = value
-    this
-  }
-
-  /**
-   * Sets arrow specification for segment endpoints.
-   *
-   * @param value arrow specification
-   * @return this builder
-   */
-  SegmentBuilder arrow(Object value) {
-    params['arrow'] = value
-    this
-  }
+class SegmentBuilder extends LineEndpointBuilder<SegmentBuilder> {
 
   @Override
   protected CharmGeomType geomType() {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/TextBuilder.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/TextBuilder.groovy
@@ -17,9 +17,7 @@ import se.alipsa.matrix.charm.CharmStatType
  * }
  * }</pre>
  */
-class TextBuilder extends LayerBuilder {
-
-  private static final String FONTFACE = 'fontface'
+class TextBuilder extends TextLayerBuilder<TextBuilder> {
 
   /**
    * Sets the label text content.
@@ -29,104 +27,6 @@ class TextBuilder extends LayerBuilder {
    */
   TextBuilder label(String value) {
     params['label'] = value
-    this
-  }
-
-  /**
-   * Sets text size.
-   *
-   * @param value size value
-   * @return this builder
-   */
-  TextBuilder size(Number value) {
-    params['size'] = value
-    this
-  }
-
-  /**
-   * Sets text colour.
-   *
-   * @param value colour value
-   * @return this builder
-   */
-  TextBuilder color(String value) {
-    params['color'] = value
-    this
-  }
-
-  /**
-   * Sets text colour (British spelling alias).
-   *
-   * @param value colour value
-   * @return this builder
-   */
-  TextBuilder colour(String value) {
-    color(value)
-  }
-
-  /**
-   * Sets text rotation angle in degrees.
-   *
-   * @param value angle in degrees
-   * @return this builder
-   */
-  TextBuilder angle(Number value) {
-    params['angle'] = value
-    this
-  }
-
-  /**
-   * Sets font family.
-   *
-   * @param value font family name
-   * @return this builder
-   */
-  TextBuilder family(String value) {
-    params['family'] = value
-    this
-  }
-
-  /**
-   * Sets font face by name (e.g. 'bold', 'italic').
-   *
-   * @param value fontface name
-   * @return this builder
-   */
-  TextBuilder fontface(String value) {
-    params[FONTFACE] = value
-    this
-  }
-
-  /**
-   * Sets font face by integer code (1 = plain, 2 = bold, 3 = italic, 4 = bold-italic).
-   *
-   * @param value fontface integer code
-   * @return this builder
-   */
-  TextBuilder fontface(int value) {
-    params[FONTFACE] = value
-    this
-  }
-
-  /**
-   * Sets horizontal justification (0 = left, 0.5 = centre, 1 = right).
-   *
-   * @param value horizontal justification
-   * @return this builder
-   */
-  TextBuilder hjust(Number value) {
-    params['hjust'] = value
-    this
-  }
-
-  /**
-   * Sets vertical justification (0 = bottom, 0.5 = middle, 1 = top).
-   *
-   * @param value vertical justification
-   * @return this builder
-   */
-  TextBuilder vjust(Number value) {
-    params['vjust'] = value
     this
   }
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/TextLayerBuilder.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/TextLayerBuilder.groovy
@@ -1,0 +1,114 @@
+package se.alipsa.matrix.charm.geom
+
+/**
+ * Shared fluent API for text-like geoms.
+ *
+ * @param <T> concrete builder type
+ */
+abstract class TextLayerBuilder<T extends TextLayerBuilder<T>> extends LayerBuilder {
+
+  private static final String FONTFACE = 'fontface'
+
+  /**
+   * Sets text size.
+   *
+   * @param value size value
+   * @return this builder
+   */
+  T size(Number value) {
+    params['size'] = value
+    self()
+  }
+
+  /**
+   * Sets text colour.
+   *
+   * @param value colour value
+   * @return this builder
+   */
+  T color(String value) {
+    params['color'] = value
+    self()
+  }
+
+  /**
+   * Sets text colour (British spelling alias).
+   *
+   * @param value colour value
+   * @return this builder
+   */
+  T colour(String value) {
+    color(value)
+  }
+
+  /**
+   * Sets text rotation angle in degrees.
+   *
+   * @param value angle in degrees
+   * @return this builder
+   */
+  T angle(Number value) {
+    params['angle'] = value
+    self()
+  }
+
+  /**
+   * Sets font family.
+   *
+   * @param value font family name
+   * @return this builder
+   */
+  T family(String value) {
+    params['family'] = value
+    self()
+  }
+
+  /**
+   * Sets font face by name (e.g. 'bold', 'italic').
+   *
+   * @param value fontface name
+   * @return this builder
+   */
+  T fontface(String value) {
+    params[FONTFACE] = value
+    self()
+  }
+
+  /**
+   * Sets font face by integer code (1 = plain, 2 = bold, 3 = italic, 4 = bold-italic).
+   *
+   * @param value fontface integer code
+   * @return this builder
+   */
+  T fontface(int value) {
+    params[FONTFACE] = value
+    self()
+  }
+
+  /**
+   * Sets horizontal justification (0 = left, 0.5 = centre, 1 = right).
+   *
+   * @param value horizontal justification
+   * @return this builder
+   */
+  T hjust(Number value) {
+    params['hjust'] = value
+    self()
+  }
+
+  /**
+   * Sets vertical justification (0 = bottom, 0.5 = middle, 1 = top).
+   *
+   * @param value vertical justification
+   * @return this builder
+   */
+  T vjust(Number value) {
+    params['vjust'] = value
+    self()
+  }
+
+  protected T self() {
+    this as T
+  }
+
+}

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/geom/ArrowMarkerSupport.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/geom/ArrowMarkerSupport.groovy
@@ -55,7 +55,7 @@ class ArrowMarkerSupport {
         .refX(arrow.length)
         .refY(mid)
         .orient('auto-start-reverse')
-        .markerUnits('strokeWidth')
+        .markerUnits('userSpaceOnUse')
     if (arrow.closed) {
       marker.addPolygon("0,0 ${arrow.length},${mid} 0,${arrow.width}")
           .fill(stroke)

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/geom/ArrowMarkerSupport.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/geom/ArrowMarkerSupport.groovy
@@ -1,0 +1,71 @@
+package se.alipsa.matrix.charm.render.geom
+
+import se.alipsa.groovy.svg.Marker
+import se.alipsa.groovy.svg.SvgElement
+import se.alipsa.matrix.charm.ArrowEnds
+import se.alipsa.matrix.charm.ArrowSpec
+import se.alipsa.matrix.charm.LayerSpec
+import se.alipsa.matrix.charm.render.RenderContext
+
+/**
+ * SVG marker support for line-like geoms with arrowheads.
+ */
+class ArrowMarkerSupport {
+
+  private static final String MARKER_START = 'marker-start'
+  private static final String MARKER_END = 'marker-end'
+
+  /**
+   * Applies an arrow marker to an SVG line/path element when the layer has an {@link ArrowSpec}.
+   *
+   * @param element SVG line or path element
+   * @param context render context
+   * @param layer layer spec
+   * @param stroke stroke colour used for the arrow
+   * @param elementIndex rendered element index within the layer
+   */
+  static void applyArrowMarker(
+      SvgElement<? extends SvgElement> element,
+      RenderContext context,
+      LayerSpec layer,
+      String stroke,
+      int elementIndex
+  ) {
+    if (!(layer.params.arrow instanceof ArrowSpec) || context.defs == null) {
+      return
+    }
+    ArrowSpec arrow = layer.params.arrow as ArrowSpec
+
+    String markerId = "charm-arrow-${context.layerIndex}-${elementIndex}"
+    createMarker(context, markerId, arrow, stroke)
+    String markerUrl = "url(#${markerId})"
+    if (arrow.ends == ArrowEnds.START || arrow.ends == ArrowEnds.BOTH) {
+      element.addAttribute(MARKER_START, markerUrl)
+    }
+    if (arrow.ends == ArrowEnds.END || arrow.ends == ArrowEnds.BOTH) {
+      element.addAttribute(MARKER_END, markerUrl)
+    }
+  }
+
+  private static void createMarker(RenderContext context, String markerId, ArrowSpec arrow, String stroke) {
+    BigDecimal mid = arrow.width / 2
+    Marker marker = context.defs.addMarker(markerId)
+        .markerWidth(arrow.length)
+        .markerHeight(arrow.width)
+        .refX(arrow.length)
+        .refY(mid)
+        .orient('auto-start-reverse')
+        .markerUnits('strokeWidth')
+    if (arrow.closed) {
+      marker.addPolygon("0,0 ${arrow.length},${mid} 0,${arrow.width}")
+          .fill(stroke)
+          .stroke(stroke)
+    } else {
+      marker.addPath()
+          .d("M 0 0 L ${arrow.length} ${mid} L 0 ${arrow.width}")
+          .fill('none')
+          .stroke(stroke)
+    }
+  }
+
+}

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/geom/CurveRenderer.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/geom/CurveRenderer.groovy
@@ -44,6 +44,7 @@ class CurveRenderer {
       if (alpha < 1.0) {
         path.addAttribute('stroke-opacity', alpha)
       }
+      ArrowMarkerSupport.applyArrowMarker(path, context, layer, stroke, elementIndex)
       GeomUtils.applyCssAttributes(path, context, layer.geomType.name(), elementIndex, datum)
       elementIndex++
     }

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/geom/SegmentRenderer.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/geom/SegmentRenderer.groovy
@@ -115,6 +115,7 @@ class SegmentRenderer {
     if (alpha < 1.0) {
       line.addAttribute('stroke-opacity', alpha)
     }
+    ArrowMarkerSupport.applyArrowMarker(line, context, layer, stroke, elementIndex)
     GeomUtils.applyCssAttributes(line, context, layer.geomType.name(), elementIndex, datum)
   }
 }

--- a/matrix-charts/src/test/groovy/charm/api/CharmTypedOverloadApiTest.groovy
+++ b/matrix-charts/src/test/groovy/charm/api/CharmTypedOverloadApiTest.groovy
@@ -6,6 +6,7 @@ import groovy.transform.CompileStatic
 
 import org.junit.jupiter.api.Test
 
+import se.alipsa.matrix.charm.ArrowSpec
 import se.alipsa.matrix.charm.CharmPositionType
 import se.alipsa.matrix.charm.CharmStatType
 import se.alipsa.matrix.charm.ColumnExpr
@@ -15,9 +16,11 @@ import se.alipsa.matrix.charm.MappingSpec
 import se.alipsa.matrix.charm.PositionSpec
 import se.alipsa.matrix.charm.StatSpec
 import se.alipsa.matrix.charm.geom.Bin2dBuilder
+import se.alipsa.matrix.charm.geom.CurveBuilder
 import se.alipsa.matrix.charm.geom.LabelBuilder
 import se.alipsa.matrix.charm.geom.LayerBuilder
 import se.alipsa.matrix.charm.geom.PointBuilder
+import se.alipsa.matrix.charm.geom.SegmentBuilder
 import se.alipsa.matrix.charm.geom.TextBuilder
 
 import java.lang.reflect.Method
@@ -114,12 +117,27 @@ class CharmTypedOverloadApiTest {
   }
 
   @Test
+  void testLineEndpointBuilderArrowTypedOverloads() {
+    ArrowSpec arrow = ArrowSpec.end()
+
+    SegmentBuilder segmentBuilder = new SegmentBuilder()
+    segmentBuilder.arrow(arrow)
+    assertSame(arrow, segmentBuilder.build().params['arrow'])
+
+    CurveBuilder curveBuilder = new CurveBuilder()
+    curveBuilder.arrow(arrow)
+    assertSame(arrow, curveBuilder.build().params['arrow'])
+  }
+
+  @Test
   void testBuilderApisDoNotExposeTargetedObjectOverloads() {
     assertNoPublicObjectOverload(TextBuilder, 'fontface')
     assertNoPublicObjectOverload(LabelBuilder, 'fontface')
     assertNoPublicObjectOverload(Bin2dBuilder, 'bins')
     assertNoPublicObjectOverload(LayerBuilder, 'stat')
     assertNoPublicObjectOverload(LayerBuilder, 'position')
+    assertNoPublicObjectOverload(SegmentBuilder, 'arrow')
+    assertNoPublicObjectOverload(CurveBuilder, 'arrow')
   }
 
   private static void assertNoPublicObjectOverload(Class<?> type, String methodName) {

--- a/matrix-charts/src/test/groovy/charm/render/geom/ArrowRendererTest.groovy
+++ b/matrix-charts/src/test/groovy/charm/render/geom/ArrowRendererTest.groovy
@@ -1,0 +1,60 @@
+package charm.render.geom
+
+import static org.junit.jupiter.api.Assertions.*
+import static se.alipsa.matrix.charm.Charts.*
+
+import org.junit.jupiter.api.Test
+
+import se.alipsa.groovy.svg.io.SvgWriter
+import se.alipsa.matrix.charm.ArrowSpec
+import se.alipsa.matrix.charm.Chart
+import se.alipsa.matrix.core.Matrix
+
+class ArrowRendererTest {
+
+  @Test
+  void testSegmentArrowRendersStartAndEndMarkers() {
+    Matrix data = segmentData()
+
+    Chart chart = plot(data) {
+      mapping { x = 'x'; y = 'y'; xend = 'xend'; yend = 'yend' }
+      layers {
+        geomSegment().arrow(ArrowSpec.both(8, 6)).color('#336699')
+      }
+    }.build()
+
+    String xml = SvgWriter.toXml(chart.render())
+
+    assertTrue(xml.contains('<marker'))
+    assertTrue(xml.contains('marker-start="url(#charm-arrow-0-0)"'))
+    assertTrue(xml.contains('marker-end="url(#charm-arrow-0-0)"'))
+    assertTrue(xml.contains('fill="#336699"'))
+  }
+
+  @Test
+  void testCurveArrowRendersEndMarker() {
+    Matrix data = segmentData()
+
+    Chart chart = plot(data) {
+      mapping { x = 'x'; y = 'y'; xend = 'xend'; yend = 'yend' }
+      layers {
+        geomCurve().arrow(ArrowSpec.end(7, 5)).color('#cc6677')
+      }
+    }.build()
+
+    String xml = SvgWriter.toXml(chart.render())
+
+    assertTrue(xml.contains('<marker'))
+    assertFalse(xml.contains('marker-start="url(#charm-arrow-0-0)"'))
+    assertTrue(xml.contains('marker-end="url(#charm-arrow-0-0)"'))
+    assertTrue(xml.contains('fill="#cc6677"'))
+  }
+
+  private static Matrix segmentData() {
+    Matrix.builder()
+        .columnNames('x', 'y', 'xend', 'yend')
+        .rows([[1, 1, 3, 3]])
+        .build()
+  }
+
+}

--- a/matrix-charts/src/test/groovy/charm/render/geom/ArrowRendererTest.groovy
+++ b/matrix-charts/src/test/groovy/charm/render/geom/ArrowRendererTest.groovy
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*
 import static se.alipsa.matrix.charm.Charts.*
 
 import org.junit.jupiter.api.Test
+import testutil.Slow
 
 import se.alipsa.groovy.svg.io.SvgWriter
 import se.alipsa.matrix.charm.ArrowSpec
@@ -13,6 +14,7 @@ import se.alipsa.matrix.core.Matrix
 class ArrowRendererTest {
 
   @Test
+  @Slow
   void testSegmentArrowRendersStartAndEndMarkers() {
     Matrix data = segmentData()
 
@@ -32,6 +34,7 @@ class ArrowRendererTest {
   }
 
   @Test
+  @Slow
   void testCurveArrowRendersEndMarker() {
     Matrix data = segmentData()
 


### PR DESCRIPTION
## Summary

Implements the first two deferred `matrix-charts/req/0.5.0-r3-plan.md` items and adds focused renderer-internal coverage for the new behavior.

- Extracts shared builder APIs into `TextLayerBuilder` and `LineEndpointBuilder`.
- Adds typed `ArrowSpec` / `ArrowEnds` APIs and removes the public `arrow(Object)` builder overloads from segment and curve builders.
- Renders segment and curve arrows as SVG marker definitions via `ArrowMarkerSupport`.
- Adds API tests for typed arrow overloads and renderer tests for segment/curve marker output.

## Notes

The broad deferred item for dedicated unit tests across all renderer/stat/position/coord internals is large enough to require its own coverage plan. This PR adds focused internal renderer coverage for the new arrow rendering support introduced here.

## Validation

- `./gradlew :matrix-charts:test --tests "charm.api.CharmTypedOverloadApiTest" --tests "charm.render.geom.ArrowRendererTest" -Pheadless=true`
- `./gradlew :matrix-charts:codenarcMain`
- `./gradlew :matrix-charts:codenarcTest`
- `./gradlew :matrix-charts:spotlessCheck`
- `./gradlew :matrix-charts:test -Pheadless=true`