### PR TITLE
Update docs and AGENTS.md for matrix-pict extraction (Phase 4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -499,8 +499,9 @@ import static se.alipsa.matrix.gg.GgPlot.*
 | **matrix-core**        | Core Matrix/Grid classes, basic statistics, data conversion              |
 | **matrix-stats**       | Statistical tests, regression, clustering, time series, and related math |
 | **matrix-datasets**    | Common datasets (mtcars, iris, diamonds, etc.)                           |
-| **matrix-charts**      | Charm rendering engine and chart-type-first API with SVG output          |
+| **matrix-charts**      | Charm rendering engine and export utilities with SVG output              |
 | **matrix-ggplot**      | GGPlot2-style charting API, delegates to Charm in matrix-charts          |
+| **matrix-pict**        | Chart-type-first API (BarChart, LineChart, etc.), delegates to Charm in matrix-charts |
 | **matrix-xchart**      | XChart integration                                                       |
 | **matrix-csv**         | Advanced CSV import/export via commons-csv                               |
 | **matrix-json**        | JSON import/export via Jackson                                           |

--- a/docs/cookbook/matrix-charts.md
+++ b/docs/cookbook/matrix-charts.md
@@ -1,9 +1,11 @@
 # Matrix Charts
 
-Matrix Charts provides various predefined charts that can easily be created based on
-Matrix data. The native representation is SVG. Export PICT charts to PNG with
-`Plot.png(...)`. The `se.alipsa.matrix.chartexport` package provides additional
-targets including JPEG, PDF, JavaFX, and Swing, plus lower-level conversion APIs.
+Matrix Charts provides the Charm rendering engine and export utilities. The separate
+`matrix-pict` module provides predefined chart types (AreaChart, BarChart, etc.) that
+can easily be created based on Matrix data. The native representation is SVG. Export
+PICT charts to PNG with `Plot.png(...)`. The `se.alipsa.matrix.chartexport` package
+provides additional targets including JPEG, PDF, JavaFX, and Swing, plus lower-level
+conversion APIs.
 
 ## Fluent Builder API
 

--- a/docs/tutorial/13-matrix-charts.md
+++ b/docs/tutorial/13-matrix-charts.md
@@ -8,16 +8,19 @@ for advanced customization.
 
 ## Installation
 
-To use the matrix-charts module, add the following dependency to your project:
+To use the PICT chart types, add the following dependency to your project:
 
 ### Gradle Configuration
 
 ```groovy
 implementation platform('se.alipsa.matrix:matrix-bom:2.5.0')
-implementation 'se.alipsa.matrix:matrix-charts'
+implementation 'se.alipsa.matrix:matrix-pict'
 implementation 'se.alipsa.matrix:matrix-core'
 implementation 'se.alipsa.matrix:matrix-stats'
 ```
+
+> Note: PICT chart types previously lived in `matrix-charts` but have been extracted
+> into the separate `matrix-pict` module. The Charm DSL remains in `matrix-charts`.
 
 ### Maven Configuration
 
@@ -42,7 +45,7 @@ implementation 'se.alipsa.matrix:matrix-stats'
       </dependency>
       <dependency>
          <groupId>se.alipsa.matrix</groupId>
-         <artifactId>matrix-charts</artifactId>
+         <artifactId>matrix-pict</artifactId>
       </dependency>
       <dependency>
          <groupId>se.alipsa.matrix</groupId>
@@ -58,7 +61,7 @@ implementation 'se.alipsa.matrix:matrix-stats'
 
 ## Chart Types
 
-The matrix-charts module supports several types of charts:
+The `matrix-pict` module supports several types of charts:
 
 1. **Area Chart**: Displays data as filled areas under a line
 2. **Bar Chart**: Displays data as horizontal or vertical bars
@@ -507,8 +510,12 @@ GGPlot compatibility (`ggplot`, `aes`, `geom_*`, `qplot`) belongs to the separat
 
 ## Conclusion
 
-The matrix-charts module provides a powerful and flexible way to create various types of charts from Matrix data. It offers a simple API for generating visualizations that can be exported to different formats, making it easy to include data visualizations in your Groovy applications.
+The `matrix-pict` module provides a powerful and flexible way to create various types
+of charts from Matrix data. It offers a simple API for generating visualizations that
+can be exported to different formats, making it easy to include data visualizations in
+your Groovy applications.
 
-In the next section, we'll cover the matrix-ggplot module for ggplot2-compatible charting built on top of matrix-charts.
+In the next section, we'll cover the matrix-ggplot module for ggplot2-compatible
+charting built on top of matrix-charts.
 
 Go to [previous section](12-matrix-bigquery.md) | Go to [next section](13b-matrix-ggplot.md) | Back to [outline](outline.md)

--- a/matrix-charts/README.md
+++ b/matrix-charts/README.md
@@ -3,17 +3,14 @@
 # Charts
 Groovy library for creating graphs based on Matrix or [][] data
 
-Matrix-charts is a "native" chart library that creates charts as SVGs.
-PICT charts can be exported to PNG with `Plot.png(...)`. The exporters in the
-`se.alipsa.matrix.chartexport` package provide Swing, JavaFX, Image, PNG, JPG,
-and PDF conversion for PICT, SVG, and Charm charts.
+Matrix-charts is a "native" chart library that creates charts as SVGs. The Charm
+rendering engine and export utilities live here. The `se.alipsa.matrix.chartexport`
+package provides Swing, JavaFX, Image, PNG, JPG, and PDF conversion for SVG and
+Charm charts.
 
-There are 2 APIs in matrix-charts, sharing the same Charm rendering engine:
-1. **[Charm](docs/charm.md)** The core chart library based on the principles of Grammar of Graphics.
-   Idiomatic Groovy closure DSL with typed specifications and immutable compiled charts.
-2. **[PICT](docs/pict.md)** The `se.alipsa.matrix.pict` package contains charts in a "familiar style"
-    (begin with the chart type, e.g. `AreaChart`, then add data and styling).
-    Backed by Charm internally.
+> **PICT has moved:** The chart-type-first API (`AreaChart`, `BarChart`, etc.) previously
+> in this module has been extracted to **[matrix-pict](../matrix-pict/README.md)**.
+> It depends on `matrix-charts` and delegates to Charm under the hood.
 
 > For ggplot2-style API, see **[matrix-ggplot](../matrix-ggplot/README.md)** — a compatibility
 > layer mimicking the ggplot2 API in R. It depends on matrix-charts and delegates to Charm under the hood.
@@ -121,40 +118,6 @@ def arrowChart = plot(Dataset.mtcars()) {
   }
 }.build()
 ```
-
-## Charts Example
-
-```groovy
-import java.time.LocalDate
-import se.alipsa.matrix.core.*
-import se.alipsa.matrix.pict.*
-
-def empData = Matrix.builder().data(
-    emp_id: 1..5,
-    emp_name: ["Rick", "Dan", "Michelle", "Ryan", "Gary"],
-    salary: [623.3, 515.2, 611.0, 729.0, 843.25],
-    start_date: toLocalDates("2012-01-01", "2013-09-23", "2014-11-15", "2014-05-11", "2015-03-27"))
-    .types(int, String, Number, LocalDate)
-    .build()
-
-def areaChart = AreaChart.builder(empData)
-    .title("Salaries").x("emp_name").y("salary").build()
-
-def barChart = BarChart.builder(empData)
-    .title("Salaries").x("emp_name").y("salary").vertical().build()
-
-def pieChart = PieChart.builder(empData)
-    .title("Salaries").x("emp_name").y("salary").build()
-
-// Export PICT charts to PNG via Plot
-Plot.png(areaChart, new File("areaChart.png"))
-Plot.png(barChart, new File("barChart.png"))
-```
-
-PICT charts are bridged through Charm. Axis scale settings, custom `style.yLabels`,
-and `style.css` are applied during rendering.
-
-See **[pict.md](docs/pict.md)** for comprehensive documentation.
 
 # Release version compatibility matrix
 See the [Matrix BOM](https://mvnrepository.com/artifact/se.alipsa.matrix/matrix-bom) for the recommended matrix library versions.

--- a/matrix-charts/req/pict-migration.md
+++ b/matrix-charts/req/pict-migration.md
@@ -162,11 +162,11 @@ All tests in both modules must pass.
 
 **PR scope:** Move `pict.md` into the new module and update all documentation to reflect the new artifact coordinate. No code changes.
 
-- 4.1 [ ] Move `matrix-charts/docs/pict.md` to `matrix-pict/docs/pict.md`
-- 4.2 [ ] Update `docs/cookbook/matrix-charts.md` — replace any pict import/dependency examples that reference `matrix-charts` with `matrix-pict`
-- 4.3 [ ] Update `docs/tutorial/13-matrix-charts.md` — same coordinate change for pict usage
-- 4.4 [ ] Update `matrix-charts/README.md` — remove pict API docs/references; note that pict is now in `matrix-pict`
-- 4.5 [ ] Update `AGENTS.md` module table — add `matrix-pict` row: `"chart-type-first API (BarChart, LineChart, etc.), delegates to Charm in matrix-charts"`; update `matrix-charts` description to remove the pict reference
+- 4.1 [x] Move `matrix-charts/docs/pict.md` to `matrix-pict/docs/pict.md`
+- 4.2 [x] Update `docs/cookbook/matrix-charts.md` — replace any pict import/dependency examples that reference `matrix-charts` with `matrix-pict`
+- 4.3 [x] Update `docs/tutorial/13-matrix-charts.md` — same coordinate change for pict usage
+- 4.4 [x] Update `matrix-charts/README.md` — remove pict API docs/references; note that pict is now in `matrix-pict`
+- 4.5 [x] Update `AGENTS.md` module table — add `matrix-pict` row: `"chart-type-first API (BarChart, LineChart, etc.), delegates to Charm in matrix-charts"`; update `matrix-charts` description to remove the pict reference
 
 **Verification:** Manual review of changed doc files. No build step required.
 

--- a/matrix-pict/README.md
+++ b/matrix-pict/README.md
@@ -1,0 +1,107 @@
+# Matrix Pict
+
+Groovy chart-type-first API for matrix data.
+
+Matrix-pict provides a familiar chart-type-first API for creating common visualizations.
+You start by choosing a chart type (e.g. `BarChart`, `LineChart`), then supply data and
+configure styling. It delegates to the
+[Charm](../matrix-charts/docs/charm.md) rendering engine in matrix-charts under the hood.
+
+## Dependencies
+
+### Gradle
+
+```groovy
+implementation(platform('se.alipsa.matrix:matrix-bom:2.5.0'))
+implementation 'se.alipsa.matrix:matrix-pict'
+implementation 'se.alipsa.matrix:matrix-core'
+implementation 'se.alipsa.matrix:matrix-stats'
+```
+
+> Note: `matrix-charts` (the Charm rendering engine) is pulled in transitively via `matrix-pict`.
+
+### Maven
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>se.alipsa.matrix</groupId>
+      <artifactId>matrix-bom</artifactId>
+      <version>2.5.0</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+<dependencies>
+  <dependency>
+    <groupId>se.alipsa.matrix</groupId>
+    <artifactId>matrix-pict</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>se.alipsa.matrix</groupId>
+    <artifactId>matrix-core</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>se.alipsa.matrix</groupId>
+    <artifactId>matrix-stats</artifactId>
+  </dependency>
+</dependencies>
+```
+
+## Quick Example
+
+```groovy
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.pict.*
+
+def data = Matrix.builder().data(
+    product: ['Apples', 'Bananas', 'Cherries', 'Dates'],
+    sales: [120, 85, 200, 150]
+).types(String, Integer).build()
+
+def chart = BarChart.builder(data)
+    .title('Fruit Sales')
+    .x('product')
+    .y('sales')
+    .build()
+
+Plot.png(chart, new File('fruit_sales.png'))
+```
+
+## Chart Types
+
+- **AreaChart** — filled area charts for trends and cumulative values
+- **BarChart** — vertical, horizontal, stacked, and grouped bars
+- **BoxChart** — box-and-whisker plots for distributions
+- **BubbleChart** — scatter with point size encoding a third variable
+- **Histogram** — frequency distribution across bins
+- **LineChart** — trends over continuous or categorical axes
+- **PieChart** — proportional distribution as slices
+- **ScatterChart** — relationships between two numeric variables
+
+## Exporting Charts
+
+Use `se.alipsa.matrix.pict.Plot` for convenient export:
+
+```groovy
+import se.alipsa.matrix.pict.Plot
+
+Plot.png(chart, new File('chart.png'))
+Plot.svg(chart, new File('chart.svg'))
+Plot.jfx(chart)              // JavaFX Node
+Plot.swing(chart)            // Swing SvgPanel
+def dataUri = Plot.base64(chart)
+```
+
+The `se.alipsa.matrix.chartexport` package (pulled in transitively from `matrix-charts`)
+provides additional formats including JPEG, PDF, and lower-level conversion APIs.
+
+## Documentation
+
+- **[pict.md](docs/pict.md)** — comprehensive API reference and examples
+
+## Release version compatibility matrix
+
+See the [Matrix BOM](https://mvnrepository.com/artifact/se.alipsa.matrix/matrix-bom) for the recommended matrix library versions.

--- a/matrix-pict/docs/pict.md
+++ b/matrix-pict/docs/pict.md
@@ -55,7 +55,7 @@ This guide reflects the current PICT implementation, including:
 ### Dependencies
 
 ```groovy
-implementation(platform('se.alipsa.matrix:matrix-bom:2.4.0'))
+implementation(platform('se.alipsa.matrix:matrix-bom:2.5.0'))
 implementation 'se.alipsa.matrix:matrix-core'
 implementation 'se.alipsa.matrix:matrix-pict'
 ```
@@ -108,42 +108,42 @@ Every chart type provides a fluent builder via `ChartType.builder(Matrix data)`.
 
 All builders inherit these methods from `Chart.ChartBuilder`:
 
-| Method | Description |
-|---|---|
-| `title(String)` | Chart title |
-| `x(String)` | X-axis (category) column name |
-| `y(String)` | Y-axis (value) column name |
-| `y(String...)` | Multiple y-axis column names (multi-series) |
-| `xAxisTitle(String)` | X-axis label |
-| `yAxisTitle(String)` | Y-axis label |
-| `xAxisScale(BigDecimal start, BigDecimal end, BigDecimal step)` | Custom x-axis scale |
-| `yAxisScale(BigDecimal start, BigDecimal end, BigDecimal step)` | Custom y-axis scale |
-| `xAxisScale(AxisScale)` | X-axis scale from AxisScale object |
-| `yAxisScale(AxisScale)` | Y-axis scale from AxisScale object |
-| `legend(Legend)` | Legend configuration object |
-| `legendTitle(String)` | Legend title text |
-| `legendVisible(boolean)` | Whether the legend is visible |
-| `legendPosition(Style.Position)` | Legend position (TOP, RIGHT, BOTTOM, LEFT) |
-| `legendFont(Font)` | Legend font (`java.awt.Font`) |
-| `legendBackgroundColor(Color)` | Legend background color (`java.awt.Color`) |
-| `legendDirection(Legend.Direction)` | Legend key layout (VERTICAL, HORIZONTAL) |
-| `style(Style)` | Style configuration object |
-| `plotBackgroundColor(Color)` | Plot area background color (`java.awt.Color`) |
-| `chartBackgroundColor(Color)` | Chart background color (`java.awt.Color`) |
-| `titleVisible(boolean)` | Whether the title is visible |
-| `xAxisVisible(boolean)` | Whether the x-axis is visible |
-| `yAxisVisible(boolean)` | Whether the y-axis is visible |
-| `css(String)` | Custom CSS string injected into Charm-rendered SVG |
-| `build()` | Build the chart |
+| Method                                                          | Description                                        |
+|-----------------------------------------------------------------|----------------------------------------------------|
+| `title(String)`                                                 | Chart title                                        |
+| `x(String)`                                                     | X-axis (category) column name                      |
+| `y(String)`                                                     | Y-axis (value) column name                         |
+| `y(String...)`                                                  | Multiple y-axis column names (multi-series)        |
+| `xAxisTitle(String)`                                            | X-axis label                                       |
+| `yAxisTitle(String)`                                            | Y-axis label                                       |
+| `xAxisScale(BigDecimal start, BigDecimal end, BigDecimal step)` | Custom x-axis scale                                |
+| `yAxisScale(BigDecimal start, BigDecimal end, BigDecimal step)` | Custom y-axis scale                                |
+| `xAxisScale(AxisScale)`                                         | X-axis scale from AxisScale object                 |
+| `yAxisScale(AxisScale)`                                         | Y-axis scale from AxisScale object                 |
+| `legend(Legend)`                                                | Legend configuration object                        |
+| `legendTitle(String)`                                           | Legend title text                                  |
+| `legendVisible(boolean)`                                        | Whether the legend is visible                      |
+| `legendPosition(Style.Position)`                                | Legend position (TOP, RIGHT, BOTTOM, LEFT)         |
+| `legendFont(Font)`                                              | Legend font (`java.awt.Font`)                      |
+| `legendBackgroundColor(Color)`                                  | Legend background color (`java.awt.Color`)         |
+| `legendDirection(Legend.Direction)`                             | Legend key layout (VERTICAL, HORIZONTAL)           |
+| `style(Style)`                                                  | Style configuration object                         |
+| `plotBackgroundColor(Color)`                                    | Plot area background color (`java.awt.Color`)      |
+| `chartBackgroundColor(Color)`                                   | Chart background color (`java.awt.Color`)          |
+| `titleVisible(boolean)`                                         | Whether the title is visible                       |
+| `xAxisVisible(boolean)`                                         | Whether the x-axis is visible                      |
+| `yAxisVisible(boolean)`                                         | Whether the y-axis is visible                      |
+| `css(String)`                                                   | Custom CSS string injected into Charm-rendered SVG |
+| `build()`                                                       | Build the chart                                    |
 
 ### Chart-Specific Builder Methods
 
-| Chart Type | Extra Methods |
-|---|---|
-| `BarChart.Builder` | `horizontal()`, `vertical()`, `stacked()`, `chartType(ChartType)`, `direction(ChartDirection)` |
-| `Histogram.Builder` | `bins(Integer)`, `binDecimals(int)` |
-| `BoxChart.Builder` | `columns(List<String>)` |
-| `BubbleChart.Builder` | `size(String)`, `group(String)` |
+| Chart Type            | Extra Methods                                                                                  |
+|-----------------------|------------------------------------------------------------------------------------------------|
+| `BarChart.Builder`    | `horizontal()`, `vertical()`, `stacked()`, `chartType(ChartType)`, `direction(ChartDirection)` |
+| `Histogram.Builder`   | `bins(Integer)`, `binDecimals(int)`                                                            |
+| `BoxChart.Builder`    | `columns(List<String>)`                                                                        |
+| `BubbleChart.Builder` | `size(String)`, `group(String)`                                                                |
 
 ### Example
 
@@ -268,18 +268,18 @@ BarChart chart = BarChart.create('Sales', ChartType.STACKED, data, 'category',
 
 **ChartType options:**
 
-| Type | Description |
-|---|---|
-| `ChartType.BASIC` | Standard non-stacked bars (default) |
+| Type                | Description                         |
+|---------------------|-------------------------------------|
+| `ChartType.BASIC`   | Standard non-stacked bars (default) |
 | `ChartType.STACKED` | Values stacked on top of each other |
-| `ChartType.GROUPED` | Values placed side by side |
+| `ChartType.GROUPED` | Values placed side by side          |
 
 **ChartDirection options:**
 
-| Direction | Description |
-|---|---|
-| `ChartDirection.VERTICAL` | Bars grow upward (default) |
-| `ChartDirection.HORIZONTAL` | Bars grow rightward |
+| Direction                   | Description                |
+|-----------------------------|----------------------------|
+| `ChartDirection.VERTICAL`   | Bars grow upward (default) |
+| `ChartDirection.HORIZONTAL` | Bars grow rightward        |
 
 **Example -- stacked bar chart:**
 
@@ -606,10 +606,10 @@ def chart = BubbleChart.builder(data)
 Plot.png(chart, new File('bubbles.png'))
 ```
 
-| Chart-Specific Builder Method | Description |
-|---|---|
-| `size(String)` | Column mapped to point radius |
-| `group(String)` | Column mapped to colour aesthetic (optional) |
+| Chart-Specific Builder Method | Description                                  |
+|-------------------------------|----------------------------------------------|
+| `size(String)`                | Column mapped to point radius                |
+| `group(String)`               | Column mapped to colour aesthetic (optional) |
 
 ## Styling
 
@@ -920,13 +920,13 @@ pict ----builds------> charm ---renders-> Svg (via CharmBridge)
 
 ### When to Use Which
 
-| Use case | Recommended API |
-|---|---|
-| Quick bar/pie/line chart with minimal configuration | **PICT** |
-| Full Grammar of Graphics with faceting, annotations, and custom scales | **Charm** |
-| Porting R ggplot2 code to Groovy | **gg** |
-| `@CompileStatic` chart code | **Charm** (programmatic API) |
-| Multi-layer plots (e.g. points + regression line) | **Charm** or **gg** |
+| Use case                                                               | Recommended API              |
+|------------------------------------------------------------------------|------------------------------|
+| Quick bar/pie/line chart with minimal configuration                    | **PICT**                     |
+| Full Grammar of Graphics with faceting, annotations, and custom scales | **Charm**                    |
+| Porting R ggplot2 code to Groovy                                       | **gg**                       |
+| `@CompileStatic` chart code                                            | **Charm** (programmatic API) |
+| Multi-layer plots (e.g. points + regression line)                      | **Charm** or **gg**          |
 
 ## Examples
 

--- a/matrix-pict/docs/pict.md
+++ b/matrix-pict/docs/pict.md
@@ -27,7 +27,7 @@ A comprehensive guide to using the `se.alipsa.matrix.pict` package for creating 
 
 The `se.alipsa.matrix.pict` package provides a chart-type-first API for creating common visualizations. You start by choosing a chart type (e.g. `BarChart`, `LineChart`), then supply data and configure styling. This is a familiar pattern for users of libraries like xchart or JavaFX charts.
 
-All chart types are backed by the [Charm](charm.md) rendering engine internally. Use
+All chart types are backed by the [Charm](../../matrix-charts/docs/charm.md) rendering engine internally. Use
 `Plot` for PICT-facing PNG, SVG, base64 PNG, and JavaFX output. The
 `se.alipsa.matrix.chartexport` package provides additional conversions such as JPEG,
 PDF, buffered images, and Swing panels.
@@ -57,7 +57,7 @@ This guide reflects the current PICT implementation, including:
 ```groovy
 implementation(platform('se.alipsa.matrix:matrix-bom:2.4.0'))
 implementation 'se.alipsa.matrix:matrix-core'
-implementation 'se.alipsa.matrix:matrix-charts'
+implementation 'se.alipsa.matrix:matrix-pict'
 ```
 
 ### Creating Your First Chart
@@ -905,7 +905,7 @@ IllegalArgumentException: "Column mismatch in series..."
 
 ## Relationship to Charm and gg APIs
 
-All three APIs in matrix-charts share the same Charm rendering engine:
+All three APIs share the same Charm rendering engine in matrix-charts:
 
 ```
 charm ----renders----> Svg (gsvg)
@@ -915,7 +915,7 @@ pict ----builds------> charm ---renders-> Svg (via CharmBridge)
 ```
 
 - **PICT** (this guide) -- chart-type-first API. Start with `BarChart.builder(data)` and configure from there.
-- **[Charm](charm.md)** -- core Grammar of Graphics DSL. More expressive, supports closures, scales, faceting, annotations, and custom themes.
+- **[Charm](../../matrix-charts/docs/charm.md)** -- core Grammar of Graphics DSL. More expressive, supports closures, scales, faceting, annotations, and custom themes.
 - **[gg](../../matrix-ggplot/docs/ggPlot.md)** -- ggplot2-compatible wrapper. Best for porting R code or when you prefer `ggplot() + geom_point()` syntax.
 
 ### When to Use Which
@@ -1027,6 +1027,6 @@ Plot.png(chart, new File('comparison.png'))
 
 ## Additional Resources
 
-- **[charm.md](charm.md)** -- Charm DSL guide (Grammar of Graphics)
+- **[charm.md](../../matrix-charts/docs/charm.md)** -- Charm DSL guide (Grammar of Graphics)
 - **[ggPlot.md](../../matrix-ggplot/docs/ggPlot.md)** -- ggplot2-compatible API guide (54+ geoms)
-- **API Documentation** -- [JavaDoc](https://javadoc.io/doc/se.alipsa.matrix/matrix-charts)
+- **API Documentation** -- [JavaDoc](https://javadoc.io/doc/se.alipsa.matrix/matrix-pict)


### PR DESCRIPTION
**Summary**
Update all documentation to reflect the new `matrix-pict` artifact coordinate:
- Move `pict.md` from `matrix-charts/docs/` to `matrix-pict/docs/`
- Update dependency examples in the tutorial and PICT guide from `matrix-charts` to `matrix-pict`
- Remove PICT API docs and examples from `matrix-charts/README.md`, adding a note that PICT has moved
- Update `AGENTS.md` module table to add `matrix-pict` and remove the pict reference from `matrix-charts`
- Update the cookbook intro to clarify the module split

**Modules touched**
- `matrix-charts` (docs, README)
- `matrix-pict` (docs)
- Root `docs/`
- `AGENTS.md`

**Tests run**
No code changes; verification was manual review of changed doc files.
