### PR TITLE
[codex] Fix matrix-csv CodeNarc test cleanup

### DIFF
--- a/matrix-csv/build.gradle
+++ b/matrix-csv/build.gradle
@@ -44,11 +44,6 @@ dependencies {
 
 }
 
-codenarcTest {
-  // TODO: Fix test CodeNarc violations and remove this override
-  ignoreFailures = true
-}
-
 test {
   useJUnitPlatform()
   testLogging {

--- a/matrix-csv/src/test/groovy/CsvExporterTest.groovy
+++ b/matrix-csv/src/test/groovy/CsvExporterTest.groovy
@@ -12,25 +12,25 @@ class CsvExporterTest {
   void exportCsv() {
     StringWriter writer = new StringWriter()
     CsvExporter.exportToCsv(Dataset.mtcars(), CSVFormat.DEFAULT, writer)
-    def content = writer.toString().split("\r\n")
+    def content = writer.toString().split('\r\n')
     assertEquals('model,mpg,cyl,disp,hp,drat,wt,qsec,vs,am,gear,carb', content[0])
-    assertEquals('Volvo 142E,21.4,4,121,109,4.11,2.78,18.6,1,1,4,2', content[content.length -1])
+    assertEquals('Volvo 142E,21.4,4,121,109,4.11,2.78,18.6,1,1,4,2', content.last())
   }
 
   @Test
   void exportToFile() {
     File file = File.createTempFile('mtcars', '.csv')
     CsvExporter.exportToCsv(Dataset.mtcars(), CSVFormat.MYSQL, file)
-    def content = file.text.split("\n")
+    def content = file.text.split('\n')
     assertEquals('model\tmpg\tcyl\tdisp\thp\tdrat\twt\tqsec\tvs\tam\tgear\tcarb', content[0])
-    assertEquals('Volvo 142E\t21.4\t4\t121\t109\t4.11\t2.78\t18.6\t1\t1\t4\t2', content[content.length -1])
+    assertEquals('Volvo 142E\t21.4\t4\t121\t109\t4.11\t2.78\t18.6\t1\t1\t4\t2', content.last())
     file.delete()
 
     file = File.createTempFile('mtcars', '.csv')
     CsvExporter.exportToCsv(Dataset.mtcars(), file)
-    content = file.text.split("\r\n")
+    content = file.text.split('\r\n')
     assertEquals('model,mpg,cyl,disp,hp,drat,wt,qsec,vs,am,gear,carb', content[0])
-    assertEquals('Volvo 142E,21.4,4,121,109,4.11,2.78,18.6,1,1,4,2', content[content.length -1])
+    assertEquals('Volvo 142E,21.4,4,121,109,4.11,2.78,18.6,1,1,4,2', content.last())
     file.delete()
   }
 
@@ -57,7 +57,7 @@ class CsvExporterTest {
     CsvExporter.exportToCsv(matrix, writer)
 
     def content = writer.toString().trim()
-    assertEquals('id,name', content, "Should export just headers for empty matrix")
+    assertEquals('id,name', content, 'Should export just headers for empty matrix')
   }
 
   // Phase 2c: Export Variations
@@ -66,10 +66,10 @@ class CsvExporterTest {
   void testExportWithoutHeader() {
     StringWriter writer = new StringWriter()
     CsvExporter.exportToCsv(Dataset.mtcars(), CSVFormat.DEFAULT, writer, false)
-    def content = writer.toString().split("\r\n")
+    def content = writer.toString().split('\r\n')
     // First line should be data, not headers
-    assertTrue(content[0].startsWith('Mazda'), "First line should be data when withHeader=false")
-    assertFalse(content[0].contains('model'), "Should not contain header row")
+    assertTrue(content[0].startsWith('Mazda'), 'First line should be data when withHeader=false')
+    assertFalse(content[0].contains('model'), 'Should not contain header row')
   }
 
   @Test
@@ -81,13 +81,13 @@ class CsvExporterTest {
 
       // Check the file exists
       File[] files = tempDir.listFiles()
-      assertNotNull(files, "Directory should contain files")
-      assertTrue(files.length > 0, "Directory should not be empty")
+      assertNotNull(files, 'Directory should contain files')
+      assertTrue(files.length > 0, 'Directory should not be empty')
 
       File exportedFile = new File(tempDir, 'mtcars.csv')
-      assertTrue(exportedFile.exists(), "File should be created in directory with matrix name")
+      assertTrue(exportedFile.exists(), 'File should be created in directory with matrix name')
 
-      def content = exportedFile.text.split("\r\n")
+      def content = exportedFile.text.split('\r\n')
       assertEquals('model,mpg,cyl,disp,hp,drat,wt,qsec,vs,am,gear,carb', content[0])
     } finally {
       tempDir.deleteDir()
@@ -106,7 +106,7 @@ class CsvExporterTest {
       File exportedFile = new File(tempDir, 'custom-name.csv')
       assertTrue(exportedFile.exists(), "File should use matrix name: ${tempDir.listFiles()*.name}")
 
-      def content = exportedFile.text.split("\r\n")
+      def content = exportedFile.text.split('\r\n')
       assertEquals('model,mpg,cyl,disp,hp,drat,wt,qsec,vs,am,gear,carb', content[0])
     } finally {
       tempDir.deleteDir()
@@ -121,7 +121,7 @@ class CsvExporterTest {
     CsvExporter.exportToCsv(Dataset.mtcars(), CSVFormat.DEFAULT, printWriter)
     printWriter.flush()
 
-    def content = stringWriter.toString().split("\r\n")
+    def content = stringWriter.toString().split('\r\n')
     assertEquals('model,mpg,cyl,disp,hp,drat,wt,qsec,vs,am,gear,carb', content[0])
   }
 
@@ -133,8 +133,8 @@ class CsvExporterTest {
         .build()
 
     CsvExporter.exportToCsv(Dataset.mtcars(), format, writer)
-    def content = writer.toString().split("\r\n")
-    assertTrue(content[0].contains(';'), "Should use semicolon delimiter")
+    def content = writer.toString().split('\r\n')
+    assertTrue(content[0].contains(';'), 'Should use semicolon delimiter')
     assertEquals('model;mpg;cyl;disp;hp;drat;wt;qsec;vs;am;gear;carb', content[0])
   }
 
@@ -156,7 +156,7 @@ class CsvExporterTest {
 
     CsvExporter.exportToCsv(matrix, format, writer)
     def content = writer.toString()
-    assertTrue(content.contains("'"), "Should use single quote character")
+    assertTrue(content.contains("'"), 'Should use single quote character')
   }
 
   @Test
@@ -184,11 +184,11 @@ class CsvExporterTest {
     File file = File.createTempFile('excel', '.csv')
     try {
       CsvExporter.exportToExcelCsv(Dataset.mtcars(), file)
-      def content = file.text.split("\r\n")
+      def content = file.text.split('\r\n')
       // Excel format uses comma delimiter and CRLF line endings
-      assertTrue(content[0].contains(','), "Should use comma delimiter")
+      assertTrue(content[0].contains(','), 'Should use comma delimiter')
       assertEquals('"model","mpg","cyl","disp","hp","drat","wt","qsec","vs","am","gear","carb"', content[0])
-      assertTrue(content[content.length - 1].startsWith('"Volvo 142E"'), "Last row should be Volvo")
+      assertTrue(content.last().startsWith('"Volvo 142E"'), 'Last row should be Volvo')
     } finally {
       file.delete()
     }
@@ -201,10 +201,10 @@ class CsvExporterTest {
       CsvExporter.exportToTsv(Dataset.mtcars(), file)
       def content = file.text
       // TDF format uses tab delimiter
-      assertTrue(content.contains('\t'), "Should use tab delimiter")
+      assertTrue(content.contains('\t'), 'Should use tab delimiter')
       assertTrue(content.startsWith('model\tmpg\tcyl\tdisp\thp\tdrat\twt\tqsec\tvs\tam\tgear\tcarb'),
-          "Should start with header row")
-      assertTrue(content.contains('Volvo 142E'), "Should contain Volvo data")
+          'Should start with header row')
+      assertTrue(content.contains('Volvo 142E'), 'Should contain Volvo data')
     } finally {
       file.delete()
     }
@@ -215,10 +215,10 @@ class CsvExporterTest {
     File file = File.createTempFile('excel-noheader', '.csv')
     try {
       CsvExporter.exportToExcelCsv(Dataset.mtcars(), file, false)
-      def content = file.text.split("\r\n")
+      def content = file.text.split('\r\n')
       // First line should be data, not headers
-      assertTrue(content[0].startsWith('"Mazda'), "First line should be data when withHeader=false")
-      assertFalse(content[0].contains('model'), "Should not contain header row")
+      assertTrue(content[0].startsWith('"Mazda'), 'First line should be data when withHeader=false')
+      assertFalse(content[0].contains('model'), 'Should not contain header row')
     } finally {
       file.delete()
     }

--- a/matrix-csv/src/test/groovy/CsvFormatTest.groovy
+++ b/matrix-csv/src/test/groovy/CsvFormatTest.groovy
@@ -28,9 +28,9 @@ Bob,25'''
 
     Matrix matrix = CsvReader.read().fromString(csvContent)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertEquals(['name', 'age'], matrix.columnNames(), "Column names")
-    assertEquals(['Alice', '30'], matrix.row(0), "first row")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertEquals(['name', 'age'], matrix.columnNames(), 'Column names')
+    assertEquals(['Alice', '30'], matrix.row(0), 'first row')
   }
 
   @Test
@@ -43,9 +43,9 @@ Bob,25'''
         .delimiter(';')
         .fromString(csvContent)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'amount'], matrix.columnNames(), "Column names")
-    assertEquals(['2', 'Bob', '200.00'], matrix.row(1), "last row")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'amount'], matrix.columnNames(), 'Column names')
+    assertEquals(['2', 'Bob', '200.00'], matrix.row(1), 'last row')
   }
 
   @Test
@@ -57,52 +57,52 @@ Bob,25'''
         .firstRowAsHeader(false)
         .fromString(csvContent)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertEquals(['c0', 'c1', 'c2'], matrix.columnNames(), "Auto-generated column names")
-    assertEquals(['1', 'Alice', '100.00'], matrix.row(0), "first row")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertEquals(['c0', 'c1', 'c2'], matrix.columnNames(), 'Auto-generated column names')
+    assertEquals(['1', 'Alice', '100.00'], matrix.row(0), 'first row')
   }
 
   @Test
   void readFromFile() {
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
     File file = new File(url.toURI())
 
     Matrix matrix = CsvReader.read().from(file)
 
-    assertEquals(4, matrix.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), "Column names")
-    assertEquals(['4', 'Arne', '2023-07-01', '222.99'], matrix.row(3), "last row")
+    assertEquals(4, matrix.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), 'Column names')
+    assertEquals(['4', 'Arne', '2023-07-01', '222.99'], matrix.row(3), 'last row')
   }
 
   @Test
   void readFromPath() {
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
     File file = new File(url.toURI())
 
     Matrix matrix = CsvReader.read().from(file.toPath())
 
-    assertEquals(4, matrix.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), "Column names")
+    assertEquals(4, matrix.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), 'Column names')
   }
 
   @Test
   void readFromUrl() {
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
 
     Matrix matrix = CsvReader.read().from(url)
 
-    assertEquals(4, matrix.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), "Column names")
+    assertEquals(4, matrix.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), 'Column names')
   }
 
   @Test
   void readFromUrlString() {
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
 
     Matrix matrix = CsvReader.read().fromUrl(url.toString())
 
-    assertEquals(4, matrix.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), "Column names")
+    assertEquals(4, matrix.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), 'Column names')
   }
 
   @Test
@@ -114,9 +114,9 @@ Bob,25'''
     InputStream is = new ByteArrayInputStream(csvContent.bytes)
     Matrix matrix = CsvReader.read().from(is)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertEquals(['name', 'age'], matrix.columnNames(), "Column names")
-    assertEquals(['Bob', '25'], matrix.row(1), "last row")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertEquals(['name', 'age'], matrix.columnNames(), 'Column names')
+    assertEquals(['Bob', '25'], matrix.row(1), 'last row')
   }
 
   @Test
@@ -128,36 +128,36 @@ Bob,25'''
     StringReader reader = new StringReader(csvContent)
     Matrix matrix = CsvReader.read().from(reader)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertEquals(['name', 'age'], matrix.columnNames(), "Column names")
-    assertEquals(['Alice', '30'], matrix.row(0), "first row")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertEquals(['name', 'age'], matrix.columnNames(), 'Column names')
+    assertEquals(['Alice', '30'], matrix.row(0), 'first row')
   }
 
   @Test
   void readFromFilePath() {
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
     File file = new File(url.toURI())
 
     Matrix matrix = CsvReader.read().fromFile(file.absolutePath)
 
-    assertEquals(4, matrix.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), "Column names")
+    assertEquals(4, matrix.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), 'Column names')
   }
 
   @Test
   void readEmptyCsv() {
     Matrix matrix = CsvReader.read().fromString('')
 
-    assertNotNull(matrix, "Matrix should not be null")
-    assertEquals(0, matrix.rowCount(), "Empty CSV should have 0 rows")
-    assertEquals(0, matrix.columnCount(), "Empty CSV should have 0 columns")
+    assertNotNull(matrix, 'Matrix should not be null')
+    assertEquals(0, matrix.rowCount(), 'Empty CSV should have 0 rows')
+    assertEquals(0, matrix.columnCount(), 'Empty CSV should have 0 columns')
   }
 
   // ── Read: presets ──────────────────────────────────────────
 
   @Test
   void readWithTsvPreset() {
-    String tsvContent = "name\tage\nAlice\t30\nBob\t25"
+    String tsvContent = 'name\tage\nAlice\t30\nBob\t25'
 
     Matrix matrix = CsvReader.read().tsv().fromString(tsvContent)
 
@@ -168,7 +168,7 @@ Bob,25'''
 
   @Test
   void readWithExcelPreset() {
-    String csvContent = "name,age\r\nAlice,30\r\nBob,25"
+    String csvContent = 'name,age\r\nAlice,30\r\nBob,25'
 
     Matrix matrix = CsvReader.read().excel().fromString(csvContent)
 
@@ -178,7 +178,7 @@ Bob,25'''
 
   @Test
   void readWithExcelPresetAllowsMissingHeaderNames() {
-    String csvContent = "id,,amount\r\n1,2,3\r\n"
+    String csvContent = 'id,,amount\r\n1,2,3\r\n'
 
     Matrix matrix = CsvReader.read().excel().fromString(csvContent)
 
@@ -188,7 +188,7 @@ Bob,25'''
 
   @Test
   void readWithRfc4180Preset() {
-    String csvContent = "name,age\r\nAlice,30\r\nBob,25"
+    String csvContent = 'name,age\r\nAlice,30\r\nBob,25'
 
     Matrix matrix = CsvReader.read().rfc4180().fromString(csvContent)
 
@@ -198,7 +198,7 @@ Bob,25'''
 
   @Test
   void readWithRfc4180PresetRejectsMissingHeaderNames() {
-    String csvContent = "id,,amount\r\n1,2,3\r\n"
+    String csvContent = 'id,,amount\r\n1,2,3\r\n'
 
     IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
       CsvReader.read().rfc4180().fromString(csvContent)
@@ -266,12 +266,12 @@ Alice,30'''
     File outputFile = tempDir.resolve('output.csv').toFile()
     CsvWriter.write(matrix).to(outputFile)
 
-    assertTrue(outputFile.exists(), "Output file should exist")
+    assertTrue(outputFile.exists(), 'Output file should exist')
 
     Matrix result = CsvReader.read().from(outputFile)
-    assertEquals(2, result.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'amount'], result.columnNames(), "Column names")
-    assertEquals(['2', 'Bob', '200.00'], result.row(1), "Last row")
+    assertEquals(2, result.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'amount'], result.columnNames(), 'Column names')
+    assertEquals(['2', 'Bob', '200.00'], result.row(1), 'Last row')
   }
 
   @Test
@@ -284,7 +284,7 @@ Alice,30'''
     Path outputPath = tempDir.resolve('output_path.csv')
     CsvWriter.write(matrix).to(outputPath)
 
-    assertTrue(outputPath.toFile().exists(), "Output file should exist")
+    assertTrue(outputPath.toFile().exists(), 'Output file should exist')
   }
 
   @Test
@@ -297,7 +297,7 @@ Alice,30'''
     String filePath = tempDir.resolve('output_strpath.csv').toFile().path
     CsvWriter.write(matrix).toFile(filePath)
 
-    assertTrue(new File(filePath).exists(), "Output file should exist")
+    assertTrue(new File(filePath).exists(), 'Output file should exist')
   }
 
   @Test
@@ -312,10 +312,10 @@ Alice,30'''
 
     String csvContent = CsvWriter.write(matrix).asString()
 
-    assertNotNull(csvContent, "CSV content should not be null")
-    assertTrue(csvContent.contains('name,age'), "Should contain header")
-    assertTrue(csvContent.contains('Alice,30'), "Should contain first row")
-    assertTrue(csvContent.contains('Bob,25'), "Should contain second row")
+    assertNotNull(csvContent, 'CSV content should not be null')
+    assertTrue(csvContent.contains('name,age'), 'Should contain header')
+    assertTrue(csvContent.contains('Alice,30'), 'Should contain first row')
+    assertTrue(csvContent.contains('Bob,25'), 'Should contain second row')
   }
 
   @Test
@@ -327,9 +327,9 @@ Alice,30'''
 
     String csvContent = CsvWriter.write(matrix).withHeader(false).asString()
 
-    assertFalse(csvContent.contains('x,y'), "Should not contain header")
-    assertTrue(csvContent.contains('1,2'), "Should contain first row")
-    assertTrue(csvContent.contains('3,4'), "Should contain second row")
+    assertFalse(csvContent.contains('x,y'), 'Should not contain header')
+    assertTrue(csvContent.contains('1,2'), 'Should contain first row')
+    assertTrue(csvContent.contains('3,4'), 'Should contain second row')
   }
 
   @Test
@@ -343,8 +343,8 @@ Alice,30'''
         .delimiter(';')
         .asString()
 
-    assertTrue(csvContent.contains('name;value'), "Should use semicolon delimiter")
-    assertTrue(csvContent.contains('Alice;100'), "Data should use semicolon delimiter")
+    assertTrue(csvContent.contains('name;value'), 'Should use semicolon delimiter')
+    assertTrue(csvContent.contains('Alice;100'), 'Data should use semicolon delimiter')
   }
 
   @Test
@@ -358,9 +358,9 @@ Alice,30'''
     CsvWriter.write(matrix).to(writer)
 
     String csvContent = writer.buffer
-    assertTrue(csvContent.contains('col1,col2'), "Should contain header")
-    assertTrue(csvContent.contains('a,b'), "Should contain first row")
-    assertTrue(csvContent.contains('c,d'), "Should contain second row")
+    assertTrue(csvContent.contains('col1,col2'), 'Should contain header')
+    assertTrue(csvContent.contains('a,b'), 'Should contain first row')
+    assertTrue(csvContent.contains('c,d'), 'Should contain second row')
   }
 
   // ── Write: presets ─────────────────────────────────────────
@@ -374,7 +374,7 @@ Alice,30'''
 
     String csvContent = CsvWriter.write(matrix).excel().asString()
 
-    assertTrue(csvContent.contains('\r\n'), "Excel preset should use CRLF")
+    assertTrue(csvContent.contains('\r\n'), 'Excel preset should use CRLF')
   }
 
   @Test
@@ -436,8 +436,8 @@ Alice,30'''
 
     String csvContent = CsvWriter.write(matrix).tsv().asString()
 
-    assertTrue(csvContent.contains("name\tvalue"), "TSV preset should use tab delimiter")
-    assertTrue(csvContent.contains("Alice\t100"), "Data should use tab delimiter")
+    assertTrue(csvContent.contains('name\tvalue'), 'TSV preset should use tab delimiter')
+    assertTrue(csvContent.contains('Alice\t100'), 'Data should use tab delimiter')
   }
 
   @Test
@@ -449,7 +449,7 @@ Alice,30'''
 
     String csvContent = CsvWriter.write(matrix).rfc4180().asString()
 
-    assertTrue(csvContent.contains('\r\n'), "RFC 4180 preset should use CRLF")
+    assertTrue(csvContent.contains('\r\n'), 'RFC 4180 preset should use CRLF')
   }
 
   // ── Round-trip tests ───────────────────────────────────────
@@ -468,8 +468,8 @@ Alice,30'''
     String csvContent = CsvWriter.write(original).asString()
     Matrix result = CsvReader.read().fromString(csvContent)
 
-    assertEquals(original.rowCount(), result.rowCount(), "Row count should match")
-    assertEquals(original.columnNames(), result.columnNames(), "Column names should match")
+    assertEquals(original.rowCount(), result.rowCount(), 'Row count should match')
+    assertEquals(original.columnNames(), result.columnNames(), 'Column names should match')
     for (int i = 0; i < original.rowCount(); i++) {
       assertEquals(original.row(i).toList(), result.row(i).toList(), "Row $i should match")
     }
@@ -488,8 +488,8 @@ Alice,30'''
     String csvContent = CsvWriter.write(original).delimiter(';').asString()
     Matrix result = CsvReader.read().delimiter(';').fromString(csvContent)
 
-    assertEquals(original.rowCount(), result.rowCount(), "Row count should match")
-    assertEquals(original.columnNames(), result.columnNames(), "Column names should match")
+    assertEquals(original.rowCount(), result.rowCount(), 'Row count should match')
+    assertEquals(original.columnNames(), result.columnNames(), 'Column names should match')
     for (int i = 0; i < original.rowCount(); i++) {
       assertEquals(original.row(i).toList(), result.row(i).toList(), "Row $i should match")
     }
@@ -505,8 +505,8 @@ Alice,30'''
     String tsvContent = CsvWriter.write(original).tsv().asString()
     Matrix result = CsvReader.read().tsv().fromString(tsvContent)
 
-    assertEquals(original.rowCount(), result.rowCount(), "Row count should match")
-    assertEquals(original.columnNames(), result.columnNames(), "Column names should match")
+    assertEquals(original.rowCount(), result.rowCount(), 'Row count should match')
+    assertEquals(original.columnNames(), result.columnNames(), 'Column names should match')
   }
 
   @Test
@@ -519,8 +519,8 @@ Alice,30'''
     String csvContent = CsvWriter.write(original).excel().asString()
     Matrix result = CsvReader.read().excel().fromString(csvContent)
 
-    assertEquals(original.rowCount(), result.rowCount(), "Row count should match")
-    assertEquals(original.columnNames(), result.columnNames(), "Column names should match")
+    assertEquals(original.rowCount(), result.rowCount(), 'Row count should match')
+    assertEquals(original.columnNames(), result.columnNames(), 'Column names should match')
   }
 
   @Test
@@ -539,8 +539,8 @@ Alice,30'''
 
     Matrix result = CsvReader.read().from(outputFile)
 
-    assertEquals(original.rowCount(), result.rowCount(), "Row count should match")
-    assertEquals(original.columnNames(), result.columnNames(), "Column names should match")
+    assertEquals(original.rowCount(), result.rowCount(), 'Row count should match')
+    assertEquals(original.columnNames(), result.columnNames(), 'Column names should match')
     for (int i = 0; i < original.rowCount(); i++) {
       assertEquals(original.row(i).toList(), result.row(i).toList(), "Row $i should match")
     }
@@ -554,8 +554,8 @@ Alice,30'''
 
     Matrix matrix = CsvReader.read().fromString(csvContent)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertEquals('Line one\nLine two', matrix.row(0)[1], "Embedded newline should be preserved")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertEquals('Line one\nLine two', matrix.row(0)[1], 'Embedded newline should be preserved')
   }
 
   @Test
@@ -566,8 +566,8 @@ Alice,30'''
 
     Matrix matrix = CsvReader.read().fromString(csvContent)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertEquals('Contains, a comma', matrix.row(0)[1], "Embedded delimiter should be preserved")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertEquals('Contains, a comma', matrix.row(0)[1], 'Embedded delimiter should be preserved')
   }
 
   @Test
@@ -578,9 +578,9 @@ Alice,30'''
 
     Matrix matrix = CsvReader.read().fromString(csvContent)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertEquals(['1', '', '3'], matrix.row(0), "Empty fields should be empty strings")
-    assertEquals(['', '2', ''], matrix.row(1), "Empty fields should be empty strings")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertEquals(['1', '', '3'], matrix.row(0), 'Empty fields should be empty strings')
+    assertEquals(['', '2', ''], matrix.row(1), 'Empty fields should be empty strings')
   }
 
   @Test
@@ -593,9 +593,9 @@ Bob,100'''
         .nullString('NA')
         .fromString(csvContent)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertNull(matrix.row(0)[1], "NA should be converted to null")
-    assertEquals('100', matrix.row(1)[1], "Non-NA values should remain")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertNull(matrix.row(0)[1], 'NA should be converted to null')
+    assertEquals('100', matrix.row(1)[1], 'Non-NA values should remain')
   }
 
   @Test
@@ -606,8 +606,8 @@ Bob,100'''
 
     String csvContent = CsvWriter.write(matrix).asString()
 
-    assertTrue(csvContent.contains('a,b,c'), "Should contain header even for empty matrix")
-    assertFalse(csvContent.contains('null'), "Should not contain null values")
+    assertTrue(csvContent.contains('a,b,c'), 'Should contain header even for empty matrix')
+    assertFalse(csvContent.contains('null'), 'Should not contain null values')
   }
 
   @Test
@@ -624,8 +624,8 @@ Bob,100'''
     String csvContent = CsvWriter.write(original).asString()
     Matrix result = CsvReader.read().fromString(csvContent)
 
-    assertEquals(original.rowCount(), result.rowCount(), "Row count should match")
-    assertEquals(original.columnNames(), result.columnNames(), "Column names should match")
+    assertEquals(original.rowCount(), result.rowCount(), 'Row count should match')
+    assertEquals(original.columnNames(), result.columnNames(), 'Column names should match')
     for (int i = 0; i < original.rowCount(); i++) {
       assertEquals(original.row(i).toList(), result.row(i).toList(), "Row $i should match")
     }
@@ -644,9 +644,9 @@ Bob,100'''
         .fromString(csvContent)
 
     assertEquals(2, matrix.rowCount())
-    assertEquals(Integer, matrix.type(0), "id column type")
-    assertEquals(String, matrix.type(1), "name column type")
-    assertEquals(BigDecimal, matrix.type(2), "amount column type")
+    assertEquals(Integer, matrix.type(0), 'id column type')
+    assertEquals(String, matrix.type(1), 'name column type')
+    assertEquals(BigDecimal, matrix.type(2), 'amount column type')
     assertEquals(1, matrix.row(0)[0])
     assertEquals(200.75, matrix.row(1)[2])
   }
@@ -661,10 +661,10 @@ Bob,100'''
         .fromString(csvContent)
 
     assertEquals(2, matrix.rowCount())
-    assertEquals(['id', 'name', 'amount'], matrix.columnNames(), "Column names from columns()")
-    assertEquals(Integer, matrix.type(0), "id column type")
-    assertEquals(String, matrix.type(1), "name column type")
-    assertEquals(BigDecimal, matrix.type(2), "amount column type")
+    assertEquals(['id', 'name', 'amount'], matrix.columnNames(), 'Column names from columns()')
+    assertEquals(Integer, matrix.type(0), 'id column type')
+    assertEquals(String, matrix.type(1), 'name column type')
+    assertEquals(BigDecimal, matrix.type(2), 'amount column type')
     assertEquals(2, matrix.row(1)[0])
     assertEquals('Bob', matrix.row(1)[1])
   }
@@ -681,7 +681,7 @@ Bob,100'''
         .fromString(csvContent)
 
     assertEquals(2, matrix.rowCount())
-    assertEquals(LocalDate, matrix.type(2), "date column type")
+    assertEquals(LocalDate, matrix.type(2), 'date column type')
     assertEquals(LocalDate.of(2023, 1, 15), matrix.row(0)[2])
     assertEquals(LocalDate.of(2023, 6, 20), matrix.row(1)[2])
   }
@@ -699,7 +699,7 @@ Bob,100'''
         .fromString(csvContent)
 
     assertEquals(2, matrix.rowCount())
-    assertEquals(BigDecimal, matrix.type(2), "amount column type")
+    assertEquals(BigDecimal, matrix.type(2), 'amount column type')
     assertEquals(1234.56, (matrix.row(0)[2] as BigDecimal).doubleValue(), 0.01)
   }
 
@@ -710,9 +710,9 @@ Bob,100'''
 
     Matrix matrix = CsvReader.read().fromString(csvContent)
 
-    assertEquals(String, matrix.type(0), "id should remain String")
-    assertEquals(String, matrix.type(1), "name should remain String")
-    assertEquals(String, matrix.type(2), "amount should remain String")
+    assertEquals(String, matrix.type(0), 'id should remain String')
+    assertEquals(String, matrix.type(1), 'name should remain String')
+    assertEquals(String, matrix.type(2), 'amount should remain String')
   }
 
   @Test

--- a/matrix-csv/src/test/groovy/CsvImportTest.groovy
+++ b/matrix-csv/src/test/groovy/CsvImportTest.groovy
@@ -13,27 +13,27 @@ class CsvImportTest {
 
   @Test
   void importCsv() {
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
     CSVFormat format = CSVFormat.Builder.create().setTrim(true).build()
     Matrix basic = CsvImporter.importCsv(url, format)
-    assertEquals(4, basic.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], basic.columnNames(), "Column names")
-    assertEquals(['4', 'Arne', '2023-07-01', '222.99'], basic.row(3), "last row")
+    assertEquals(4, basic.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], basic.columnNames(), 'Column names')
+    assertEquals(['4', 'Arne', '2023-07-01', '222.99'], basic.row(3), 'last row')
 
     Matrix b = CsvImporter.importCsv((CsvImporter.Format.Trim): true, url)
-    assertEquals(4, b.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], b.columnNames(), "Column names")
-    assertEquals(['4', 'Arne', '2023-07-01', '222.99'], b.row(3), "last row")
+    assertEquals(4, b.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], b.columnNames(), 'Column names')
+    assertEquals(['4', 'Arne', '2023-07-01', '222.99'], b.row(3), 'last row')
 
     Matrix b2 = CsvImporter.importCsv(Trim: true, url)
-    assertEquals(4, b2.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], b2.columnNames(), "Column names")
-    assertEquals(['4', 'Arne', '2023-07-01', '222.99'], b2.row(3), "last row")
+    assertEquals(4, b2.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], b2.columnNames(), 'Column names')
+    assertEquals(['4', 'Arne', '2023-07-01', '222.99'], b2.row(3), 'last row')
   }
 
   @Test
   void csvWithSemiColonsQuoteAndEmptyLine() {
-    URL url = getClass().getResource("/colonQuotesEmptyLine.csv")
+    URL url = getClass().getResource('/colonQuotesEmptyLine.csv')
     CSVFormat format = CSVFormat.Builder.create()
         .setTrim(true)
         .setDelimiter(';')
@@ -42,9 +42,9 @@ class CsvImportTest {
         .setHeader('id', 'name', 'date', 'amount')
         .get()
     Matrix matrix = CsvImporter.importCsv(url, format)
-    assertEquals(4, matrix.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), "Column names")
-    assertEquals(['4', 'Arne', '2023-Jul-01', '222,99'], matrix.row(3), "last row")
+    assertEquals(4, matrix.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), 'Column names')
+    assertEquals(['4', 'Arne', '2023-Jul-01', '222,99'], matrix.row(3), 'last row')
 
     Matrix m = CsvImporter.importCsv(
         (CsvImporter.Format.Trim): true,
@@ -54,8 +54,8 @@ class CsvImportTest {
         (CsvImporter.Format.Header): ['id', 'name', 'date', 'amount'],
         url)
     assertEquals(4, m.rowCount(), "Number of rows \\n ${m.content()}")
-    assertEquals(['id', 'name', 'date', 'amount'], m.columnNames(), "Column names")
-    assertEquals(['4', 'Arne', '2023-Jul-01', '222,99'], m.row(3), "last row")
+    assertEquals(['id', 'name', 'date', 'amount'], m.columnNames(), 'Column names')
+    assertEquals(['4', 'Arne', '2023-Jul-01', '222,99'], m.row(3), 'last row')
 
     Matrix m2 = CsvImporter.importCsv(
         Trim: true,
@@ -65,51 +65,51 @@ class CsvImportTest {
         Header: ['id', 'name', 'date', 'amount'],
         url)
     assertEquals(4, m2.rowCount(), "Number of rows: \n ${m2.content()}")
-    assertEquals(['id', 'name', 'date', 'amount'], m2.columnNames(), "Column names")
-    assertEquals(['4', 'Arne', '2023-Jul-01', '222,99'], m2.row(3), "last row")
+    assertEquals(['id', 'name', 'date', 'amount'], m2.columnNames(), 'Column names')
+    assertEquals(['4', 'Arne', '2023-Jul-01', '222,99'], m2.row(3), 'last row')
 
     Matrix table = matrix.clone().convert(
-        ["id": Integer,
-         "name": String,
-         "date": LocalDate,
-         "amount": BigDecimal
+        ['id': Integer,
+         'name': String,
+         'date': LocalDate,
+         'amount': BigDecimal
         ],
-        "yyyy-MMM-dd",
+        'yyyy-MMM-dd',
         NumberFormat.getInstance(Locale.GERMANY)
     )
-    assertEquals(4, table.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], table.columnNames(), "Column names")
-    assertEquals([4, 'Arne', LocalDate.parse('2023-07-01'), 222.99], table.row(3), "last row")
+    assertEquals(4, table.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], table.columnNames(), 'Column names')
+    assertEquals([4, 'Arne', LocalDate.parse('2023-07-01'), 222.99], table.row(3), 'last row')
   }
 
   // Phase 2a: Critical Edge Cases
 
   @Test
   void testEmptyCsv() {
-    URL url = getClass().getResource("/empty.csv")
+    URL url = getClass().getResource('/empty.csv')
     Matrix matrix = CsvImporter.importCsv(url)
-    assertNotNull(matrix, "Matrix should not be null")
-    assertEquals(0, matrix.rowCount(), "Empty CSV should have 0 rows")
-    assertEquals(0, matrix.columnCount(), "Empty CSV should have 0 columns")
+    assertNotNull(matrix, 'Matrix should not be null')
+    assertEquals(0, matrix.rowCount(), 'Empty CSV should have 0 rows')
+    assertEquals(0, matrix.columnCount(), 'Empty CSV should have 0 columns')
   }
 
   @Test
   void testHeaderOnlyCsv() {
-    URL url = getClass().getResource("/headerOnly.csv")
+    URL url = getClass().getResource('/headerOnly.csv')
     Matrix matrix = CsvImporter.importCsv(url)
-    assertNotNull(matrix, "Matrix should not be null")
-    assertEquals(0, matrix.rowCount(), "Header-only CSV should have 0 data rows")
-    assertEquals(3, matrix.columnCount(), "Should have 3 columns")
-    assertEquals(['id', 'name', 'amount'], matrix.columnNames(), "Column names should be parsed from header")
+    assertNotNull(matrix, 'Matrix should not be null')
+    assertEquals(0, matrix.rowCount(), 'Header-only CSV should have 0 data rows')
+    assertEquals(3, matrix.columnCount(), 'Should have 3 columns')
+    assertEquals(['id', 'name', 'amount'], matrix.columnNames(), 'Column names should be parsed from header')
   }
 
   @Test
   void testSingleColumnCsv() {
-    URL url = getClass().getResource("/singleColumn.csv")
+    URL url = getClass().getResource('/singleColumn.csv')
     Matrix matrix = CsvImporter.importCsv(url)
-    assertNotNull(matrix, "Matrix should not be null")
-    assertEquals(4, matrix.rowCount(), "Should have 4 data rows")
-    assertEquals(1, matrix.columnCount(), "Should have 1 column")
+    assertNotNull(matrix, 'Matrix should not be null')
+    assertEquals(4, matrix.rowCount(), 'Should have 4 data rows')
+    assertEquals(1, matrix.columnCount(), 'Should have 1 column')
     assertEquals(['value'], matrix.columnNames(), "Column name should be 'value'")
     assertEquals(['10'], matrix.row(0), "First row should be ['10']")
     assertEquals(['40'], matrix.row(3), "Last row should be ['40']")
@@ -117,104 +117,104 @@ class CsvImportTest {
 
   @Test
   void testSingleRowCsv() {
-    URL url = getClass().getResource("/singleRow.csv")
+    URL url = getClass().getResource('/singleRow.csv')
     Matrix matrix = CsvImporter.importCsv(url)
-    assertNotNull(matrix, "Matrix should not be null")
-    assertEquals(1, matrix.rowCount(), "Should have 1 data row")
-    assertEquals(3, matrix.columnCount(), "Should have 3 columns")
-    assertEquals(['id', 'name', 'amount'], matrix.columnNames(), "Column names")
-    assertEquals(['1', 'John', '100.50'], matrix.row(0), "Single row data")
+    assertNotNull(matrix, 'Matrix should not be null')
+    assertEquals(1, matrix.rowCount(), 'Should have 1 data row')
+    assertEquals(3, matrix.columnCount(), 'Should have 3 columns')
+    assertEquals(['id', 'name', 'amount'], matrix.columnNames(), 'Column names')
+    assertEquals(['1', 'John', '100.50'], matrix.row(0), 'Single row data')
   }
 
   @Test
   void testMismatchedColumns() {
-    URL url = getClass().getResource("/mismatchedColumns.csv")
+    URL url = getClass().getResource('/mismatchedColumns.csv')
     IllegalArgumentException ex = assertThrows(IllegalArgumentException) {
       CsvImporter.importCsv(url)
     }
-    assertTrue(ex.message.contains("expected"), "Error message should mention expected column count")
+    assertTrue(ex.message.contains('expected'), 'Error message should mention expected column count')
   }
 
   @Test
   void testFirstRowAsHeaderFalse() {
     // Use basic.csv which has multiple rows
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
     // Use trim but don't configure header in CSVFormat, let the firstRowAsHeader parameter handle it
     CSVFormat format = CSVFormat.Builder.create()
         .setTrim(true)
         .build()
     Matrix matrix = CsvImporter.importCsv(url, format, false)
-    assertNotNull(matrix, "Matrix should not be null")
-    assertEquals(5, matrix.rowCount(), "Should have 5 rows (all rows as data)")
-    assertEquals(4, matrix.columnCount(), "Should have 4 columns")
-    assertEquals(['c0', 'c1', 'c2', 'c3'], matrix.columnNames(), "Auto-generated column names")
-    assertEquals(['id', 'name', 'date', 'amount'], matrix.row(0), "First row is original header")
+    assertNotNull(matrix, 'Matrix should not be null')
+    assertEquals(5, matrix.rowCount(), 'Should have 5 rows (all rows as data)')
+    assertEquals(4, matrix.columnCount(), 'Should have 4 columns')
+    assertEquals(['c0', 'c1', 'c2', 'c3'], matrix.columnNames(), 'Auto-generated column names')
+    assertEquals(['id', 'name', 'date', 'amount'], matrix.row(0), 'First row is original header')
   }
 
   @Test
   void testInvalidFormatOptions() {
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
 
     // Trim must be Boolean
     IllegalArgumentException ex1 = assertThrows(IllegalArgumentException) {
-      CsvImporter.importCsv((CsvImporter.Format.Trim): "invalid", url)
+      CsvImporter.importCsv((CsvImporter.Format.Trim): 'invalid', url)
     }
-    assertTrue(ex1.message.contains("Boolean"), "Error should mention Boolean type")
+    assertTrue(ex1.message.contains('Boolean'), 'Error should mention Boolean type')
 
     // Delimiter must be String or Character
     IllegalArgumentException ex2 = assertThrows(IllegalArgumentException) {
       CsvImporter.importCsv((CsvImporter.Format.Delimiter): 123, url)
     }
-    assertTrue(ex2.message.contains("Character"), "Error should mention Character type")
+    assertTrue(ex2.message.contains('Character'), 'Error should mention Character type')
   }
 
   @Test
   void testCommentMarkerFormat() {
     // Create CSV content with comments
-    String csvContent = """# This is a comment
+    String csvContent = '''# This is a comment
 id,name,amount
 1,John,100.50
 # Another comment
-2,Jane,200.75"""
+2,Jane,200.75'''
 
     Reader reader = new StringReader(csvContent)
     Matrix matrix = CsvImporter.importCsv(
         (CsvImporter.Format.CommentMarker): '#',
         reader)
 
-    assertEquals(2, matrix.rowCount(), "Should have 2 data rows (comments ignored)")
+    assertEquals(2, matrix.rowCount(), 'Should have 2 data rows (comments ignored)')
     assertEquals(['id', 'name', 'amount'], matrix.columnNames())
-    assertEquals(['2', 'Jane', '200.75'], matrix.row(1), "Last data row")
+    assertEquals(['2', 'Jane', '200.75'], matrix.row(1), 'Last data row')
   }
 
   @Test
   void testNullStringFormat() {
-    String csvContent = """id,name,amount
+    String csvContent = '''id,name,amount
 1,John,100.50
 2,NULL,200.75
-3,Jane,NULL"""
+3,Jane,NULL'''
 
     Reader reader = new StringReader(csvContent)
     Matrix matrix = CsvImporter.importCsv(
         (CsvImporter.Format.NullString): 'NULL',
         reader)
 
-    assertEquals(3, matrix.rowCount(), "Should have 3 rows")
-    assertNull(matrix.row(1)[1], "NULL string should be converted to null")
-    assertNull(matrix.row(2)[2], "NULL string should be converted to null")
+    assertEquals(3, matrix.rowCount(), 'Should have 3 rows')
+    assertNull(matrix.row(1)[1], 'NULL string should be converted to null')
+    assertNull(matrix.row(2)[2], 'NULL string should be converted to null')
   }
 
   @Test
   void testCustomRecordSeparator() {
     // CSV with custom record separator (using actual newlines in the content)
-    String csvContent = "id,name,amount\r\n1,John,100.50\r\n2,Jane,200.75"
+    String csvContent = 'id,name,amount\r\n1,John,100.50\r\n2,Jane,200.75'
 
     Reader reader = new StringReader(csvContent)
     Matrix matrix = CsvImporter.importCsv(
         (CsvImporter.Format.RecordSeparator): '\r\n',
         reader)
 
-    assertEquals(2, matrix.rowCount(), "Should have 2 data rows")
+    assertEquals(2, matrix.rowCount(), 'Should have 2 data rows')
     assertEquals(['1', 'John', '100.50'], matrix.row(0))
     assertEquals(['2', 'Jane', '200.75'], matrix.row(1))
   }
@@ -224,32 +224,32 @@ id,name,amount
   @Test
   void testImportCsvFromStringPath() {
     // Test the convenience method that takes a String file path
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
     File file = new File(url.toURI())
 
     Matrix matrix = CsvImporter.importCsvFromFile(file.absolutePath)
-    assertNotNull(matrix, "Matrix should not be null")
-    assertEquals(4, matrix.rowCount(), "Should have 4 data rows")
-    assertEquals(4, matrix.columnCount(), "Should have 4 columns")
+    assertNotNull(matrix, 'Matrix should not be null')
+    assertEquals(4, matrix.rowCount(), 'Should have 4 data rows')
+    assertEquals(4, matrix.columnCount(), 'Should have 4 columns')
     // Note: basic.csv has spaces after commas, default CSVFormat doesn't trim
-    assertEquals(['id', ' name', ' date', ' amount'], matrix.columnNames(), "Column names with spaces")
-    assertEquals(['1', ' Per', ' 2023-04-30', ' 234.12'], matrix.row(0), "First row")
+    assertEquals(['id', ' name', ' date', ' amount'], matrix.columnNames(), 'Column names with spaces')
+    assertEquals(['1', ' Per', ' 2023-04-30', ' 234.12'], matrix.row(0), 'First row')
   }
 
   // String Content Support Tests
 
   @Test
   void testImportCsvString() {
-    String csvContent = """id,name,amount
+    String csvContent = '''id,name,amount
 1,Alice,100.50
 2,Bob,200.75
-3,Charlie,300.00"""
+3,Charlie,300.00'''
 
     Matrix matrix = CsvImporter.importCsvString(csvContent)
 
-    assertNotNull(matrix, "Matrix should not be null")
-    assertEquals(3, matrix.rowCount(), "Should have 3 data rows")
-    assertEquals(3, matrix.columnCount(), "Should have 3 columns")
+    assertNotNull(matrix, 'Matrix should not be null')
+    assertEquals(3, matrix.rowCount(), 'Should have 3 data rows')
+    assertEquals(3, matrix.columnCount(), 'Should have 3 columns')
     assertEquals(['id', 'name', 'amount'], matrix.columnNames())
     assertEquals(['1', 'Alice', '100.50'], matrix.row(0))
     assertEquals(['2', 'Bob', '200.75'], matrix.row(1))
@@ -258,9 +258,9 @@ id,name,amount
 
   @Test
   void testImportCsvStringWithCustomFormat() {
-    String csvContent = """id;name;amount
+    String csvContent = '''id;name;amount
 1;Alice;100.50
-2;Bob;200.75"""
+2;Bob;200.75'''
 
     CSVFormat format = CSVFormat.Builder.create()
         .setDelimiter(';')
@@ -269,16 +269,16 @@ id,name,amount
 
     Matrix matrix = CsvImporter.importCsvString(csvContent, format)
 
-    assertEquals(2, matrix.rowCount(), "Should have 2 data rows")
-    assertEquals(3, matrix.columnCount(), "Should have 3 columns")
+    assertEquals(2, matrix.rowCount(), 'Should have 2 data rows')
+    assertEquals(3, matrix.columnCount(), 'Should have 3 columns')
     assertEquals(['id', 'name', 'amount'], matrix.columnNames())
     assertEquals(['1', 'Alice', '100.50'], matrix.row(0))
   }
 
   @Test
   void testImportCsvStringWithoutHeader() {
-    String csvContent = """1,Alice,100.50
-2,Bob,200.75"""
+    String csvContent = '''1,Alice,100.50
+2,Bob,200.75'''
 
     CSVFormat format = CSVFormat.Builder.create()
         .setTrim(true)
@@ -286,9 +286,9 @@ id,name,amount
 
     Matrix matrix = CsvImporter.importCsvString(csvContent, format, false)
 
-    assertEquals(2, matrix.rowCount(), "Should have 2 data rows")
-    assertEquals(3, matrix.columnCount(), "Should have 3 columns")
-    assertEquals(['c0', 'c1', 'c2'], matrix.columnNames(), "Auto-generated column names")
+    assertEquals(2, matrix.rowCount(), 'Should have 2 data rows')
+    assertEquals(3, matrix.columnCount(), 'Should have 3 columns')
+    assertEquals(['c0', 'c1', 'c2'], matrix.columnNames(), 'Auto-generated column names')
     assertEquals(['1', 'Alice', '100.50'], matrix.row(0))
   }
 }

--- a/matrix-csv/src/test/groovy/CsvReaderTest.groovy
+++ b/matrix-csv/src/test/groovy/CsvReaderTest.groovy
@@ -13,41 +13,41 @@ class CsvReaderTest {
 
   @Test
   void readCsvFromFile() {
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
     File file = new File(url.toURI())
     CSVFormat format = CSVFormat.Builder.create().setTrim(true).build()
 
     Matrix basic = CsvReader.read(file, format)
-    assertEquals(4, basic.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], basic.columnNames(), "Column names")
-    assertEquals(['4', 'Arne', '2023-07-01', '222.99'], basic.row(3), "last row")
+    assertEquals(4, basic.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], basic.columnNames(), 'Column names')
+    assertEquals(['4', 'Arne', '2023-07-01', '222.99'], basic.row(3), 'last row')
   }
 
   @Test
   void readCsvFromUrl() {
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
     CSVFormat format = CSVFormat.Builder.create().setTrim(true).build()
 
     Matrix basic = CsvReader.read(url, format)
-    assertEquals(4, basic.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], basic.columnNames(), "Column names")
-    assertEquals(['4', 'Arne', '2023-07-01', '222.99'], basic.row(3), "last row")
+    assertEquals(4, basic.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], basic.columnNames(), 'Column names')
+    assertEquals(['4', 'Arne', '2023-07-01', '222.99'], basic.row(3), 'last row')
   }
 
   @Test
   void readCsvWithMapFormat() {
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
 
     Matrix b = CsvReader.read((CsvOption.Trim): true, url)
-    assertEquals(4, b.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], b.columnNames(), "Column names")
-    assertEquals(['4', 'Arne', '2023-07-01', '222.99'], b.row(3), "last row")
+    assertEquals(4, b.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], b.columnNames(), 'Column names')
+    assertEquals(['4', 'Arne', '2023-07-01', '222.99'], b.row(3), 'last row')
 
     // Test beautiful named arguments syntax
     Matrix b2 = CsvReader.read(Trim: true, url)
-    assertEquals(4, b2.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], b2.columnNames(), "Column names")
-    assertEquals(['4', 'Arne', '2023-07-01', '222.99'], b2.row(3), "last row")
+    assertEquals(4, b2.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], b2.columnNames(), 'Column names')
+    assertEquals(['4', 'Arne', '2023-07-01', '222.99'], b2.row(3), 'last row')
   }
 
   @Test
@@ -59,10 +59,10 @@ class CsvReaderTest {
 
     Matrix matrix = CsvReader.readString(csvContent)
 
-    assertEquals(3, matrix.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), "Column names")
-    assertEquals(['1', 'Alice', '2023-01-01', '100.00'], matrix.row(0), "first row")
-    assertEquals(['3', 'Charlie', '2023-01-03', '150.50'], matrix.row(2), "last row")
+    assertEquals(3, matrix.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), 'Column names')
+    assertEquals(['1', 'Alice', '2023-01-01', '100.00'], matrix.row(0), 'first row')
+    assertEquals(['3', 'Charlie', '2023-01-03', '150.50'], matrix.row(2), 'last row')
   }
 
   @Test
@@ -78,9 +78,9 @@ class CsvReaderTest {
 
     Matrix matrix = CsvReader.readString(csvContent, format)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), "Column names")
-    assertEquals(['2', 'Bob', '2023-01-02', '200,00'], matrix.row(1), "last row")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), 'Column names')
+    assertEquals(['2', 'Bob', '2023-01-02', '200,00'], matrix.row(1), 'last row')
   }
 
   @Test
@@ -90,32 +90,32 @@ class CsvReaderTest {
 
     Matrix matrix = CsvReader.readString(csvContent, CSVFormat.DEFAULT, false)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertEquals(['c0', 'c1', 'c2'], matrix.columnNames(), "Auto-generated column names")
-    assertEquals(['1', 'Alice', '100.00'], matrix.row(0), "first row")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertEquals(['c0', 'c1', 'c2'], matrix.columnNames(), 'Auto-generated column names')
+    assertEquals(['1', 'Alice', '100.00'], matrix.row(0), 'first row')
   }
 
   @Test
   void readFileFromStringPath() {
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
     File file = new File(url.toURI())
     String filePath = file.absolutePath
 
     Matrix matrix = CsvReader.readFile(filePath, CSVFormat.Builder.create().setTrim(true).build())
 
-    assertEquals(4, matrix.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), "Column names")
+    assertEquals(4, matrix.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), 'Column names')
   }
 
   @Test
   void readUrlFromString() {
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
     String urlString = url.toExternalForm()
 
     Matrix matrix = CsvReader.readUrl(urlString, CSVFormat.Builder.create().setTrim(true).build())
 
-    assertEquals(4, matrix.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), "Column names")
+    assertEquals(4, matrix.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), 'Column names')
   }
 
   @Test
@@ -127,9 +127,9 @@ Bob,25'''
     StringReader reader = new StringReader(csvContent)
     Matrix matrix = CsvReader.read(reader)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertEquals(['name', 'age'], matrix.columnNames(), "Column names")
-    assertEquals(['Alice', '30'], matrix.row(0), "first row")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertEquals(['name', 'age'], matrix.columnNames(), 'Column names')
+    assertEquals(['Alice', '30'], matrix.row(0), 'first row')
   }
 
   @Test
@@ -141,20 +141,20 @@ Bob,25'''
     InputStream is = new ByteArrayInputStream(csvContent.bytes)
     Matrix matrix = CsvReader.read(is)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertEquals(['name', 'age'], matrix.columnNames(), "Column names")
-    assertEquals(['Bob', '25'], matrix.row(1), "last row")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertEquals(['name', 'age'], matrix.columnNames(), 'Column names')
+    assertEquals(['Bob', '25'], matrix.row(1), 'last row')
   }
 
   @Test
   void readFromPath() {
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
     File file = new File(url.toURI())
 
     Matrix matrix = CsvReader.read(file.toPath(), CSVFormat.Builder.create().setTrim(true).build())
 
-    assertEquals(4, matrix.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), "Column names")
+    assertEquals(4, matrix.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], matrix.columnNames(), 'Column names')
   }
 
   @Test
@@ -163,9 +163,9 @@ Bob,25'''
 
     Matrix matrix = CsvReader.readString(csvContent)
 
-    assertNotNull(matrix, "Matrix should not be null")
-    assertEquals(0, matrix.rowCount(), "Empty CSV should have 0 rows")
-    assertEquals(0, matrix.columnCount(), "Empty CSV should have 0 columns")
+    assertNotNull(matrix, 'Matrix should not be null')
+    assertEquals(0, matrix.rowCount(), 'Empty CSV should have 0 rows')
+    assertEquals(0, matrix.columnCount(), 'Empty CSV should have 0 columns')
   }
 
   @Test
@@ -174,10 +174,10 @@ Bob,25'''
 
     Matrix matrix = CsvReader.readString(csvContent)
 
-    assertNotNull(matrix, "Matrix should not be null")
-    assertEquals(0, matrix.rowCount(), "Header-only CSV should have 0 data rows")
-    assertEquals(3, matrix.columnCount(), "Should have 3 columns")
-    assertEquals(['id', 'name', 'amount'], matrix.columnNames(), "Column names")
+    assertNotNull(matrix, 'Matrix should not be null')
+    assertEquals(0, matrix.rowCount(), 'Header-only CSV should have 0 data rows')
+    assertEquals(3, matrix.columnCount(), 'Should have 3 columns')
+    assertEquals(['id', 'name', 'amount'], matrix.columnNames(), 'Column names')
   }
 
   @Test
@@ -187,9 +187,9 @@ Alice,95'''
 
     Matrix matrix = CsvReader.readString(csvContent)
 
-    assertEquals(1, matrix.rowCount(), "Should have 1 row")
-    assertEquals(['name', 'score'], matrix.columnNames(), "Column names")
-    assertEquals(['Alice', '95'], matrix.row(0), "Single row content")
+    assertEquals(1, matrix.rowCount(), 'Should have 1 row')
+    assertEquals(['name', 'score'], matrix.columnNames(), 'Column names')
+    assertEquals(['Alice', '95'], matrix.row(0), 'Single row content')
   }
 
   @Test
@@ -200,14 +200,14 @@ Alice,95'''
 
     Matrix matrix = CsvReader.readString(csvContent)
 
-    assertEquals(2, matrix.rowCount(), "Number of rows")
-    assertEquals(['Alice', 'Works at "Tech Corp"', '100'], matrix.row(0), "Quoted values handled correctly")
-    assertEquals(['Bob', 'Said: "Hello, World!"', '200'], matrix.row(1), "Escaped quotes handled correctly")
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
+    assertEquals(['Alice', 'Works at "Tech Corp"', '100'], matrix.row(0), 'Quoted values handled correctly')
+    assertEquals(['Bob', 'Said: "Hello, World!"', '200'], matrix.row(1), 'Escaped quotes handled correctly')
   }
 
   @Test
   void readCsvWithMapFormatAndComplexOptions() {
-    URL url = getClass().getResource("/colonQuotesEmptyLine.csv")
+    URL url = getClass().getResource('/colonQuotesEmptyLine.csv')
 
     Matrix m = CsvReader.read(
         Trim: true,
@@ -217,9 +217,9 @@ Alice,95'''
         Header: ['id', 'name', 'date', 'amount'],
         url)
 
-    assertEquals(4, m.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'date', 'amount'], m.columnNames(), "Column names")
-    assertEquals(['4', 'Arne', '2023-Jul-01', '222,99'], m.row(3), "last row")
+    assertEquals(4, m.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'date', 'amount'], m.columnNames(), 'Column names')
+    assertEquals(['4', 'Arne', '2023-Jul-01', '222,99'], m.row(3), 'last row')
   }
 
   @Test
@@ -231,24 +231,24 @@ Alice,95'''
     InputStream is = new ByteArrayInputStream(csvContent.bytes)
     Matrix matrix = CsvReader.read(is, CSVFormat.DEFAULT, true, java.nio.charset.StandardCharsets.UTF_8, 'TestMatrix')
 
-    assertEquals('TestMatrix', matrix.matrixName, "Matrix name should be set")
-    assertEquals(2, matrix.rowCount(), "Number of rows")
+    assertEquals('TestMatrix', matrix.matrixName, 'Matrix name should be set')
+    assertEquals(2, matrix.rowCount(), 'Number of rows')
   }
 
   @Test
   void readWithTypesOption() {
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
 
     Matrix m = CsvReader.read(
         types: [Integer, String, LocalDate, BigDecimal],
         dateTimeFormat: 'yyyy-MM-dd',
         url)
 
-    assertEquals(4, m.rowCount(), "Number of rows")
-    assertEquals(Integer, m.type(0), "id column type")
-    assertEquals(String, m.type(1), "name column type")
-    assertEquals(LocalDate, m.type(2), "date column type")
-    assertEquals(BigDecimal, m.type(3), "amount column type")
+    assertEquals(4, m.rowCount(), 'Number of rows')
+    assertEquals(Integer, m.type(0), 'id column type')
+    assertEquals(String, m.type(1), 'name column type')
+    assertEquals(LocalDate, m.type(2), 'date column type')
+    assertEquals(BigDecimal, m.type(3), 'amount column type')
     assertEquals(4, m.row(3)[0])
     assertEquals(LocalDate.of(2023, 7, 1), m.row(3)[2])
     assertEquals(222.99, m.row(3)[3])
@@ -256,14 +256,14 @@ Alice,95'''
 
   @Test
   void readWithCaseInsensitiveKeys() {
-    URL url = getClass().getResource("/basic.csv")
+    URL url = getClass().getResource('/basic.csv')
 
     // camelCase keys
     Matrix m1 = CsvReader.read(trim: true, url)
-    assertEquals(4, m1.rowCount(), "camelCase keys should work")
+    assertEquals(4, m1.rowCount(), 'camelCase keys should work')
 
     // PascalCase keys
     Matrix m2 = CsvReader.read(Trim: true, url)
-    assertEquals(4, m2.rowCount(), "PascalCase keys should work")
+    assertEquals(4, m2.rowCount(), 'PascalCase keys should work')
   }
 }

--- a/matrix-csv/src/test/groovy/CsvTypedOptionsTest.groovy
+++ b/matrix-csv/src/test/groovy/CsvTypedOptionsTest.groovy
@@ -14,7 +14,6 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.text.NumberFormat
-import java.util.Locale
 
 class CsvTypedOptionsTest {
 

--- a/matrix-csv/src/test/groovy/CsvWriterTest.groovy
+++ b/matrix-csv/src/test/groovy/CsvWriterTest.groovy
@@ -29,13 +29,13 @@ class CsvWriterTest {
     File outputFile = tempDir.resolve('output.csv').toFile()
     CsvWriter.write(matrix, outputFile)
 
-    assertTrue(outputFile.exists(), "Output file should exist")
+    assertTrue(outputFile.exists(), 'Output file should exist')
 
     // Read it back and verify
     Matrix result = CsvReader.read(outputFile)
-    assertEquals(2, result.rowCount(), "Number of rows")
-    assertEquals(['id', 'name', 'amount'], result.columnNames(), "Column names")
-    assertEquals(['2', 'Bob', '200.00'], result.row(1), "Last row")
+    assertEquals(2, result.rowCount(), 'Number of rows')
+    assertEquals(['id', 'name', 'amount'], result.columnNames(), 'Column names')
+    assertEquals(['2', 'Bob', '200.00'], result.row(1), 'Last row')
   }
 
   @Test
@@ -48,10 +48,10 @@ class CsvWriterTest {
     Path outputPath = tempDir.resolve('output2.csv')
     CsvWriter.write(matrix, outputPath)
 
-    assertTrue(outputPath.toFile().exists(), "Output file should exist")
+    assertTrue(outputPath.toFile().exists(), 'Output file should exist')
 
     Matrix result = CsvReader.read(outputPath)
-    assertEquals(2, result.rowCount(), "Number of rows")
+    assertEquals(2, result.rowCount(), 'Number of rows')
   }
 
   @Test
@@ -64,7 +64,7 @@ class CsvWriterTest {
     String filePath = tempDir.resolve('output3.csv').toFile().path
     CsvWriter.write(matrix, filePath)
 
-    assertTrue(new File(filePath).exists(), "Output file should exist")
+    assertTrue(new File(filePath).exists(), 'Output file should exist')
   }
 
   @Test
@@ -80,16 +80,16 @@ class CsvWriterTest {
 
     String csvContent = CsvWriter.writeString(matrix)
 
-    assertNotNull(csvContent, "CSV content should not be null")
-    assertTrue(csvContent.contains('name,age'), "Should contain header")
-    assertTrue(csvContent.contains('Alice,30'), "Should contain first row")
-    assertTrue(csvContent.contains('Bob,25'), "Should contain second row")
-    assertTrue(csvContent.contains('Charlie,35'), "Should contain third row")
+    assertNotNull(csvContent, 'CSV content should not be null')
+    assertTrue(csvContent.contains('name,age'), 'Should contain header')
+    assertTrue(csvContent.contains('Alice,30'), 'Should contain first row')
+    assertTrue(csvContent.contains('Bob,25'), 'Should contain second row')
+    assertTrue(csvContent.contains('Charlie,35'), 'Should contain third row')
 
     // Verify by parsing it back
     Matrix result = CsvReader.readString(csvContent)
-    assertEquals(3, result.rowCount(), "Number of rows")
-    assertEquals(['name', 'age'], result.columnNames(), "Column names")
+    assertEquals(3, result.rowCount(), 'Number of rows')
+    assertEquals(['name', 'age'], result.columnNames(), 'Column names')
   }
 
   @Test
@@ -101,9 +101,9 @@ class CsvWriterTest {
 
     String csvContent = CsvWriter.writeString(matrix, CSVFormat.DEFAULT, false)
 
-    assertFalse(csvContent.contains('x,y'), "Should not contain header")
-    assertTrue(csvContent.contains('1,2'), "Should contain first row")
-    assertTrue(csvContent.contains('3,4'), "Should contain second row")
+    assertFalse(csvContent.contains('x,y'), 'Should not contain header')
+    assertTrue(csvContent.contains('1,2'), 'Should contain first row')
+    assertTrue(csvContent.contains('3,4'), 'Should contain second row')
   }
 
   @Test
@@ -116,12 +116,12 @@ class CsvWriterTest {
     File outputFile = tempDir.resolve('excel.csv').toFile()
     CsvWriter.writeExcelCsv(matrix, outputFile)
 
-    assertTrue(outputFile.exists(), "Excel CSV file should exist")
+    assertTrue(outputFile.exists(), 'Excel CSV file should exist')
 
     // Read it back
     Matrix result = CsvReader.read(outputFile, CSVFormat.EXCEL)
-    assertEquals(1, result.rowCount(), "Number of rows")
-    assertEquals(['name', 'value'], result.columnNames(), "Column names")
+    assertEquals(1, result.rowCount(), 'Number of rows')
+    assertEquals(['name', 'value'], result.columnNames(), 'Column names')
   }
 
   @Test
@@ -133,9 +133,9 @@ class CsvWriterTest {
 
     String csvContent = CsvWriter.writeExcelCsvString(matrix)
 
-    assertNotNull(csvContent, "Excel CSV string should not be null")
-    assertTrue(csvContent.contains('"a","b"'), "Should contain quoted header")
-    assertTrue(csvContent.contains('"1","2"'), "Should contain quoted data")
+    assertNotNull(csvContent, 'Excel CSV string should not be null')
+    assertTrue(csvContent.contains('"a","b"'), 'Should contain quoted header')
+    assertTrue(csvContent.contains('"1","2"'), 'Should contain quoted data')
   }
 
   @Test
@@ -151,12 +151,12 @@ class CsvWriterTest {
     File outputFile = tempDir.resolve('output.tsv').toFile()
     CsvWriter.writeTsv(matrix, outputFile)
 
-    assertTrue(outputFile.exists(), "TSV file should exist")
+    assertTrue(outputFile.exists(), 'TSV file should exist')
 
     // Read it back
     Matrix result = CsvReader.read(outputFile, CSVFormat.TDF)
-    assertEquals(2, result.rowCount(), "Number of rows")
-    assertEquals(['name', 'age', 'city'], result.columnNames(), "Column names")
+    assertEquals(2, result.rowCount(), 'Number of rows')
+    assertEquals(['name', 'age', 'city'], result.columnNames(), 'Column names')
   }
 
   @Test
@@ -168,9 +168,9 @@ class CsvWriterTest {
 
     String tsvContent = CsvWriter.writeTsvString(matrix)
 
-    assertNotNull(tsvContent, "TSV string should not be null")
-    assertTrue(tsvContent.contains("x\ty\tz"), "Should contain tab-separated header")
-    assertTrue(tsvContent.contains("1\t2\t3"), "Should contain tab-separated data")
+    assertNotNull(tsvContent, 'TSV string should not be null')
+    assertTrue(tsvContent.contains('x\ty\tz'), 'Should contain tab-separated header')
+    assertTrue(tsvContent.contains('1\t2\t3'), 'Should contain tab-separated data')
   }
 
   @Test
@@ -184,9 +184,9 @@ class CsvWriterTest {
     CsvWriter.write(matrix, writer)
 
     String csvContent = writer.buffer
-    assertTrue(csvContent.contains('col1,col2'), "Should contain header")
-    assertTrue(csvContent.contains('a,b'), "Should contain first row")
-    assertTrue(csvContent.contains('c,d'), "Should contain second row")
+    assertTrue(csvContent.contains('col1,col2'), 'Should contain header')
+    assertTrue(csvContent.contains('a,b'), 'Should contain first row')
+    assertTrue(csvContent.contains('c,d'), 'Should contain second row')
   }
 
   @Test
@@ -202,8 +202,8 @@ class CsvWriterTest {
 
     String csvContent = CsvWriter.writeString(matrix, format)
 
-    assertTrue(csvContent.contains('name;value'), "Should use semicolon delimiter")
-    assertTrue(csvContent.contains('Alice;100'), "Data should use semicolon delimiter")
+    assertTrue(csvContent.contains('name;value'), 'Should use semicolon delimiter')
+    assertTrue(csvContent.contains('Alice;100'), 'Data should use semicolon delimiter')
   }
 
   @Test
@@ -218,10 +218,10 @@ class CsvWriterTest {
     CsvWriter.write(matrix, directory)
 
     File expectedFile = new File(directory, 'TestMatrix.csv')
-    assertTrue(expectedFile.exists(), "File should be created in directory with matrix name")
+    assertTrue(expectedFile.exists(), 'File should be created in directory with matrix name')
 
     Matrix result = CsvReader.read(expectedFile)
-    assertEquals(1, result.rowCount(), "Number of rows")
+    assertEquals(1, result.rowCount(), 'Number of rows')
   }
 
   @Test
@@ -232,8 +232,8 @@ class CsvWriterTest {
 
     String csvContent = CsvWriter.writeString(matrix)
 
-    assertTrue(csvContent.contains('a,b,c'), "Should contain header even for empty matrix")
-    assertFalse(csvContent.contains('null'), "Should not contain null values")
+    assertTrue(csvContent.contains('a,b,c'), 'Should contain header even for empty matrix')
+    assertFalse(csvContent.contains('null'), 'Should not contain null values')
   }
 
   @Test
@@ -267,8 +267,8 @@ class CsvWriterTest {
     // Read it back
     Matrix result = CsvReader.readString(csvContent)
 
-    assertEquals(original.rowCount(), result.rowCount(), "Row count should match")
-    assertEquals(original.columnNames(), result.columnNames(), "Column names should match")
+    assertEquals(original.rowCount(), result.rowCount(), 'Row count should match')
+    assertEquals(original.columnNames(), result.columnNames(), 'Column names should match')
     for (int i = 0; i < original.rowCount(); i++) {
       assertEquals(original.row(i).toList(), result.row(i).toList(), "Row $i should match")
     }

--- a/req/codenarc-consolidation-2.md
+++ b/req/codenarc-consolidation-2.md
@@ -201,7 +201,7 @@
 - `matrix-csv/build.gradle` (remove the `codenarcTest { ignoreFailures = true }` block near line 49)
 - `matrix-csv/src/test/groovy/` (7 test files + 1 internal)
 
-- [ ] **3.1 Audit violations from the XML report**
+- [x] **3.1 Audit violations from the XML report**
 
   ```bash
   ./gradlew :matrix-csv:codenarcTest
@@ -216,26 +216,34 @@
   "
   ```
 
-- [ ] **3.2 Fix UnnecessaryGString violations (320)**
+- [x] **3.2 Fix UnnecessaryGString violations (320)**
 
   Replace uninterpolated `"string"` → `'string'` in all test files.
 
-- [ ] **3.3 Fix UnnecessaryCallForLastElement violations (4)**
+- [x] **3.3 Fix UnnecessaryCallForLastElement violations (4)**
 
   Replace `list[list.size() - 1]` with `list.last()`.
 
-- [ ] **3.4 Fix UnnecessaryGroovyImport violation (1)**
+- [x] **3.4 Fix UnnecessaryGroovyImport violation (1)**
 
   Remove the explicit import of a `java.lang.*` or `groovy.lang.*` class (e.g., `import java.lang.String`).
 
-- [ ] **3.5 Remove the codenarcTest override**
+- [x] **3.5 Remove the codenarcTest override**
 
   In `matrix-csv/build.gradle`, delete the `codenarcTest { ignoreFailures = true }` block (near line 49).
 
-- [ ] **3.6 Verify**
+- [x] **3.6 Verify**
 
   ```bash
   ./gradlew :matrix-csv:codenarcTest
+  ./gradlew :matrix-csv:test
+  ```
+
+  Completed verification:
+  ```bash
+  ./gradlew :matrix-csv:codenarcTest
+  ./gradlew :matrix-csv:codenarcMain
+  ./gradlew :matrix-csv:spotlessCheck
   ./gradlew :matrix-csv:test
   ```
 


### PR DESCRIPTION
## Summary
- Remove the `matrix-csv` `codenarcTest` `ignoreFailures` override.
- Fix all reported CSV test CodeNarc violations: `UnnecessaryGString`, `UnnecessaryCallForLastElement`, and `UnnecessaryGroovyImport`.
- Mark task 3 verification complete in `req/codenarc-consolidation-2.md`.

## Modules touched
- `matrix-csv`

## Validation
- `./gradlew :matrix-csv:codenarcTest`
- `./gradlew :matrix-csv:codenarcMain`
- `./gradlew :matrix-csv:spotlessCheck`
- `./gradlew :matrix-csv:test` (`136 tests, 136 passed`)
- `git diff --check`