### PR TITLE
Register matrix-pict in matrix-bom (Phase 5)

### DIFF
--- a/matrix-bom/bom.xml
+++ b/matrix-bom/bom.xml
@@ -45,6 +45,7 @@
     <matrixJsonVersion>2.2.0</matrixJsonVersion>
     <matrixLoggingVersion>0.1.0-SNAPSHOT</matrixLoggingVersion>
     <matrixParquetVersion>0.5.0</matrixParquetVersion>
+    <matrixPictVersion>0.5.0-SNAPSHOT</matrixPictVersion>
     <matrixSmileVersion>0.2.0</matrixSmileVersion>
     <matrixSpreadsheetVersion>2.4.0</matrixSpreadsheetVersion>
     <matrixSqlVersion>2.4.0</matrixSqlVersion>
@@ -118,6 +119,11 @@
         <groupId>se.alipsa.matrix</groupId>
         <artifactId>matrix-parquet</artifactId>
         <version>${matrixParquetVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>se.alipsa.matrix</groupId>
+        <artifactId>matrix-pict</artifactId>
+        <version>${matrixPictVersion}</version>
       </dependency>
       <dependency>
         <groupId>se.alipsa.matrix</groupId>

--- a/matrix-bom/pom.xml
+++ b/matrix-bom/pom.xml
@@ -97,8 +97,13 @@
       <groupId>se.alipsa.matrix</groupId>
       <artifactId>matrix-ggplot</artifactId>
     </dependency>
+    <dependency>
+      <groupId>se.alipsa.matrix</groupId>
+      <artifactId>matrix-pict</artifactId>
+    </dependency>
     <!-- matrix-ggplot provides the gg API used in testGgPlot(); -->
-    <!-- testCharts() covers Charm + legacy export via matrix-charts (charm rendering engine) -->
+    <!-- testCharts() covers Charm via matrix-charts (charm rendering engine) -->
+    <!-- testPict() covers the chart-type-first API via matrix-pict -->
     <dependency>
       <groupId>se.alipsa.matrix</groupId>
       <artifactId>matrix-xchart</artifactId>

--- a/matrix-bom/src/test/groovy/test/alipsa/matrix/MatrixModulesTest.groovy
+++ b/matrix-bom/src/test/groovy/test/alipsa/matrix/MatrixModulesTest.groovy
@@ -12,8 +12,8 @@ import se.alipsa.matrix.arff.MatrixArffWriter
 import se.alipsa.matrix.avro.MatrixAvroReader
 import se.alipsa.matrix.avro.MatrixAvroWriter
 import se.alipsa.matrix.charm.Chart
+import se.alipsa.matrix.pict.Plot
 import se.alipsa.matrix.pict.ScatterChart
-import se.alipsa.matrix.chartexport.ChartToSvg
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.MatrixAssertions
 import se.alipsa.matrix.csv.CsvExporter
@@ -275,16 +275,21 @@ class MatrixModulesTest {
     String svg = SvgWriter.toXml(svgObj)
     assertTrue(svg.contains('<svg'), "Output should contain SVG tag")
     assertTrue(svg.contains('MPG vs Weight'), "SVG should contain title")
+  }
 
-    // Test legacy chart export via ChartToSvg
+  @Test
+  void testPict() {
+    // Test chart-type-first API via matrix-pict
+    Matrix mtcars = Dataset.mtcars()
     ScatterChart scatterChart = ScatterChart.builder(mtcars)
         .title('MPG vs Weight')
         .x('wt')
         .y('mpg')
         .build()
+
     File svgFile = tempDir.resolve('scatter_chart.svg').toFile()
-    ChartToSvg.export(scatterChart, svgFile)
-    assertTrue(svgFile.exists(), "SVG file should be created by ChartToSvg.export")
+    Plot.svg(scatterChart, svgFile)
+    assertTrue(svgFile.exists(), "SVG file should be created by Plot.svg")
     assertTrue(svgFile.length() > 0, "SVG file should not be empty")
   }
 

--- a/matrix-charts/req/pict-migration.md
+++ b/matrix-charts/req/pict-migration.md
@@ -178,8 +178,8 @@ All tests in both modules must pass.
 
 > **Note:** The published BOM definition is `matrix-bom/bom.xml`. The sibling `matrix-bom/pom.xml` is the BOM integration-test project. Edit `matrix-bom/bom.xml` directly.
 
-- 5.1 [ ] Add `<matrixPictVersion>0.5.0-SNAPSHOT</matrixPictVersion>` to the `bom.xml` `<properties>` block immediately after `<matrixGgplotVersion>`. Verify that `<matrixChartsVersion>` in `bom.xml` matches the version in `matrix-charts/build.gradle` before committing — they must stay in sync.
-- 5.2 [ ] Add a `<dependency>` entry for `matrix-pict` in `bom.xml`'s `<dependencyManagement>/<dependencies>` block, immediately after the `matrix-ggplot` entry:
+- 5.1 [x] Add `<matrixPictVersion>0.5.0-SNAPSHOT</matrixPictVersion>` to the `bom.xml` `<properties>` block immediately after `<matrixGgplotVersion>`. Verify that `<matrixChartsVersion>` in `bom.xml` matches the version in `matrix-charts/build.gradle` before committing — they must stay in sync.
+- 5.2 [x] Add a `<dependency>` entry for `matrix-pict` in `bom.xml`'s `<dependencyManagement>/<dependencies>` block, immediately after the `matrix-ggplot` entry:
 
 ```xml
 <dependency>


### PR DESCRIPTION
**Summary**
Register `matrix-pict` in the BOM so consumers can manage its version centrally.

- Add `<matrixPictVersion>0.5.0-SNAPSHOT</matrixPictVersion>` to `bom.xml` properties
  (immediately after `<matrixGgplotVersion>`)
- Add `matrix-pict` dependency entry to `<dependencyManagement>` (immediately after
  `matrix-ggplot`)
- Verified `<matrixChartsVersion>` (0.5.0-SNAPSHOT) matches `matrix-charts/build.gradle`

**Modules touched**
- `matrix-bom`

**Tests run**
```bash
mvn -f matrix-bom/bom.xml validate  # BUILD SUCCESS
```
