### PR TITLE
Apply matrix-charts CSS bridge docs

### DIFF
--- a/docs/cookbook/matrix-charts.md
+++ b/docs/cookbook/matrix-charts.md
@@ -1,8 +1,9 @@
 # Matrix Charts
 
 Matrix Charts provides various predefined charts that can easily be created based on
-Matrix data. There are two different Plot classes that can either produce JavaFX (Plot) or Swing-based
-charts (SwingPlot) respectively.
+Matrix data. The native representation is SVG, and charts can be exported through the
+`se.alipsa.matrix.chartexport` package to PNG, JPEG, SVG, PDF, JavaFX, or Swing.
+The older `Plot` helper remains available for compatibility but is deprecated.
 
 ## Fluent Builder API
 
@@ -110,6 +111,10 @@ All builders share these methods inherited from `Chart.ChartBuilder`:
 - `legend(Legend)` — legend configuration
 - `style(Style)` — style configuration
 
+`AxisScale` settings are applied during Charm rendering. `Style.yLabels` can be used for
+custom y-axis labels on legacy PICT charts. `Style.css` is injected into Charm-rendered
+SVG as a stylesheet.
+
 ## Charm API Recipes
 
 The `matrix-charts` module also includes the Charm Grammar-of-Graphics DSL.
@@ -185,6 +190,71 @@ def chart = plot(mtcars) {
 }.build()
 
 chart.writeTo('charm-histogram.svg')
+```
+
+### Recipe: Charm Segment Arrows
+
+```groovy
+import se.alipsa.matrix.charm.ArrowSpec
+import static se.alipsa.matrix.charm.Charts.plot
+
+def chart = plot(data) {
+  mapping {
+    x = 'x'
+    y = 'y'
+    xend = 'x2'
+    yend = 'y2'
+  }
+  layers {
+    geomSegment().arrow(ArrowSpec.end(8, 6)).color('#336699')
+  }
+}.build()
+
+chart.writeTo('segment-arrows.svg')
+```
+
+Use `ArrowSpec.start(...)`, `ArrowSpec.end(...)`, or `ArrowSpec.both(...)` to choose
+where arrowheads are rendered. Length and width are SVG user-unit pixels.
+
+### Recipe: PICT Axis Scale and Y Labels
+
+```groovy
+import se.alipsa.matrix.pict.LineChart
+import se.alipsa.matrix.pict.Style
+import se.alipsa.matrix.chartexport.ChartToPng
+
+def style = new Style()
+style.yLabels = ['0': 'Low', '50': 'Target', '100': 'High']
+
+def chart = LineChart.builder(data)
+    .title('Capacity')
+    .x('month')
+    .y('capacity')
+    .yAxisScale(0, 100, 50)
+    .style(style)
+    .build()
+
+ChartToPng.export(chart, new File('capacity.png'))
+```
+
+### Recipe: Export a Plot Grid with Dimensions
+
+```groovy
+import static se.alipsa.matrix.charm.Charts.plotGrid
+
+def grid = plotGrid([chart1, chart2, chart3, chart4], 2)
+
+grid.writeTo('dashboard.png', 1200, 800)
+grid.writeTo('dashboard.pdf', 1200, 800)
+```
+
+### Recipe: Export SVG XML to PDF
+
+```groovy
+import se.alipsa.matrix.chartexport.ChartToPdf
+
+String svgXml = charmChart.render().toXml()
+ChartToPdf.export(svgXml, new File('chart.pdf'))
 ```
 
 ## GGPlot Cookbook

--- a/docs/tutorial/13-matrix-charts.md
+++ b/docs/tutorial/13-matrix-charts.md
@@ -1,8 +1,9 @@
 # Matrix Charts Module
 
 The Matrix Charts module is a Groovy library for creating various types of graphs and charts based on Matrix data. 
-It provides a simple and intuitive API for generating visualizations that can be exported to different formats but the
-"native" format is SVG. It uses the gsvg SVG model to greate charts and it is always possible to access the model directly
+It provides a simple and intuitive API for generating visualizations that can be exported to SVG, PNG, JPEG, PDF,
+JavaFX, or Swing, but the
+"native" format is SVG. It uses the gsvg SVG model to create charts and it is always possible to access the model directly
 for advanced customization.
 
 ## Installation
@@ -104,6 +105,7 @@ Area charts are useful for showing trends over time or comparing values across c
 ```groovy
 import se.alipsa.matrix.core.*
 import se.alipsa.matrix.pict.*
+import se.alipsa.matrix.chartexport.ChartToPng
 
 // Create a Matrix with time series data
 def timeData = Matrix.builder().data(
@@ -117,7 +119,7 @@ def timeData = Matrix.builder().data(
 def areaChart = AreaChart.create("Monthly Performance", timeData, "month", "sales", "profit")
 
 // Export the chart to PNG
-Plot.png(areaChart, new File("monthly_performance.png"))
+ChartToPng.export(areaChart, new File("monthly_performance.png"))
 ```
 
 ### Bar Chart
@@ -127,6 +129,7 @@ Bar charts are excellent for comparing values across different categories. You c
 ```groovy
 import se.alipsa.matrix.core.*
 import se.alipsa.matrix.pict.*
+import se.alipsa.matrix.chartexport.ChartToPng
 
 // Create a Matrix with categorical data
 def productData = Matrix.builder().data(
@@ -155,8 +158,8 @@ def horizontalBarChart = BarChart.createHorizontal(
 )
 
 // Export the charts
-Plot.png(verticalBarChart, new File("vertical_bar_chart.png"))
-Plot.png(horizontalBarChart, new File("horizontal_bar_chart.png"))
+ChartToPng.export(verticalBarChart, new File("vertical_bar_chart.png"))
+ChartToPng.export(horizontalBarChart, new File("horizontal_bar_chart.png"))
 ```
 
 The `ChartType` enum provides different styles for bar charts:
@@ -171,6 +174,7 @@ Pie charts are useful for showing proportions of a whole.
 ```groovy
 import se.alipsa.matrix.core.*
 import se.alipsa.matrix.pict.*
+import se.alipsa.matrix.chartexport.ChartToPng
 
 // Create a Matrix with market share data
 def marketData = Matrix.builder().data(
@@ -183,7 +187,7 @@ def marketData = Matrix.builder().data(
 def pieChart = PieChart.create("Market Share", marketData, "company", "market_share")
 
 // Export the chart
-Plot.png(pieChart, new File("market_share.png"))
+ChartToPng.export(pieChart, new File("market_share.png"))
 ```
 
 ### Line Chart
@@ -193,6 +197,7 @@ Line charts are ideal for showing trends over time or continuous data.
 ```groovy
 import se.alipsa.matrix.core.*
 import se.alipsa.matrix.pict.*
+import se.alipsa.matrix.chartexport.ChartToPng
 import java.time.LocalDate
 
 // Create a Matrix with time series data
@@ -219,7 +224,7 @@ def lineChart = LineChart.create(
 )
 
 // Export the chart
-Plot.png(lineChart, new File("temperature_trends.png"))
+ChartToPng.export(lineChart, new File("temperature_trends.png"))
 ```
 
 ### Scatter Chart
@@ -229,6 +234,7 @@ Scatter charts are useful for showing the relationship between two variables.
 ```groovy
 import se.alipsa.matrix.core.*
 import se.alipsa.matrix.pict.*
+import se.alipsa.matrix.chartexport.ChartToPng
 
 // Create a Matrix with correlation data
 def correlationData = Matrix.builder().data(
@@ -246,43 +252,70 @@ def scatterChart = ScatterChart.create(
 )
 
 // Export the chart
-Plot.png(scatterChart, new File("height_weight_correlation.png"))
+ChartToPng.export(scatterChart, new File("height_weight_correlation.png"))
 ```
 
 ## Exporting Charts
 
-The matrix-charts module provides several ways to export charts using the `Plot` class:
+The recommended export API lives in `se.alipsa.matrix.chartexport`. It accepts PICT charts,
+Charm charts, `Svg` objects, and SVG XML strings where the target format supports them.
 
-### Export to PNG
-
-```groovy
-// Export to PNG file
-Plot.png(chart, new File("chart.png"))
-
-// Export to PNG with custom dimensions
-Plot.png(chart, new File("chart.png"), 800, 600)
-```
-
-### Export to SVG
+### Export to PNG, JPEG, SVG, or PDF
 
 ```groovy
-// Export to SVG file
-Plot.svg(chart, new File("chart.svg"))
+import se.alipsa.matrix.chartexport.ChartToJpeg
+import se.alipsa.matrix.chartexport.ChartToPdf
+import se.alipsa.matrix.chartexport.ChartToPng
+import se.alipsa.matrix.chartexport.ChartToSvg
 
-// Export to SVG with custom dimensions
-Plot.svg(chart, new File("chart.svg"), 800, 600)
+ChartToPng.export(chart, new File("chart.png"))
+ChartToJpeg.export(chart, new File("chart.jpg"), 0.9)
+ChartToSvg.export(chart, new File("chart.svg"))
+ChartToPdf.export(chart, new File("chart.pdf"))
 ```
 
-### Export to JavaFX
-
-If you're working with a JavaFX application, you can convert the chart to a JavaFX chart:
+PDF export now scales screen pixels to PDF points, so an 800x600 chart is written as a
+600x450 point PDF page. Raw SVG XML from a Charm chart can also be converted directly
+to PDF:
 
 ```groovy
-// Get a JavaFX chart object
-javafx.scene.chart.Chart jfxChart = Plot.jfx(chart)
-
-// Now you can add this chart to your JavaFX scene
+String svgXml = charmChart.render().toXml()
+ChartToPdf.export(svgXml, new File("chart-from-svg.pdf"))
 ```
+
+### Export Plot Grids with Custom Dimensions
+
+For Charm charts, `PlotGrid.writeTo` accepts explicit dimensions for PNG, JPEG, SVG,
+and PDF output:
+
+```groovy
+import static se.alipsa.matrix.charm.Charts.plotGrid
+
+def grid = plotGrid([charmChart1, charmChart2], 2)
+grid.writeTo("dashboard.png", 1200, 700)
+grid.writeTo("dashboard.pdf", 1200, 700)
+```
+
+### Export to JavaFX or Swing
+
+If you're working with a JavaFX application, export to a JavaFX `Node`:
+
+```groovy
+import se.alipsa.matrix.chartexport.ChartToJfx
+
+javafx.scene.Node node = ChartToJfx.export(chart)
+```
+
+For Swing:
+
+```groovy
+import se.alipsa.matrix.chartexport.ChartToSwing
+
+def panel = ChartToSwing.export(chart)
+```
+
+The older `Plot` helper class remains available for source compatibility, but it is deprecated.
+Use the `chartexport` classes for new code.
 
 ## Customizing Charts
 
@@ -340,6 +373,7 @@ import java.time.LocalDate
 import javafx.scene.paint.Color
 import se.alipsa.matrix.core.*
 import se.alipsa.matrix.pict.*
+import se.alipsa.matrix.chartexport.ChartToPng
 
 // Create a sample Matrix with sales data
 def salesData = Matrix.builder().data(
@@ -361,7 +395,7 @@ def barChart = BarChart.createVertical(
     .setXAxisTitle("Quarter")
     .setYAxisTitle("Sales (in thousands)")
 File file = new File("quarterly_sales_bar.png")
-Plot.png(barChart, file)
+ChartToPng.export(barChart, file)
 println "saved barchart to $file.absolutePath"
 
 salesData['quarter'] = [1, 2, 3, 4]
@@ -376,7 +410,7 @@ def lineChart = LineChart.create(
     .setXAxisTitle("Quarter")
     .setYAxisTitle("Sales (in thousands)")
 file = new File("quarterly_sales_line.png")
-Plot.png(lineChart, file)
+ChartToPng.export(lineChart, file)
 println "saved lineChart to $file.absolutePath"
 
 // Create a pie chart (using only one quarter for demonstration)
@@ -393,7 +427,7 @@ def pieChart = PieChart.create(
     "sales"
 )
 file = new File("q4_sales_pie.png")
-Plot.png(pieChart, file)
+ChartToPng.export(pieChart, file)
 println "saved pieChart to $file.absolutePath"
 println "Charts have been exported successfully."
 ```
@@ -443,6 +477,28 @@ def chart = plot(mtcars) {
 
 chart.writeTo('charm-mtcars.svg')
 ```
+
+Charm segment and curve layers can draw arrowheads using `ArrowSpec`:
+
+```groovy
+import se.alipsa.matrix.charm.ArrowSpec
+
+def arrows = plot(mtcars) {
+  mapping {
+    x = 'mpg'
+    y = 'wt'
+    xend = 'hp'
+    yend = 'qsec'
+  }
+  layers {
+    geomSegment().arrow(ArrowSpec.end(8, 6)).color('#336699')
+  }
+}.build()
+```
+
+PICT charts continue to render through Charm. Custom `AxisScale` settings and
+`style.yLabels` are applied by the bridge, and `style.css` is injected into the
+rendered SVG as a stylesheet.
 
 For full Charm coverage, see:
 - [matrix-charts/docs/charm.md](../../matrix-charts/docs/charm.md)

--- a/matrix-charts/README.md
+++ b/matrix-charts/README.md
@@ -4,7 +4,7 @@
 Groovy library for creating graphs based on Matrix or [][] data
 
 Matrix-charts is a "native" chart library that creates charts as SVGs.
-An SVG chart can be exported to Swing, JavaFX, Image, PNG, or JPG using
+An SVG chart can be exported to Swing, JavaFX, Image, PNG, JPG, or PDF using
 the exporters in the se.alipsa.matrix.chartexport package.
 
 There are 2 APIs in matrix-charts, sharing the same Charm rendering engine:
@@ -84,6 +84,43 @@ chart.writeTo('mpg_chart.svg')
 
 See **[charm.md](docs/charm.md)** for comprehensive documentation.
 
+### Charm Export Examples
+
+```groovy
+import se.alipsa.matrix.chartexport.ChartToPdf
+
+chart.writeTo('mpg_chart.svg')
+chart.writeTo('mpg_chart.png')
+ChartToPdf.export(chart, new File('mpg_chart.pdf'))
+
+// Raw SVG XML can also be exported directly to PDF.
+String svgXml = chart.render().toXml()
+ChartToPdf.export(svgXml, new File('mpg_chart_from_svg.pdf'))
+```
+
+Plot grids support explicit output dimensions for every writable format:
+
+```groovy
+import static se.alipsa.matrix.charm.Charts.plotGrid
+
+def grid = plotGrid([chart, chart], 2)
+grid.writeTo('mpg_dashboard.png', 1200, 700)
+grid.writeTo('mpg_dashboard.pdf', 1200, 700)
+```
+
+Segment and curve layers can render SVG arrow markers:
+
+```groovy
+import se.alipsa.matrix.charm.ArrowSpec
+
+def arrowChart = plot(Dataset.mtcars()) {
+  mapping { x = 'mpg'; y = 'wt'; xend = 'hp'; yend = 'qsec' }
+  layers {
+    geomSegment().arrow(ArrowSpec.end(8, 6)).color('#336699')
+  }
+}.build()
+```
+
 ## Charts Example
 
 ```groovy
@@ -113,6 +150,9 @@ def pieChart = PieChart.builder(empData)
 ChartToPng.export(areaChart, new File("areaChart.png"))
 ChartToPng.export(barChart, new File("barChart.png"))
 ```
+
+PICT charts are bridged through Charm. Axis scale settings, custom `style.yLabels`,
+and `style.css` are applied during rendering.
 
 See **[pict.md](docs/pict.md)** for comprehensive documentation.
 

--- a/matrix-charts/docs/charm.md
+++ b/matrix-charts/docs/charm.md
@@ -253,6 +253,31 @@ layers {
 
 Layer params take priority over mapped aesthetics: if both `mapping { fill = 'status' }` and `geomCol().fill('#336699')` are present, the literal layer param wins. This matches ggplot2 behavior.
 
+### Segment and Curve Arrows
+
+`geomSegment()` and `geomCurve()` support SVG arrow markers through `ArrowSpec`:
+
+```groovy
+import se.alipsa.matrix.charm.ArrowSpec
+
+plot(data) {
+  mapping {
+    x = 'x'
+    y = 'y'
+    xend = 'x2'
+    yend = 'y2'
+  }
+  layers {
+    geomSegment().arrow(ArrowSpec.end(8, 6)).color('#336699')
+    geomCurve().arrow(ArrowSpec.both(7, 5)).curvature(0.25)
+  }
+}
+```
+
+Use `ArrowSpec.start(...)`, `ArrowSpec.end(...)`, or `ArrowSpec.both(...)` to choose
+the endpoint markers. Length and width are SVG user-unit pixels. Pass `false` as the
+third argument for an open arrowhead, for example `ArrowSpec.end(8, 6, false)`.
+
 ### Style Callbacks
 
 For per-datum conditional styling, use the `style {}` callback on a layer. The callback receives a `Row` from the original data matrix and a mutable `StyleOverride` object:
@@ -754,6 +779,21 @@ Available properties in `animation {}`:
 
 Note: CSS `@keyframes` animations are embedded in the SVG `<style>` block and are visible only in SVG viewers that support CSS animation. Animation styles are silently stripped when exporting to PNG/JPEG with `ChartToPng`/`ChartToJpeg` because raster output is static.
 
+## Raw SVG Stylesheets
+
+Charm can inject raw CSS text into the rendered SVG:
+
+```groovy
+def chart = plot(data) {
+  mapping { x = 'x'; y = 'y' }
+  layers { geomPoint() }
+  stylesheet('.charm-point { stroke-width: 2; }')
+}.build()
+```
+
+The stylesheet is emitted as an SVG `<style type="text/css">` element. PICT
+`Style.css` values use the same mechanism when legacy charts are bridged to Charm.
+
 ## Multi-plot Composition
 
 Charm provides `PlotGrid` for arranging multiple independent charts into a single SVG. Each subplot is rendered into a nested `<svg>` element for viewport isolation (independent clipping and coordinate spaces).
@@ -806,6 +846,14 @@ grid = plot_grid(c1, c2)
 Svg svg = grid.render(1200, 800)
 ChartToPng.export(svg, new File('dashboard.png'))
 new File('dashboard.svg').text = SvgWriter.toXml(svg)
+```
+
+`PlotGrid.writeTo` also accepts explicit dimensions and chooses the exporter from the
+file extension:
+
+```groovy
+grid.writeTo('dashboard.png', 1200, 800)
+grid.writeTo('dashboard.pdf', 1200, 800)
 ```
 
 ### Options
@@ -926,6 +974,20 @@ import se.alipsa.matrix.chartexport.ChartToJpeg
 ChartToJpeg.export(chart, new File('plot.jpg'), 0.9)
 ```
 
+### PDF
+
+```groovy
+import se.alipsa.matrix.chartexport.ChartToPdf
+
+ChartToPdf.export(chart, new File('plot.pdf'))
+
+String svgXml = chart.render().toXml()
+ChartToPdf.export(svgXml, new File('plot-from-svg.pdf'))
+```
+
+PDF pages are sized in points. Chart images are converted from screen pixels at 96 DPI
+to PDF's 72 points per inch.
+
 ### JavaFX
 
 ```groovy
@@ -943,6 +1005,9 @@ import se.alipsa.matrix.chartexport.ChartToSwing
 def panel = ChartToSwing.export(chart)
 // Add panel to your Swing container
 ```
+
+`ChartToSwing` provides typed overloads for SVG strings, `Svg`, Charm `Chart`, PICT
+`Chart`, and `PlotGrid`.
 
 ## Static Compilation
 
@@ -965,6 +1030,12 @@ class MyCharts {
 }
 ```
 
+Public fluent builder methods use typed overloads for common multi-type settings:
+column mappings accept `String` or `ColumnExpr`, `stat` accepts `CharmStatType`,
+`StatSpec`, or `String`, `position` accepts `CharmPositionType`, `PositionSpec`, or
+`String`, and `fontface` accepts `String` or `int`. Passing unsupported arbitrary
+objects now fails through normal Groovy method dispatch.
+
 ## Relationship to gg and charts APIs
 
 All three APIs in matrix-charts share the same Charm rendering engine:
@@ -973,7 +1044,7 @@ All three APIs in matrix-charts share the same Charm rendering engine:
 charm ----renders----> Svg (gsvg)
 gg ------adapts------> charm ---renders-> Svg
 charts --builds------> charm ---renders-> Svg
-         Svg ----exports----> chartexport ------> PNG/JPEG/JFX/Swing
+         Svg ----exports----> chartexport ------> PNG/JPEG/PDF/JFX/Swing
 ```
 
 - **Charm** is the core. Use it for new code and when you want the most idiomatic Groovy experience.

--- a/matrix-charts/docs/pict.md
+++ b/matrix-charts/docs/pict.md
@@ -27,7 +27,7 @@ A comprehensive guide to using the `se.alipsa.matrix.pict` package for creating 
 
 The `se.alipsa.matrix.pict` package provides a chart-type-first API for creating common visualizations. You start by choosing a chart type (e.g. `BarChart`, `LineChart`), then supply data and configure styling. This is a familiar pattern for users of libraries like xchart or JavaFX charts.
 
-All chart types are backed by the [Charm](charm.md) rendering engine internally. Charts render to SVG and can be exported to PNG, JPEG, JavaFX, or Swing via `se.alipsa.matrix.chartexport`.
+All chart types are backed by the [Charm](charm.md) rendering engine internally. Charts render to SVG and can be exported to PNG, JPEG, PDF, JavaFX, or Swing via `se.alipsa.matrix.chartexport`.
 
 ### Key Features
 - Fluent builder API for creating and configuring charts in one chain
@@ -44,8 +44,8 @@ This guide reflects the current PICT implementation, including:
 - Legend API is centered around `Legend` and fluent builder methods (`legendTitle`, `legendPosition`, etc.)
 - Builder style methods now include `titleVisible`, `xAxisVisible`, `yAxisVisible`, and `css`
 - `AxisScale` is immutable and validated (`start < end`, `step > 0`, non-null values)
-- Axis visibility flags are bridged to Charm rendering (`xAxisVisible(false)`, `yAxisVisible(false)`)
-- `Style.css` is stored in the chart style but not injected into rendered SVG by Charm
+- Axis scale settings, axis visibility flags, `Style.yLabels`, and `Style.css` are bridged to Charm rendering
+- Histogram bin calculations preserve exact bin boundaries internally and round labels only for display
 
 ## Quick Start
 
@@ -84,7 +84,7 @@ ChartToPng.export(chart, new File('fruit_sales.png'))
 1. **Create** a chart via the fluent builder (or a static factory method)
 2. **Configure** title, axes, and chart-specific options in the builder chain
 3. **Build** the chart with `.build()`
-4. **Export** to SVG, PNG, JPEG, JavaFX, or Swing
+4. **Export** to SVG, PNG, JPEG, PDF, JavaFX, or Swing
 
 ```groovy
 def chart = LineChart.builder(data)
@@ -131,7 +131,7 @@ All builders inherit these methods from `Chart.ChartBuilder`:
 | `titleVisible(boolean)` | Whether the title is visible |
 | `xAxisVisible(boolean)` | Whether the x-axis is visible |
 | `yAxisVisible(boolean)` | Whether the y-axis is visible |
-| `css(String)` | Custom CSS string (stored on style; not injected by Charm renderer) |
+| `css(String)` | Custom CSS string injected into Charm-rendered SVG |
 | `build()` | Build the chart |
 
 ### Chart-Specific Builder Methods
@@ -687,7 +687,16 @@ chart.style.yAxisVisible = false
 chart.style.css = 'stroke-width: 2; font-family: Arial;'
 ```
 
-`Style.css` is currently persisted on the chart style object for compatibility, but is not injected into Charm-rendered SVG output.
+`Style.css` is injected into Charm-rendered SVG output as a raw stylesheet.
+
+### Custom Y Labels
+
+```groovy
+chart.style.yLabels = ['0': 'Low', '50': 'Target', '100': 'High']
+```
+
+Custom y labels are applied by the Charm bridge. Map keys are parsed as numeric axis
+breaks and sorted numerically before rendering.
 
 ### Fluent Configuration
 
@@ -734,6 +743,8 @@ chart.setYAxisScale(0, 500, 50)
 - `start` must be less than `end`
 - `step` must be greater than `0`
 
+Axis scales are applied to the rendered Charm axis limits and breaks.
+
 ### Axis Titles
 
 ```groovy
@@ -778,7 +789,9 @@ chart.valueSeriesNames      // List<String> -- series names
 
 ## Output Formats
 
-All export classes are in the `se.alipsa.matrix.chartexport` package and accept legacy `Chart` objects, Charm `Chart`, `Svg`, or SVG strings.
+All export classes are in the `se.alipsa.matrix.chartexport` package and accept legacy
+`Chart` objects, Charm `Chart`, and `Svg` objects where applicable. PNG, PDF, JavaFX,
+and Swing exporters also accept raw SVG XML strings.
 
 ### PNG
 
@@ -816,6 +829,18 @@ ChartToJpeg.export(chart, new File('chart.jpg'), 0.9)
 // To OutputStream
 ChartToJpeg.export(chart, outputStream, 0.9)
 ```
+
+### PDF
+
+```groovy
+import se.alipsa.matrix.chartexport.ChartToPdf
+
+ChartToPdf.export(chart, new File('chart.pdf'))
+ChartToPdf.export(chart, outputStream)
+```
+
+PDF page dimensions are written in points. Rasterized chart pixels are scaled from
+96 DPI screen units to PDF's 72 points per inch.
 
 ### Base64 Data URI
 
@@ -883,7 +908,7 @@ All three APIs in matrix-charts share the same Charm rendering engine:
 charm ----renders----> Svg (gsvg)
 gg ------adapts------> charm ---renders-> Svg
 pict ----builds------> charm ---renders-> Svg (via CharmBridge)
-        Svg ----exports----> chartexport ------> PNG/JPEG/JFX/Swing
+        Svg ----exports----> chartexport ------> PNG/JPEG/PDF/JFX/Swing
 ```
 
 - **PICT** (this guide) -- chart-type-first API. Start with `BarChart.builder(data)` and configure from there.

--- a/matrix-charts/release.md
+++ b/matrix-charts/release.md
@@ -7,7 +7,7 @@ See [charm.md](docs/charm.md) for the Charm user guide and [ggPlot.md](ggPlot.md
 
 **Architecture**
   - Introduced `se.alipsa.matrix.charm` as the single rendering engine for all three charting APIs (Charm, gg, charts).
-  - All chart rendering now produces SVG via gsvg. Export to PNG/JPEG/JavaFX/Swing goes through `se.alipsa.matrix.chartexport`.
+  - All chart rendering now produces SVG via gsvg. Export to PNG/JPEG/PDF/JavaFX/Swing goes through `se.alipsa.matrix.chartexport`.
   - The gg API (`se.alipsa.matrix.gg`) is preserved as a thin compatibility wrapper delegating to Charm.
   - The pictura API (`se.alipsa.matrix.pict`) is backed by Charm via `CharmBridge`. `Plot` is `@Deprecated` but functional.
   - `Plot.png()` no longer requires JavaFX toolkit initialization.
@@ -17,14 +17,26 @@ See [charm.md](docs/charm.md) for the Charm user guide and [ggPlot.md](ggPlot.md
   - **`Plot.jfx()` return type changed** from `javafx.scene.chart.Chart` to `javafx.scene.Node`. Code using `view()` or similar methods that accept `Node` is unaffected.
   - **Legacy backend packages removed:** `se.alipsa.matrix.charts.jfx`, `se.alipsa.matrix.charts.swing`, `se.alipsa.matrix.charts.png`, `se.alipsa.matrix.charts.svg`, and `se.alipsa.matrix.charts.util.StyleUtil`. Use `chartexport` classes (`ChartToPng`, `ChartToJfx`, `ChartToSwing`, `ChartToJpeg`, `ChartToImage`) instead.
   - **`org.knowm.xchart:xchart` dependency removed.** If you depended on xchart transitively, add it directly.
+  - Public builder APIs now prefer typed overloads for mapping, layer `stat`, layer `position`, `fontface`, bin counts, and segment/curve arrows. Unsupported argument types now fail earlier through Groovy method dispatch instead of broad `Object` catch-all methods.
 
 **New Features**
   - Charm closure DSL for idiomatic Groovy chart specifications (`Charts.plot(data) { ... }`).
   - Immutable compiled chart models (`Chart`) with deterministic lifecycle (spec -> build -> render).
   - Typed column references via `col` proxy (`col.name`, `col['name']`).
   - `@CompileStatic` support throughout Charm core.
-  - Charm export overloads added to all five chartexport classes.
+  - Charm export overloads added to the chartexport classes.
+  - `ChartToPdf.export(String, File)` and `ChartToPdf.export(String, OutputStream)` now accept raw SVG XML strings, matching the PNG export API.
+  - `PlotGrid.writeTo(File, int, int)` and `PlotGrid.writeTo(String, int, int)` now export grid layouts with explicit output dimensions.
+  - Segment and curve geoms now support rendered arrowheads through `ArrowSpec.start(...)`, `ArrowSpec.end(...)`, and `ArrowSpec.both(...)`.
+  - Charm `stylesheet(String)` injects raw CSS into rendered SVG, and PICT `Style.css` now uses that path.
   - `verifyGgRegression` Gradle task for pre-merge gg test regression gating.
+
+**Compatibility and Rendering Fixes**
+  - PDF export now closes partially-created PDF documents if image embedding fails, and PDF page sizes now convert screen pixels to PDF points at 96 DPI.
+  - `Chart.render()` now preserves an existing `CharmRenderException` instead of wrapping it in a second `CharmRenderException`.
+  - Temporal scale fallbacks and spatial geometry parse fallbacks now emit logger diagnostics instead of failing silently.
+  - Legacy PICT `AxisScale`, `Style.yLabels`, and `Style.css` settings are applied by the Charm bridge.
+  - Legacy histogram bin counting preserves exact internal bin boundaries and rounds labels only for display.
 
 **Documentation**
   - Added [charm.md](docs/charm.md) with comprehensive Charm DSL guide and migration notes.

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Chart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Chart.groovy
@@ -28,6 +28,7 @@ class Chart {
   private final List<AnnotationSpec> annotations
   private final CssAttributesSpec cssAttributes
   private final AnimationSpec animation
+  private final String stylesheet
 
   /**
    * Creates a new compiled chart model.
@@ -44,6 +45,7 @@ class Chart {
    * @param annotations annotation list
    * @param cssAttributes css attribute configuration
    * @param animation animation specification
+   * @param stylesheet raw SVG stylesheet text
    */
   Chart(
       Matrix data,
@@ -57,7 +59,8 @@ class Chart {
       GuidesSpec guides,
       List<AnnotationSpec> annotations,
       CssAttributesSpec cssAttributes = null,
-      AnimationSpec animation = null
+      AnimationSpec animation = null,
+      String stylesheet = null
   ) {
     this.data = data
     this.mapping = toMappingSpec(mapping)
@@ -75,6 +78,7 @@ class Chart {
     )
     this.cssAttributes = cssAttributes?.copy() ?: new CssAttributesSpec()
     this.animation = animation?.copy()
+    this.stylesheet = stylesheet
   }
 
   /**
@@ -186,6 +190,15 @@ class Chart {
    */
   AnimationSpec getAnimation() {
     animation?.copy()
+  }
+
+  /**
+   * Returns raw SVG stylesheet text.
+   *
+   * @return stylesheet text or null
+   */
+  String getStylesheet() {
+    stylesheet
   }
 
   private static MappingSpec toMappingSpec(Mapping value) {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/PlotSpec.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/PlotSpec.groovy
@@ -69,6 +69,7 @@ class PlotSpec {
   private final GuidesSpec guides = new GuidesSpec()
   private AnimationSpec animation
   private CssAttributesSpec cssAttributes
+  private String stylesheet
   private final List<AnnotationSpec> annotations = []
 
   /**
@@ -171,6 +172,15 @@ class PlotSpec {
    */
   AnimationSpec getAnimation() {
     animation?.copy()
+  }
+
+  /**
+   * Returns raw SVG stylesheet text.
+   *
+   * @return stylesheet text or null
+   */
+  String getStylesheet() {
+    stylesheet
   }
 
   /**
@@ -479,6 +489,17 @@ class PlotSpec {
   }
 
   /**
+   * Sets raw SVG stylesheet text to inject into the rendered chart.
+   *
+   * @param css raw CSS text
+   * @return this plot spec
+   */
+  PlotSpec stylesheet(String css) {
+    stylesheet = css
+    this
+  }
+
+  /**
    * Adds annotations via closure DSL.
    *
    * @param configure closure for annotation declarations
@@ -517,7 +538,8 @@ class PlotSpec {
           compiledGuides,
           compiledAnnotations,
           cssAttributes?.copy(),
-          compiledAnimation
+          compiledAnimation,
+          stylesheet
       )
     } catch (CharmException e) {
       throw e

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/CharmRenderer.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/CharmRenderer.groovy
@@ -6,6 +6,7 @@ import se.alipsa.matrix.charm.AnimationSpec
 import se.alipsa.matrix.charm.AnnotationSpec
 import se.alipsa.matrix.charm.CharmCoordType
 import se.alipsa.matrix.charm.CharmGeomType
+import se.alipsa.matrix.charm.CharmRenderException
 import se.alipsa.matrix.charm.Chart
 import se.alipsa.matrix.charm.CoordSpec
 import se.alipsa.matrix.charm.FacetType
@@ -350,7 +351,7 @@ class CharmRenderer {
 
   private static void ensureNoCdataTerminator(String stylesheet) {
     if (stylesheet.contains(']]>')) {
-      throw new IllegalArgumentException("Stylesheet must not contain ']]>'")
+      throw new CharmRenderException("Stylesheet must not contain ']]>'")
     }
   }
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/CharmRenderer.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/CharmRenderer.groovy
@@ -88,8 +88,8 @@ class CharmRenderer {
     renderPanels(context)
     renderLabels(context)
     legendRenderer.render(context)
-    injectStylesheet(context)
     injectAnimationStyle(context)
+    injectStylesheet(context)
     svg
   }
 
@@ -342,9 +342,16 @@ class CharmRenderer {
     if (!stylesheet?.trim()) {
       return
     }
+    ensureNoCdataTerminator(stylesheet)
     context.svg.addStyle()
         .type('text/css')
         .addCdataContent(stylesheet)
+  }
+
+  private static void ensureNoCdataTerminator(String stylesheet) {
+    if (stylesheet.contains(']]>')) {
+      throw new IllegalArgumentException("Stylesheet must not contain ']]>'")
+    }
   }
 
   private static void renderAnnotationsAtOrder(

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/CharmRenderer.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/CharmRenderer.groovy
@@ -88,6 +88,7 @@ class CharmRenderer {
     renderPanels(context)
     renderLabels(context)
     legendRenderer.render(context)
+    injectStylesheet(context)
     injectAnimationStyle(context)
     svg
   }
@@ -334,6 +335,16 @@ class CharmRenderer {
     context.svg.addStyle()
         .type('text/css')
         .addCdataContent(animation.toCss())
+  }
+
+  private static void injectStylesheet(RenderContext context) {
+    String stylesheet = context.chart.stylesheet
+    if (!stylesheet?.trim()) {
+      return
+    }
+    context.svg.addStyle()
+        .type('text/css')
+        .addCdataContent(stylesheet)
   }
 
   private static void renderAnnotationsAtOrder(

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
@@ -268,6 +268,9 @@ class CharmBridge {
     if (chart.yAxisTitle) {
       labels.y = chart.yAxisTitle
     }
+    if (chart.style?.css?.trim()) {
+      spec.stylesheet(chart.style.css)
+    }
     applyAxisScales(spec, chart)
 
     se.alipsa.matrix.charm.ThemeSpec theme = spec.theme as se.alipsa.matrix.charm.ThemeSpec

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Chart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Chart.groovy
@@ -286,13 +286,11 @@ abstract class Chart<T extends Chart> {
     B yAxisVisible(boolean visible) { ensureStyle(); style.yAxisVisible = visible; this as B }
 
     /**
-     * Sets legacy raw CSS text.
+     * Sets raw CSS text to inject into Charm-rendered SVG output.
      *
      * @param css raw CSS text
      * @return this builder
-     * @deprecated Raw CSS is not applied by the Charm bridge; use Charm theme settings instead.
      */
-    @Deprecated
     B css(String css) { ensureStyle(); style.css = css; this as B }
 
     private void ensureStyle() {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Style.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Style.groovy
@@ -51,15 +51,7 @@ import java.awt.Color
  */
 class Style {
 
-  /**
-   * Legacy raw CSS text retained for source compatibility.
-   *
-   * <p>The Charm bridge does not inject arbitrary stylesheet text. Prefer Charm theme
-   * settings and CSS attribute APIs for new code.</p>
-   *
-   * @deprecated Raw CSS is not applied by the Charm bridge.
-   */
-  @Deprecated
+  /** Raw CSS text injected into Charm-rendered SVG output. */
   String css
 
   /** The back ground color of the plot area (where the actual chart is drawn) */
@@ -78,23 +70,19 @@ class Style {
   Map<String, String> yLabels = [:]
 
   /**
-   * Sets legacy raw CSS text.
+   * Sets raw CSS text.
    *
    * @param css raw CSS text
-   * @deprecated Raw CSS is not applied by the Charm bridge; use Charm theme settings instead.
    */
-  @Deprecated
   void setCss(String css) {
     this.css = css
   }
 
   /**
-   * Returns legacy raw CSS text.
+   * Returns raw CSS text.
    *
    * @return raw CSS text
-   * @deprecated Raw CSS is not applied by the Charm bridge; use Charm theme settings instead.
    */
-  @Deprecated
   String getCss() {
     return css
   }

--- a/matrix-charts/src/test/groovy/charm/render/CharmRendererTest.groovy
+++ b/matrix-charts/src/test/groovy/charm/render/CharmRendererTest.groovy
@@ -91,7 +91,12 @@ class CharmRendererTest {
 
     String xml = SvgWriter.toXml(chart.render())
 
-    assertTrue(xml.indexOf('/* charm-animation */') < xml.indexOf('.charm-point { animation-name: none; }'))
+    int animationIndex = xml.indexOf('/* charm-animation */')
+    int stylesheetIndex = xml.indexOf('.charm-point { animation-name: none; }')
+
+    assertTrue(animationIndex >= 0)
+    assertTrue(stylesheetIndex >= 0)
+    assertTrue(animationIndex < stylesheetIndex)
   }
 
   @Test

--- a/matrix-charts/src/test/groovy/charm/render/CharmRendererTest.groovy
+++ b/matrix-charts/src/test/groovy/charm/render/CharmRendererTest.groovy
@@ -13,6 +13,7 @@ import se.alipsa.groovy.svg.Circle
 import se.alipsa.groovy.svg.Line
 import se.alipsa.groovy.svg.Rect
 import se.alipsa.groovy.svg.Svg
+import se.alipsa.groovy.svg.io.SvgWriter
 import se.alipsa.matrix.charm.CharmRenderException
 import se.alipsa.matrix.charm.Chart
 import se.alipsa.matrix.charm.Charts
@@ -49,6 +50,67 @@ class CharmRendererTest {
         ex.cause instanceof CharmRenderException,
         "render() must not double-wrap CharmRenderException; cause was: ${ex.cause?.getClass()?.name}"
     )
+  }
+
+  @Test
+  void testPlotSpecStylesheetInjectsRawCss() {
+    Matrix data = Matrix.builder()
+        .columnNames('x', 'y')
+        .rows([[1, 2], [2, 4]])
+        .build()
+
+    Chart chart = Charts.plot(data) {
+      mapping { x = 'x'; y = 'y' }
+      layers { geomPoint() }
+      stylesheet('.custom-point { stroke: red; }')
+    }.build()
+
+    String xml = SvgWriter.toXml(chart.render())
+
+    assertTrue(xml.contains('<style'))
+    assertTrue(xml.contains('.custom-point { stroke: red; }'))
+  }
+
+  @Test
+  void testUserStylesheetIsInjectedAfterAnimationCss() {
+    Matrix data = Matrix.builder()
+        .columnNames('x', 'y')
+        .rows([[1, 2], [2, 4]])
+        .build()
+
+    Chart chart = Charts.plot(data) {
+      mapping { x = 'x'; y = 'y' }
+      layers { geomPoint() }
+      animation {
+        selector = '.charm-point'
+        name = 'fade'
+        keyframes = 'from { opacity: 0; } to { opacity: 1; }'
+      }
+      stylesheet('.charm-point { animation-name: none; }')
+    }.build()
+
+    String xml = SvgWriter.toXml(chart.render())
+
+    assertTrue(xml.indexOf('/* charm-animation */') < xml.indexOf('.charm-point { animation-name: none; }'))
+  }
+
+  @Test
+  void testStylesheetRejectsCdataTerminator() {
+    Matrix data = Matrix.builder()
+        .columnNames('x', 'y')
+        .rows([[1, 2]])
+        .build()
+
+    Chart chart = Charts.plot(data) {
+      mapping { x = 'x'; y = 'y' }
+      layers { geomPoint() }
+      stylesheet('.custom { content: "]]>"; }')
+    }.build()
+
+    CharmRenderException ex = assertThrows(CharmRenderException) {
+      chart.render()
+    }
+    assertTrue(ex.message.contains("Stylesheet must not contain ']]>'"))
   }
 
   private static void setField(Object target, String name, Object value) {

--- a/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
@@ -226,8 +226,7 @@ class PlotCompatibilityTest {
   }
 
   @Test
-  @SuppressWarnings('GrDeprecatedAPIUsage')
-  void testLegacyCssApiRemainsCallableWithoutRawCharmCssInjection() {
+  void testLegacyCssApiInjectsRawCharmCss() {
     Matrix data = sampleData()
     BarChart chart = BarChart.builder(data)
         .title('CSS Compatibility')
@@ -237,7 +236,9 @@ class PlotCompatibilityTest {
         .build()
 
     assertEquals('.legacy-custom { fill: red; }', chart.style.css)
-    assertFalse(SvgWriter.toXml(CharmBridge.renderSvg(chart, 800, 600)).contains('.legacy-custom'))
+    String xml = SvgWriter.toXml(CharmBridge.renderSvg(chart, 800, 600))
+    assertTrue(xml.contains('<style'))
+    assertTrue(xml.contains('.legacy-custom { fill: red; }'))
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Add Charm `stylesheet(String)` support and render raw stylesheet CSS into SVG output.
- Bridge legacy PICT `Style.css` through Charm so it is applied instead of documented as a no-op.
- Update matrix-charts release notes, README, Charm/PICT docs, tutorial, and cookbook for the 0.5.0-r3 user-impacting changes.

## Validation
- `./gradlew :matrix-charts:test --tests "chart.PlotCompatibilityTest.testLegacyCssApiInjectsRawCharmCss" -Pheadless=true`
- `./gradlew :matrix-charts:codenarcMain :matrix-charts:codenarcTest :matrix-charts:spotlessCheck :matrix-charts:test -Pheadless=true`
- `git diff --check`