### PR TITLE
Treat pict as a first-class chart API over Charm

### DIFF
--- a/docs/cookbook/matrix-charts.md
+++ b/docs/cookbook/matrix-charts.md
@@ -1,9 +1,9 @@
 # Matrix Charts
 
 Matrix Charts provides various predefined charts that can easily be created based on
-Matrix data. The native representation is SVG, and charts can be exported through the
-`se.alipsa.matrix.chartexport` package to PNG, JPEG, SVG, PDF, JavaFX, or Swing.
-The older `Plot` helper remains available for compatibility but is deprecated.
+Matrix data. The native representation is SVG. Export PICT charts to PNG with
+`Plot.png(...)`. The `se.alipsa.matrix.chartexport` package provides additional
+targets including JPEG, PDF, JavaFX, and Swing, plus lower-level conversion APIs.
 
 ## Fluent Builder API
 
@@ -221,7 +221,7 @@ where arrowheads are rendered. Length and width are SVG user-unit pixels.
 ```groovy
 import se.alipsa.matrix.pict.LineChart
 import se.alipsa.matrix.pict.Style
-import se.alipsa.matrix.chartexport.ChartToPng
+import se.alipsa.matrix.pict.Plot
 
 def style = new Style()
 style.yLabels = ['0': 'Low', '50': 'Target', '100': 'High']
@@ -234,7 +234,7 @@ def chart = LineChart.builder(data)
     .style(style)
     .build()
 
-ChartToPng.export(chart, new File('capacity.png'))
+Plot.png(chart, new File('capacity.png'))
 ```
 
 ### Recipe: Export a Plot Grid with Dimensions

--- a/docs/tutorial/13-matrix-charts.md
+++ b/docs/tutorial/13-matrix-charts.md
@@ -262,11 +262,10 @@ Charm charts, `Svg` objects, and SVG XML strings where the target format support
 import se.alipsa.matrix.chartexport.ChartToJpeg
 import se.alipsa.matrix.chartexport.ChartToPdf
 import se.alipsa.matrix.pict.Plot
-import se.alipsa.matrix.chartexport.ChartToSvg
 
 Plot.png(chart, new File("chart.png"))
 ChartToJpeg.export(chart, new File("chart.jpg"), 0.9)
-ChartToSvg.export(chart, new File("chart.svg"))
+Plot.svg(chart, new File("chart.svg"))
 ChartToPdf.export(chart, new File("chart.pdf"))
 ```
 

--- a/docs/tutorial/13-matrix-charts.md
+++ b/docs/tutorial/13-matrix-charts.md
@@ -105,7 +105,6 @@ Area charts are useful for showing trends over time or comparing values across c
 ```groovy
 import se.alipsa.matrix.core.*
 import se.alipsa.matrix.pict.*
-import se.alipsa.matrix.chartexport.ChartToPng
 
 // Create a Matrix with time series data
 def timeData = Matrix.builder().data(
@@ -119,7 +118,7 @@ def timeData = Matrix.builder().data(
 def areaChart = AreaChart.create("Monthly Performance", timeData, "month", "sales", "profit")
 
 // Export the chart to PNG
-ChartToPng.export(areaChart, new File("monthly_performance.png"))
+Plot.png(areaChart, new File("monthly_performance.png"))
 ```
 
 ### Bar Chart
@@ -129,7 +128,6 @@ Bar charts are excellent for comparing values across different categories. You c
 ```groovy
 import se.alipsa.matrix.core.*
 import se.alipsa.matrix.pict.*
-import se.alipsa.matrix.chartexport.ChartToPng
 
 // Create a Matrix with categorical data
 def productData = Matrix.builder().data(
@@ -158,8 +156,8 @@ def horizontalBarChart = BarChart.createHorizontal(
 )
 
 // Export the charts
-ChartToPng.export(verticalBarChart, new File("vertical_bar_chart.png"))
-ChartToPng.export(horizontalBarChart, new File("horizontal_bar_chart.png"))
+Plot.png(verticalBarChart, new File("vertical_bar_chart.png"))
+Plot.png(horizontalBarChart, new File("horizontal_bar_chart.png"))
 ```
 
 The `ChartType` enum provides different styles for bar charts:
@@ -174,7 +172,6 @@ Pie charts are useful for showing proportions of a whole.
 ```groovy
 import se.alipsa.matrix.core.*
 import se.alipsa.matrix.pict.*
-import se.alipsa.matrix.chartexport.ChartToPng
 
 // Create a Matrix with market share data
 def marketData = Matrix.builder().data(
@@ -187,7 +184,7 @@ def marketData = Matrix.builder().data(
 def pieChart = PieChart.create("Market Share", marketData, "company", "market_share")
 
 // Export the chart
-ChartToPng.export(pieChart, new File("market_share.png"))
+Plot.png(pieChart, new File("market_share.png"))
 ```
 
 ### Line Chart
@@ -197,7 +194,6 @@ Line charts are ideal for showing trends over time or continuous data.
 ```groovy
 import se.alipsa.matrix.core.*
 import se.alipsa.matrix.pict.*
-import se.alipsa.matrix.chartexport.ChartToPng
 import java.time.LocalDate
 
 // Create a Matrix with time series data
@@ -224,7 +220,7 @@ def lineChart = LineChart.create(
 )
 
 // Export the chart
-ChartToPng.export(lineChart, new File("temperature_trends.png"))
+Plot.png(lineChart, new File("temperature_trends.png"))
 ```
 
 ### Scatter Chart
@@ -234,7 +230,6 @@ Scatter charts are useful for showing the relationship between two variables.
 ```groovy
 import se.alipsa.matrix.core.*
 import se.alipsa.matrix.pict.*
-import se.alipsa.matrix.chartexport.ChartToPng
 
 // Create a Matrix with correlation data
 def correlationData = Matrix.builder().data(
@@ -252,12 +247,13 @@ def scatterChart = ScatterChart.create(
 )
 
 // Export the chart
-ChartToPng.export(scatterChart, new File("height_weight_correlation.png"))
+Plot.png(scatterChart, new File("height_weight_correlation.png"))
 ```
 
 ## Exporting Charts
 
-The recommended export API lives in `se.alipsa.matrix.chartexport`. It accepts PICT charts,
+Use `Plot.png(...)` as the PICT-facing PNG export API. The
+`se.alipsa.matrix.chartexport` package provides additional formats and accepts PICT charts,
 Charm charts, `Svg` objects, and SVG XML strings where the target format supports them.
 
 ### Export to PNG, JPEG, SVG, or PDF
@@ -265,10 +261,10 @@ Charm charts, `Svg` objects, and SVG XML strings where the target format support
 ```groovy
 import se.alipsa.matrix.chartexport.ChartToJpeg
 import se.alipsa.matrix.chartexport.ChartToPdf
-import se.alipsa.matrix.chartexport.ChartToPng
+import se.alipsa.matrix.pict.Plot
 import se.alipsa.matrix.chartexport.ChartToSvg
 
-ChartToPng.export(chart, new File("chart.png"))
+Plot.png(chart, new File("chart.png"))
 ChartToJpeg.export(chart, new File("chart.jpg"), 0.9)
 ChartToSvg.export(chart, new File("chart.svg"))
 ChartToPdf.export(chart, new File("chart.pdf"))
@@ -314,8 +310,9 @@ import se.alipsa.matrix.chartexport.ChartToSwing
 def panel = ChartToSwing.export(chart)
 ```
 
-The older `Plot` helper class remains available for source compatibility, but it is deprecated.
-Use the `chartexport` classes for new code.
+For PICT charts, use `Plot.png(...)`, `Plot.svg(...)`, `Plot.base64(...)`, or
+`Plot.jfx(...)` where applicable. Use the `chartexport` classes for formats and targets
+that are not exposed by `Plot`.
 
 ## Customizing Charts
 
@@ -373,7 +370,6 @@ import java.time.LocalDate
 import javafx.scene.paint.Color
 import se.alipsa.matrix.core.*
 import se.alipsa.matrix.pict.*
-import se.alipsa.matrix.chartexport.ChartToPng
 
 // Create a sample Matrix with sales data
 def salesData = Matrix.builder().data(
@@ -395,7 +391,7 @@ def barChart = BarChart.createVertical(
     .setXAxisTitle("Quarter")
     .setYAxisTitle("Sales (in thousands)")
 File file = new File("quarterly_sales_bar.png")
-ChartToPng.export(barChart, file)
+Plot.png(barChart, file)
 println "saved barchart to $file.absolutePath"
 
 salesData['quarter'] = [1, 2, 3, 4]
@@ -410,7 +406,7 @@ def lineChart = LineChart.create(
     .setXAxisTitle("Quarter")
     .setYAxisTitle("Sales (in thousands)")
 file = new File("quarterly_sales_line.png")
-ChartToPng.export(lineChart, file)
+Plot.png(lineChart, file)
 println "saved lineChart to $file.absolutePath"
 
 // Create a pie chart (using only one quarter for demonstration)
@@ -427,7 +423,7 @@ def pieChart = PieChart.create(
     "sales"
 )
 file = new File("q4_sales_pie.png")
-ChartToPng.export(pieChart, file)
+Plot.png(pieChart, file)
 println "saved pieChart to $file.absolutePath"
 println "Charts have been exported successfully."
 ```

--- a/matrix-charts/README.md
+++ b/matrix-charts/README.md
@@ -4,8 +4,9 @@
 Groovy library for creating graphs based on Matrix or [][] data
 
 Matrix-charts is a "native" chart library that creates charts as SVGs.
-An SVG chart can be exported to Swing, JavaFX, Image, PNG, JPG, or PDF using
-the exporters in the se.alipsa.matrix.chartexport package.
+PICT charts can be exported to PNG with `Plot.png(...)`. The exporters in the
+`se.alipsa.matrix.chartexport` package provide Swing, JavaFX, Image, PNG, JPG,
+and PDF conversion for PICT, SVG, and Charm charts.
 
 There are 2 APIs in matrix-charts, sharing the same Charm rendering engine:
 1. **[Charm](docs/charm.md)** The core chart library based on the principles of Grammar of Graphics.
@@ -127,7 +128,6 @@ def arrowChart = plot(Dataset.mtcars()) {
 import java.time.LocalDate
 import se.alipsa.matrix.core.*
 import se.alipsa.matrix.pict.*
-import se.alipsa.matrix.chartexport.ChartToPng
 
 def empData = Matrix.builder().data(
     emp_id: 1..5,
@@ -146,9 +146,9 @@ def barChart = BarChart.builder(empData)
 def pieChart = PieChart.builder(empData)
     .title("Salaries").x("emp_name").y("salary").build()
 
-// Export to PNG via chartexport
-ChartToPng.export(areaChart, new File("areaChart.png"))
-ChartToPng.export(barChart, new File("barChart.png"))
+// Export PICT charts to PNG via Plot
+Plot.png(areaChart, new File("areaChart.png"))
+Plot.png(barChart, new File("barChart.png"))
 ```
 
 PICT charts are bridged through Charm. Axis scale settings, custom `style.yLabels`,

--- a/matrix-charts/docs/charm.md
+++ b/matrix-charts/docs/charm.md
@@ -1049,7 +1049,7 @@ charts --builds------> charm ---renders-> Svg
 
 - **Charm** is the core. Use it for new code and when you want the most idiomatic Groovy experience.
 - **gg** is a compatibility wrapper that builds the same Charm `PlotSpec` under the hood. Use it when porting R code or when you prefer ggplot2 syntax.
-- **charts** (`AreaChart`, `BarChart`, etc.) is a chart-type-first API backed by Charm via `CharmBridge`. The `Plot` class is `@Deprecated` but continues to work.
+- **charts** (`AreaChart`, `BarChart`, etc.) is a chart-type-first API backed by Charm via `CharmBridge`. Use `Plot` as its PICT-facing export helper.
 
 ## Migration Guide
 
@@ -1064,9 +1064,9 @@ The `charts` package previously used multiple backend-specific converters:
 | `charts.png.PngConverter`                         | **Removed**         | `ChartToPng.export(chart, file)` via chartexport             |
 | `charts.svg.SvgBarChart` / `SvgChart`             | **Removed**         | Use Charm DSL or gg API, then `chart.render()` for SVG       |
 | `charts.util.StyleUtil`                           | **Removed**         | No replacement needed (was JavaFX-specific)                  |
-| `Plot.jfx(chart)`                                 | Deprecated, rewired | Returns `javafx.scene.Node` (was `javafx.scene.chart.Chart`) |
-| `Plot.png(chart, file)`                           | Deprecated, rewired | Works as before, no longer requires JavaFX toolkit           |
-| `Plot.base64(chart)`                              | Deprecated, rewired | Works as before                                              |
+| `Plot.jfx(chart)`                                 | Rewired             | Returns `javafx.scene.Node` (was `javafx.scene.chart.Chart`) |
+| `Plot.png(chart, file)`                           | Rewired             | Works as before, no longer requires JavaFX toolkit           |
+| `Plot.base64(chart)`                              | Rewired             | Works as before                                              |
 
 ### Breaking changes in this release
 
@@ -1081,7 +1081,7 @@ The `charts` package previously used multiple backend-specific converters:
 // Old
 SwingPlot.png(chart, file)
 
-// New (via deprecated but working Plot)
+// New PICT-facing helper
 Plot.png(chart, file)
 
 // New (via chartexport directly)
@@ -1099,7 +1099,7 @@ Node node = JfxConverter.convert(chart)
 import se.alipsa.matrix.chartexport.ChartToJfx
 def node = ChartToJfx.export(chart)
 
-// Or via deprecated Plot
+// Or via the PICT-facing helper
 def node = Plot.jfx(chart)
 ```
 

--- a/matrix-charts/docs/pict.md
+++ b/matrix-charts/docs/pict.md
@@ -27,7 +27,10 @@ A comprehensive guide to using the `se.alipsa.matrix.pict` package for creating 
 
 The `se.alipsa.matrix.pict` package provides a chart-type-first API for creating common visualizations. You start by choosing a chart type (e.g. `BarChart`, `LineChart`), then supply data and configure styling. This is a familiar pattern for users of libraries like xchart or JavaFX charts.
 
-All chart types are backed by the [Charm](charm.md) rendering engine internally. Charts render to SVG and can be exported to PNG, JPEG, PDF, JavaFX, or Swing via `se.alipsa.matrix.chartexport`.
+All chart types are backed by the [Charm](charm.md) rendering engine internally. Use
+`Plot` for PICT-facing PNG, SVG, base64 PNG, and JavaFX output. The
+`se.alipsa.matrix.chartexport` package provides additional conversions such as JPEG,
+PDF, buffered images, and Swing panels.
 
 ### Key Features
 - Fluent builder API for creating and configuring charts in one chain
@@ -62,7 +65,6 @@ implementation 'se.alipsa.matrix:matrix-charts'
 ```groovy
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.pict.*
-import se.alipsa.matrix.chartexport.ChartToPng
 
 def data = Matrix.builder().data(
     product: ['Apples', 'Bananas', 'Cherries', 'Dates'],
@@ -76,7 +78,7 @@ def chart = BarChart.builder(data)
     .build()
 
 // Export to PNG
-ChartToPng.export(chart, new File('fruit_sales.png'))
+Plot.png(chart, new File('fruit_sales.png'))
 ```
 
 ### General Workflow
@@ -95,7 +97,7 @@ def chart = LineChart.builder(data)
     .yAxisTitle('Revenue (USD)')
     .build()
 
-ChartToPng.export(chart, new File('revenue.png'))
+Plot.png(chart, new File('revenue.png'))
 ```
 
 ## Builder API
@@ -213,7 +215,7 @@ def chart = AreaChart.builder(data)
     .yAxisTitle('Visitors')
     .build()
 
-ChartToPng.export(chart, new File('visitors.png'))
+Plot.png(chart, new File('visitors.png'))
 ```
 
 ### BarChart
@@ -298,7 +300,7 @@ def chart = BarChart.builder(data)
     .yAxisTitle('Revenue')
     .build()
 
-ChartToPng.export(chart, new File('stacked_bars.png'))
+Plot.png(chart, new File('stacked_bars.png'))
 ```
 
 **Querying bar chart properties:**
@@ -355,7 +357,7 @@ def chart = BoxChart.builder(data)
     .yAxisTitle('Score')
     .build()
 
-ChartToPng.export(chart, new File('boxplot.png'))
+Plot.png(chart, new File('boxplot.png'))
 ```
 
 ### Histogram
@@ -418,7 +420,7 @@ def chart = Histogram.builder(mtcars)
     .yAxisTitle('Frequency')
     .build()
 
-ChartToPng.export(chart, new File('mpg_histogram.png'))
+Plot.png(chart, new File('mpg_histogram.png'))
 ```
 
 ### LineChart
@@ -467,7 +469,7 @@ def chart = LineChart.builder(data)
     .yAxisTitle('Sales')
     .build()
 
-ChartToPng.export(chart, new File('line_chart.png'))
+Plot.png(chart, new File('line_chart.png'))
 ```
 
 ### PieChart
@@ -509,7 +511,7 @@ def chart = PieChart.builder(data)
     .y('amount')
     .build()
 
-ChartToPng.export(chart, new File('budget_pie.png'))
+Plot.png(chart, new File('budget_pie.png'))
 ```
 
 ### ScatterChart
@@ -548,7 +550,7 @@ def chart = ScatterChart.builder(data)
     .yAxisTitle('Weight (kg)')
     .build()
 
-ChartToPng.export(chart, new File('scatter.png'))
+Plot.png(chart, new File('scatter.png'))
 ```
 
 ### BubbleChart
@@ -601,7 +603,7 @@ def chart = BubbleChart.builder(data)
     .yAxisTitle('Latitude')
     .build()
 
-ChartToPng.export(chart, new File('bubbles.png'))
+Plot.png(chart, new File('bubbles.png'))
 ```
 
 | Chart-Specific Builder Method | Description |
@@ -789,33 +791,36 @@ chart.valueSeriesNames      // List<String> -- series names
 
 ## Output Formats
 
-All export classes are in the `se.alipsa.matrix.chartexport` package and accept legacy
-`Chart` objects, Charm `Chart`, and `Svg` objects where applicable. PNG, PDF, JavaFX,
-and Swing exporters also accept raw SVG XML strings.
+Use `Plot` as the PICT-facing export helper. The classes in
+`se.alipsa.matrix.chartexport` provide additional formats and accept PICT `Chart`
+objects, Charm `Chart`, and `Svg` objects where applicable. PNG, PDF, JavaFX, and
+Swing exporters also accept raw SVG XML strings.
 
 ### PNG
 
 ```groovy
-import se.alipsa.matrix.chartexport.ChartToPng
+import se.alipsa.matrix.pict.Plot
 
 // To file
-ChartToPng.export(chart, new File('chart.png'))
+Plot.png(chart, new File('chart.png'))
 
 // To OutputStream
 ByteArrayOutputStream baos = new ByteArrayOutputStream()
-ChartToPng.export(chart, baos)
+Plot.png(chart, baos)
 ```
 
 ### SVG
 
 ```groovy
 import se.alipsa.matrix.chartexport.ChartToSvg
+import se.alipsa.matrix.pict.Plot
 
-ChartToSvg.export(chart, new File('chart.svg'))
+def svg = Plot.svg(chart)
+ChartToSvg.export(svg, new File('chart.svg'))
 
 // To OutputStream or Writer
-ChartToSvg.export(chart, outputStream)
-ChartToSvg.export(chart, writer)
+ChartToSvg.export(svg, outputStream)
+ChartToSvg.export(svg, writer)
 ```
 
 ### JPEG
@@ -845,9 +850,9 @@ PDF page dimensions are written in points. Rasterized chart pixels are scaled fr
 ### Base64 Data URI
 
 ```groovy
-import se.alipsa.matrix.chartexport.ChartToImage
+import se.alipsa.matrix.pict.Plot
 
-String dataUri = ChartToImage.base64(chart)
+String dataUri = Plot.base64(chart)
 // Returns: "data:image/png;base64,iVBOR..."
 ```
 
@@ -862,9 +867,9 @@ BufferedImage image = ChartToImage.export(chart)
 ### JavaFX
 
 ```groovy
-import se.alipsa.matrix.chartexport.ChartToJfx
+import se.alipsa.matrix.pict.Plot
 
-javafx.scene.Node node = ChartToJfx.export(chart)
+javafx.scene.Node node = Plot.jfx(chart)
 ```
 
 ### Swing
@@ -876,7 +881,7 @@ def panel = ChartToSwing.export(chart)
 // Add panel to a Swing container
 ```
 
-> **Note:** The `Plot` class is `@Deprecated`. Use the `chartexport` classes above instead.
+Use `chartexport` directly when you need a format or target that is not exposed by `Plot`.
 
 ## Error Handling
 
@@ -932,7 +937,6 @@ pict ----builds------> charm ---renders-> Svg (via CharmBridge)
 ```groovy
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.pict.*
-import se.alipsa.matrix.chartexport.ChartToPng
 
 def sales = Matrix.builder().data(
     month: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
@@ -949,7 +953,7 @@ def lineChart = LineChart.builder(sales)
     .yAxisTitle('Units')
     .build()
 lineChart.setValueSeriesNames(['Online', 'Retail'])
-ChartToPng.export(lineChart, new File('trend.png'))
+Plot.png(lineChart, new File('trend.png'))
 
 // Stacked bar chart for composition
 def barChart = BarChart.builder(sales)
@@ -959,7 +963,7 @@ def barChart = BarChart.builder(sales)
     .stacked()
     .build()
 barChart.setValueSeriesNames(['Online', 'Retail'])
-ChartToPng.export(barChart, new File('composition.png'))
+Plot.png(barChart, new File('composition.png'))
 ```
 
 ### Histogram from a Dataset
@@ -967,7 +971,6 @@ ChartToPng.export(barChart, new File('composition.png'))
 ```groovy
 import se.alipsa.matrix.datasets.Dataset
 import se.alipsa.matrix.pict.*
-import se.alipsa.matrix.chartexport.ChartToPng
 
 def mtcars = Dataset.mtcars()
 def chart = Histogram.builder(mtcars)
@@ -978,7 +981,7 @@ def chart = Histogram.builder(mtcars)
     .yAxisTitle('Count')
     .build()
 
-ChartToPng.export(chart, new File('displacement.png'))
+Plot.png(chart, new File('displacement.png'))
 ```
 
 ### Styled Pie Chart
@@ -1000,7 +1003,7 @@ def chart = PieChart.builder(data)
     .build()
 chart.style.chartBackgroundColor = Color.WHITE
 
-ChartToPng.export(chart, new File('languages.png'))
+Plot.png(chart, new File('languages.png'))
 ```
 
 ### Box Plot Comparison
@@ -1021,7 +1024,7 @@ def chart = BoxChart.builder(data)
     .yAxisTitle('Result')
     .build()
 
-ChartToPng.export(chart, new File('comparison.png'))
+Plot.png(chart, new File('comparison.png'))
 ```
 
 ## Additional Resources

--- a/matrix-charts/docs/pict.md
+++ b/matrix-charts/docs/pict.md
@@ -812,15 +812,13 @@ Plot.png(chart, baos)
 ### SVG
 
 ```groovy
-import se.alipsa.matrix.chartexport.ChartToSvg
 import se.alipsa.matrix.pict.Plot
 
-def svg = Plot.svg(chart)
-ChartToSvg.export(svg, new File('chart.svg'))
+Plot.svg(chart, new File('chart.svg'))
 
 // To OutputStream or Writer
-ChartToSvg.export(svg, outputStream)
-ChartToSvg.export(svg, writer)
+Plot.svg(chart, outputStream)
+Plot.svg(chart, writer)
 ```
 
 ### JPEG

--- a/matrix-charts/release.md
+++ b/matrix-charts/release.md
@@ -9,7 +9,7 @@ See [charm.md](docs/charm.md) for the Charm user guide and [ggPlot.md](ggPlot.md
   - Introduced `se.alipsa.matrix.charm` as the single rendering engine for all three charting APIs (Charm, gg, charts).
   - All chart rendering now produces SVG via gsvg. Export to PNG/JPEG/PDF/JavaFX/Swing goes through `se.alipsa.matrix.chartexport`.
   - The gg API (`se.alipsa.matrix.gg`) is preserved as a thin compatibility wrapper delegating to Charm.
-  - The pictura API (`se.alipsa.matrix.pict`) is backed by Charm via `CharmBridge`. `Plot` is `@Deprecated` but functional.
+  - The pictura API (`se.alipsa.matrix.pict`) is backed by Charm via `CharmBridge`. Use `Plot` as its PICT-facing export helper.
   - `Plot.png()` no longer requires JavaFX toolkit initialization.
 
 **Breaking Changes**

--- a/matrix-charts/req/pict-migration.md
+++ b/matrix-charts/req/pict-migration.md
@@ -1,0 +1,158 @@
+# matrix-pict extraction plan
+
+> **For agentic workers:** Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+## Context
+
+Pict is the chart-type-first API (BarChart, LineChart, ScatterChart, etc.) that delegates to the Charm rendering engine via `CharmBridge`. It currently lives inside `matrix-charts`, but its relationship to Charm is structurally identical to `matrix-ggplot`'s: a user-facing facade with its own data model that bridges into Charm's PlotSpec. Keeping pict inside `matrix-charts` conflates the engine with a consumer of the engine, and forces users who only want the simpler pict API to take the full Charm engine as a direct dependency rather than a transitive one.
+
+This plan extracts pict into a new `matrix-pict` module (version 0.5.0-SNAPSHOT) so that the dependency graph mirrors ggplot:
+
+```
+matrix-charts  (Charm engine + export utilities)
+    ├── matrix-ggplot   (ggplot2-style API → Charm)
+    └── matrix-pict     (chart-type API → Charm)   ← new
+```
+
+No package renames. The `se.alipsa.matrix.pict` package stays as-is; only the artifact coordinate changes from `matrix-charts` to `matrix-pict`. This is a clean cut — 0.x versions allow breaking changes.
+
+---
+
+## Phase 1: Scaffold matrix-pict module
+
+**PR scope:** Create the empty module wired into the build, before any source moves.
+
+- 1.1 [ ] Create directory `matrix-pict/src/main/groovy/se/alipsa/matrix/pict/` and `matrix-pict/src/test/groovy/`
+- 1.2 [ ] Write `matrix-pict/build.gradle` modelled on `matrix-ggplot/build.gradle`:
+  - `version = '0.5.0-SNAPSHOT'`
+  - `description = "Groovy chart-type-first API for matrix (pict)"`
+  - `api project(':matrix-charts')` — transitively provides gsvg, chartexport, Charm, JavaFX compileOnly
+  - `compileOnly project(':matrix-core')`
+  - `compileOnly project(':matrix-stats')`
+  - `compileOnly libs.groovy`
+  - JavaFX `compileOnly` quartet (graphics, base, controls, swing) — same qualifier logic as matrix-ggplot
+  - Standard test dependencies: groovy, groovy-xml, matrix-core, matrix-stats, matrix-datasets, JavaFX, groovier-junit, junit-jupiter, junit-jupiter-engine, junit-platform-launcher
+  - `testFast` task identical to matrix-charts/matrix-ggplot
+  - Maven publishing block: `name = 'Groovy Matrix Pict'`, SCM url `matrix-pict`
+  - Signing block (same guard as other modules)
+- 1.3 [ ] Add `include 'matrix-pict'` to `settings.gradle` (place it after `matrix-ggplot`)
+- 1.4 [ ] Copy `testutil/Slow.groovy` to `matrix-pict/src/test/groovy/testutil/Slow.groovy` (it's a local JUnit tag annotation; each module keeps its own copy)
+
+**Verification:**
+```bash
+./gradlew :matrix-pict:build
+```
+Expected: empty module compiles and produces an (empty) jar.
+
+---
+
+## Phase 2: Move pict source files
+
+**PR scope:** Move all 17 production source files from `matrix-charts` to `matrix-pict`. No content changes — move only.
+
+Files to move from `matrix-charts/src/main/groovy/se/alipsa/matrix/pict/` to the identical path under `matrix-pict/`:
+
+- 2.1 [ ] `AreaChart.groovy`
+- 2.2 [ ] `AxisScale.groovy`
+- 2.3 [ ] `BarChart.groovy`
+- 2.4 [ ] `BoxChart.groovy`
+- 2.5 [ ] `BubbleChart.groovy`
+- 2.6 [ ] `Chart.groovy`
+- 2.7 [ ] `CharmBridge.groovy`
+- 2.8 [ ] `ChartDirection.groovy`
+- 2.9 [ ] `ChartType.groovy`
+- 2.10 [ ] `DataType.groovy`
+- 2.11 [ ] `Histogram.groovy`
+- 2.12 [ ] `Legend.groovy`
+- 2.13 [ ] `LineChart.groovy`
+- 2.14 [ ] `PieChart.groovy`
+- 2.15 [ ] `Plot.groovy`
+- 2.16 [ ] `ScatterChart.groovy`
+- 2.17 [ ] `Style.groovy`
+
+After moving, delete `matrix-charts/src/main/groovy/se/alipsa/matrix/pict/` entirely.
+
+**Verification:**
+```bash
+./gradlew :matrix-pict:compileGroovy
+./gradlew :matrix-charts:compileGroovy
+```
+Both must compile cleanly with no unresolved references.
+
+---
+
+## Phase 3: Move pict tests
+
+**PR scope:** Relocate tests that depend on `se.alipsa.matrix.pict` from `matrix-charts` to `matrix-pict`. No content changes other than removing now-redundant `project(':matrix-ggplot')` from matrix-charts test dependencies if it becomes unused.
+
+Tests to move from `matrix-charts/src/test/groovy/` to the identical path under `matrix-pict/src/test/groovy/`:
+
+- 3.1 [ ] `chart/BoxChartTest.groovy`
+- 3.2 [ ] `chart/ChartBuilderTest.groovy`
+- 3.3 [ ] `chart/ChartFactoryBaselineTest.groovy`
+- 3.4 [ ] `chart/ChartsCharmIntegrationTest.groovy`
+- 3.5 [ ] `chart/HistogramTest.groovy`
+- 3.6 [ ] `chart/LineChartTest.groovy`
+- 3.7 [ ] `chart/PlotCompatibilityTest.groovy`
+- 3.8 [ ] `PngTest.groovy`
+- 3.9 [ ] `export/CharmExportTest.groovy` — imports `se.alipsa.matrix.pict.Chart` and `se.alipsa.matrix.pict.ScatterChart`; since `matrix-pict` has access to all chartexport utilities transitively, this test moves cleanly
+
+After moving, delete the now-empty `chart/` directory from `matrix-charts/src/test/groovy/`.
+
+Verify that `matrix-charts` test compilation no longer requires any pict imports. If `charm/api/CharmApiDesignTest.groovy` still compiles without a `project(':matrix-pict')` test dependency (it does — it only imports `se.alipsa.matrix.gg.GgChart`, not pict), leave `matrix-charts/build.gradle` test dependencies unchanged.
+
+**Verification:**
+```bash
+./gradlew :matrix-pict:test -Pheadless=true
+./gradlew :matrix-charts:test -Pheadless=true
+```
+All tests in both modules must pass.
+
+---
+
+## Phase 4: Update matrix-bom
+
+**Note:** `matrix-bom` is a Maven project (`pom.xml`), not a Gradle module. Edit `matrix-bom/pom.xml` directly.
+
+- 4.1 [ ] Add a `<dependency>` entry for `matrix-pict` in `pom.xml`'s `<dependencyManagement>/<dependencies>` block, immediately after the `matrix-ggplot` entry, following the same pattern:
+
+```xml
+<dependency>
+  <groupId>se.alipsa.matrix</groupId>
+  <artifactId>matrix-pict</artifactId>
+  <version>${project.version}</version>
+</dependency>
+```
+
+**Note:** `${project.version}` resolves to the bom's own version (`2.5.0-SNAPSHOT`). The bom and the individual modules currently have separate version numbers (`matrix-pict` is `0.5.0`), so verify whether the existing `matrix-charts` and `matrix-ggplot` entries use `${project.version}` or hardcode versions, and follow the same convention.
+
+**Verification:**
+```bash
+cd matrix-bom && mvn validate
+```
+pom.xml must parse without errors.
+
+---
+
+## Phase 5: Update docs and AGENTS.md
+
+**PR scope:** Update all documentation to reflect the new artifact coordinate.
+
+- 5.1 [ ] Move `matrix-charts/docs/pict.md` to `matrix-pict/docs/pict.md`
+- 5.2 [ ] Update `docs/cookbook/matrix-charts.md` — replace any pict import/dependency examples that reference `matrix-charts` with `matrix-pict`
+- 5.3 [ ] Update `docs/tutorial/13-matrix-charts.md` — same coordinate change for pict usage
+- 5.4 [ ] Update `matrix-charts/README.md` — remove pict API docs/references; note that pict is now in `matrix-pict`
+- 5.5 [ ] Update `AGENTS.md` module table — add `matrix-pict` row: `"chart-type-first API (BarChart, LineChart, etc.), delegates to Charm in matrix-charts"`; update `matrix-charts` description to remove the pict reference
+
+**Verification:**
+Manual review of changed doc files. No build step required.
+
+---
+
+## Final regression check
+
+Run the full test suite to confirm no cross-module regressions:
+
+```bash
+./gradlew test -Pheadless=true
+```

--- a/matrix-charts/req/pict-migration.md
+++ b/matrix-charts/req/pict-migration.md
@@ -112,25 +112,33 @@ All tests in both modules must pass.
 
 ## Phase 4: Update matrix-bom
 
-**Note:** `matrix-bom` is a Maven project (`pom.xml`), not a Gradle module. Edit `matrix-bom/pom.xml` directly.
+**Note:** The published BOM definition is `matrix-bom/bom.xml`. The sibling
+`matrix-bom/pom.xml` is the BOM integration-test project. Edit `matrix-bom/bom.xml`
+directly.
 
-- 4.1 [ ] Add a `<dependency>` entry for `matrix-pict` in `pom.xml`'s `<dependencyManagement>/<dependencies>` block, immediately after the `matrix-ggplot` entry, following the same pattern:
+- 4.1 [ ] Add `<matrixPictVersion>0.5.0-SNAPSHOT</matrixPictVersion>` to the
+  `bom.xml` `<properties>` block immediately after `<matrixGgplotVersion>`.
+- 4.2 [ ] Add a `<dependency>` entry for `matrix-pict` in `bom.xml`'s
+  `<dependencyManagement>/<dependencies>` block, immediately after the
+  `matrix-ggplot` entry:
 
 ```xml
 <dependency>
   <groupId>se.alipsa.matrix</groupId>
   <artifactId>matrix-pict</artifactId>
-  <version>${project.version}</version>
+  <version>${matrixPictVersion}</version>
 </dependency>
 ```
 
-**Note:** `${project.version}` resolves to the bom's own version (`2.5.0-SNAPSHOT`). The bom and the individual modules currently have separate version numbers (`matrix-pict` is `0.5.0`), so verify whether the existing `matrix-charts` and `matrix-ggplot` entries use `${project.version}` or hardcode versions, and follow the same convention.
+This follows the existing `matrix-charts` and `matrix-ggplot` convention: each module
+has a dedicated version property in `bom.xml`. Use `0.5.0-SNAPSHOT` consistently for
+the initial `matrix-pict` module and BOM property.
 
 **Verification:**
 ```bash
-cd matrix-bom && mvn validate
+mvn -f matrix-bom/bom.xml validate
 ```
-pom.xml must parse without errors.
+`bom.xml` must parse without errors.
 
 ---
 

--- a/matrix-charts/req/pict-migration.md
+++ b/matrix-charts/req/pict-migration.md
@@ -26,7 +26,7 @@ No package renames. The `se.alipsa.matrix.pict` package stays as-is; only the ar
 - 1.2 [ ] Write `matrix-pict/build.gradle` modelled on `matrix-ggplot/build.gradle`:
   - `version = '0.5.0-SNAPSHOT'`
   - `description = "Groovy chart-type-first API for matrix (pict)"`
-  - `api project(':matrix-charts')` — transitively provides gsvg, chartexport, Charm, JavaFX compileOnly
+  - `api project(':matrix-charts')` — transitively provides gsvg, chartexport, Charm, JavaFX compileOnly. Use `api` (not `implementation` as matrix-ggplot does) because `Plot.svg()` returns `Svg` from gsvg; callers need that type visible without adding matrix-charts to their own dependencies.
   - `compileOnly project(':matrix-core')`
   - `compileOnly project(':matrix-stats')`
   - `compileOnly libs.groovy`
@@ -37,6 +37,7 @@ No package renames. The `se.alipsa.matrix.pict` package stays as-is; only the ar
   - Signing block (same guard as other modules)
 - 1.3 [ ] Add `include 'matrix-pict'` to `settings.gradle` (place it after `matrix-ggplot`)
 - 1.4 [ ] Copy `testutil/Slow.groovy` to `matrix-pict/src/test/groovy/testutil/Slow.groovy` (it's a local JUnit tag annotation; each module keeps its own copy)
+- 1.5 [ ] Create `matrix-pict/docs/` directory (needed for the `pict.md` move in Phase 5.1)
 
 **Verification:**
 ```bash
@@ -79,11 +80,21 @@ After moving, delete `matrix-charts/src/main/groovy/se/alipsa/matrix/pict/` enti
 ```
 Both must compile cleanly with no unresolved references.
 
+After moving, confirm no pict source remains in matrix-charts:
+```bash
+grep -r "se.alipsa.matrix.pict" matrix-charts/src/main/
+```
+Expected: zero results.
+
 ---
 
 ## Phase 3: Move pict tests
 
-**PR scope:** Relocate tests that depend on `se.alipsa.matrix.pict` from `matrix-charts` to `matrix-pict`. No content changes other than removing now-redundant `project(':matrix-ggplot')` from matrix-charts test dependencies if it becomes unused.
+**PR scope:** Relocate tests that depend on `se.alipsa.matrix.pict` from `matrix-charts` to `matrix-pict`. Includes one surgical edit to `CharmApiDesignTest.groovy` (see 3.0 below) to remove its sole pict reference before moving the pict test files.
+
+- 3.0 [ ] **Edit `charm/api/CharmApiDesignTest.groovy` in `matrix-charts`** (do not move this file — it tests the Charm DSL and belongs in matrix-charts):
+  - Extract the `testImportAliasStrategyCompilesAndRuns` test method into `chart/PlotCompatibilityTest.groovy` in `matrix-pict` (add it there as part of step 3.7). In matrix-pict's test classpath, pict.Chart is present directly and charm.Chart is available transitively, so the test works without any build.gradle changes.
+  - Remove the extracted method and the `import se.alipsa.matrix.pict.Chart as LegacyChart` line from `CharmApiDesignTest.groovy`.
 
 Tests to move from `matrix-charts/src/test/groovy/` to the identical path under `matrix-pict/src/test/groovy/`:
 
@@ -93,13 +104,17 @@ Tests to move from `matrix-charts/src/test/groovy/` to the identical path under 
 - 3.4 [ ] `chart/ChartsCharmIntegrationTest.groovy`
 - 3.5 [ ] `chart/HistogramTest.groovy`
 - 3.6 [ ] `chart/LineChartTest.groovy`
-- 3.7 [ ] `chart/PlotCompatibilityTest.groovy`
+- 3.7 [ ] `chart/PlotCompatibilityTest.groovy` — add the `testImportAliasStrategyCompilesAndRuns` method extracted in step 3.0 here
 - 3.8 [ ] `PngTest.groovy`
 - 3.9 [ ] `export/CharmExportTest.groovy` — imports `se.alipsa.matrix.pict.Chart` and `se.alipsa.matrix.pict.ScatterChart`; since `matrix-pict` has access to all chartexport utilities transitively, this test moves cleanly
 
 After moving, delete the now-empty `chart/` directory from `matrix-charts/src/test/groovy/`.
 
-Verify that `matrix-charts` test compilation no longer requires any pict imports. If `charm/api/CharmApiDesignTest.groovy` still compiles without a `project(':matrix-pict')` test dependency (it does — it only imports `se.alipsa.matrix.gg.GgChart`, not pict), leave `matrix-charts/build.gradle` test dependencies unchanged.
+**Tests that stay in `matrix-charts`:**
+- `charm/api/CharmApiDesignTest.groovy` — Charm DSL design tests; after step 3.0 it has no pict imports
+- `export/WriteToAndPlotGridExportTest.groovy` — no pict imports; tests PlotGrid and SVG/PNG export at the chartexport level
+
+**Build dependency check:** `matrix-charts/build.gradle` already has `testImplementation project(':matrix-ggplot')`. This remains needed — `CharmApiDesignTest` imports `se.alipsa.matrix.gg.GgChart`. Do not remove it. No `project(':matrix-pict')` test dependency is needed.
 
 **Verification:**
 ```bash
@@ -118,6 +133,8 @@ directly.
 
 - 4.1 [ ] Add `<matrixPictVersion>0.5.0-SNAPSHOT</matrixPictVersion>` to the
   `bom.xml` `<properties>` block immediately after `<matrixGgplotVersion>`.
+  Verify that the `<matrixChartsVersion>` property in `bom.xml` matches the version
+  in `matrix-charts/build.gradle` before committing — they must stay in sync.
 - 4.2 [ ] Add a `<dependency>` entry for `matrix-pict` in `bom.xml`'s
   `<dependencyManagement>/<dependencies>` block, immediately after the
   `matrix-ggplot` entry:

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/sf/SfGeometryUtils.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/sf/SfGeometryUtils.groovy
@@ -37,19 +37,11 @@ class SfGeometryUtils {
   static SfPoint representativePoint(SfGeometry geometry) {
     if (geometry == null || geometry.empty || geometry.shapes.isEmpty()) return null
     switch (geometry.type) {
-      case SfType.POINT:
-      case SfType.MULTIPOINT:
-        return averagePoint(geometry)
-      case SfType.LINESTRING:
-      case SfType.MULTILINESTRING:
-        return averagePoint(geometry)
-      case SfType.POLYGON:
-      case SfType.MULTIPOLYGON:
-        return polygonCentroid(geometry)
-      case SfType.GEOMETRYCOLLECTION:
-        return averagePoint(geometry)
-      default:
-        return averagePoint(geometry)
+      case SfType.POINT, SfType.MULTIPOINT -> averagePoint(geometry)
+      case SfType.LINESTRING, SfType.MULTILINESTRING -> averagePoint(geometry)
+      case SfType.POLYGON, SfType.MULTIPOLYGON -> polygonCentroid(geometry)
+      case SfType.GEOMETRYCOLLECTION -> averagePoint(geometry)
+      default -> averagePoint(geometry)
     }
   }
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/sf/WktReader.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/sf/WktReader.groovy
@@ -50,21 +50,14 @@ class WktReader {
 
   private static SfGeometry parseGeometry(WktTokenizer tokenizer, SfType type, Integer srid) {
     switch (type) {
-      case SfType.POINT:
-        return parsePointGeometry(tokenizer, type, srid)
-      case SfType.LINESTRING:
-        return parseLineStringGeometry(tokenizer, type, srid)
-      case SfType.POLYGON:
-        return parsePolygonGeometry(tokenizer, type, srid)
-      case SfType.MULTIPOINT:
-        return parseMultiPointGeometry(tokenizer, type, srid)
-      case SfType.MULTILINESTRING:
-        return parseMultiLineStringGeometry(tokenizer, type, srid)
-      case SfType.MULTIPOLYGON:
-        return parseMultiPolygonGeometry(tokenizer, type, srid)
-      case SfType.GEOMETRYCOLLECTION:
-        return parseGeometryCollectionGeometry(tokenizer, type, srid)
-      default:
+      case SfType.POINT -> parsePointGeometry(tokenizer, type, srid)
+      case SfType.LINESTRING -> parseLineStringGeometry(tokenizer, type, srid)
+      case SfType.POLYGON -> parsePolygonGeometry(tokenizer, type, srid)
+      case SfType.MULTIPOINT -> parseMultiPointGeometry(tokenizer, type, srid)
+      case SfType.MULTILINESTRING -> parseMultiLineStringGeometry(tokenizer, type, srid)
+      case SfType.MULTIPOLYGON -> parseMultiPolygonGeometry(tokenizer, type, srid)
+      case SfType.GEOMETRYCOLLECTION -> parseGeometryCollectionGeometry(tokenizer, type, srid)
+      default ->
         throw new IllegalArgumentException("Unsupported geometry type: $type")
     }
   }
@@ -234,15 +227,14 @@ class WktReader {
       throw new IllegalArgumentException('Geometry type is missing')
     }
     switch (typeName.toUpperCase(Locale.ROOT)) {
-      case 'POINT': return SfType.POINT
-      case 'LINESTRING': return SfType.LINESTRING
-      case 'POLYGON': return SfType.POLYGON
-      case 'MULTIPOINT': return SfType.MULTIPOINT
-      case 'MULTILINESTRING': return SfType.MULTILINESTRING
-      case 'MULTIPOLYGON': return SfType.MULTIPOLYGON
-      case 'GEOMETRYCOLLECTION': return SfType.GEOMETRYCOLLECTION
-      default:
-        throw new IllegalArgumentException("Unsupported geometry type: $typeName")
+      case 'POINT' -> SfType.POINT
+      case 'LINESTRING' -> SfType.LINESTRING
+      case 'POLYGON' -> SfType.POLYGON
+      case 'MULTIPOINT'-> SfType.MULTIPOINT
+      case 'MULTILINESTRING' -> SfType.MULTILINESTRING
+      case 'MULTIPOLYGON' -> SfType.MULTIPOLYGON
+      case 'GEOMETRYCOLLECTION' -> SfType.GEOMETRYCOLLECTION
+      default -> throw new IllegalArgumentException("Unsupported geometry type: $typeName")
     }
   }
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToJfx.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToJfx.groovy
@@ -8,8 +8,6 @@ import org.girod.javafx.svgimage.SVGLoader
 import se.alipsa.groovy.svg.Svg
 import se.alipsa.matrix.charm.Chart as CharmChart
 import se.alipsa.matrix.charm.PlotGrid
-import se.alipsa.matrix.pict.CharmBridge
-import se.alipsa.matrix.pict.Chart
 
 /**
  * Exports charts as JavaFX {@link SVGImage} nodes.
@@ -66,20 +64,6 @@ class ChartToJfx {
   }
 
   /**
-   * Create a JavaFX {@link SVGImage} from a legacy {@link Chart} (e.g. BarChart, ScatterChart).
-   *
-   * @param chart the legacy chart to render and convert
-   * @return an {@link SVGImage} representing the rendered chart
-   * @throws RuntimeException if rendering or SVG loading fails
-   */
-  static SVGImage export(Chart chart) {
-    if (chart == null) {
-      throw new IllegalArgumentException('chart cannot be null')
-    }
-    export(CharmBridge.convert(chart).render())
-  }
-
-  /**
    * Create a JavaFX {@link SVGImage} from a {@link PlotGrid}.
    *
    * @param grid the plot grid to render and convert
@@ -107,7 +91,6 @@ class ChartToJfx {
     switch (chart) {
       case PlotGrid -> export(chart as PlotGrid)
       case CharmChart -> export(chart as CharmChart)
-      case Chart -> export(chart as Chart)
       case Svg -> export(chart as Svg)
       case CharSequence -> export(chart.toString())
       default -> throw new IllegalArgumentException("Unsupported chart type: ${chart.getClass().name}")

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToJpeg.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToJpeg.groovy
@@ -6,8 +6,6 @@ import se.alipsa.groovy.svg.Svg
 import se.alipsa.groovy.svg.export.SvgRenderer
 import se.alipsa.matrix.charm.Chart as CharmChart
 import se.alipsa.matrix.charm.PlotGrid
-import se.alipsa.matrix.pict.CharmBridge
-import se.alipsa.matrix.pict.Chart
 
 /**
  * Exports charts as JPEG images.
@@ -57,25 +55,6 @@ class ChartToJpeg {
   }
 
   /**
-   * Export a legacy {@link Chart} (e.g. BarChart, ScatterChart) as a JPEG image file.
-   *
-   * @param chart the legacy chart to export
-   * @param targetFile the {@link File} where the JPEG image will be written
-   * @param quality JPEG compression quality (0.0 to 1.0)
-   * @throws IllegalArgumentException if chart or targetFile is null
-   */
-  static void export(Chart chart, File targetFile, BigDecimal quality = 1.0) {
-    if (chart == null) {
-      throw new IllegalArgumentException('chart cannot be null')
-    }
-    if (targetFile == null) {
-      throw new IllegalArgumentException('targetFile cannot be null')
-    }
-    CharmChart converted = CharmBridge.convert(chart)
-    export(converted, targetFile, quality)
-  }
-
-  /**
    * Export an {@link Svg} chart as JPEG to an {@link OutputStream}.
    *
    * @param svgChart the {@link Svg} object containing the chart
@@ -109,25 +88,6 @@ class ChartToJpeg {
       throw new IllegalArgumentException('outputStream cannot be null')
     }
     SvgRenderer.toJpeg(stripAnimationCss(chart.render()), os, [quality: quality])
-  }
-
-  /**
-   * Export a legacy {@link Chart} as JPEG to an {@link OutputStream}.
-   *
-   * @param chart the legacy chart to export
-   * @param os the output stream to write the JPEG to
-   * @param quality JPEG compression quality (0.0 to 1.0)
-   * @throws IllegalArgumentException if chart or os is null
-   */
-  static void export(Chart chart, OutputStream os, BigDecimal quality = 1.0) {
-    if (chart == null) {
-      throw new IllegalArgumentException('chart cannot be null')
-    }
-    if (os == null) {
-      throw new IllegalArgumentException('outputStream cannot be null')
-    }
-    CharmChart converted = CharmBridge.convert(chart)
-    export(converted, os, quality)
   }
 
   /**
@@ -182,7 +142,6 @@ class ChartToJpeg {
     switch (chart) {
       case PlotGrid -> export(chart as PlotGrid, targetFile, quality)
       case CharmChart -> export(chart as CharmChart, targetFile, quality)
-      case Chart -> export(chart as Chart, targetFile, quality)
       case Svg -> export(chart as Svg, targetFile, quality)
       default -> throw new IllegalArgumentException("Unsupported chart type: ${chart.getClass().name}")
     }
@@ -204,7 +163,6 @@ class ChartToJpeg {
     switch (chart) {
       case PlotGrid -> export(chart as PlotGrid, os, quality)
       case CharmChart -> export(chart as CharmChart, os, quality)
-      case Chart -> export(chart as Chart, os, quality)
       case Svg -> export(chart as Svg, os, quality)
       default -> throw new IllegalArgumentException("Unsupported chart type: ${chart.getClass().name}")
     }

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToPdf.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToPdf.groovy
@@ -13,7 +13,6 @@ import se.alipsa.groovy.svg.Svg
 import se.alipsa.groovy.svg.io.SvgReader
 import se.alipsa.matrix.charm.Chart as CharmChart
 import se.alipsa.matrix.charm.PlotGrid
-import se.alipsa.matrix.pict.Chart
 
 import java.awt.image.BufferedImage
 
@@ -24,7 +23,7 @@ import java.awt.image.BufferedImage
  * pipeline and embeds the resulting image on a single PDF page.</p>
  *
  * <p>Accepts SVG strings, {@link Svg} objects, {@link CharmChart} instances,
- * legacy {@link Chart} instances, and {@link PlotGrid} grids.</p>
+ * and {@link PlotGrid} grids.</p>
  */
 @SuppressWarnings('DuplicateStringLiteral')
 class ChartToPdf {
@@ -110,32 +109,6 @@ class ChartToPdf {
   }
 
   /**
-   * Export a legacy {@link Chart} as a PDF file.
-   *
-   * @param chart the legacy chart to export
-   * @param targetFile the PDF file to write
-   */
-  static void export(Chart chart, File targetFile) throws IOException {
-    if (chart == null) {
-      throw new IllegalArgumentException('chart cannot be null')
-    }
-    writePdf(ChartToImage.export(chart), targetFile)
-  }
-
-  /**
-   * Export a legacy {@link Chart} as PDF to an {@link OutputStream}.
-   *
-   * @param chart the legacy chart to export
-   * @param os the output stream to write
-   */
-  static void export(Chart chart, OutputStream os) throws IOException {
-    if (chart == null) {
-      throw new IllegalArgumentException('chart cannot be null')
-    }
-    writePdf(ChartToImage.export(chart), os)
-  }
-
-  /**
    * Export a {@link PlotGrid} as a PDF file.
    *
    * @param grid the plot grid to export
@@ -204,7 +177,6 @@ class ChartToPdf {
     switch (chart) {
       case PlotGrid -> export(chart as PlotGrid, targetFile)
       case CharmChart -> export(chart as CharmChart, targetFile)
-      case Chart -> export(chart as Chart, targetFile)
       case Svg -> export(chart as Svg, targetFile)
       case CharSequence -> export(chart.toString(), targetFile)
       default -> throw new IllegalArgumentException("Unsupported chart type: ${chart.getClass().name}")
@@ -226,7 +198,6 @@ class ChartToPdf {
     switch (chart) {
       case PlotGrid -> export(chart as PlotGrid, os)
       case CharmChart -> export(chart as CharmChart, os)
-      case Chart -> export(chart as Chart, os)
       case Svg -> export(chart as Svg, os)
       case CharSequence -> export(chart.toString(), os)
       default -> throw new IllegalArgumentException("Unsupported chart type: ${chart.getClass().name}")

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToPng.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToPng.groovy
@@ -9,8 +9,6 @@ import com.github.weisj.jsvg.parser.SVGLoader
 import se.alipsa.groovy.svg.Svg
 import se.alipsa.matrix.charm.Chart as CharmChart
 import se.alipsa.matrix.charm.PlotGrid
-import se.alipsa.matrix.pict.CharmBridge
-import se.alipsa.matrix.pict.Chart
 
 import java.awt.Graphics2D
 import java.awt.RenderingHints
@@ -140,42 +138,6 @@ class ChartToPng {
   }
 
   /**
-   * Export a legacy {@link Chart} (e.g. BarChart, ScatterChart) as a PNG image file.
-   *
-   * @param chart the legacy chart to export
-   * @param targetFile the {@link File} where the PNG image will be written
-   * @throws IOException if an error occurs during file writing
-   * @throws IllegalArgumentException if chart or targetFile is null
-   */
-  static void export(Chart chart, File targetFile) throws IOException {
-    if (chart == null) {
-      throw new IllegalArgumentException('chart cannot be null')
-    }
-    if (targetFile == null) {
-      throw new IllegalArgumentException('targetFile cannot be null')
-    }
-    export(CharmBridge.convert(chart).render(), targetFile)
-  }
-
-  /**
-   * Export a legacy {@link Chart} (e.g. BarChart, ScatterChart) as PNG to an {@link OutputStream}.
-   *
-   * @param chart the legacy chart to export
-   * @param os the output stream to write the PNG to
-   * @throws IOException if an error occurs during writing
-   * @throws IllegalArgumentException if chart or os is null
-   */
-  static void export(Chart chart, OutputStream os) throws IOException {
-    if (chart == null) {
-      throw new IllegalArgumentException('chart cannot be null')
-    }
-    if (os == null) {
-      throw new IllegalArgumentException('outputStream cannot be null')
-    }
-    export(CharmBridge.convert(chart).render(), os)
-  }
-
-  /**
    * Export a {@link PlotGrid} as a PNG image file.
    *
    * @param grid the plot grid to export
@@ -254,7 +216,6 @@ class ChartToPng {
     switch (chart) {
       case PlotGrid -> export(chart as PlotGrid, targetFile)
       case CharmChart -> export(chart as CharmChart, targetFile)
-      case Chart -> export(chart as Chart, targetFile)
       case Svg -> export(chart as Svg, targetFile)
       case CharSequence -> export(chart.toString(), targetFile)
       default -> throw new IllegalArgumentException("Unsupported chart type: ${chart.getClass().name}")
@@ -276,7 +237,6 @@ class ChartToPng {
     switch (chart) {
       case PlotGrid -> export(chart as PlotGrid, os)
       case CharmChart -> export(chart as CharmChart, os)
-      case Chart -> export(chart as Chart, os)
       case Svg -> export(chart as Svg, os)
       case CharSequence -> export(chart.toString(), os)
       default -> throw new IllegalArgumentException("Unsupported chart type: ${chart.getClass().name}")

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToSvg.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToSvg.groovy
@@ -6,46 +6,21 @@ import se.alipsa.groovy.svg.Svg
 import se.alipsa.groovy.svg.io.SvgWriter
 import se.alipsa.matrix.charm.Chart as CharmChart
 import se.alipsa.matrix.charm.PlotGrid
-import se.alipsa.matrix.pict.CharmBridge
-import se.alipsa.matrix.pict.Chart
 
 import java.nio.charset.StandardCharsets
 
 /**
  * Exports charts as SVG files.
  *
- * <p>Accepts legacy {@link Chart} instances (e.g. ScatterChart, BarChart)
- * and Charm {@link CharmChart} instances. Legacy charts are converted
- * via {@link CharmBridge} before rendering.</p>
+ * <p>Accepts Charm {@link CharmChart} instances.</p>
  *
  * <pre>
- * // Export a legacy chart
- * ChartToSvg.export(scatterChart, new File('chart.svg'))
- *
  * // Export a Charm chart
  * ChartToSvg.export(charmChart, new File('chart.svg'))
  * </pre>
  */
 @SuppressWarnings('DuplicateStringLiteral')
 class ChartToSvg {
-
-  /**
-   * Export a legacy chart as an SVG file.
-   *
-   * @param chart the chart to export
-   * @param targetFile the file to write the SVG to
-   * @throws IOException if an error occurs during file writing
-   * @throws IllegalArgumentException if chart or targetFile is null
-   */
-  static void export(Chart chart, File targetFile) throws IOException {
-    if (chart == null) {
-      throw new IllegalArgumentException('chart cannot be null')
-    }
-    if (targetFile == null) {
-      throw new IllegalArgumentException('targetFile cannot be null')
-    }
-    writeSvg(CharmBridge.convert(chart).render(), targetFile)
-  }
 
   /**
    * Export a Charm chart as an SVG file.
@@ -66,25 +41,6 @@ class ChartToSvg {
   }
 
   /**
-   * Export a legacy chart as SVG to an {@link OutputStream}.
-   * The caller is responsible for closing the OutputStream.
-   *
-   * @param chart the chart to export
-   * @param os the output stream to write the SVG to
-   * @throws IOException if an error occurs during writing
-   * @throws IllegalArgumentException if chart or os is null
-   */
-  static void export(Chart chart, OutputStream os) throws IOException {
-    if (chart == null) {
-      throw new IllegalArgumentException('chart cannot be null')
-    }
-    if (os == null) {
-      throw new IllegalArgumentException('outputStream cannot be null')
-    }
-    writeSvg(CharmBridge.convert(chart).render(), os)
-  }
-
-  /**
    * Export a Charm chart as SVG to an {@link OutputStream}.
    * The caller is responsible for closing the OutputStream.
    *
@@ -101,25 +57,6 @@ class ChartToSvg {
       throw new IllegalArgumentException('outputStream cannot be null')
     }
     writeSvg(chart.render(), os)
-  }
-
-  /**
-   * Export a legacy chart as SVG to a {@link Writer}.
-   * The caller is responsible for closing the Writer.
-   *
-   * @param chart the chart to export
-   * @param writer the writer to write the SVG to
-   * @throws IOException if an error occurs during writing
-   * @throws IllegalArgumentException if chart or writer is null
-   */
-  static void export(Chart chart, Writer writer) throws IOException {
-    if (chart == null) {
-      throw new IllegalArgumentException('chart cannot be null')
-    }
-    if (writer == null) {
-      throw new IllegalArgumentException('writer cannot be null')
-    }
-    writeSvg(CharmBridge.convert(chart).render(), writer)
   }
 
   /**
@@ -220,7 +157,6 @@ class ChartToSvg {
     switch (chart) {
       case PlotGrid -> export(chart as PlotGrid, targetFile)
       case CharmChart -> export(chart as CharmChart, targetFile)
-      case Chart -> export(chart as Chart, targetFile)
       default -> throw new IllegalArgumentException("Unsupported chart type: ${chart.getClass().name}")
     }
   }
@@ -240,7 +176,6 @@ class ChartToSvg {
     switch (chart) {
       case PlotGrid -> export(chart as PlotGrid, os)
       case CharmChart -> export(chart as CharmChart, os)
-      case Chart -> export(chart as Chart, os)
       default -> throw new IllegalArgumentException("Unsupported chart type: ${chart.getClass().name}")
     }
   }
@@ -260,7 +195,6 @@ class ChartToSvg {
     switch (chart) {
       case PlotGrid -> export(chart as PlotGrid, writer)
       case CharmChart -> export(chart as CharmChart, writer)
-      case Chart -> export(chart as Chart, writer)
       default -> throw new IllegalArgumentException("Unsupported chart type: ${chart.getClass().name}")
     }
   }

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToSwing.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/chartexport/ChartToSwing.groovy
@@ -5,8 +5,6 @@ import groovy.transform.CompileDynamic
 import se.alipsa.groovy.svg.Svg
 import se.alipsa.matrix.charm.Chart as CharmChart
 import se.alipsa.matrix.charm.PlotGrid
-import se.alipsa.matrix.pict.CharmBridge
-import se.alipsa.matrix.pict.Chart
 
 /**
  * Exports charts as Swing {@link SvgPanel} components.
@@ -72,19 +70,6 @@ class ChartToSwing {
   }
 
   /**
-   * Create a {@link SvgPanel} from a legacy {@link Chart} (e.g. BarChart, ScatterChart).
-   *
-   * @param chart the legacy chart to render
-   * @return a {@link SvgPanel} displaying the rendered chart
-   */
-  static SvgPanel export(Chart chart) {
-    if (chart == null) {
-      throw new IllegalArgumentException('chart cannot be null')
-    }
-    export(CharmBridge.convert(chart).render())
-  }
-
-  /**
    * Create a {@link SvgPanel} from a {@link PlotGrid}.
    *
    * @param grid the plot grid to render
@@ -112,7 +97,6 @@ class ChartToSwing {
     switch (chart) {
       case PlotGrid -> export(chart as PlotGrid)
       case CharmChart -> export(chart as CharmChart)
-      case Chart -> export(chart as Chart)
       case Svg -> export(chart as Svg)
       case CharSequence -> export(chart as CharSequence)
       default -> throw new IllegalArgumentException("Unsupported chart type: ${chart.getClass().name}")

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/BarChart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/BarChart.groovy
@@ -144,6 +144,9 @@ class BarChart extends Chart<BarChart> {
     /** Sets the chart type to stacked. */
     Builder stacked() { this.chartType = ChartType.STACKED; this }
 
+    /** Sets the chart type to grouped (side-by-side bars). */
+    Builder grouped() { this.chartType = ChartType.GROUPED; this }
+
     /**
      * Builds the configured {@link BarChart}.
      *

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
@@ -175,8 +175,9 @@ class CharmBridge {
 
   private static PlotSpec buildScatterSpec(ScatterChart chart) {
     Matrix data = buildLongFormatMatrix(chart)
+    boolean multiSeries = chart.valueSeries.size() > 1
     PlotSpec spec = Charts.plot(data)
-    spec.mapping([x: 'x', y: 'y'])
+    spec.mapping(multiSeries ? [x: 'x', y: 'y', color: 'series'] : [x: 'x', y: 'y'])
     spec.addLayer(new PointBuilder())
     applyLabelsAndTheme(spec, chart)
     spec

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
@@ -33,7 +33,7 @@ import java.awt.Font
 class CharmBridge {
 
   /**
-   * Converts a legacy charts {@link Chart} to a Charm {@link se.alipsa.matrix.charm.Chart}
+   * Converts a pict chart {@link Chart} to a Charm {@link se.alipsa.matrix.charm.Chart}
    * using default dimensions (800x600).
    *
    * @param chart the legacy chart

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Plot.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Plot.groovy
@@ -20,11 +20,13 @@ import javafx.scene.Group
  * <p>Example:
  * <pre>
  * LineChart chart = LineChart.builder(data).title('Sales').x('month').y('revenue').build()
- * inout.view(Plot.jfx(chart))
+ * javafx.scene.Node node = Plot.jfx(chart)
  * Plot.png(chart, new File('chart.png'))
  * </pre>
  */
 class Plot {
+
+  private static final String CHART_CANNOT_BE_NULL = 'chart cannot be null'
 
   /**
    * Exports a chart as a PNG image file.
@@ -67,7 +69,7 @@ class Plot {
   */
   static Svg svg(Chart chart, int width = 800, int height = 600) {
     if (chart == null) {
-      throw new IllegalArgumentException('chart cannot be null')
+      throw new IllegalArgumentException(CHART_CANNOT_BE_NULL)
     }
     CharmBridge.renderSvg(chart, width, height)
   }
@@ -89,7 +91,8 @@ class Plot {
 
   /**
    * Exports a chart as SVG to an output stream.
-   * The caller is responsible for closing the output stream.
+   * The method flushes the output stream after writing. The caller is responsible
+   * for closing the output stream.
    *
    * @param chart the chart to export
    * @param os target output stream
@@ -104,7 +107,8 @@ class Plot {
 
   /**
    * Exports a chart as SVG to a writer.
-   * The caller is responsible for closing the writer.
+   * The method flushes the writer after writing. The caller is responsible for
+   * closing the writer.
    *
    * @param chart the chart to export
    * @param writer target writer
@@ -122,13 +126,15 @@ class Plot {
    *
    * <p><b>Breaking change:</b> Previously returned {@code javafx.scene.chart.Chart}.
    * Now returns {@code javafx.scene.Group} (an SVGImage extending Group).
-   * Callers using {@code inout.view(Plot.jfx(chart))} are unaffected since
-   * {@code view()} accepts {@code Node}.</p>
+   * Use the returned {@code Node} in a JavaFX scene graph.</p>
    *
    * @param chart the chart to convert
    * @return a JavaFX Node rendering the chart
    */
   static Group jfx(Chart chart) {
+    if (chart == null) {
+      throw new IllegalArgumentException(CHART_CANNOT_BE_NULL)
+    }
     ChartToJfx.export(chart)
   }
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Plot.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Plot.groovy
@@ -4,7 +4,11 @@ import se.alipsa.groovy.svg.Svg
 import se.alipsa.groovy.svg.io.SvgWriter
 import se.alipsa.matrix.chartexport.ChartToImage
 import se.alipsa.matrix.chartexport.ChartToJfx
+import se.alipsa.matrix.chartexport.ChartToJpeg
+import se.alipsa.matrix.chartexport.ChartToPdf
 import se.alipsa.matrix.chartexport.ChartToPng
+import se.alipsa.matrix.chartexport.ChartToSwing
+import se.alipsa.matrix.chartexport.SvgPanel
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -62,6 +66,34 @@ class Plot {
     requireOutputStream(os)
     Svg svg = CharmBridge.renderSvg(chart, width as int, height as int)
     ChartToPng.export(svg, os)
+  }
+
+  /**
+   * Export a {@link Chart} (e.g. BarChart, ScatterChart) to a JPEG image file.
+   *
+   * @param chart the legacy chart to export
+   * @param targetFile the {@link File} where the JPEG image will be written
+   * @param quality JPEG compression quality (0.0 to 1.0), default to 1.0 (maximum quality)
+   * @throws IllegalArgumentException if chart or targetFile is null
+   */
+  static void jpg(Chart chart, File targetFile, BigDecimal quality = 1.0) {
+    requireChart(chart)
+    requireFile(targetFile)
+    ChartToJpeg.export(CharmBridge.convert(chart), targetFile, quality)
+  }
+
+  /**
+   * Export a legacy {@link Chart} as JPEG to an {@link OutputStream}.
+   *
+   * @param chart the legacy chart to export
+   * @param os the output stream to write the JPEG to
+   * @param quality JPEG compression quality (0.0 to 1.0)
+   * @throws IllegalArgumentException if chart or os is null
+   */
+  static void jpg(Chart chart, OutputStream os, BigDecimal quality = 1.0) {
+    requireChart(chart)
+    requireOutputStream(os)
+    ChartToJpeg.export(CharmBridge.convert(chart), os, quality)
   }
 
   /**
@@ -136,6 +168,30 @@ class Plot {
   }
 
   /**
+   * Export a {@link Chart} to a PDF file.
+   *
+   * @param chart the chart to export
+   * @param targetFile the PDF file to write
+   */
+  static void pdf(Chart chart, File targetFile) throws IOException {
+    requireChart(chart)
+    requireFile(targetFile)
+    ChartToPdf.export(CharmBridge.convert(chart), targetFile)
+  }
+
+  /**
+   * Export a {@link Chart} to a PDF file.
+   *
+   * @param chart the chart to export
+   * @param os the output stream to write
+   */
+  static void pdf(Chart chart, OutputStream os) throws IOException {
+    requireChart(chart)
+    requireOutputStream(os)
+    ChartToPdf.export(CharmBridge.convert(chart), os)
+  }
+
+  /**
    * Converts a chart to a JavaFX Node for display.
    *
    * <p><b>Breaking change:</b> Previously returned {@code javafx.scene.chart.Chart}.
@@ -147,7 +203,19 @@ class Plot {
    * @throws IllegalArgumentException if chart is null
    */
   static Group jfx(Chart chart) {
-    ChartToJfx.export(requireChart(chart))
+    requireChart(chart)
+    ChartToJfx.export(CharmBridge.convert(chart))
+  }
+
+  /**
+   * Create a {@link se.alipsa.matrix.chartexport.SvgPanel} from a legacy {@link Chart} (e.g. BarChart, ScatterChart).
+   *
+   * @param chart the legacy chart to render
+   * @return a {@link se.alipsa.matrix.chartexport.SvgPanel} displaying the rendered chart
+   */
+  static SvgPanel swing(Chart chart) {
+    requireChart(chart)
+    ChartToSwing.export(CharmBridge.convert(chart).render())
   }
 
   /**

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Plot.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Plot.groovy
@@ -27,6 +27,9 @@ import javafx.scene.Group
 class Plot {
 
   private static final String CHART_CANNOT_BE_NULL = 'chart cannot be null'
+  private static final String FILE_CANNOT_BE_NULL = 'file cannot be null'
+  private static final String OUTPUT_STREAM_CANNOT_BE_NULL = 'output stream cannot be null'
+  private static final String WRITER_CANNOT_BE_NULL = 'writer cannot be null'
 
   /**
    * Exports a chart as a PNG image file.
@@ -35,10 +38,12 @@ class Plot {
    * @param file target file
    * @param width image width in pixels
    * @param height image height in pixels
+   * @throws IllegalArgumentException if chart or file is null
    * @throws IOException if file writing fails
    */
   static void png(Chart chart, File file, double width = 800, double height = 600) throws IOException {
-    try (OutputStream os = Files.newOutputStream(file.toPath())) {
+    requireChart(chart)
+    try (OutputStream os = Files.newOutputStream(requireFile(file).toPath())) {
       png(chart, os, width, height)
     }
   }
@@ -50,8 +55,11 @@ class Plot {
    * @param os target output stream
    * @param width image width in pixels
    * @param height image height in pixels
+   * @throws IllegalArgumentException if chart or output stream is null
    */
   static void png(Chart chart, OutputStream os, double width = 800, double height = 600) {
+    requireChart(chart)
+    requireOutputStream(os)
     Svg svg = CharmBridge.renderSvg(chart, width as int, height as int)
     ChartToPng.export(svg, os)
   }
@@ -66,12 +74,10 @@ class Plot {
    * @param width SVG width in pixels
    * @param height SVG height in pixels
    * @return the rendered SVG
+   * @throws IllegalArgumentException if chart is null
   */
   static Svg svg(Chart chart, int width = 800, int height = 600) {
-    if (chart == null) {
-      throw new IllegalArgumentException(CHART_CANNOT_BE_NULL)
-    }
-    CharmBridge.renderSvg(chart, width, height)
+    CharmBridge.renderSvg(requireChart(chart), width, height)
   }
 
   /**
@@ -81,10 +87,12 @@ class Plot {
    * @param file target file
    * @param width SVG width in pixels
    * @param height SVG height in pixels
+   * @throws IllegalArgumentException if chart or file is null
    * @throws IOException if file writing fails
    */
   static void svg(Chart chart, File file, int width = 800, int height = 600) throws IOException {
-    try (OutputStream os = Files.newOutputStream(file.toPath())) {
+    requireChart(chart)
+    try (OutputStream os = Files.newOutputStream(requireFile(file).toPath())) {
       svg(chart, os, width, height)
     }
   }
@@ -98,9 +106,12 @@ class Plot {
    * @param os target output stream
    * @param width SVG width in pixels
    * @param height SVG height in pixels
+   * @throws IllegalArgumentException if chart or output stream is null
    * @throws IOException if writing fails
    */
   static void svg(Chart chart, OutputStream os, int width = 800, int height = 600) throws IOException {
+    requireChart(chart)
+    requireOutputStream(os)
     os.write(SvgWriter.toXml(svg(chart, width, height)).getBytes(StandardCharsets.UTF_8))
     os.flush()
   }
@@ -114,9 +125,12 @@ class Plot {
    * @param writer target writer
    * @param width SVG width in pixels
    * @param height SVG height in pixels
+   * @throws IllegalArgumentException if chart or writer is null
    * @throws IOException if writing fails
    */
   static void svg(Chart chart, Writer writer, int width = 800, int height = 600) throws IOException {
+    requireChart(chart)
+    requireWriter(writer)
     writer.write(SvgWriter.toXml(svg(chart, width, height)))
     writer.flush()
   }
@@ -130,12 +144,10 @@ class Plot {
    *
    * @param chart the chart to convert
    * @return a JavaFX Node rendering the chart
+   * @throws IllegalArgumentException if chart is null
    */
   static Group jfx(Chart chart) {
-    if (chart == null) {
-      throw new IllegalArgumentException(CHART_CANNOT_BE_NULL)
-    }
-    ChartToJfx.export(chart)
+    ChartToJfx.export(requireChart(chart))
   }
 
   /**
@@ -145,10 +157,39 @@ class Plot {
    * @param width image width in pixels
    * @param height image height in pixels
    * @return data URI string
+   * @throws IllegalArgumentException if chart is null
    */
   static String base64(Chart chart, double width = 800, double height = 600) {
-    Svg svg = CharmBridge.renderSvg(chart, width as int, height as int)
+    Svg svg = CharmBridge.renderSvg(requireChart(chart), width as int, height as int)
     ChartToImage.base64(svg)
+  }
+
+  private static Chart requireChart(Chart chart) {
+    if (chart == null) {
+      throw new IllegalArgumentException(CHART_CANNOT_BE_NULL)
+    }
+    chart
+  }
+
+  private static File requireFile(File file) {
+    if (file == null) {
+      throw new IllegalArgumentException(FILE_CANNOT_BE_NULL)
+    }
+    file
+  }
+
+  private static OutputStream requireOutputStream(OutputStream os) {
+    if (os == null) {
+      throw new IllegalArgumentException(OUTPUT_STREAM_CANNOT_BE_NULL)
+    }
+    os
+  }
+
+  private static Writer requireWriter(Writer writer) {
+    if (writer == null) {
+      throw new IllegalArgumentException(WRITER_CANNOT_BE_NULL)
+    }
+    writer
   }
 
 }

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Plot.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Plot.groovy
@@ -1,10 +1,12 @@
 package se.alipsa.matrix.pict
 
 import se.alipsa.groovy.svg.Svg
+import se.alipsa.groovy.svg.io.SvgWriter
 import se.alipsa.matrix.chartexport.ChartToImage
 import se.alipsa.matrix.chartexport.ChartToJfx
 import se.alipsa.matrix.chartexport.ChartToPng
 
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import javafx.scene.Group
 
@@ -68,6 +70,51 @@ class Plot {
   }
 
   /**
+   * Exports a chart as an SVG file.
+   *
+   * @param chart the chart to export
+   * @param file target file
+   * @param width SVG width in pixels
+   * @param height SVG height in pixels
+   * @throws IOException if file writing fails
+   */
+  static void svg(Chart chart, File file, int width = 800, int height = 600) throws IOException {
+    try (OutputStream os = Files.newOutputStream(file.toPath())) {
+      svg(chart, os, width, height)
+    }
+  }
+
+  /**
+   * Exports a chart as SVG to an output stream.
+   * The caller is responsible for closing the output stream.
+   *
+   * @param chart the chart to export
+   * @param os target output stream
+   * @param width SVG width in pixels
+   * @param height SVG height in pixels
+   * @throws IOException if writing fails
+   */
+  static void svg(Chart chart, OutputStream os, int width = 800, int height = 600) throws IOException {
+    os.write(SvgWriter.toXml(svg(chart, width, height)).getBytes(StandardCharsets.UTF_8))
+    os.flush()
+  }
+
+  /**
+   * Exports a chart as SVG to a writer.
+   * The caller is responsible for closing the writer.
+   *
+   * @param chart the chart to export
+   * @param writer target writer
+   * @param width SVG width in pixels
+   * @param height SVG height in pixels
+   * @throws IOException if writing fails
+   */
+  static void svg(Chart chart, Writer writer, int width = 800, int height = 600) throws IOException {
+    writer.write(SvgWriter.toXml(svg(chart, width, height)))
+    writer.flush()
+  }
+
+  /**
    * Converts a chart to a JavaFX Node for display.
    *
    * <p><b>Breaking change:</b> Previously returned {@code javafx.scene.chart.Chart}.
@@ -91,8 +138,8 @@ class Plot {
    * @return data URI string
    */
   static String base64(Chart chart, double width = 800, double height = 600) {
-    Svg svgChart = CharmBridge.renderSvg(chart, width as int, height as int)
-    ChartToImage.base64(svgChart)
+    Svg svg = CharmBridge.renderSvg(chart, width as int, height as int)
+    ChartToImage.base64(svg)
   }
 
 }

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Plot.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Plot.groovy
@@ -64,8 +64,11 @@ class Plot {
    * @param width SVG width in pixels
    * @param height SVG height in pixels
    * @return the rendered SVG
-   */
+  */
   static Svg svg(Chart chart, int width = 800, int height = 600) {
+    if (chart == null) {
+      throw new IllegalArgumentException('chart cannot be null')
+    }
     CharmBridge.renderSvg(chart, width, height)
   }
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Plot.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/pict/Plot.groovy
@@ -9,15 +9,19 @@ import java.nio.file.Files
 import javafx.scene.Group
 
 /**
- * Exports legacy chart types to PNG, base64, and JavaFX formats.
+ * Primary export API for pict chart types (AreaChart, BarChart, BoxChart, BubbleChart,
+ * Histogram, LineChart, PieChart, ScatterChart).
  *
- * <p>All methods now delegate through Charm for SVG-first rendering.
+ * <p>All methods delegate through {@link CharmBridge} for SVG-first rendering via Charm.
  * For direct Charm API usage, see {@link se.alipsa.matrix.charm.Charts}.</p>
  *
- * @deprecated Use the Charm API ({@link se.alipsa.matrix.charm.Charts#plot}) directly for
- * new code. This class is retained for backward compatibility with existing chart type factories.
+ * <p>Example:
+ * <pre>
+ * LineChart chart = LineChart.builder(data).title('Sales').x('month').y('revenue').build()
+ * inout.view(Plot.jfx(chart))
+ * Plot.png(chart, new File('chart.png'))
+ * </pre>
  */
-@Deprecated
 class Plot {
 
   /**
@@ -49,6 +53,21 @@ class Plot {
   }
 
   /**
+   * Renders a chart to an SVG object.
+   *
+   * <p>Use this when you need the raw SVG for HTML embedding, further manipulation,
+   * or writing to a file.</p>
+   *
+   * @param chart the chart to render
+   * @param width SVG width in pixels
+   * @param height SVG height in pixels
+   * @return the rendered SVG
+   */
+  static Svg svg(Chart chart, int width = 800, int height = 600) {
+    CharmBridge.renderSvg(chart, width, height)
+  }
+
+  /**
    * Converts a chart to a JavaFX Node for display.
    *
    * <p><b>Breaking change:</b> Previously returned {@code javafx.scene.chart.Chart}.
@@ -60,8 +79,7 @@ class Plot {
    * @return a JavaFX Node rendering the chart
    */
   static Group jfx(Chart chart) {
-    Svg svg = CharmBridge.convert(chart).render()
-    ChartToJfx.export(svg)
+    ChartToJfx.export(chart)
   }
 
   /**
@@ -73,8 +91,8 @@ class Plot {
    * @return data URI string
    */
   static String base64(Chart chart, double width = 800, double height = 600) {
-    Svg svg = CharmBridge.renderSvg(chart, width as int, height as int)
-    ChartToImage.base64(svg)
+    Svg svgChart = CharmBridge.renderSvg(chart, width as int, height as int)
+    ChartToImage.base64(svgChart)
   }
 
 }

--- a/matrix-charts/src/test/groovy/PngTest.groovy
+++ b/matrix-charts/src/test/groovy/PngTest.groovy
@@ -3,6 +3,7 @@ import static se.alipsa.matrix.core.ListConverter.*
 
 import org.junit.jupiter.api.Test
 
+import se.alipsa.matrix.charm.Charts
 import se.alipsa.matrix.chartexport.ChartToImage
 import se.alipsa.matrix.chartexport.ChartToPng
 import se.alipsa.matrix.core.Matrix
@@ -23,9 +24,33 @@ class PngTest {
     @Test
     void testBarchartToPng() {
         def file = File.createTempFile('barchart', '.png')
-        BarChart chart = BarChart.createVertical('Salaries', empData, 'emp_name', ChartType.BASIC, 'salary')
+        def chart = Charts.plot(empData)
+            .mapping {
+                x = 'emp_name'
+                y = 'salary'
+            }
+            .labels {
+                title = 'Salaries'
+            }
+            .layers {
+                geomBar()
+            }
+        .build()
+
         try {
             ChartToPng.export(chart, file)
+            assertTrue(file.exists())
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    void testPictBarchartToPng() {
+        def file = File.createTempFile('barchart', '.png')
+        BarChart chart = BarChart.createVertical('Salaries', empData, 'emp_name', ChartType.BASIC, 'salary')
+        try {
+            Plot.png(chart, file)
             assertTrue(file.exists())
         } finally {
             file.delete()
@@ -43,9 +68,13 @@ class PngTest {
     @Test
     void testAreaChartToPng() {
         def file = File.createTempFile('areaChart', '.png')
-        AreaChart chart = AreaChart.create('Salaries', empData, 'emp_name', 'salary')
+        AreaChart chart = AreaChart.builder(empData)
+            .title('Salaries')
+            .x('emp_name')
+            .y('salary')
+            .build()
         try {
-            ChartToPng.export(chart, file)
+            Plot.png(chart, file)
             assertTrue(file.exists())
         } finally {
             file.delete()

--- a/matrix-charts/src/test/groovy/chart/BoxChartTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/BoxChartTest.groovy
@@ -5,10 +5,11 @@ import static org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
 
-import se.alipsa.matrix.chartexport.ChartToJfx
-import se.alipsa.matrix.chartexport.ChartToPng
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.pict.BoxChart
+import se.alipsa.matrix.pict.Plot
+
+import javafx.scene.Group
 
 class BoxChartTest {
 
@@ -57,9 +58,9 @@ class BoxChartTest {
     ]).types([String, int]).build()
 
     def chart = BoxChart.create('JFX Box Chart', data, 'group', 'value')
-    def jfxNode = ChartToJfx.export(chart)
+    def jfxNode = Plot.jfx(chart)
     assertNotNull(jfxNode)
-    assertTrue(jfxNode instanceof javafx.scene.Node, "Expected javafx.scene.Node but got ${jfxNode.getClass().name}")
+    assertTrue(jfxNode instanceof Group, "Expected javafx.scene.Group but got ${jfxNode.getClass().name}")
   }
 
   @Test
@@ -76,7 +77,7 @@ class BoxChartTest {
     def chart = BoxChart.create('PNG Box Chart', data, 'group', 'value')
     File file = File.createTempFile('BoxChart', '.png')
     try {
-      ChartToPng.export(chart, file)
+      Plot.png(chart, file)
       assertTrue(file.exists(), 'PNG file should exist')
       assertTrue(file.length() > 0, 'PNG file should not be empty')
     } finally {

--- a/matrix-charts/src/test/groovy/chart/ChartBuilderTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/ChartBuilderTest.groovy
@@ -112,6 +112,27 @@ class ChartBuilderTest {
   }
 
   @Test
+  void testBarChartBuilderGrouped() {
+    def data = Matrix.builder()
+        .columnNames(['region', 'q1', 'q2'])
+        .rows([
+            ['North', 100, 120], ['South', 200, 180]
+        ])
+        .types([String, int, int])
+        .build()
+
+    def chart = BarChart.builder(data)
+        .title('Grouped Bars')
+        .x('region')
+        .y('q1', 'q2')
+        .grouped()
+        .build()
+
+    assertEquals(ChartType.GROUPED, chart.chartType)
+    assertFalse(chart.isStacked())
+  }
+
+  @Test
   void testLineChartBuilder() {
     def data = Matrix.builder()
         .columnNames(['year', 'sales', 'profit'])

--- a/matrix-charts/src/test/groovy/chart/ChartsCharmIntegrationTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/ChartsCharmIntegrationTest.groovy
@@ -292,6 +292,35 @@ class ChartsCharmIntegrationTest {
   }
 
   @Test
+  void testMultiSeriesScatterChartMapsColorAesthetic() {
+    Matrix data = Matrix.builder()
+        .matrixName('MultiScatter')
+        .columns([
+            x: [1, 2, 3, 4],
+            s1: [10, 20, 15, 25],
+            s2: [5, 15, 10, 20]
+        ])
+        .types([Number, Number, Number])
+        .build()
+
+    ScatterChart chart = ScatterChart.builder(data)
+        .title('Multi Scatter')
+        .x('x')
+        .y('s1', 's2')
+        .build()
+
+    se.alipsa.matrix.charm.Chart charmChart = CharmBridge.convert(chart)
+    assertNotNull(charmChart)
+    assertEquals('series', charmChart.mapping.color?.toString(),
+        'Multi-series scatter should map color aesthetic to series column')
+
+    Svg svg = charmChart.render()
+    assertNotNull(svg)
+    def circles = svg.descendants().findAll { it instanceof Circle }
+    assertEquals(8, circles.size(), 'Multi-series scatter should render 8 circles (4 per series)')
+  }
+
+  @Test
   void testStyleThemePassthrough() {
     Matrix data = Matrix.builder()
         .matrixName('StyledChart')

--- a/matrix-charts/src/test/groovy/chart/ChartsCharmIntegrationTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/ChartsCharmIntegrationTest.groovy
@@ -311,7 +311,7 @@ class ChartsCharmIntegrationTest {
 
     se.alipsa.matrix.charm.Chart charmChart = CharmBridge.convert(chart)
     assertNotNull(charmChart)
-    assertEquals('series', charmChart.mapping.color?.toString(),
+    assertEquals('series', charmChart.mapping.color?.columnName(),
         'Multi-series scatter should map color aesthetic to series column')
 
     Svg svg = charmChart.render()

--- a/matrix-charts/src/test/groovy/chart/LineChartTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/LineChartTest.groovy
@@ -4,9 +4,9 @@ import static org.junit.jupiter.api.Assertions.*
 
 import org.junit.jupiter.api.Test
 
-import se.alipsa.matrix.chartexport.ChartToPng
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.pict.LineChart
+import se.alipsa.matrix.pict.Plot
 
 import java.time.YearMonth
 
@@ -33,14 +33,18 @@ class LineChartTest {
     .types([YearMonth, int])
     .build()
 
-    def chart = LineChart.create(salesData, 'yearMonth', 'sales')
+    def chart = LineChart.builder(salesData)
+        .title('Monthly Sales')
+        .x('yearMonth')
+        .y('sales')
+        .build()
     assertIterableEquals(['sales'], chart.valueSeriesNames, 'ValueSeries Names')
     assertEquals(1, chart.valueSeries.size(), 'Number of valueseries')
     assertEquals(12, chart.categorySeries.size(), 'Number of elements in x')
     assertEquals(12, chart.valueSeries[0].size(), 'Number of elements in y')
     File file = File.createTempFile('JfxLineChart', '.png')
     try {
-      ChartToPng.export(chart, file)
+      Plot.png(chart, file)
       assertTrue(file.exists())
     } finally {
       file.delete()

--- a/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
@@ -19,6 +19,7 @@ import se.alipsa.matrix.pict.ChartType
 import se.alipsa.matrix.pict.Histogram
 import se.alipsa.matrix.pict.LineChart
 import se.alipsa.matrix.pict.PieChart
+import se.alipsa.matrix.pict.Plot
 import se.alipsa.matrix.pict.ScatterChart
 
 /**
@@ -37,6 +38,17 @@ class PlotCompatibilityTest {
             value   : [10, 25, 15, 30]
         ])
         .types([String, Number])
+        .build()
+  }
+
+  private static Matrix sampleNumericData() {
+    Matrix.builder()
+        .matrixName('Numeric')
+        .columns([
+            x: [1, 2, 3, 4],
+            y: [10, 20, 15, 25]
+        ])
+        .types([int, Number])
         .build()
   }
 
@@ -239,6 +251,27 @@ class PlotCompatibilityTest {
     String xml = SvgWriter.toXml(CharmBridge.renderSvg(chart, 800, 600))
     assertTrue(xml.contains('<style'))
     assertTrue(xml.contains('.legacy-custom { fill: red; }'))
+  }
+
+  @Test
+  void testPlotSvgReturnsSvgObject() {
+    Matrix data = sampleData()
+    BarChart chart = BarChart.createVertical('SVG Test', data, 'category', ChartType.BASIC, 'value')
+    Svg svg = Plot.svg(chart)
+    assertNotNull(svg, 'Plot.svg() should return a non-null Svg')
+    String xml = SvgWriter.toXml(svg)
+    assertTrue(xml.contains('<svg'), 'Result should contain an SVG element')
+  }
+
+  @Test
+  void testPlotSvgWithExplicitDimensions() {
+    Matrix data = sampleData()
+    LineChart chart = LineChart.create('Sized SVG', sampleNumericData(), 'x', 'y')
+    Svg svg = Plot.svg(chart, 1200, 900)
+    assertNotNull(svg, 'Plot.svg() with dimensions should return a non-null Svg')
+    String xml = SvgWriter.toXml(svg)
+    assertTrue(xml.contains('1200'), 'SVG should reflect requested width')
+    assertTrue(xml.contains('900'), 'SVG should reflect requested height')
   }
 
   @Test

--- a/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
@@ -270,8 +270,39 @@ class PlotCompatibilityTest {
     Svg svg = Plot.svg(chart, 1200, 900)
     assertNotNull(svg, 'Plot.svg() with dimensions should return a non-null Svg')
     String xml = SvgWriter.toXml(svg)
-    assertTrue(xml.contains('1200'), 'SVG should reflect requested width')
-    assertTrue(xml.contains('900'), 'SVG should reflect requested height')
+    assertTrue(xml.contains('width="1200"'), 'SVG should reflect requested width')
+    assertTrue(xml.contains('height="900"'), 'SVG should reflect requested height')
+  }
+
+  @Test
+  void testPlotSvgToFile() {
+    BarChart chart = BarChart.createVertical('SVG File', sampleData(), 'category', ChartType.BASIC, 'value')
+    File file = File.createTempFile('BarChart', '.svg')
+    try {
+      Plot.svg(chart, file, 1200, 900)
+      String xml = file.text
+      assertTrue(xml.contains('<svg'), 'SVG file should contain an SVG element')
+      assertTrue(xml.contains('width="1200"'), 'SVG file should reflect requested width')
+      assertTrue(xml.contains('height="900"'), 'SVG file should reflect requested height')
+    } finally {
+      file.delete()
+    }
+  }
+
+  @Test
+  void testPlotSvgToOutputStream() {
+    BarChart chart = BarChart.createVertical('SVG Stream', sampleData(), 'category', ChartType.BASIC, 'value')
+    ByteArrayOutputStream baos = new ByteArrayOutputStream()
+    Plot.svg(chart, baos)
+    assertTrue(baos.toString('UTF-8').contains('<svg'), 'SVG output stream should contain an SVG element')
+  }
+
+  @Test
+  void testPlotSvgToWriter() {
+    BarChart chart = BarChart.createVertical('SVG Writer', sampleData(), 'category', ChartType.BASIC, 'value')
+    StringWriter writer = new StringWriter()
+    Plot.svg(chart, writer)
+    assertTrue(writer.toString().contains('<svg'), 'SVG writer should contain an SVG element')
   }
 
   @Test
@@ -282,9 +313,17 @@ class PlotCompatibilityTest {
     )
     Matrix data = sampleData()
     ScatterChart chart = ScatterChart.create('JFX Test', data, 'category', 'value')
-    javafx.scene.Node node = ChartToJfx.export(chart)
+    javafx.scene.Node node = Plot.jfx(chart)
     assertNotNull(node, 'export() should return a non-null Node')
     assertTrue(node instanceof javafx.scene.Node, 'Result should be a javafx.scene.Node')
+  }
+
+  @Test
+  void testPlotJfxRejectsNullChart() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      Plot.jfx((se.alipsa.matrix.pict.Chart) null)
+    }
+    assertEquals('chart cannot be null', exception.message)
   }
 
   private static void assertPngHeader(File file) {

--- a/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
@@ -265,7 +265,6 @@ class PlotCompatibilityTest {
 
   @Test
   void testPlotSvgWithExplicitDimensions() {
-    Matrix data = sampleData()
     LineChart chart = LineChart.create('Sized SVG', sampleNumericData(), 'x', 'y')
     Svg svg = Plot.svg(chart, 1200, 900)
     assertNotNull(svg, 'Plot.svg() with dimensions should return a non-null Svg')

--- a/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
@@ -267,15 +267,45 @@ class PlotCompatibilityTest {
     LineChart chart = LineChart.create('Sized SVG', sampleNumericData(), 'x', 'y')
     Svg svg = Plot.svg(chart, 1200, 900)
     assertNotNull(svg, 'Plot.svg() with dimensions should return a non-null Svg')
-    String xml = SvgWriter.toXml(svg)
-    assertTrue(xml.contains('width="1200"'), 'SVG should reflect requested width')
-    assertTrue(xml.contains('height="900"'), 'SVG should reflect requested height')
+    assertEquals('1200', svg.width.toString())
+    assertEquals('900', svg.height.toString())
   }
 
   @Test
   void testPlotSvgRejectsNullChart() {
     IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
       Plot.svg((se.alipsa.matrix.pict.Chart) null)
+    }
+    assertEquals('chart cannot be null', exception.message)
+  }
+
+  @Test
+  void testPlotPngRejectsNullChart() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      Plot.png((se.alipsa.matrix.pict.Chart) null, new ByteArrayOutputStream())
+    }
+    assertEquals('chart cannot be null', exception.message)
+  }
+
+  @Test
+  void testPlotPngRejectsNullTargets() {
+    BarChart chart = BarChart.createVertical('PNG Null Targets', sampleData(), 'category', ChartType.BASIC, 'value')
+
+    IllegalArgumentException fileException = assertThrows(IllegalArgumentException) {
+      Plot.png(chart, (File) null)
+    }
+    assertEquals('file cannot be null', fileException.message)
+
+    IllegalArgumentException outputStreamException = assertThrows(IllegalArgumentException) {
+      Plot.png(chart, (OutputStream) null)
+    }
+    assertEquals('output stream cannot be null', outputStreamException.message)
+  }
+
+  @Test
+  void testPlotBase64RejectsNullChart() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      Plot.base64((se.alipsa.matrix.pict.Chart) null)
     }
     assertEquals('chart cannot be null', exception.message)
   }
@@ -309,6 +339,26 @@ class PlotCompatibilityTest {
     StringWriter writer = new StringWriter()
     Plot.svg(chart, writer)
     assertTrue(writer.toString().contains('<svg'), 'SVG writer should contain an SVG element')
+  }
+
+  @Test
+  void testPlotSvgRejectsNullTargets() {
+    BarChart chart = BarChart.createVertical('SVG Null Targets', sampleData(), 'category', ChartType.BASIC, 'value')
+
+    IllegalArgumentException fileException = assertThrows(IllegalArgumentException) {
+      Plot.svg(chart, (File) null)
+    }
+    assertEquals('file cannot be null', fileException.message)
+
+    IllegalArgumentException outputStreamException = assertThrows(IllegalArgumentException) {
+      Plot.svg(chart, (OutputStream) null)
+    }
+    assertEquals('output stream cannot be null', outputStreamException.message)
+
+    IllegalArgumentException writerException = assertThrows(IllegalArgumentException) {
+      Plot.svg(chart, (Writer) null)
+    }
+    assertEquals('writer cannot be null', writerException.message)
   }
 
   @Test

--- a/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
@@ -275,6 +275,14 @@ class PlotCompatibilityTest {
   }
 
   @Test
+  void testPlotSvgRejectsNullChart() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      Plot.svg((se.alipsa.matrix.pict.Chart) null)
+    }
+    assertEquals('chart cannot be null', exception.message)
+  }
+
+  @Test
   void testPlotSvgToFile() {
     BarChart chart = BarChart.createVertical('SVG File', sampleData(), 'category', ChartType.BASIC, 'value')
     File file = File.createTempFile('BarChart', '.svg')

--- a/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
@@ -9,7 +9,6 @@ import se.alipsa.groovy.svg.Svg
 import se.alipsa.groovy.svg.Text
 import se.alipsa.groovy.svg.io.SvgWriter
 import se.alipsa.matrix.chartexport.ChartToImage
-import se.alipsa.matrix.chartexport.ChartToJfx
 import se.alipsa.matrix.chartexport.ChartToPng
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.pict.AreaChart
@@ -23,8 +22,8 @@ import se.alipsa.matrix.pict.Plot
 import se.alipsa.matrix.pict.ScatterChart
 
 /**
- * Tests verifying that legacy chart types produce valid export output
- * through the current export API (ChartToPng, ChartToImage, ChartToJfx).
+ * Tests verifying that PICT chart types produce valid output through Plot
+ * and remain compatible with the underlying image export APIs.
  */
 class PlotCompatibilityTest {
 

--- a/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
+++ b/matrix-charts/src/test/groovy/chart/PlotCompatibilityTest.groovy
@@ -9,7 +9,6 @@ import se.alipsa.groovy.svg.Svg
 import se.alipsa.groovy.svg.Text
 import se.alipsa.groovy.svg.io.SvgWriter
 import se.alipsa.matrix.chartexport.ChartToImage
-import se.alipsa.matrix.chartexport.ChartToPng
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.pict.AreaChart
 import se.alipsa.matrix.pict.BarChart
@@ -20,6 +19,8 @@ import se.alipsa.matrix.pict.LineChart
 import se.alipsa.matrix.pict.PieChart
 import se.alipsa.matrix.pict.Plot
 import se.alipsa.matrix.pict.ScatterChart
+
+import javafx.scene.Group
 
 /**
  * Tests verifying that PICT chart types produce valid output through Plot
@@ -57,7 +58,7 @@ class PlotCompatibilityTest {
     AreaChart chart = AreaChart.create('Area PNG', data, 'category', 'value')
     File file = File.createTempFile('AreaChart', '.png')
     try {
-      ChartToPng.export(chart, file)
+      Plot.png(chart, file)
       assertTrue(file.exists(), 'PNG file should exist')
       assertTrue(file.length() > 100, 'PNG file should have content')
       assertPngHeader(file)
@@ -72,7 +73,7 @@ class PlotCompatibilityTest {
     BarChart chart = BarChart.createVertical('Bar PNG', data, 'category', ChartType.BASIC, 'value')
     File file = File.createTempFile('BarChart', '.png')
     try {
-      ChartToPng.export(chart, file)
+      Plot.png(chart, file)
       assertTrue(file.exists(), 'PNG file should exist')
       assertTrue(file.length() > 100, 'PNG file should have content')
       assertPngHeader(file)
@@ -91,10 +92,14 @@ class PlotCompatibilityTest {
         ])
         .types([int, Number])
         .build()
-    LineChart chart = LineChart.create('Line PNG', data, 'x', 'y')
+    LineChart chart = LineChart.builder(data)
+        .title('Line PNG')
+        .x('x')
+        .y('y')
+        .build()
     File file = File.createTempFile('LineChart', '.png')
     try {
-      ChartToPng.export(chart, file)
+      Plot.png(chart, file)
       assertTrue(file.exists(), 'PNG file should exist')
       assertTrue(file.length() > 100, 'PNG file should have content')
       assertPngHeader(file)
@@ -109,7 +114,7 @@ class PlotCompatibilityTest {
     PieChart chart = PieChart.create('Pie PNG', data, 'category', 'value')
     File file = File.createTempFile('PieChart', '.png')
     try {
-      ChartToPng.export(chart, file)
+      Plot.png(chart, file)
       assertTrue(file.exists(), 'PNG file should exist')
       assertTrue(file.length() > 100, 'PNG file should have content')
       assertPngHeader(file)
@@ -131,7 +136,7 @@ class PlotCompatibilityTest {
     ScatterChart chart = ScatterChart.create('Scatter PNG', data, 'x', 'y')
     File file = File.createTempFile('ScatterChart', '.png')
     try {
-      ChartToPng.export(chart, file)
+      Plot.png(chart, file)
       assertTrue(file.exists(), 'PNG file should exist')
       assertTrue(file.length() > 100, 'PNG file should have content')
       assertPngHeader(file)
@@ -147,10 +152,14 @@ class PlotCompatibilityTest {
         .columns([score: [55, 60, 65, 70, 75, 80, 85, 90]])
         .types([Number])
         .build()
-    Histogram chart = Histogram.create('Hist PNG', data, 'score', 4)
+    Histogram chart = Histogram.builder(data)
+        .title('Hist PNG')
+        .x('score')
+        .bins(4)
+        .build()
     File file = File.createTempFile('Histogram', '.png')
     try {
-      ChartToPng.export(chart, file)
+      Plot.png(chart, file)
       assertTrue(file.exists(), 'PNG file should exist')
       assertTrue(file.length() > 100, 'PNG file should have content')
       assertPngHeader(file)
@@ -164,7 +173,7 @@ class PlotCompatibilityTest {
     Matrix data = sampleData()
     BarChart chart = BarChart.createVertical('Bar OS', data, 'category', ChartType.BASIC, 'value')
     ByteArrayOutputStream baos = new ByteArrayOutputStream()
-    ChartToPng.export(chart, baos)
+    Plot.png(chart, baos)
     byte[] bytes = baos.toByteArray()
     assertTrue(bytes.length > 100, 'PNG output should have content')
     for (int i = 0; i < PNG_HEADER.length; i++) {
@@ -368,10 +377,13 @@ class PlotCompatibilityTest {
         'No DISPLAY available; skipping JavaFX test. Run with -Pheadless=true for headless mode.'
     )
     Matrix data = sampleData()
-    ScatterChart chart = ScatterChart.create('JFX Test', data, 'category', 'value')
-    javafx.scene.Node node = Plot.jfx(chart)
+    ScatterChart chart = ScatterChart.builder(data).title('JFX Test')
+        .x('category')
+        .y('value')
+        .build()
+    def node = Plot.jfx(chart)
     assertNotNull(node, 'export() should return a non-null Node')
-    assertTrue(node instanceof javafx.scene.Node, 'Result should be a javafx.scene.Node')
+    assertTrue(node instanceof Group, 'Result should be a javafx.scene.Group')
   }
 
   @Test

--- a/matrix-charts/src/test/groovy/export/CharmExportTest.groovy
+++ b/matrix-charts/src/test/groovy/export/CharmExportTest.groovy
@@ -21,6 +21,7 @@ import se.alipsa.matrix.chartexport.ChartToSwing
 import se.alipsa.matrix.chartexport.SvgPanel
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.pict.Chart
+import se.alipsa.matrix.pict.Plot
 import se.alipsa.matrix.pict.ScatterChart
 
 import java.awt.image.BufferedImage
@@ -96,14 +97,14 @@ class CharmExportTest {
     Svg svg = charmChart.render()
     String svgText = svg.toXml()
     CharSequence svgSequence = new StringBuilder(svgText)
-    Chart legacyChart = buildLegacyChart()
+    Chart pictChart = buildPictChart()
     PlotGrid grid = Charts.plotGrid([charmChart], 1)
 
     assertNotNull(ChartToSwing.export(svgText))
     assertNotNull(ChartToSwing.export(svgSequence))
     assertNotNull(ChartToSwing.export(svg))
     assertNotNull(ChartToSwing.export(charmChart))
-    assertNotNull(ChartToSwing.export(legacyChart))
+    assertNotNull(Plot.swing(pictChart))
     assertNotNull(ChartToSwing.export(grid))
   }
 
@@ -171,10 +172,10 @@ class CharmExportTest {
   }
 
   @Test
-  void testChartToSvgLegacyOutputStream() {
-    def chart = buildLegacyChart()
+  void testChartToSvgPictOutputStream() {
+    def chart = buildPictChart()
     ByteArrayOutputStream baos = new ByteArrayOutputStream()
-    ChartToSvg.export(chart, baos)
+    Plot.svg(chart, baos)
     String svg = baos.toString('UTF-8')
     assertTrue(svg.length() > 0, 'SVG output should not be empty')
     assertTrue(svg.contains('<svg'), 'Output should contain SVG content')
@@ -182,20 +183,20 @@ class CharmExportTest {
 
   @Test
   void testChartToSvgLegacyWriter() {
-    def chart = buildLegacyChart()
+    def chart = buildPictChart()
     StringWriter writer = new StringWriter()
-    ChartToSvg.export(chart, writer)
+    Plot.svg(chart, writer)
     String svg = writer
     assertTrue(svg.length() > 0, 'SVG output should not be empty')
     assertTrue(svg.contains('<svg'), 'Output should contain SVG content')
   }
 
-  private static Chart buildLegacyChart() {
+  private static Chart buildPictChart() {
     Matrix data = Matrix.builder()
         .columnNames('x', 'y')
         .rows([[1, 3], [2, 5], [3, 4]])
         .build()
-    ScatterChart.create('Test', data, 'x', 'y')
+    ScatterChart.builder(data).title('Test').x('x').y('y').build()
   }
 
   private static CharmChart buildCharmChart() {


### PR DESCRIPTION
## Summary

- Remove `@Deprecated` from `Plot` — `png()`, `jfx()`, `base64()`, and the new `svg()` are the pict export API, not legacy wrappers; update javadoc to reflect this
- Add `Plot.svg(Chart, int, int)` for callers who need the `Svg` object directly (HTML embedding, `SvgWriter`, further manipulation)
- Fix `Plot.jfx()` to delegate to `ChartToJfx.export(chart)` directly, picking up its null guard instead of duplicating the bridge call
- Fix `CharmBridge.buildScatterSpec()` to map `color:'series'` for multi-series scatter charts — previously all series rendered with the same colour; now matches the pattern used in `buildLineSpec` / `buildAreaSpec`
- Add `BarChart.Builder.grouped()` convenience method, symmetric with the existing `stacked()`

## Test plan

- [ ] `testMultiSeriesScatterChartMapsColorAesthetic` — verifies `color` aesthetic is mapped and 8 circles (4 per series) are rendered
- [ ] `testBarChartBuilderGrouped` — verifies `.grouped()` sets `ChartType.GROUPED` and `isStacked()` returns false
- [ ] `testPlotSvgReturnsSvgObject` — verifies `Plot.svg()` returns a non-null `Svg` containing an `<svg>` element
- [ ] `testPlotSvgWithExplicitDimensions` — verifies requested width/height appear in rendered SVG output
- [ ] Full `chart.*` test suite: 81 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)