### PR TITLE
[codex] Fix matrix-json CodeNarc test cleanup

### DIFF
--- a/matrix-json/build.gradle
+++ b/matrix-json/build.gradle
@@ -44,11 +44,6 @@ dependencies {
   testRuntimeOnly libs.junit.platform.launcher
 }
 
-codenarcTest {
-  // TODO: Fix UnnecessaryGString violations in test sources and remove this override
-  ignoreFailures = true
-}
-
 test {
   testLogging.showStandardStreams = true
   useJUnitPlatform()

--- a/matrix-json/src/test/groovy/DuplicateKeyTest.groovy
+++ b/matrix-json/src/test/groovy/DuplicateKeyTest.groovy
@@ -21,8 +21,8 @@ class DuplicateKeyTest {
       JsonImporter.parse(json)
     }
 
-    assertTrue(exception.message.contains("Duplicate key detected"))
-    assertTrue(exception.message.contains("a.b"))
+    assertTrue(exception.message.contains('Duplicate key detected'))
+    assertTrue(exception.message.contains('a.b'))
   }
 
   @Test
@@ -36,8 +36,8 @@ class DuplicateKeyTest {
       JsonImporter.parse(json)
     }
 
-    assertTrue(exception.message.contains("Duplicate key detected"))
-    assertTrue(exception.message.contains("x.y.z"))
+    assertTrue(exception.message.contains('Duplicate key detected'))
+    assertTrue(exception.message.contains('x.y.z'))
   }
 
   @Test
@@ -49,6 +49,6 @@ class DuplicateKeyTest {
     Matrix m = JsonImporter.parse(json)
 
     assertEquals(2, m.columnCount())
-    assertEquals(["a.b", "c"], m.columnNames())
+    assertEquals(['a.b', 'c'], m.columnNames())
   }
 }

--- a/matrix-json/src/test/groovy/JsonExporterTest.groovy
+++ b/matrix-json/src/test/groovy/JsonExporterTest.groovy
@@ -19,9 +19,9 @@ class JsonExporterTest {
     void testExportJson() {
         def empData = Matrix.builder().data(
                 emp_id: 1..3,
-                emp_name: ["Rick","Dan","Michelle"],
+                emp_name: ['Rick','Dan','Michelle'],
                 salary: [623.3,515.2,611.0],
-                start_date: toLocalDates("2012-01-01", "2013-09-23", "2014-11-15"))
+                start_date: toLocalDates('2012-01-01', '2013-09-23', '2014-11-15'))
             .types([int, String, Number, LocalDate])
             .build()
         //println empData.content()
@@ -51,9 +51,9 @@ class JsonExporterTest {
     void testExportJsonWithConverter() {
         def empData = Matrix.builder().data(
             emp_id: 1..3,
-            emp_name: ["Rick","Dan","Michelle"],
+            emp_name: ['Rick','Dan','Michelle'],
             salary: [623.3,515.2,611.0],
-            start_date: toLocalDates("2012-01-01", "2013-09-23", "2014-11-15"))
+            start_date: toLocalDates('2012-01-01', '2013-09-23', '2014-11-15'))
             .types([int, String, Number, LocalDate])
             .build()
         //println empData.content()
@@ -103,7 +103,7 @@ class JsonExporterTest {
         Matrix empty = Matrix.builder().build()
         JsonExporter exporter = new JsonExporter(empty)
         String json = exporter.toJson()
-        assertEquals('[]', json, "Empty matrix should export as empty JSON array")
+        assertEquals('[]', json, 'Empty matrix should export as empty JSON array')
     }
 
     @Test
@@ -115,7 +115,7 @@ class JsonExporterTest {
 
         JsonExporter exporter = new JsonExporter(m)
         String json = exporter.toJson()
-        assertEquals('[]', json, "Matrix with 0 rows should export as empty array")
+        assertEquals('[]', json, 'Matrix with 0 rows should export as empty array')
     }
 
     @Test
@@ -127,10 +127,10 @@ class JsonExporterTest {
         JsonExporter exporter = new JsonExporter(m)
         String json = exporter.toJson(true)
 
-        assertTrue(json.contains('\n'), "Pretty printed JSON should contain newlines")
-        assertTrue(json.contains('  '), "Pretty printed JSON should contain indentation")
-        assertTrue(json.contains('"id"'), "Should contain id field")
-        assertTrue(json.contains('"name"'), "Should contain name field")
+        assertTrue(json.contains('\n'), 'Pretty printed JSON should contain newlines')
+        assertTrue(json.contains('  '), 'Pretty printed JSON should contain indentation')
+        assertTrue(json.contains('"id"'), 'Should contain id field')
+        assertTrue(json.contains('"name"'), 'Should contain name field')
     }
 
     // Phase 3: API Enhancement Tests
@@ -140,7 +140,7 @@ class JsonExporterTest {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException) {
             new JsonExporter(null)
         }
-        assertTrue(ex.message.contains("cannot be null"), "Error should mention null validation")
+        assertTrue(ex.message.contains('cannot be null'), 'Error should mention null validation')
     }
 
     @Test
@@ -148,7 +148,7 @@ class JsonExporterTest {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException) {
             new JsonExporter(null, ['col1', 'col2'])
         }
-        assertTrue(ex.message.contains("cannot be null"), "Error should mention null validation")
+        assertTrue(ex.message.contains('cannot be null'), 'Error should mention null validation')
     }
 
     @Test
@@ -157,7 +157,7 @@ class JsonExporterTest {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException) {
             new JsonExporter(m.grid(), null)
         }
-        assertTrue(ex.message.contains("cannot be null"), "Error should mention null validation")
+        assertTrue(ex.message.contains('cannot be null'), 'Error should mention null validation')
     }
 
     @Test
@@ -169,11 +169,11 @@ class JsonExporterTest {
         // Static method - one-liner convenience
         String json = JsonExporter.toJson(m)
 
-        assertNotNull(json, "JSON should not be null")
-        assertTrue(json.contains('"id"'), "Should contain id field")
-        assertTrue(json.contains('"name"'), "Should contain name field")
-        assertTrue(json.contains('Alice'), "Should contain Alice")
-        assertTrue(json.contains('Bob'), "Should contain Bob")
+        assertNotNull(json, 'JSON should not be null')
+        assertTrue(json.contains('"id"'), 'Should contain id field')
+        assertTrue(json.contains('"name"'), 'Should contain name field')
+        assertTrue(json.contains('Alice'), 'Should contain Alice')
+        assertTrue(json.contains('Bob'), 'Should contain Bob')
     }
 
     @Test
@@ -184,8 +184,8 @@ class JsonExporterTest {
 
         String json = JsonExporter.toJson(m, true)
 
-        assertTrue(json.contains('\n'), "Pretty printed JSON should contain newlines")
-        assertTrue(json.contains('  '), "Pretty printed JSON should contain indentation")
+        assertTrue(json.contains('\n'), 'Pretty printed JSON should contain newlines')
+        assertTrue(json.contains('  '), 'Pretty printed JSON should contain indentation')
     }
 
     @Test
@@ -198,17 +198,17 @@ class JsonExporterTest {
         try {
             JsonExporter.toJsonFile(m, tempFile)
 
-            assertTrue(tempFile.exists(), "File should exist")
-            assertTrue(tempFile.length() > 0, "File should not be empty")
+            assertTrue(tempFile.exists(), 'File should exist')
+            assertTrue(tempFile.length() > 0, 'File should not be empty')
 
             String content = tempFile.text
-            assertTrue(content.contains('"id"'), "Should contain id field")
-            assertTrue(content.contains('"value"'), "Should contain value field")
+            assertTrue(content.contains('"id"'), 'Should contain id field')
+            assertTrue(content.contains('"value"'), 'Should contain value field')
 
             // Verify we can parse it back
             Matrix parsed = JsonImporter.parse(tempFile)
-            assertEquals(3, parsed.rowCount(), "Should have 3 rows")
-            assertEquals(2, parsed.columnCount(), "Should have 2 columns")
+            assertEquals(3, parsed.rowCount(), 'Should have 3 rows')
+            assertEquals(2, parsed.columnCount(), 'Should have 2 columns')
         } finally {
             tempFile.delete()
         }
@@ -225,7 +225,7 @@ class JsonExporterTest {
             JsonExporter.toJsonFile(m, tempFile, true)
 
             String content = tempFile.text
-            assertTrue(content.contains('\n'), "Should have pretty printing with newlines")
+            assertTrue(content.contains('\n'), 'Should have pretty printing with newlines')
         } finally {
             tempFile.delete()
         }

--- a/matrix-json/src/test/groovy/JsonFormatProviderTest.groovy
+++ b/matrix-json/src/test/groovy/JsonFormatProviderTest.groovy
@@ -91,6 +91,6 @@ class JsonFormatProviderTest {
 
     Matrix matrix = Matrix.read([matrixName: 'custom_name'], file)
 
-    assertEquals('custom_name', matrix.matrixName, "matrixName option should override file-derived name")
+    assertEquals('custom_name', matrix.matrixName, 'matrixName option should override file-derived name')
   }
 }

--- a/matrix-json/src/test/groovy/JsonImporterTest.groovy
+++ b/matrix-json/src/test/groovy/JsonImporterTest.groovy
@@ -42,9 +42,9 @@ class JsonImporterTest {
 
     Matrix empData = Matrix.builder().data(
         emp_id: 1..3,
-        emp_name: ["Rick","Dan","Michelle"],
+        emp_name: ['Rick','Dan','Michelle'],
         salary: [623.3,515.2,611.0],
-        start_date: toLocalDates("2012-01-01", "2013-09-23", "2014-11-15"))
+        start_date: toLocalDates('2012-01-01', '2013-09-23', '2014-11-15'))
       .types(int, String, Number, LocalDate)
       .build()
     assertEquals(empData, table, empData.diff(table))
@@ -54,7 +54,7 @@ class JsonImporterTest {
   void testNested() {
     ObjectMapper mapper = new ObjectMapper()
 
-    Family f1 = new Family("Nyfelt-Wersäll")
+    Family f1 = new Family('Nyfelt-Wersäll')
     f1.members.add(new Person('Per'))
     f1.members.add(new Person('Louise'))
 
@@ -130,7 +130,7 @@ class JsonImporterTest {
     if (jsonNode.isObject()) {
       ObjectNode objectNode = (ObjectNode) jsonNode
       Iterator<Map.Entry<String, JsonNode>> iter = objectNode.fields()
-      String pathPrefix = currentPath.isEmpty() ? "" : currentPath + "."
+      String pathPrefix = currentPath.isEmpty() ? '' : currentPath + '.'
 
       while (iter.hasNext()) {
         Map.Entry<String, JsonNode> entry = iter.next()
@@ -169,8 +169,8 @@ class JsonImporterTest {
 
       Matrix table = JsonImporter.parseFromFile(tempFile.absolutePath)
 
-      assertEquals(2, table.rowCount(), "Should have 2 rows")
-      assertEquals(3, table.columnCount(), "Should have 3 columns")
+      assertEquals(2, table.rowCount(), 'Should have 2 rows')
+      assertEquals(3, table.columnCount(), 'Should have 3 columns')
       assertEquals(['emp_id', 'emp_name', 'salary'], table.columnNames())
       // Check individual values rather than comparing lists directly
       assertEquals(1, table.row(0)[0])
@@ -195,8 +195,8 @@ class JsonImporterTest {
 
       Matrix table = JsonImporter.parse(tempFile.toPath())
 
-      assertEquals(3, table.rowCount(), "Should have 3 rows")
-      assertEquals(2, table.columnCount(), "Should have 2 columns")
+      assertEquals(3, table.rowCount(), 'Should have 3 rows')
+      assertEquals(2, table.columnCount(), 'Should have 2 columns')
       assertEquals(['id', 'name'], table.columnNames())
       assertEquals(3, table.row(2)[0])
       assertEquals('Charlie', table.row(2)[1])
@@ -218,8 +218,8 @@ class JsonImporterTest {
       URL url = tempFile.toURI().toURL()
       Matrix table = JsonImporter.parse(url)
 
-      assertEquals(2, table.rowCount(), "Should have 2 rows")
-      assertEquals(2, table.columnCount(), "Should have 2 columns")
+      assertEquals(2, table.rowCount(), 'Should have 2 rows')
+      assertEquals(2, table.columnCount(), 'Should have 2 columns')
       assertEquals(['x', 'y'], table.columnNames())
       assertEquals(10, table.row(0)[0])
       assertEquals(20, table.row(0)[1])
@@ -242,8 +242,8 @@ class JsonImporterTest {
       String urlString = tempFile.toURI().toURL() as String
       Matrix table = JsonImporter.parseFromUrl(urlString)
 
-      assertEquals(1, table.rowCount(), "Should have 1 row")
-      assertEquals(2, table.columnCount(), "Should have 2 columns")
+      assertEquals(1, table.rowCount(), 'Should have 1 row')
+      assertEquals(2, table.columnCount(), 'Should have 2 columns')
       assertEquals(['a', 'b'], table.columnNames())
       assertEquals(1, table.row(0)[0])
       assertEquals(2, table.row(0)[1])
@@ -257,16 +257,16 @@ class JsonImporterTest {
   @Test
   void testEmptyJsonArray() {
     Matrix m = JsonImporter.parse('[]')
-    assertNotNull(m, "Matrix should not be null")
-    assertEquals(0, m.rowCount(), "Empty JSON should have 0 rows")
-    assertEquals(0, m.columnCount(), "Empty JSON should have 0 columns")
+    assertNotNull(m, 'Matrix should not be null')
+    assertEquals(0, m.rowCount(), 'Empty JSON should have 0 rows')
+    assertEquals(0, m.columnCount(), 'Empty JSON should have 0 columns')
   }
 
   @Test
   void testSingleRow() {
     Matrix m = JsonImporter.parse('[{"id": 1, "name": "Alice"}]')
-    assertEquals(1, m.rowCount(), "Should have 1 row")
-    assertEquals(2, m.columnCount(), "Should have 2 columns")
+    assertEquals(1, m.rowCount(), 'Should have 1 row')
+    assertEquals(2, m.columnCount(), 'Should have 2 columns')
     assertEquals(['id', 'name'], m.columnNames())
     assertEquals(1, m.row(0)[0])
     assertEquals('Alice', m.row(0)[1])
@@ -279,19 +279,19 @@ class JsonImporterTest {
       {"a": 3},
       {"b": 4, "c": 5}
     ]''')
-    assertEquals(3, m.rowCount(), "Should have 3 rows")
-    assertEquals(3, m.columnCount(), "Should have 3 columns")
+    assertEquals(3, m.rowCount(), 'Should have 3 rows')
+    assertEquals(3, m.columnCount(), 'Should have 3 columns')
     assertEquals(['a', 'b', 'c'], m.columnNames())
     // Row 0: [1, 2, null]
     // Row 1: [3, null, null]
     // Row 2: [null, 4, 5]
     assertEquals(1, m[0, 'a'])
     assertEquals(2, m[0, 'b'])
-    assertNull(m[0, 'c'], "Row 0 column c should be null")
+    assertNull(m[0, 'c'], 'Row 0 column c should be null')
     assertEquals(3, m[1, 'a'])
-    assertNull(m[1, 'b'], "Row 1 column b should be null")
-    assertNull(m[1, 'c'], "Row 1 column c should be null")
-    assertNull(m[2, 'a'], "Row 2 column a should be null")
+    assertNull(m[1, 'b'], 'Row 1 column b should be null')
+    assertNull(m[1, 'c'], 'Row 1 column c should be null')
+    assertNull(m[2, 'a'], 'Row 2 column a should be null')
     assertEquals(4, m[2, 'b'])
     assertEquals(5, m[2, 'c'])
   }
@@ -301,7 +301,7 @@ class JsonImporterTest {
     IllegalArgumentException ex = assertThrows(IllegalArgumentException) {
       JsonImporter.parse('{"not": "an array"}')
     }
-    assertTrue(ex.message.contains("Expected JSON array"), "Error should mention array expectation")
+    assertTrue(ex.message.contains('Expected JSON array'), 'Error should mention array expectation')
   }
 
   @Test
@@ -314,7 +314,7 @@ class JsonImporterTest {
   @Test
   void testFileNotFound() {
     assertThrows(FileNotFoundException) {
-      JsonImporter.parse(new File("/nonexistent/path/file.json"))
+      JsonImporter.parse(new File('/nonexistent/path/file.json'))
     }
   }
 }

--- a/matrix-json/src/test/groovy/JsonReaderTest.groovy
+++ b/matrix-json/src/test/groovy/JsonReaderTest.groovy
@@ -40,9 +40,9 @@ class JsonReaderTest {
 
     Matrix empData = Matrix.builder().data(
         emp_id: 1..3,
-        emp_name: ["Rick","Dan","Michelle"],
+        emp_name: ['Rick','Dan','Michelle'],
         salary: [623.3,515.2,611.0],
-        start_date: toLocalDates("2012-01-01", "2013-09-23", "2014-11-15"))
+        start_date: toLocalDates('2012-01-01', '2013-09-23', '2014-11-15'))
       .types(int, String, Number, LocalDate)
       .build()
 
@@ -58,10 +58,10 @@ class JsonReaderTest {
 
     Matrix matrix = JsonReader.read(jsonFile)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertEquals(['id', 'name'], matrix.columnNames(), "Column names")
-    assertEquals([1, 'Alice'], matrix.row(0).toList(), "First row")
-    assertEquals([2, 'Bob'], matrix.row(1).toList(), "Second row")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name'], matrix.columnNames(), 'Column names')
+    assertEquals([1, 'Alice'], matrix.row(0).toList(), 'First row')
+    assertEquals([2, 'Bob'], matrix.row(1).toList(), 'Second row')
   }
 
   @Test
@@ -73,8 +73,8 @@ class JsonReaderTest {
     String filePath = jsonFile.absolutePath
     Matrix matrix = JsonReader.readFile(filePath)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertEquals(['x', 'y'], matrix.columnNames(), "Column names")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertEquals(['x', 'y'], matrix.columnNames(), 'Column names')
   }
 
   @Test
@@ -84,8 +84,8 @@ class JsonReaderTest {
 
     Matrix matrix = JsonReader.read(reader)
 
-    assertEquals(3, matrix.rowCount(), "Number of rows")
-    assertEquals(['a'], matrix.columnNames(), "Column names")
+    assertEquals(3, matrix.rowCount(), 'Number of rows')
+    assertEquals(['a'], matrix.columnNames(), 'Column names')
   }
 
   @Test
@@ -95,9 +95,9 @@ class JsonReaderTest {
 
     Matrix matrix = JsonReader.read(is)
 
-    assertEquals(1, matrix.rowCount(), "Number of rows")
-    assertEquals(['name', 'value'], matrix.columnNames(), "Column names")
-    assertEquals(['test', 123], matrix.row(0).toList(), "Row content")
+    assertEquals(1, matrix.rowCount(), 'Number of rows')
+    assertEquals(['name', 'value'], matrix.columnNames(), 'Column names')
+    assertEquals(['test', 123], matrix.row(0).toList(), 'Row content')
   }
 
   @Test
@@ -108,7 +108,7 @@ class JsonReaderTest {
 
     Matrix matrix = JsonReader.read(jsonPath)
 
-    assertEquals(1, matrix.rowCount(), "Number of rows")
+    assertEquals(1, matrix.rowCount(), 'Number of rows')
   }
 
   @Test
@@ -120,8 +120,8 @@ class JsonReaderTest {
     URL url = jsonFile.toURI().toURL()
     Matrix matrix = JsonReader.read(url)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertEquals(['id'], matrix.columnNames(), "Column names")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertEquals(['id'], matrix.columnNames(), 'Column names')
   }
 
   @Test
@@ -133,7 +133,7 @@ class JsonReaderTest {
     String urlString = jsonFile.toURI().toURL() as String
     Matrix matrix = JsonReader.readUrl(urlString)
 
-    assertEquals(1, matrix.rowCount(), "Number of rows")
+    assertEquals(1, matrix.rowCount(), 'Number of rows')
   }
 
   @Test
@@ -157,10 +157,10 @@ class JsonReaderTest {
 
     Matrix matrix = JsonReader.read(json)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertTrue(matrix.columnNames().contains('person.name'), "Should flatten nested objects")
-    assertTrue(matrix.columnNames().contains('person.age'), "Should flatten nested objects")
-    assertEquals('Alice', matrix.row(0)[matrix.columnNames().indexOf('person.name')], "Nested value")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertTrue(matrix.columnNames().contains('person.name'), 'Should flatten nested objects')
+    assertTrue(matrix.columnNames().contains('person.age'), 'Should flatten nested objects')
+    assertEquals('Alice', matrix.row(0)[matrix.columnNames().indexOf('person.name')], 'Nested value')
   }
 
   @Test
@@ -171,10 +171,10 @@ class JsonReaderTest {
 
     Matrix matrix = JsonReader.read(json)
 
-    assertEquals(1, matrix.rowCount(), "Number of rows")
-    assertTrue(matrix.columnNames().contains('items[0]'), "Should flatten arrays")
-    assertTrue(matrix.columnNames().contains('items[1]'), "Should flatten arrays")
-    assertTrue(matrix.columnNames().contains('items[2]'), "Should flatten arrays")
+    assertEquals(1, matrix.rowCount(), 'Number of rows')
+    assertTrue(matrix.columnNames().contains('items[0]'), 'Should flatten arrays')
+    assertTrue(matrix.columnNames().contains('items[1]'), 'Should flatten arrays')
+    assertTrue(matrix.columnNames().contains('items[2]'), 'Should flatten arrays')
   }
 
   @Test
@@ -183,8 +183,8 @@ class JsonReaderTest {
 
     Matrix matrix = JsonReader.read(json)
 
-    assertEquals(0, matrix.rowCount(), "Empty array should produce empty matrix")
-    assertEquals(0, matrix.columnCount(), "Empty array should have no columns")
+    assertEquals(0, matrix.rowCount(), 'Empty array should produce empty matrix')
+    assertEquals(0, matrix.columnCount(), 'Empty array should have no columns')
   }
 
   @Test
@@ -198,16 +198,16 @@ class JsonReaderTest {
 
     Matrix matrix = JsonReader.read(json)
 
-    assertEquals(3, matrix.rowCount(), "Number of rows")
-    assertEquals(3, matrix.columnCount(), "Should have all unique keys as columns")
+    assertEquals(3, matrix.rowCount(), 'Number of rows')
+    assertEquals(3, matrix.columnCount(), 'Should have all unique keys as columns')
     assertTrue(matrix.columnNames().contains('a'), "Should have column 'a'")
     assertTrue(matrix.columnNames().contains('b'), "Should have column 'b'")
     assertTrue(matrix.columnNames().contains('c'), "Should have column 'c'")
 
     // Check nulls for missing values
-    assertNull(matrix.row(0)[matrix.columnNames().indexOf('c')], "Missing value should be null")
-    assertNull(matrix.row(1)[matrix.columnNames().indexOf('b')], "Missing value should be null")
-    assertNull(matrix.row(2)[matrix.columnNames().indexOf('a')], "Missing value should be null")
+    assertNull(matrix.row(0)[matrix.columnNames().indexOf('c')], 'Missing value should be null')
+    assertNull(matrix.row(1)[matrix.columnNames().indexOf('b')], 'Missing value should be null')
+    assertNull(matrix.row(2)[matrix.columnNames().indexOf('a')], 'Missing value should be null')
   }
 
   @Test
@@ -233,8 +233,8 @@ class JsonReaderTest {
 
     Matrix matrix = JsonReader.read(jsonFile, java.nio.charset.StandardCharsets.UTF_8)
 
-    assertEquals(1, matrix.rowCount(), "Number of rows")
-    assertEquals("Grüße", matrix.row(0)[matrix.columnNames().indexOf('text')], "Should handle UTF-8 characters")
+    assertEquals(1, matrix.rowCount(), 'Number of rows')
+    assertEquals('Grüße', matrix.row(0)[matrix.columnNames().indexOf('text')], 'Should handle UTF-8 characters')
   }
 
   @Test
@@ -245,7 +245,7 @@ class JsonReaderTest {
 
     Matrix matrix = JsonReader.read(jsonFile)
 
-    assertEquals('employees', matrix.matrixName, "Matrix name should be derived from filename without extension")
+    assertEquals('employees', matrix.matrixName, 'Matrix name should be derived from filename without extension')
   }
 
   @Test
@@ -257,7 +257,7 @@ class JsonReaderTest {
     URL url = jsonFile.toURI().toURL()
     Matrix matrix = JsonReader.read(url)
 
-    assertEquals('people', matrix.matrixName, "Matrix name should be derived from URL filename")
+    assertEquals('people', matrix.matrixName, 'Matrix name should be derived from URL filename')
   }
 
   @Test
@@ -266,7 +266,7 @@ class JsonReaderTest {
     Matrix fromRead = JsonReader.read(json)
     Matrix fromReadString = JsonReader.readString(json)
 
-    assertEquals(fromRead.rowCount(), fromReadString.rowCount(), "readString should produce same row count as read")
-    assertEquals(fromRead.columnNames(), fromReadString.columnNames(), "readString should produce same columns as read")
+    assertEquals(fromRead.rowCount(), fromReadString.rowCount(), 'readString should produce same row count as read')
+    assertEquals(fromRead.columnNames(), fromReadString.columnNames(), 'readString should produce same columns as read')
   }
 }

--- a/matrix-json/src/test/groovy/JsonWriterTest.groovy
+++ b/matrix-json/src/test/groovy/JsonWriterTest.groovy
@@ -22,11 +22,11 @@ class JsonWriterTest {
 
     String json = JsonWriter.writeString(matrix)
 
-    assertNotNull(json, "JSON string should not be null")
-    assertTrue(json.contains('"id":1'), "Should contain id field")
-    assertTrue(json.contains('"name":"Alice"'), "Should contain name field")
-    assertTrue(json.startsWith('['), "Should be a JSON array")
-    assertTrue(json.endsWith(']'), "Should be a JSON array")
+    assertNotNull(json, 'JSON string should not be null')
+    assertTrue(json.contains('"id":1'), 'Should contain id field')
+    assertTrue(json.contains('"name":"Alice"'), 'Should contain name field')
+    assertTrue(json.startsWith('['), 'Should be a JSON array')
+    assertTrue(json.endsWith(']'), 'Should be a JSON array')
   }
 
   @Test
@@ -37,8 +37,8 @@ class JsonWriterTest {
 
     String json = JsonWriter.writeString(matrix, true)
 
-    assertTrue(json.contains('\n'), "Indented JSON should contain newlines")
-    assertTrue(json.contains('  '), "Indented JSON should contain spaces")
+    assertTrue(json.contains('\n'), 'Indented JSON should contain newlines')
+    assertTrue(json.contains('  '), 'Indented JSON should contain spaces')
   }
 
   @Test
@@ -50,12 +50,12 @@ class JsonWriterTest {
     File outputFile = tempDir.resolve('output.json').toFile()
     JsonWriter.write(matrix, outputFile)
 
-    assertTrue(outputFile.exists(), "Output file should exist")
+    assertTrue(outputFile.exists(), 'Output file should exist')
 
     // Read it back and verify
     Matrix result = JsonReader.read(outputFile)
-    assertEquals(2, result.rowCount(), "Number of rows should match")
-    assertEquals(matrix.columnNames(), result.columnNames(), "Column names should match")
+    assertEquals(2, result.rowCount(), 'Number of rows should match')
+    assertEquals(matrix.columnNames(), result.columnNames(), 'Column names should match')
   }
 
   @Test
@@ -67,7 +67,7 @@ class JsonWriterTest {
     Path outputPath = tempDir.resolve('path_output.json')
     JsonWriter.write(matrix, outputPath)
 
-    assertTrue(outputPath.toFile().exists(), "Output file should exist")
+    assertTrue(outputPath.toFile().exists(), 'Output file should exist')
   }
 
   @Test
@@ -79,7 +79,7 @@ class JsonWriterTest {
     String filePath = tempDir.resolve('string_path.json') as String
     JsonWriter.write(matrix, filePath)
 
-    assertTrue(new File(filePath).exists(), "Output file should exist")
+    assertTrue(new File(filePath).exists(), 'Output file should exist')
   }
 
   @Test
@@ -92,8 +92,8 @@ class JsonWriterTest {
     JsonWriter.write(matrix, writer)
 
     String json = writer as String
-    assertTrue(json.contains('"key":"value1"'), "Should contain data")
-    assertTrue(json.contains('"key":"value2"'), "Should contain data")
+    assertTrue(json.contains('"key":"value1"'), 'Should contain data')
+    assertTrue(json.contains('"key":"value2"'), 'Should contain data')
   }
 
   @Test
@@ -111,10 +111,10 @@ class JsonWriterTest {
     JsonWriter.write(matrix, writer, formatters)
 
     String json = writer as String
-    assertTrue(json.contains('10000'), "Should apply salary formatter")
-    assertTrue(json.contains('20000'), "Should apply salary formatter")
-    assertTrue(json.contains('500'), "Should apply bonus formatter")
-    assertTrue(json.contains('1000'), "Should apply bonus formatter")
+    assertTrue(json.contains('10000'), 'Should apply salary formatter')
+    assertTrue(json.contains('20000'), 'Should apply salary formatter')
+    assertTrue(json.contains('500'), 'Should apply bonus formatter')
+    assertTrue(json.contains('1000'), 'Should apply bonus formatter')
   }
 
   @Test
@@ -133,16 +133,16 @@ class JsonWriterTest {
     // Read it back
     Matrix result = JsonReader.read(json)
 
-    assertEquals(original.rowCount(), result.rowCount(), "Row count should match")
-    assertEquals(original.columnNames().sort(), result.columnNames().sort(), "Column names should match")
+    assertEquals(original.rowCount(), result.rowCount(), 'Row count should match')
+    assertEquals(original.columnNames().sort(), result.columnNames().sort(), 'Column names should match')
 
     // JSON round-trip converts types, so we check values are present rather than exact equality
-    assertTrue(result.columnNames().contains('id'), "Should have id column")
-    assertTrue(result.columnNames().contains('name'), "Should have name column")
-    assertTrue(result.columnNames().contains('score'), "Should have score column")
+    assertTrue(result.columnNames().contains('id'), 'Should have id column')
+    assertTrue(result.columnNames().contains('name'), 'Should have name column')
+    assertTrue(result.columnNames().contains('score'), 'Should have score column')
 
     // Verify row count matches
-    assertEquals(3, result.rowCount(), "Should have 3 rows")
+    assertEquals(3, result.rowCount(), 'Should have 3 rows')
   }
 
   @Test
@@ -153,7 +153,7 @@ class JsonWriterTest {
 
     String json = JsonWriter.writeString(matrix)
 
-    assertEquals('[]', json, "Empty matrix should produce empty JSON array")
+    assertEquals('[]', json, 'Empty matrix should produce empty JSON array')
   }
 
   @Test
@@ -168,7 +168,7 @@ class JsonWriterTest {
 
     String json = JsonWriter.writeString(matrix, 'MM/dd/yyyy')
 
-    assertTrue(json.contains('01/15/2023'), "Should format date with custom pattern")
+    assertTrue(json.contains('01/15/2023'), 'Should format date with custom pattern')
   }
 
   @Test
@@ -186,7 +186,7 @@ class JsonWriterTest {
     JsonWriter.write(matrix, outputFile, formatters)
 
     String content = outputFile.text
-    assertTrue(content.contains('"price":"$99.99"'), "Should apply formatter to file output")
+    assertTrue(content.contains('"price":"$99.99"'), 'Should apply formatter to file output')
   }
 
   @Test
@@ -201,7 +201,7 @@ class JsonWriterTest {
 
     String json = JsonWriter.writeString(matrix)
 
-    assertTrue(json.contains('null'), "Should include null values in JSON")
+    assertTrue(json.contains('null'), 'Should include null values in JSON')
   }
 
   @Test
@@ -238,8 +238,8 @@ class JsonWriterTest {
     String prettyJson = JsonWriter.writeString(original, true)
     Matrix result = JsonReader.read(prettyJson)
 
-    assertEquals(original.rowCount(), result.rowCount(), "Row count should match after pretty print")
-    assertEquals(original.columnNames(), result.columnNames(), "Column names should match")
+    assertEquals(original.rowCount(), result.rowCount(), 'Row count should match after pretty print')
+    assertEquals(original.columnNames(), result.columnNames(), 'Column names should match')
   }
 
   @Test
@@ -252,8 +252,8 @@ class JsonWriterTest {
     JsonWriter.write(matrix, outputPath, [price: { it * 10 }])
 
     String content = outputPath.toFile().text
-    assertTrue(content.contains('1000'), "Should apply formatter via Path overload")
-    assertTrue(content.contains('2000'), "Should apply formatter via Path overload")
+    assertTrue(content.contains('1000'), 'Should apply formatter via Path overload')
+    assertTrue(content.contains('2000'), 'Should apply formatter via Path overload')
   }
 
   @Test
@@ -266,7 +266,7 @@ class JsonWriterTest {
     JsonWriter.write(matrix, filePath, [value: { it * 3 }])
 
     String content = new File(filePath).text
-    assertTrue(content.contains('15'), "Should apply formatter via String path overload")
+    assertTrue(content.contains('15'), 'Should apply formatter via String path overload')
   }
 
   @Test
@@ -276,12 +276,12 @@ class JsonWriterTest {
         .build()
 
     File outputFile = tempDir.resolve('sub/dir/output.json').toFile()
-    assertFalse(outputFile.getParentFile().exists(), "Parent dir should not exist yet")
+    assertFalse(outputFile.getParentFile().exists(), 'Parent dir should not exist yet')
 
     JsonWriter.write(matrix, outputFile, [x: { it + 1 }])
 
-    assertTrue(outputFile.exists(), "File should be created with parent dirs")
-    assertTrue(outputFile.text.contains('2'), "Should apply formatter")
+    assertTrue(outputFile.exists(), 'File should be created with parent dirs')
+    assertTrue(outputFile.text.contains('2'), 'Should apply formatter')
   }
 
   @Test
@@ -307,7 +307,7 @@ class JsonWriterTest {
 
     JsonWriter.write(matrix).to(file)
 
-    assertTrue(file.exists(), "File should exist")
+    assertTrue(file.exists(), 'File should exist')
     Matrix result = JsonReader.read(file)
     assertEquals(2, result.rowCount())
   }
@@ -319,7 +319,7 @@ class JsonWriterTest {
 
     JsonWriter.write(matrix).to(path)
 
-    assertTrue(path.toFile().exists(), "File should exist via Path")
+    assertTrue(path.toFile().exists(), 'File should exist via Path')
   }
 
   @Test
@@ -329,7 +329,7 @@ class JsonWriterTest {
 
     JsonWriter.write(matrix).to(filePath)
 
-    assertTrue(new File(filePath).exists(), "File should exist via String path")
+    assertTrue(new File(filePath).exists(), 'File should exist via String path')
   }
 
   @Test
@@ -339,7 +339,7 @@ class JsonWriterTest {
 
     JsonWriter.write(matrix).to(sw)
 
-    assertTrue(sw.toString().contains('"k"'), "Writer output should contain field")
+    assertTrue(sw.toString().contains('"k"'), 'Writer output should contain field')
   }
 
   @Test
@@ -348,8 +348,8 @@ class JsonWriterTest {
 
     String json = JsonWriter.write(matrix).asString()
 
-    assertTrue(json.contains('"id"'), "asString should contain field name")
-    assertTrue(json.contains('1'), "asString should contain value")
+    assertTrue(json.contains('"id"'), 'asString should contain field name')
+    assertTrue(json.contains('1'), 'asString should contain value')
   }
 
   @Test
@@ -358,7 +358,7 @@ class JsonWriterTest {
 
     String json = JsonWriter.write(matrix).indent().asString()
 
-    assertTrue(json.contains('\n'), "Indented output should contain newlines")
+    assertTrue(json.contains('\n'), 'Indented output should contain newlines')
   }
 
   @Test
@@ -368,8 +368,8 @@ class JsonWriterTest {
     String compact = JsonWriter.write(matrix).indent(false).asString()
     String indented = JsonWriter.write(matrix).indent(true).asString()
 
-    assertFalse(compact.contains('\n'), "Compact should not contain newlines")
-    assertTrue(indented.contains('\n'), "Indented should contain newlines")
+    assertFalse(compact.contains('\n'), 'Compact should not contain newlines')
+    assertTrue(indented.contains('\n'), 'Indented should contain newlines')
   }
 
   @Test
@@ -381,7 +381,7 @@ class JsonWriterTest {
 
     String json = JsonWriter.write(matrix).dateFormat('dd/MM/yyyy').asString()
 
-    assertTrue(json.contains('15/06/2024'), "Should format date with custom pattern")
+    assertTrue(json.contains('15/06/2024'), 'Should format date with custom pattern')
   }
 
   @Test
@@ -390,7 +390,7 @@ class JsonWriterTest {
 
     String json = JsonWriter.write(matrix).formatter('price') { it * 2 }.asString()
 
-    assertTrue(json.contains('200'), "Should apply single formatter")
+    assertTrue(json.contains('200'), 'Should apply single formatter')
   }
 
   @Test
@@ -402,8 +402,8 @@ class JsonWriterTest {
         .formatter('b') { it * 20 }
         .asString()
 
-    assertTrue(json.contains('10'), "Should apply formatter to column a")
-    assertTrue(json.contains('40'), "Should apply formatter to column b")
+    assertTrue(json.contains('10'), 'Should apply formatter to column a')
+    assertTrue(json.contains('40'), 'Should apply formatter to column b')
   }
 
   @Test
@@ -414,7 +414,7 @@ class JsonWriterTest {
         .columnFormatters([x: { it * 100 }, y: { it * 200 }])
         .asString()
 
-    assertTrue(json.contains('300'), "Should apply column formatters map")
-    assertTrue(json.contains('800'), "Should apply column formatters map")
+    assertTrue(json.contains('300'), 'Should apply column formatters map')
+    assertTrue(json.contains('800'), 'Should apply column formatters map')
   }
 }

--- a/req/codenarc-consolidation-2.md
+++ b/req/codenarc-consolidation-2.md
@@ -140,7 +140,7 @@
 - `matrix-json/build.gradle` (remove lines 47–50)
 - `matrix-json/src/test/groovy/` (6 test files)
 
-- [ ] **2.1 Audit violations from the XML report**
+- [x] **2.1 Audit violations from the XML report**
 
   ```bash
   ./gradlew :matrix-json:codenarcTest
@@ -155,13 +155,13 @@
   "
   ```
 
-- [ ] **2.2 Fix UnnecessaryGString violations**
+- [x] **2.2 Fix UnnecessaryGString violations**
 
   Replace uninterpolated `"string"` → `'string'` in all 6 test files:
   - `JsonWriterTest.groovy`, `JsonFormatProviderTest.groovy`, `JsonImporterTest.groovy`
   - `DuplicateKeyTest.groovy`, `JsonExporterTest.groovy`, `JsonReaderTest.groovy`
 
-- [ ] **2.3 Remove the codenarcTest override from matrix-json/build.gradle**
+- [x] **2.3 Remove the codenarcTest override from matrix-json/build.gradle**
 
   Delete lines 47–50:
   ```groovy
@@ -171,10 +171,18 @@
   }
   ```
 
-- [ ] **2.4 Verify**
+- [x] **2.4 Verify**
 
   ```bash
   ./gradlew :matrix-json:codenarcTest
+  ./gradlew :matrix-json:test
+  ```
+
+  Completed verification:
+  ```bash
+  ./gradlew :matrix-json:codenarcTest
+  ./gradlew :matrix-json:codenarcMain
+  ./gradlew :matrix-json:spotlessCheck
   ./gradlew :matrix-json:test
   ```
 


### PR DESCRIPTION
## Summary
- Remove the `matrix-json` `codenarcTest` `ignoreFailures` override.
- Replace reported uninterpolated double-quoted literals in the JSON test suite so CodeNarc test checks pass cleanly.
- Mark task 2 verification complete in `req/codenarc-consolidation-2.md`.

## Modules touched
- `matrix-json`

## Validation
- `./gradlew :matrix-json:codenarcTest`
- `./gradlew :matrix-json:codenarcMain`
- `./gradlew :matrix-json:spotlessCheck`
- `./gradlew :matrix-json:test`
- `git diff --check`