### PR TITLE
[codex] Fix CodeNarc violations in matrix-stats

### DIFF
--- a/matrix-stats/build.gradle
+++ b/matrix-stats/build.gradle
@@ -13,11 +13,6 @@ group = 'se.alipsa.matrix'
 version = '2.4.1-SNAPSHOT'
 description = "Statistical hypothesis tests based on Matrix data."
 
-codenarc {
-  // TODO: Fix ~1000 CodeNarc violations and remove this override
-  ignoreFailures = true
-}
-
 ext.nexusUrl = version.contains("SNAPSHOT")
     ? "https://oss.sonatype.org/content/repositories/snapshots/"
     : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Correlation.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Correlation.groovy
@@ -60,9 +60,9 @@ package se.alipsa.matrix.stats
 @SuppressWarnings('DuplicateNumberLiteral')
 class Correlation {
 
-  static final String PEARSON = "pearson"
-  static final String SPEARMAN = "spearman"
-  static final String KENDALL = "kendall"
+  static final String PEARSON = 'pearson'
+  static final String SPEARMAN = 'spearman'
+  static final String KENDALL = 'kendall'
 
   static BigDecimal cor(List<? extends Number> valuesX, List<? extends Number> valuesY, String method = PEARSON) {
     if (method == PEARSON) {
@@ -87,7 +87,7 @@ class Correlation {
    * @throws IllegalArgumentException if inputs are null, empty, of different sizes, or have insufficient observations
    */
   static BigDecimal corPearson(List<? extends Number> numbersX, List<? extends Number> numbersY) {
-    validateCorrelationInputs(numbersX, numbersY, "Pearson correlation")
+    validateCorrelationInputs(numbersX, numbersY, 'Pearson correlation')
 
     BigDecimal sumX = 0
     BigDecimal sumY = 0
@@ -128,7 +128,7 @@ class Correlation {
    * @throws IllegalArgumentException if inputs are null, empty, of different sizes, or have insufficient observations
    */
   static BigDecimal corSpearman(List<? extends Number> numbersX, List<? extends Number> numbersY) {
-    validateCorrelationInputs(numbersX, numbersY, "Spearman correlation")
+    validateCorrelationInputs(numbersX, numbersY, 'Spearman correlation')
 
     List<BigDecimal> ranksX = rank(numbersX)
     List<BigDecimal> ranksY = rank(numbersY)
@@ -143,7 +143,7 @@ class Correlation {
    * @throws IllegalArgumentException if inputs are null, empty, of different sizes, or have insufficient observations
    */
   static BigDecimal corKendall(List<? extends Number> numbersX, List<? extends Number> numbersY) {
-    validateCorrelationInputs(numbersX, numbersY, "Kendall correlation")
+    validateCorrelationInputs(numbersX, numbersY, 'Kendall correlation')
 
     final int n = numbersX.size()
     final long numPairs = sumN(n - 1)

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Sampler.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Sampler.groovy
@@ -25,7 +25,7 @@ class Sampler {
    */
   static List<Matrix> split(Matrix data, BigDecimal ratio) {
     if (ratio > 1.0 || ratio <= 0) {
-      throw new IllegalArgumentException("Ratio must be greater than 0 and at most 1")
+      throw new IllegalArgumentException('Ratio must be greater than 0 and at most 1')
     }
     int size = (int) (data.rowCount() * ratio)
     if (size == 0) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/StatUtils.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/StatUtils.groovy
@@ -7,9 +7,8 @@ package se.alipsa.matrix.stats
  * for numerical stability. For BigDecimal / List-based mean and variance, use
  * {@link se.alipsa.matrix.core.Stat} instead.</p>
  */
+@SuppressWarnings('DuplicateNumberLiteral')
 final class StatUtils {
-  private static final double ZERO_VALUE = 0.0d
-
   private StatUtils() {
   }
 
@@ -23,8 +22,8 @@ final class StatUtils {
   static double mean(double[] values) {
     validateNotEmpty(values, 'Mean')
 
-    double sum = ZERO_VALUE
-    double compensation = ZERO_VALUE
+    double sum = 0.0d
+    double compensation = 0.0d
     for (double value : values) {
       double adjusted = value - compensation
       double nextSum = sum + adjusted
@@ -56,7 +55,7 @@ final class StatUtils {
   static double variance(double[] values, double mean) {
     validateForVariance(values)
 
-    double sumSquaredDeviation = ZERO_VALUE
+    double sumSquaredDeviation = 0.0d
     for (double value : values) {
       double deviation = value - mean
       sumSquaredDeviation += deviation * deviation

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/StatUtils.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/StatUtils.groovy
@@ -8,6 +8,7 @@ package se.alipsa.matrix.stats
  * {@link se.alipsa.matrix.core.Stat} instead.</p>
  */
 final class StatUtils {
+  private static final double ZERO_VALUE = 0.0d
 
   private StatUtils() {
   }
@@ -22,8 +23,8 @@ final class StatUtils {
   static double mean(double[] values) {
     validateNotEmpty(values, 'Mean')
 
-    double sum = 0.0d
-    double compensation = 0.0d
+    double sum = ZERO_VALUE
+    double compensation = ZERO_VALUE
     for (double value : values) {
       double adjusted = value - compensation
       double nextSum = sum + adjusted
@@ -55,7 +56,7 @@ final class StatUtils {
   static double variance(double[] values, double mean) {
     validateForVariance(values)
 
-    double sumSquaredDeviation = 0.0d
+    double sumSquaredDeviation = ZERO_VALUE
     for (double value : values) {
       double deviation = value - mean
       sumSquaredDeviation += deviation * deviation
@@ -71,7 +72,7 @@ final class StatUtils {
 
   private static void validateForVariance(double[] values) {
     if (values == null || values.length < 2) {
-      throw new IllegalArgumentException("Variance requires at least two observations")
+      throw new IllegalArgumentException('Variance requires at least two observations')
     }
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/ClusteredPoint.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/ClusteredPoint.groovy
@@ -122,6 +122,8 @@ import se.alipsa.matrix.stats.util.NumericConversion
  * @see KMeans
  */
 class ClusteredPoint {
+  private static final String POINT_LABEL = 'point'
+
   final int clusterId
   final double[] point
 
@@ -131,13 +133,13 @@ class ClusteredPoint {
   }
 
   ClusteredPoint(int clusterId, List<? extends Number> point) {
-    this(clusterId, NumericConversion.toDoubleArray(point, 'point'))
+    this(clusterId, NumericConversion.toDoubleArray(point, POINT_LABEL))
   }
 
   int getClusterId() { clusterId }
   double[] getPoint() { point }
 
   List<BigDecimal> getPointValues() {
-    NumericConversion.toBigDecimalList(point, 'point')
+    NumericConversion.toBigDecimalList(point, POINT_LABEL)
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeans.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeans.groovy
@@ -110,7 +110,7 @@ class KMeans {
 
   KMeans(Matrix matrix) {
     if (matrix == null || matrix.rowCount() == 0 || matrix.columnCount() == 0) {
-      throw new IllegalArgumentException("Matrix must contain data")
+      throw new IllegalArgumentException('Matrix must contain data')
     }
     this.matrix = matrix
   }
@@ -130,7 +130,7 @@ class KMeans {
     points
   }
 
-  Matrix fit(List<String> columnNames, int k, int iterations, String columnName = "Group", boolean mutate = true) {
+  Matrix fit(List<String> columnNames, int k, int iterations, String columnName = 'Group', boolean mutate = true) {
     double[][] points = extractPoints(columnNames)
     clustering = new KMeansPlusPlus.Builder(k, points)
         .iterations(iterations)
@@ -140,7 +140,7 @@ class KMeans {
     addClusterColumn(clustering, columnName, mutate)
   }
 
-  Matrix fit(List<String> columnNames, int iterations = 30, GroupEstimator.CalculationMethod method = GroupEstimator.CalculationMethod.ELBOW, String columnName = "Group", boolean mutate = true) {
+  Matrix fit(List<String> columnNames, int iterations = 30, GroupEstimator.CalculationMethod method = GroupEstimator.CalculationMethod.ELBOW, String columnName = 'Group', boolean mutate = true) {
     double[][] points = extractPoints(columnNames)
     clustering = new KMeansPlusPlus.Builder(points, method)
         .iterations(iterations)
@@ -154,13 +154,12 @@ class KMeans {
     List<Integer> clusterIds = clustering.assignment*.clusterId
     if (mutate) {
       return matrix.addColumn(columnName, Integer, clusterIds)
-    } else {
-      return matrix.clone().addColumn(columnName, Integer, clusterIds)
     }
+    return matrix.clone().addColumn(columnName, Integer, clusterIds)
   }
 
   String reportTime() {
-    clustering?.timing ?: "No clustering performed yet, call fit() first."
+    clustering?.timing ?: 'No clustering performed yet, call fit() first.'
   }
 
   int getExecutionTimeMillis() {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeansPlusPlus.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/cluster/KMeansPlusPlus.groovy
@@ -293,7 +293,7 @@ class KMeansPlusPlus {
      */
     Builder(double[][] points, GroupEstimator.CalculationMethod method = GroupEstimator.CalculationMethod.ELBOW) {
       if (points == null || points.length == 0 || points[0].length == 0) {
-        throw new IllegalArgumentException("Input data must be non-null and contain at least one point with one dimension.")
+        throw new IllegalArgumentException('Input data must be non-null and contain at least one point with one dimension.')
       }
 
       this.points = points
@@ -321,7 +321,7 @@ class KMeansPlusPlus {
      */
     Builder(int k, double[][] points) {
       if (points == null || points.length == 0 || points[0].length == 0) {
-        throw new IllegalArgumentException("Input data must be non-null and contain at least one point with one dimension.")
+        throw new IllegalArgumentException('Input data must be non-null and contain at least one point with one dimension.')
       }
 
       if (k > points.length) {
@@ -364,7 +364,7 @@ class KMeansPlusPlus {
      */
     Builder iterations(int iterations) {
       if (iterations < 1) {
-        throw new IllegalArgumentException("Required: non-negative number of iterations. Ex: 50")
+        throw new IllegalArgumentException('Required: non-negative number of iterations. Ex: 50')
       }
       this.iterations = iterations
       this
@@ -401,7 +401,7 @@ class KMeansPlusPlus {
     Builder epsilon(Number epsilon) {
       double normalizedEpsilon = NumericConversion.toFiniteDouble(epsilon, 'epsilon')
       if (normalizedEpsilon < 0.0d) {
-        throw new IllegalArgumentException("Required: non-negative value of epsilon. Ex: .001")
+        throw new IllegalArgumentException('Required: non-negative value of epsilon. Ex: .001')
       }
 
       this.epsilon = normalizedEpsilon
@@ -691,9 +691,8 @@ class KMeansPlusPlus {
   private boolean stop(double prevWCSS) {
     if (useEpsilon) {
       return epsilonTest(prevWCSS)
-    } else {
-      return prevWCSS == wcss
     }
+    return prevWCSS == wcss
   }
 
   /**
@@ -734,7 +733,7 @@ class KMeansPlusPlus {
      */
     static double manhattanDistance(double[] x, double[] y) {
       if (x.length != y.length) {
-        throw new IllegalArgumentException("dimension error")
+        throw new IllegalArgumentException('dimension error')
       }
       double dist = 0
       for (int i = 0; i < x.length; i++) {
@@ -752,7 +751,7 @@ class KMeansPlusPlus {
      */
     static double euclideanDistance(double[] x, double[] y) {
       if (x.length != y.length) {
-        throw new IllegalArgumentException("dimension error")
+        throw new IllegalArgumentException('dimension error')
       }
       double dist = 0
       for (int i = 0; i < x.length; i++) {
@@ -814,7 +813,7 @@ class KMeansPlusPlus {
 
     Map<Integer, Matrix> result = [:]
     grouped.each { Integer clusterId, List<double[]> pointList ->
-      List<List<Double>> rows = pointList.collect { double[] row -> row.toList() }
+      List<List<Double>> rows = pointList*.toList()
       result[clusterId] = Matrix.builder("Cluster $clusterId").data(rows).build()
     }
     result
@@ -872,7 +871,7 @@ class KMeansPlusPlus {
    * @return a string indicating the time taken for KMeans++ clustering
    */
   String getTiming() {
-    "KMeans++ took: " + getExecutionTimeMillis() / 1000.0 + " seconds"
+    'KMeans++ took: ' + getExecutionTimeMillis() / 1000.0 + ' seconds'
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Barnard.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Barnard.groovy
@@ -86,7 +86,7 @@ class Barnard {
     int n = n1 + n2  // Grand total
 
     if (n == 0) {
-      throw new IllegalArgumentException("Table cannot have zero total count")
+      throw new IllegalArgumentException('Table cannot have zero total count')
     }
 
     // Calculate observed Wald score statistic
@@ -258,7 +258,7 @@ class Barnard {
 
   private static void validateTable(int[][] table) {
     if (table == null) {
-      throw new IllegalArgumentException("Table cannot be null")
+      throw new IllegalArgumentException('Table cannot be null')
     }
 
     if (table.length != 2) {
@@ -307,9 +307,8 @@ class Barnard {
       BigDecimal normalizedAlpha = NumericConversion.toAlpha(alpha)
       if (pValue < normalizedAlpha) {
         return "Reject H0: Significant association detected (T = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
-      } else {
-        return "Fail to reject H0: No significant association detected (T = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
       }
+      return "Fail to reject H0: No significant association detected (T = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
     }
 
     /**
@@ -319,15 +318,15 @@ class Barnard {
      */
     String evaluate(Number alpha = 0.05) {
       BigDecimal normalizedAlpha = NumericConversion.toAlpha(alpha)
-      String significance = pValue < normalizedAlpha ? "significant" : "not significant"
+      String significance = pValue < normalizedAlpha ? 'significant' : 'not significant'
 
       String.format(
         "Barnard's exact test:\\n" +
-        "Wald score statistic: %.4f\\n" +
-        "p-value: %.4f\\n" +
-        "Nuisance parameter (π): %.4f\\n" +
-        "Sample size: %d\\n" +
-        "Conclusion: Association is %s at %.0f%% significance level",
+        'Wald score statistic: %.4f\\n' +
+        'p-value: %.4f\\n' +
+        'Nuisance parameter (π): %.4f\\n' +
+        'Sample size: %d\\n' +
+        'Conclusion: Association is %s at %.0f%% significance level',
         statistic, pValue, nuisanceParameter, sampleSize, significance, normalizedAlpha * 100
       )
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Boschloo.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Boschloo.groovy
@@ -100,7 +100,7 @@ class Boschloo {
     int n = n1 + n2  // Grand total
 
     if (n == 0) {
-      throw new IllegalArgumentException("Table cannot have zero total count")
+      throw new IllegalArgumentException('Table cannot have zero total count')
     }
 
     // Calculate Fisher's exact p-value for the observed table
@@ -273,7 +273,7 @@ class Boschloo {
 
   private static void validateTable(int[][] table) {
     if (table == null) {
-      throw new IllegalArgumentException("Table cannot be null")
+      throw new IllegalArgumentException('Table cannot be null')
     }
 
     if (table.length != 2) {
@@ -322,9 +322,8 @@ class Boschloo {
       BigDecimal normalizedAlpha = NumericConversion.toAlpha(alpha)
       if (pValue < normalizedAlpha) {
         return "Reject H0: Significant association detected (p = ${String.format('%.4f', pValue)})"
-      } else {
-        return "Fail to reject H0: No significant association detected (p = ${String.format('%.4f', pValue)})"
       }
+      return "Fail to reject H0: No significant association detected (p = ${String.format('%.4f', pValue)})"
     }
 
     /**
@@ -334,15 +333,15 @@ class Boschloo {
      */
     String evaluate(Number alpha = 0.05) {
       BigDecimal normalizedAlpha = NumericConversion.toAlpha(alpha)
-      String significance = pValue < normalizedAlpha ? "significant" : "not significant"
+      String significance = pValue < normalizedAlpha ? 'significant' : 'not significant'
 
       String.format(
         "Boschloo's exact test:\\n" +
-        "p-value: %.4f\\n" +
+        'p-value: %.4f\\n' +
         "Fisher's p-value: %.4f\\n" +
-        "Nuisance parameter (π): %.4f\\n" +
-        "Sample size: %d\\n" +
-        "Conclusion: Association is %s at %.0f%% significance level",
+        'Nuisance parameter (π): %.4f\\n' +
+        'Sample size: %d\\n' +
+        'Conclusion: Association is %s at %.0f%% significance level',
         pValue, fisherPValue, nuisanceParameter, sampleSize, significance, normalizedAlpha * 100
       )
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/ChiSquared.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/ChiSquared.groovy
@@ -79,7 +79,7 @@ class ChiSquared {
       testStatistic: BigDecimal.valueOf(chiSquared),
       degreesOfFreedom: degreesOfFreedom,
       pValue: BigDecimal.valueOf(pValue),
-      testType: "Pearson"
+      testType: 'Pearson'
     )
   }
 
@@ -126,7 +126,7 @@ class ChiSquared {
       testStatistic: BigDecimal.valueOf(gStatistic),
       degreesOfFreedom: degreesOfFreedom,
       pValue: BigDecimal.valueOf(pValue),
-      testType: "G-test"
+      testType: 'G-test'
     )
   }
 
@@ -182,13 +182,13 @@ class ChiSquared {
       testStatistic: BigDecimal.valueOf(chiSquared),
       degreesOfFreedom: degreesOfFreedom,
       pValue: BigDecimal.valueOf(pValue),
-      testType: "Yates"
+      testType: 'Yates'
     )
   }
 
   private static void validateTable(Matrix table) {
     if (table == null) {
-      throw new IllegalArgumentException("Table cannot be null")
+      throw new IllegalArgumentException('Table cannot be null')
     }
     if (table.rowCount() < 2 || table.columnCount() < 2) {
       throw new IllegalArgumentException("Table must be at least 2×2 (got ${table.rowCount()}×${table.columnCount()})")

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranArmitage.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranArmitage.groovy
@@ -184,7 +184,7 @@ class CochranArmitage {
 
   private static void validateInput(int[] cases, int[] controls, double[] scores) {
     if (cases == null || controls == null) {
-      throw new IllegalArgumentException("Cases and controls cannot be null")
+      throw new IllegalArgumentException('Cases and controls cannot be null')
     }
     if (cases.length != controls.length) {
       throw new IllegalArgumentException(
@@ -264,11 +264,10 @@ class CochranArmitage {
     String interpret(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toBigDecimal(alpha, 'alpha')
       if (pValue < alphaValue) {
-        String direction = statistic > 0 ? "increasing" : "decreasing"
+        String direction = statistic > 0 ? 'increasing' : 'decreasing'
         return "Reject H0: Significant ${direction} trend detected (Z = ${String.format('%.4f', statistic as double)}, p = ${String.format('%.4f', pValue as double)})"
-      } else {
-        return "Fail to reject H0: No significant trend detected (Z = ${String.format('%.4f', statistic as double)}, p = ${String.format('%.4f', pValue as double)})"
       }
+      return "Fail to reject H0: No significant trend detected (Z = ${String.format('%.4f', statistic as double)}, p = ${String.format('%.4f', pValue as double)})"
     }
 
     /**
@@ -278,15 +277,15 @@ class CochranArmitage {
      */
     String evaluate(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toBigDecimal(alpha, 'alpha')
-      String direction = statistic > 0 ? "increasing" : "decreasing"
-      String significance = pValue < alphaValue ? "significant" : "not significant"
+      String direction = statistic > 0 ? 'increasing' : 'decreasing'
+      String significance = pValue < alphaValue ? 'significant' : 'not significant'
 
       String.format(
-        "Cochran-Armitage trend test:\n" +
-        "Z-statistic: %.4f (direction: %s)\n" +
-        "p-value: %.4f\n" +
-        "Sample: n=%d (%d cases, %d controls across %d categories)\n" +
-        "Conclusion: Trend is %s at %.0f%% significance level",
+        'Cochran-Armitage trend test:\n' +
+        'Z-statistic: %.4f (direction: %s)\n' +
+        'p-value: %.4f\n' +
+        'Sample: n=%d (%d cases, %d controls across %d categories)\n' +
+        'Conclusion: Trend is %s at %.0f%% significance level',
         statistic as double, direction, pValue as double, sampleSize, cases, controls, categories, significance, alphaValue * 100
       )
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranMantelHaenszel.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/CochranMantelHaenszel.groovy
@@ -140,7 +140,7 @@ class CochranMantelHaenszel {
       int n = a + b + c + d  // Total for this stratum
 
       if (n == 0) {
-        throw new IllegalArgumentException("Stratum has zero total count")
+        throw new IllegalArgumentException('Stratum has zero total count')
       }
 
       int r1 = a + b  // Row 1 total
@@ -170,7 +170,7 @@ class CochranMantelHaenszel {
     }
 
     if (sumVariance < 1e-10) {
-      throw new IllegalArgumentException("Total variance is too small - data may have no variation")
+      throw new IllegalArgumentException('Total variance is too small - data may have no variation')
     }
 
     // Calculate CMH statistic
@@ -197,7 +197,7 @@ class CochranMantelHaenszel {
 
   private static void validateInput(List<int[][]> strata) {
     if (strata == null || strata.isEmpty()) {
-      throw new IllegalArgumentException("Strata list cannot be null or empty")
+      throw new IllegalArgumentException('Strata list cannot be null or empty')
     }
 
     for (int i = 0; i < strata.size(); i++) {
@@ -264,9 +264,8 @@ class CochranMantelHaenszel {
       BigDecimal normalizedAlpha = NumericConversion.toAlpha(alpha)
       if (pValue < normalizedAlpha) {
         return "Reject H0: Significant association detected across strata (χ² = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
-      } else {
-        return "Fail to reject H0: No significant association detected across strata (χ² = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
       }
+      return "Fail to reject H0: No significant association detected across strata (χ² = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
     }
 
     /**
@@ -276,32 +275,32 @@ class CochranMantelHaenszel {
      */
     String evaluate(Number alpha = 0.05) {
       BigDecimal normalizedAlpha = NumericConversion.toAlpha(alpha)
-      String significance = pValue < normalizedAlpha ? "significant" : "not significant"
+      String significance = pValue < normalizedAlpha ? 'significant' : 'not significant'
       String oddsRatioStr = commonOddsRatio == null ?
-        "undefined" :
-        String.format("%.4f", commonOddsRatio)
+        'undefined' :
+        String.format('%.4f', commonOddsRatio)
 
-      String direction = ""
+      String direction = ''
       if (commonOddsRatio != null) {
         if (commonOddsRatio > 1) {
-          direction = " (positive association)"
+          direction = ' (positive association)'
         } else if (commonOddsRatio < 1) {
-          direction = " (negative association)"
+          direction = ' (negative association)'
         } else {
-          direction = " (no association)"
+          direction = ' (no association)'
         }
       }
 
       String.format(
-        "Cochran-Mantel-Haenszel test:\n" +
-        "χ² statistic: %.4f\n" +
-        "p-value: %.4f\n" +
-        "Common odds ratio: %s%s\n" +
-        "Strata: %d\n" +
-        "Continuity correction: %s\n" +
-        "Conclusion: Association is %s at %.0f%% significance level",
+        'Cochran-Mantel-Haenszel test:\n' +
+        'χ² statistic: %.4f\n' +
+        'p-value: %.4f\n' +
+        'Common odds ratio: %s%s\n' +
+        'Strata: %d\n' +
+        'Continuity correction: %s\n' +
+        'Conclusion: Association is %s at %.0f%% significance level',
         statistic, pValue, oddsRatioStr, direction, strata,
-        continuityCorrection ? "yes" : "no",
+        continuityCorrection ? 'yes' : 'no',
         significance, normalizedAlpha * 100
       )
     }
@@ -309,7 +308,7 @@ class CochranMantelHaenszel {
     @Override
     String toString() {
       String oddsRatioStr = commonOddsRatio == null ?
-        "undefined" :
+        'undefined' :
         String.format('%.4f', commonOddsRatio)
 
       """Cochran-Mantel-Haenszel Test

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
@@ -33,7 +33,7 @@ class Fisher {
    * @return FisherResult containing p-value, odds ratio, and confidence interval
    * @throws IllegalArgumentException if table is not 2×2 or contains negative values
    */
-  static FisherResult test(List<List<Integer>> table, String alternative = "two.sided") {
+  static FisherResult test(List<List<Integer>> table, String alternative = 'two.sided') {
     validateTable(table)
 
     int a = table[0][0]
@@ -52,7 +52,7 @@ class Fisher {
    * @return FisherResult containing p-value, odds ratio, and confidence interval
    * @throws IllegalArgumentException if table is not 2×2 or contains negative values
    */
-  static FisherResult test(Matrix table, String alternative = "two.sided") {
+  static FisherResult test(Matrix table, String alternative = 'two.sided') {
     if (table.rowCount() != 2 || table.columnCount() != 2) {
       throw new IllegalArgumentException("Fisher's exact test requires a 2×2 table (got ${table.rowCount()}×${table.columnCount()})")
     }
@@ -75,7 +75,7 @@ class Fisher {
     for (List<Integer> row : table) {
       for (Integer val : row) {
         if (val == null || val < 0) {
-          throw new IllegalArgumentException("Table values must be non-negative integers")
+          throw new IllegalArgumentException('Table values must be non-negative integers')
         }
       }
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/FDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/FDistribution.groovy
@@ -10,6 +10,7 @@ import se.alipsa.matrix.stats.util.NumericConversion
  */
 @SuppressWarnings('DuplicateNumberLiteral')
 class FDistribution implements ContinuousDistribution {
+  private static final String GROUP_LABEL = 'group'
 
   private final BigDecimal dfNumerator
   private final BigDecimal dfDenominator
@@ -133,7 +134,7 @@ class FDistribution implements ContinuousDistribution {
       groups,
       { List<?> g -> oneWayAnovaFValueArrays(g as List<double[]>) },
       { List<?> g -> oneWayAnovaFValueFromLists(g as Collection<? extends List<? extends Number>>) },
-      'group'
+      GROUP_LABEL
     )
   }
 
@@ -160,7 +161,7 @@ class FDistribution implements ContinuousDistribution {
   private static double oneWayAnovaFValueInternal(List<double[]> groups) {
     int k = groups.size()  // number of groups
     double grandSum = 0.0
-    List<Integer> groupSizes = groups.collect { double[] group -> group.length }
+    List<Integer> groupSizes = groups*.length
     int n = groupSizes.sum() as int  // total observations
     double[] groupMeans = new double[k]
     groups.eachWithIndex { double[] group, int i ->
@@ -215,7 +216,7 @@ class FDistribution implements ContinuousDistribution {
       groups,
       { List<?> g -> oneWayAnovaPValueArrays(g as List<double[]>) },
       { List<?> g -> oneWayAnovaPValueFromLists(g as Collection<? extends List<? extends Number>>) },
-      'group'
+      GROUP_LABEL
     )
   }
 
@@ -275,7 +276,7 @@ class FDistribution implements ContinuousDistribution {
       return []
     }
     groups.collect { List<? extends Number> group ->
-      NumericConversion.toDoubleArray(group, 'group')
+      NumericConversion.toDoubleArray(group, GROUP_LABEL)
     }
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/HypergeometricDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/HypergeometricDistribution.groovy
@@ -7,6 +7,7 @@ import se.alipsa.matrix.stats.util.NumericConversion
  */
 @SuppressWarnings('DuplicateNumberLiteral')
 class HypergeometricDistribution {
+  private static final String X_LABEL = 'x'
 
   private final int populationSize
   private final int numberOfSuccesses
@@ -43,7 +44,7 @@ class HypergeometricDistribution {
   }
 
   BigDecimal probability(Number x) {
-    BigDecimal.valueOf(probability(NumericConversion.toExactInt(x, 'x')))
+    BigDecimal.valueOf(probability(NumericConversion.toExactInt(x, X_LABEL)))
   }
 
   @Deprecated
@@ -60,7 +61,7 @@ class HypergeometricDistribution {
   }
 
   BigDecimal cumulativeProbability(Number x) {
-    BigDecimal.valueOf(cumulativeProbability(NumericConversion.toExactInt(x, 'x')))
+    BigDecimal.valueOf(cumulativeProbability(NumericConversion.toExactInt(x, X_LABEL)))
   }
 
   @Deprecated
@@ -80,7 +81,7 @@ class HypergeometricDistribution {
   }
 
   BigDecimal upperCumulativeProbability(Number x) {
-    BigDecimal.valueOf(upperCumulativeProbability(NumericConversion.toExactInt(x, 'x')))
+    BigDecimal.valueOf(upperCumulativeProbability(NumericConversion.toExactInt(x, X_LABEL)))
   }
 
   @Deprecated

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/SpecialFunctions.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/SpecialFunctions.groovy
@@ -24,6 +24,19 @@ class SpecialFunctions {
   private static final MathContext BETA_MC = new MathContext(50, RoundingMode.HALF_EVEN)
   private static final BigDecimal BETA_EPSILON = new BigDecimal('1e-30')
   private static final BigDecimal BETA_TINY = new BigDecimal('1e-40')
+  private static final String A_LABEL = 'a'
+  private static final String X_LABEL = 'x'
+  private static final List<BigDecimal> LANCZOS_COEFFICIENTS = [
+      0.99999999999980993,
+      676.5203681218851,
+      -1259.1392167224028,
+      771.32342877765313,
+      -176.61502916214059,
+      12.507343278686905,
+      -0.13857109526572012,
+      9.9843695780195716e-6,
+      1.5056327351493116e-7
+  ].asImmutable() as List<BigDecimal>
 
   /**
    * Computes the regularized incomplete beta function I_x(a, b).
@@ -79,8 +92,8 @@ class SpecialFunctions {
    */
   static BigDecimal regularizedIncompleteBeta(Number x, Number a, Number b) {
     BigDecimal.valueOf(regularizedIncompleteBeta(
-      NumericConversion.toFiniteDouble(x, 'x'),
-      NumericConversion.toFiniteDouble(a, 'a'),
+      NumericConversion.toFiniteDouble(x, X_LABEL),
+      NumericConversion.toFiniteDouble(a, A_LABEL),
       NumericConversion.toFiniteDouble(b, 'b')
     ))
   }
@@ -235,18 +248,7 @@ class SpecialFunctions {
       throw new IllegalArgumentException("x must be positive, got: $x")
     }
 
-    // Lanczos coefficients for g=7, n=9
-    double[] coef = [
-        0.99999999999980993,
-        676.5203681218851,
-        -1259.1392167224028,
-        771.32342877765313,
-        -176.61502916214059,
-        12.507343278686905,
-        -0.13857109526572012,
-        9.9843695780195716e-6,
-        1.5056327351493116e-7
-    ] as double[]
+    double[] coef = LANCZOS_COEFFICIENTS*.doubleValue() as double[]
 
     if (x < 0.5d) {
       // Use reflection formula
@@ -268,18 +270,7 @@ class SpecialFunctions {
       throw new IllegalArgumentException("x must be positive, got: $x")
     }
 
-    // Lanczos coefficients for g=7, n=9
-    BigDecimal[] coef = [
-        0.99999999999980993,
-        676.5203681218851,
-        -1259.1392167224028,
-        771.32342877765313,
-        -176.61502916214059,
-        12.507343278686905,
-        -0.13857109526572012,
-        9.9843695780195716e-6,
-        1.5056327351493116e-7
-    ] as BigDecimal[]
+    BigDecimal[] coef = LANCZOS_COEFFICIENTS as BigDecimal[]
 
     if (x < 0.5) {
       // Use reflection formula
@@ -356,8 +347,8 @@ class SpecialFunctions {
    */
   static BigDecimal regularizedIncompleteGammaP(Number a, Number x) {
     BigDecimal.valueOf(regularizedIncompleteGammaP(
-      NumericConversion.toFiniteDouble(a, 'a'),
-      NumericConversion.toFiniteDouble(x, 'x')
+      NumericConversion.toFiniteDouble(a, A_LABEL),
+      NumericConversion.toFiniteDouble(x, X_LABEL)
     ))
   }
 
@@ -397,8 +388,8 @@ class SpecialFunctions {
    */
   static BigDecimal regularizedIncompleteGammaQ(Number a, Number x) {
     BigDecimal.valueOf(regularizedIncompleteGammaQ(
-      NumericConversion.toFiniteDouble(a, 'a'),
-      NumericConversion.toFiniteDouble(x, 'x')
+      NumericConversion.toFiniteDouble(a, A_LABEL),
+      NumericConversion.toFiniteDouble(x, X_LABEL)
     ))
   }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/TDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/TDistribution.groovy
@@ -11,6 +11,7 @@ import se.alipsa.matrix.stats.util.NumericConversion
  */
 @SuppressWarnings('DuplicateNumberLiteral')
 class TDistribution {
+  private static final String T_LABEL = 't'
 
   private final BigDecimal degreesOfFreedom
 
@@ -42,9 +43,8 @@ class TDistribution {
 
     if (t >= 0) {
       return 1.0d - 0.5d * beta
-    } else {
-      return 0.5d * beta
     }
+    return 0.5d * beta
   }
 
   BigDecimal cdf(BigDecimal t) {
@@ -54,13 +54,12 @@ class TDistribution {
 
     if (t >= 0) {
       return BigDecimal.ONE - 0.5 * beta
-    } else {
-      return 0.5 * beta
     }
+    return 0.5 * beta
   }
 
   BigDecimal cdf(Number t) {
-    cdf(NumericConversion.toBigDecimal(t, 't'))
+    cdf(NumericConversion.toBigDecimal(t, T_LABEL))
   }
 
   /**
@@ -81,7 +80,7 @@ class TDistribution {
   }
 
   BigDecimal twoTailedPValue(Number t) {
-    twoTailedPValue(NumericConversion.toBigDecimal(t, 't'))
+    twoTailedPValue(NumericConversion.toBigDecimal(t, T_LABEL))
   }
 
   /**
@@ -96,7 +95,7 @@ class TDistribution {
   }
 
   BigDecimal oneTailedPValueUpper(Number t) {
-    oneTailedPValueUpper(NumericConversion.toBigDecimal(t, 't'))
+    oneTailedPValueUpper(NumericConversion.toBigDecimal(t, T_LABEL))
   }
 
   double oneTailedPValueUpper(double t) {
@@ -115,7 +114,7 @@ class TDistribution {
   }
 
   BigDecimal oneTailedPValueLower(Number t) {
-    cdf(NumericConversion.toBigDecimal(t, 't'))
+    cdf(NumericConversion.toBigDecimal(t, T_LABEL))
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/DesignMatrixBuilder.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/DesignMatrixBuilder.groovy
@@ -143,7 +143,7 @@ final class DesignMatrixBuilder {
     FormulaExpression degreeExpr = call.arguments[1]
 
     if (!(degreeExpr instanceof FormulaExpression.NumberLiteral)) {
-      throw new IllegalArgumentException("poly() degree must be a numeric literal")
+      throw new IllegalArgumentException('poly() degree must be a numeric literal')
     }
 
     BigDecimal degreeValue = (degreeExpr as FormulaExpression.NumberLiteral).value

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/FormulaExpression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/FormulaExpression.groovy
@@ -4,6 +4,9 @@ package se.alipsa.matrix.stats.formula
  * Base type for parsed formula expressions.
  */
 abstract class FormulaExpression {
+  private static final char DOT_CHAR = '.' as char
+  private static final char UNDERSCORE_CHAR = '_' as char
+  private static final String DOT_IDENTIFIER = '.'
 
   final int start
   final int end
@@ -95,7 +98,7 @@ abstract class FormulaExpression {
 
     @Override
     String asFormulaString() {
-      "${name}(${arguments.collect { FormulaExpression arg -> arg.asFormulaString() }.join(', ')})"
+      "${name}(${arguments*.asFormulaString().join(', ')})"
     }
   }
 
@@ -179,19 +182,19 @@ abstract class FormulaExpression {
   }
 
   private static boolean isSimpleIdentifier(String name) {
-    if (name == '.') {
+    if (name == DOT_IDENTIFIER) {
       return false
     }
     char first = name.charAt(0)
-    if (!(Character.isLetter(first) || first == '_' || first == '.')) {
+    if (!(Character.isLetter(first) || first == UNDERSCORE_CHAR || first == DOT_CHAR)) {
       return false
     }
-    if (first == '.' && name.length() > 1 && Character.isDigit(name.charAt(1))) {
+    if (first == DOT_CHAR && name.length() > 1 && Character.isDigit(name.charAt(1))) {
       return false
     }
     for (int i = 1; i < name.length(); i++) {
       char value = name.charAt(i)
-      if (!(Character.isLetterOrDigit(value) || value == '_' || value == '.')) {
+      if (!(Character.isLetterOrDigit(value) || value == UNDERSCORE_CHAR || value == DOT_CHAR)) {
         return false
       }
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/FormulaSupport.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/FormulaSupport.groovy
@@ -324,7 +324,7 @@ final class FormulaSupport {
   private static Set<FormulaTerm> powerTerms(FormulaExpression left, FormulaExpression right) {
     if (containsDot(left)) {
       throw new FormulaParseException(
-        "Dot expansion with interaction power (^) cannot be normalized before model-frame expansion",
+        'Dot expansion with interaction power (^) cannot be normalized before model-frame expansion',
         left.start
       )
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/FormulaTerm.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/FormulaTerm.groovy
@@ -50,7 +50,7 @@ final class FormulaTerm {
    * @return the term label
    */
   String asFormulaString() {
-    factors.collect { FormulaExpression factor -> factor.asFormulaString() }.join(':')
+    factors*.asFormulaString().join(':')
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ModelFrame.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/ModelFrame.groovy
@@ -416,9 +416,9 @@ final class ModelFrame {
 
   private static List<List<FormulaExpression>> cartesianProduct(List<List<FormulaExpression>> lists) {
     if (lists.isEmpty()) {
-      return [[]]
+      return emptyProduct()
     }
-    List<List<FormulaExpression>> result = [[]]
+    List<List<FormulaExpression>> result = emptyProduct()
     for (List<FormulaExpression> list : lists) {
       List<List<FormulaExpression>> newResult = []
       for (List<FormulaExpression> existing : result) {
@@ -431,6 +431,10 @@ final class ModelFrame {
       result = newResult
     }
     result
+  }
+
+  private static List<List<FormulaExpression>> emptyProduct() {
+    [[]]
   }
 
   private List<String> computeDotColumns(

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/NormalizedFormula.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/NormalizedFormula.groovy
@@ -29,7 +29,7 @@ final class NormalizedFormula {
    */
   String asFormulaString() {
     List<String> parts = [includeIntercept ? '1' : '0']
-    parts.addAll(predictorTerms.collect { FormulaTerm term -> term.asFormulaString() })
+    parts.addAll(predictorTerms*.asFormulaString())
     "${response.asFormulaString()} ~ ${parts.join(' + ')}"
   }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaDsl.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/GroovyFormulaDsl.groovy
@@ -10,6 +10,8 @@ import groovy.transform.CompileDynamic
  * support is not required for the operator DSL.</p>
  */
 class GroovyFormulaDsl {
+  private static final String INTERACTION_ARITY_MESSAGE = 'interaction(...) requires at least two terms'
+  private static final String SMOOTH_FUNCTION = 's'
 
   /**
    * Evaluates a Groovy formula closure.
@@ -124,7 +126,7 @@ class GroovyFormulaDsl {
    * @return the smooth term
    */
   TermExpr smooth(TermExpr expression) {
-    new FunctionTermExpr('s', [expression])
+    new FunctionTermExpr(SMOOTH_FUNCTION, [expression])
   }
 
   /**
@@ -138,7 +140,7 @@ class GroovyFormulaDsl {
     if (df == null) {
       throw new IllegalArgumentException('df cannot be null')
     }
-    new FunctionTermExpr('s', [expression, df])
+    new FunctionTermExpr(SMOOTH_FUNCTION, [expression, df])
   }
 
   /**
@@ -203,7 +205,7 @@ class GroovyFormulaDsl {
    */
   @SuppressWarnings('UnusedMethodParameter')
   TermExpr interaction(TermExpr first) {
-    throw new IllegalArgumentException('interaction(...) requires at least two terms')
+    throw new IllegalArgumentException(INTERACTION_ARITY_MESSAGE)
   }
 
   /**
@@ -212,6 +214,6 @@ class GroovyFormulaDsl {
    * @return never returns normally
    */
   TermExpr interaction() {
-    throw new IllegalArgumentException('interaction(...) requires at least two terms')
+    throw new IllegalArgumentException(INTERACTION_ARITY_MESSAGE)
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/IdentifierRenderingSupport.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/IdentifierRenderingSupport.groovy
@@ -7,6 +7,9 @@ import groovy.transform.PackageScope
  */
 @PackageScope
 final class IdentifierRenderingSupport {
+  private static final char DOT_CHAR = '.' as char
+  private static final char UNDERSCORE_CHAR = '_' as char
+  private static final String DOT_IDENTIFIER = '.'
 
   private IdentifierRenderingSupport() {
   }
@@ -26,19 +29,19 @@ final class IdentifierRenderingSupport {
   }
 
   private static boolean simpleIdentifier(String value) {
-    if (value == '.') {
+    if (value == DOT_IDENTIFIER) {
       return false
     }
     char first = value.charAt(0)
-    if (!(Character.isLetter(first) || first == '_' || first == '.')) {
+    if (!(Character.isLetter(first) || first == UNDERSCORE_CHAR || first == DOT_CHAR)) {
       return false
     }
-    if (first == '.' && value.length() > 1 && Character.isDigit(value.charAt(1))) {
+    if (first == DOT_CHAR && value.length() > 1 && Character.isDigit(value.charAt(1))) {
       return false
     }
     for (int i = 1; i < value.length(); i++) {
       char current = value.charAt(i)
-      if (!(Character.isLetterOrDigit(current) || current == '_' || current == '.')) {
+      if (!(Character.isLetterOrDigit(current) || current == UNDERSCORE_CHAR || current == DOT_CHAR)) {
         return false
       }
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/InteractionExpr.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/InteractionExpr.groovy
@@ -18,7 +18,7 @@ class InteractionExpr extends TermExpr {
 
   @Override
   String render() {
-    terms.collect { TermExpr term -> term.render() }.join(':')
+    terms*.render().join(':')
   }
 
   private static List<TermExpr> copyTerms(List<? extends TermExpr> terms) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/TermExpr.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/formula/dsl/TermExpr.groovy
@@ -6,6 +6,7 @@ import groovy.transform.CompileDynamic
  * Base type for Groovy-native formula DSL term expressions.
  */
 abstract class TermExpr {
+  private static final String OTHER_LABEL = 'other'
 
   /**
    * Adds a term to this expression.
@@ -14,7 +15,7 @@ abstract class TermExpr {
    * @return a combined term expression
    */
   TermExpr plus(TermExpr other) {
-    new BinaryTermExpr(this, '+', requireTerm(other, 'other'))
+    new BinaryTermExpr(this, '+', requireTerm(other, OTHER_LABEL))
   }
 
   /**
@@ -24,7 +25,7 @@ abstract class TermExpr {
    * @return a subtraction term expression
    */
   TermExpr minus(TermExpr other) {
-    new BinaryTermExpr(this, '-', requireTerm(other, 'other'))
+    new BinaryTermExpr(this, '-', requireTerm(other, OTHER_LABEL))
   }
 
   /**
@@ -35,7 +36,7 @@ abstract class TermExpr {
    * @return an interaction term expression
    */
   TermExpr remainder(TermExpr other) {
-    new InteractionExpr([this, requireTerm(other, 'other')])
+    new InteractionExpr([this, requireTerm(other, OTHER_LABEL)])
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/interpolation/Interpolation.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/interpolation/Interpolation.groovy
@@ -50,8 +50,9 @@ final class Interpolation {
     List<BigDecimal> range = InterpolationAdapters.validateRange(ListConverter.toBigDecimals(y), domain.size())
     BigDecimal target = InterpolationAdapters.validateTarget(targetX, TARGET_X_LABEL)
 
-    if (target < domain[0] || target > domain[-1]) {
-      throw new IllegalArgumentException("TargetX ${target} is outside the interpolation domain [${domain[0]}, ${domain[-1]}]")
+    BigDecimal lastDomain = domain.last()
+    if (target < domain[0] || target > lastDomain) {
+      throw new IllegalArgumentException("TargetX ${target} is outside the interpolation domain [${domain[0]}, ${lastDomain}]")
     }
 
     if (domain.size() == 1) {
@@ -70,7 +71,7 @@ final class Interpolation {
         return interpolate(domain[i - 1], range[i - 1], domain[i], range[i], target)
       }
     }
-    range[-1]
+    range.last()
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/Kernel.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/kde/Kernel.groovy
@@ -196,7 +196,7 @@ enum Kernel {
       case 'uniform', 'rectangular', 'rect' -> UNIFORM
       case 'triangular', 'triangle' -> TRIANGULAR
       default -> throw new IllegalArgumentException("Unknown kernel type: ${name}. " +
-          "Supported kernels: gaussian, epanechnikov, uniform, triangular")
+          'Supported kernels: gaussian, epanechnikov, uniform, triangular')
     }
   }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linalg/Linalg.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linalg/Linalg.groovy
@@ -27,6 +27,9 @@ final class Linalg {
 
   private static final double SINGULARITY_TOLERANCE = 1e-12
   private static final double IMAGINARY_TOLERANCE = 1e-10
+  private static final String MATRIX_LABEL = 'matrix'
+  private static final String MATRIX_TYPE_LABEL = 'Matrix'
+  private static final String VECTOR_LABEL = 'vector'
 
   private Linalg() {
   }
@@ -136,9 +139,9 @@ final class Linalg {
    * @param matrix the matrix to decompose
    * @return the singular value decomposition result
    * @throws IllegalArgumentException if the matrix is null, empty, or ragged
-   */
+  */
   private static SvdResult svdValues(double[][] matrix) {
-    LinalgAdapters.validateRectangular(matrix, 'matrix')
+    LinalgAdapters.validateRectangular(matrix, MATRIX_LABEL)
     SimpleSVD<SimpleMatrix> decomposition = dense(matrix).svd()
     SimpleMatrix u = decomposition.getU()
     SimpleMatrix w = decomposition.getW()
@@ -178,38 +181,38 @@ final class Linalg {
   }
 
   private static double[][] inverseValues(double[][] matrix) {
-    int[] shape = LinalgAdapters.validateRectangular(matrix, 'matrix')
-    requireSquare(shape, 'Matrix')
+    int[] shape = LinalgAdapters.validateRectangular(matrix, MATRIX_LABEL)
+    requireSquare(shape, MATRIX_TYPE_LABEL)
 
     SimpleMatrix dense = dense(matrix)
-    requireNonSingular(dense, 'Matrix')
+    requireNonSingular(dense, MATRIX_TYPE_LABEL)
     LinalgAdapters.toDoubleArray(dense.invert())
   }
 
   private static double detValue(double[][] matrix) {
-    int[] shape = LinalgAdapters.validateRectangular(matrix, 'matrix')
-    requireSquare(shape, 'Matrix')
+    int[] shape = LinalgAdapters.validateRectangular(matrix, MATRIX_LABEL)
+    requireSquare(shape, MATRIX_TYPE_LABEL)
     dense(matrix).determinant()
   }
 
   private static double[] solveValues(double[][] matrix, List<? extends Number> vector) {
-    solveValues(matrix, NumericConversion.toDoubleArray(vector, 'vector'))
+    solveValues(matrix, NumericConversion.toDoubleArray(vector, VECTOR_LABEL))
   }
 
   private static double[] solveValues(double[][] matrix, double[] vector) {
-    int[] shape = LinalgAdapters.validateRectangular(matrix, 'matrix')
-    requireSquare(shape, 'Matrix')
-    double[] rhs = validateVector(vector, shape[0], 'vector')
+    int[] shape = LinalgAdapters.validateRectangular(matrix, MATRIX_LABEL)
+    requireSquare(shape, MATRIX_TYPE_LABEL)
+    double[] rhs = validateVector(vector, shape[0], VECTOR_LABEL)
 
     SimpleMatrix dense = dense(matrix)
-    requireNonSingular(dense, 'Matrix')
+    requireNonSingular(dense, MATRIX_TYPE_LABEL)
     SimpleMatrix solution = dense.solve(new SimpleMatrix(rhs.length, 1, true, rhs))
     toVector(solution)
   }
 
   private static double[] eigenvaluesValues(double[][] matrix) {
-    int[] shape = LinalgAdapters.validateRectangular(matrix, 'matrix')
-    requireSquare(shape, 'Matrix')
+    int[] shape = LinalgAdapters.validateRectangular(matrix, MATRIX_LABEL)
+    requireSquare(shape, MATRIX_TYPE_LABEL)
 
     SimpleEVD<SimpleMatrix> decomposition = dense(matrix).eig()
     List<Double> values = []

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linalg/LinalgAdapters.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linalg/LinalgAdapters.groovy
@@ -17,6 +17,8 @@ import se.alipsa.matrix.stats.util.NumericConversion
  */
 @PackageScope
 final class LinalgAdapters {
+  private static final String VALUES_LABEL = 'values'
+
 
   private static final String SYNTHETIC_COLUMN_PREFIX = 'c'
 
@@ -44,9 +46,9 @@ final class LinalgAdapters {
    *
    * @param values the dense numeric array
    * @return a matrix containing the supplied values
-   */
+  */
   static Matrix toMatrix(double[][] values) {
-    int[] shape = validateRectangular(values, 'values')
+    int[] shape = validateRectangular(values, VALUES_LABEL)
     List<String> columnNames = syntheticColumnNames(shape[1])
     List<List> rows = []
     for (int row = 0; row < shape[0]; row++) {
@@ -70,7 +72,7 @@ final class LinalgAdapters {
    * @return a grid containing the supplied values
    */
   static Grid<BigDecimal> toGrid(double[][] values) {
-    int[] shape = validateRectangular(values, 'values')
+    int[] shape = validateRectangular(values, VALUES_LABEL)
     List<List<BigDecimal>> rows = []
     for (int row = 0; row < shape[0]; row++) {
       List<BigDecimal> currentRow = []

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linear/MatrixAlgebra.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/linear/MatrixAlgebra.groovy
@@ -13,6 +13,9 @@ final class MatrixAlgebra {
   private static final double SYMMETRY_THRESHOLD = 1e-10
   private static final double JACOBI_CONVERGENCE_THRESHOLD = 1e-10
   private static final int MAX_JACOBI_SWEEPS = 100
+  private static final String LEFT_MATRIX_LABEL = 'left matrix'
+  private static final String MATRIX_LABEL = 'matrix'
+  private static final String RIGHT_MATRIX_LABEL = 'right matrix'
   private static final Logger log = Logger.getLogger(MatrixAlgebra)
 
   private MatrixAlgebra() {
@@ -26,7 +29,7 @@ final class MatrixAlgebra {
    * @throws IllegalArgumentException if the matrix is null, empty, or ragged
    */
   static double[][] transpose(double[][] matrix) {
-    int[] shape = validateRectangular(matrix, 'matrix')
+    int[] shape = validateRectangular(matrix, MATRIX_LABEL)
     int rows = shape[0]
     int columns = shape[1]
     double[][] result = new double[columns][rows]
@@ -47,8 +50,8 @@ final class MatrixAlgebra {
    * @throws IllegalArgumentException if either matrix is invalid or the inner dimensions do not match
    */
   static double[][] multiply(double[][] left, double[][] right) {
-    int[] leftShape = validateRectangular(left, 'left matrix')
-    int[] rightShape = validateRectangular(right, 'right matrix')
+    int[] leftShape = validateRectangular(left, LEFT_MATRIX_LABEL)
+    int[] rightShape = validateRectangular(right, RIGHT_MATRIX_LABEL)
     if (leftShape[1] != rightShape[0]) {
       throw new IllegalArgumentException(
           "Matrix dimension mismatch: ${leftShape[0]}x${leftShape[1]} cannot be multiplied by ${rightShape[0]}x${rightShape[1]}"
@@ -80,8 +83,8 @@ final class MatrixAlgebra {
    * @throws IllegalArgumentException if the matrices are invalid or shapes differ
    */
   static double[][] subtract(double[][] left, double[][] right) {
-    int[] leftShape = validateRectangular(left, 'left matrix')
-    int[] rightShape = validateRectangular(right, 'right matrix')
+    int[] leftShape = validateRectangular(left, LEFT_MATRIX_LABEL)
+    int[] rightShape = validateRectangular(right, RIGHT_MATRIX_LABEL)
     if (leftShape[0] != rightShape[0] || leftShape[1] != rightShape[1]) {
       throw new IllegalArgumentException(
           "Matrix dimension mismatch: ${leftShape[0]}x${leftShape[1]} does not match ${rightShape[0]}x${rightShape[1]}"
@@ -107,7 +110,7 @@ final class MatrixAlgebra {
    * @throws IllegalArgumentException if the matrix is invalid or the result contains non-finite values
    */
   static double[][] scale(double[][] matrix, double scalar) {
-    int[] shape = validateRectangular(matrix, 'matrix')
+    int[] shape = validateRectangular(matrix, MATRIX_LABEL)
     double[][] result = new double[shape[0]][shape[1]]
     for (int i = 0; i < shape[0]; i++) {
       for (int j = 0; j < shape[1]; j++) {
@@ -127,10 +130,10 @@ final class MatrixAlgebra {
    * @throws SingularMatrixException if the matrix is singular
    */
   static double[][] inverse(double[][] matrix) {
-    int[] shape = validateRectangular(matrix, 'matrix')
+    int[] shape = validateRectangular(matrix, MATRIX_LABEL)
     int n = shape[0]
     if (n != shape[1]) {
-      throw new IllegalArgumentException("Only square matrices can be inverted")
+      throw new IllegalArgumentException('Only square matrices can be inverted')
     }
 
     double[][] augmented = new double[n][2 * n]
@@ -187,10 +190,10 @@ final class MatrixAlgebra {
    * @throws SingularMatrixException if the matrix is not positive definite
    */
   static double[][] cholesky(double[][] matrix) {
-    int[] shape = validateRectangular(matrix, 'matrix')
+    int[] shape = validateRectangular(matrix, MATRIX_LABEL)
     int n = shape[0]
     if (n != shape[1]) {
-      throw new IllegalArgumentException("Cholesky decomposition requires a square matrix")
+      throw new IllegalArgumentException('Cholesky decomposition requires a square matrix')
     }
     validateSymmetric(matrix)
 
@@ -205,7 +208,7 @@ final class MatrixAlgebra {
         if (i == j) {
           if (sum <= SINGULARITY_THRESHOLD) {
             log.warn("Non-positive diagonal at row $i during Cholesky decomposition")
-            throw new SingularMatrixException("Matrix is not positive definite")
+            throw new SingularMatrixException('Matrix is not positive definite')
           }
           lower[i][j] = Math.sqrt(sum)
         } else {
@@ -225,10 +228,10 @@ final class MatrixAlgebra {
    * @throws IllegalArgumentException if the matrix is invalid or non-symmetric
    */
   static double[] symmetricEigenvalues(double[][] matrix) {
-    int[] shape = validateRectangular(matrix, 'matrix')
+    int[] shape = validateRectangular(matrix, MATRIX_LABEL)
     int n = shape[0]
     if (n != shape[1]) {
-      throw new IllegalArgumentException("Eigenvalue decomposition requires a square matrix")
+      throw new IllegalArgumentException('Eigenvalue decomposition requires a square matrix')
     }
     validateSymmetric(matrix)
 
@@ -286,7 +289,7 @@ final class MatrixAlgebra {
     }
 
     log.warn("Jacobi eigenvalue iteration did not converge after $MAX_JACOBI_SWEEPS sweeps")
-    throw new IllegalArgumentException("Jacobi eigenvalue iteration failed to converge")
+    throw new IllegalArgumentException('Jacobi eigenvalue iteration failed to converge')
   }
 
   private static int[] validateRectangular(double[][] matrix, String label) {
@@ -308,7 +311,7 @@ final class MatrixAlgebra {
         double difference = Math.abs(matrix[i][j] - matrix[j][i])
         double scale = Math.max(1.0d, Math.max(Math.abs(matrix[i][j]), Math.abs(matrix[j][i])))
         if (difference > SYMMETRY_THRESHOLD * scale) {
-          throw new IllegalArgumentException("Matrix must be symmetric")
+          throw new IllegalArgumentException('Matrix must be symmetric')
         }
       }
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/AndersonDarling.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/AndersonDarling.groovy
@@ -38,7 +38,7 @@ class AndersonDarling {
     int n = data.size()
 
     // Calculate sample mean and standard deviation
-    double[] values = data.collect { it.doubleValue() } as double[]
+    double[] values = data*.doubleValue() as double[]
     double mean = values.sum() / n
     double variance = 0.0
     for (double val : values) {
@@ -110,21 +110,22 @@ class AndersonDarling {
   private static double calculatePValue(double adjustedASquared) {
     if (adjustedASquared < 0.2) {
       return 1.0 - Math.exp(-13.436 + 101.14 * adjustedASquared - 223.73 * adjustedASquared * adjustedASquared)
-    } else if (adjustedASquared < 0.34) {
-      return 1.0 - Math.exp(-8.318 + 42.796 * adjustedASquared - 59.938 * adjustedASquared * adjustedASquared)
-    } else if (adjustedASquared < 0.6) {
-      return Math.exp(0.9177 - 4.279 * adjustedASquared - 1.38 * adjustedASquared * adjustedASquared)
-    } else {
-      return Math.exp(1.2937 - 5.709 * adjustedASquared + 0.0186 * adjustedASquared * adjustedASquared)
     }
+    if (adjustedASquared < 0.34) {
+      return 1.0 - Math.exp(-8.318 + 42.796 * adjustedASquared - 59.938 * adjustedASquared * adjustedASquared)
+    }
+    if (adjustedASquared < 0.6) {
+      return Math.exp(0.9177 - 4.279 * adjustedASquared - 1.38 * adjustedASquared * adjustedASquared)
+    }
+    return Math.exp(1.2937 - 5.709 * adjustedASquared + 0.0186 * adjustedASquared * adjustedASquared)
   }
 
   private static void validateInput(List<? extends Number> data) {
     if (data == null) {
-      throw new IllegalArgumentException("Data cannot be null")
+      throw new IllegalArgumentException('Data cannot be null')
     }
     if (data.isEmpty()) {
-      throw new IllegalArgumentException("Data cannot be empty")
+      throw new IllegalArgumentException('Data cannot be empty')
     }
     if (data.size() < 3) {
       throw new IllegalArgumentException("Anderson-Darling test requires at least 3 observations, got ${data.size()}")
@@ -132,7 +133,7 @@ class AndersonDarling {
     // Check for non-null values
     for (Number value : data) {
       if (value == null) {
-        throw new IllegalArgumentException("Data contains null values")
+        throw new IllegalArgumentException('Data contains null values')
       }
     }
   }
@@ -170,23 +171,22 @@ class AndersonDarling {
      */
     String evaluate() {
       if (pValue < alpha) {
-        return String.format("Reject H0: Data does not appear to be normally distributed (p = %.4f < α = %.2f)",
-                             pValue, alpha)
-      } else {
-        return String.format("Fail to reject H0: Data appears to be normally distributed (p = %.4f >= α = %.2f)",
+        return String.format('Reject H0: Data does not appear to be normally distributed (p = %.4f < α = %.2f)',
                              pValue, alpha)
       }
+      return String.format('Fail to reject H0: Data appears to be normally distributed (p = %.4f >= α = %.2f)',
+                           pValue, alpha)
     }
 
     @Override
     String toString() {
       """Anderson-Darling Normality Test
   Sample size: ${sampleSize}
-  Sample mean: ${String.format("%.4f", mean)}
-  Sample SD: ${String.format("%.4f", stdDev)}
-  Test statistic (A²): ${String.format("%.4f", statistic)}
-  Adjusted statistic (A²*): ${String.format("%.4f", adjustedStatistic)}
-  P-value: ${String.format("%.4f", pValue)}
+  Sample mean: ${String.format('%.4f', mean)}
+  Sample SD: ${String.format('%.4f', stdDev)}
+  Test statistic (A²): ${String.format('%.4f', statistic)}
+  Adjusted statistic (A²*): ${String.format('%.4f', adjustedStatistic)}
+  P-value: ${String.format('%.4f', pValue)}
 
   ${evaluate()}"""
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/CramerVonMises.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/CramerVonMises.groovy
@@ -40,7 +40,7 @@ class CramerVonMises {
     int n = data.size()
 
     // Convert to array and calculate sample mean and standard deviation
-    double[] values = data.collect { it.doubleValue() } as double[]
+    double[] values = data*.doubleValue() as double[]
 
     double mean = 0.0
     for (double val : values) {
@@ -57,7 +57,7 @@ class CramerVonMises {
     double stdDev = Math.sqrt(variance)
 
     if (stdDev < 1e-10) {
-      throw new IllegalArgumentException("Data has no variation (constant or near-constant values)")
+      throw new IllegalArgumentException('Data has no variation (constant or near-constant values)')
     }
 
     // Sort the data
@@ -117,22 +117,26 @@ class CramerVonMises {
     } else if (wSquared < 0.051) {
       // Linear interpolation in the lower range
       return 1.0 - (wSquared - 0.0275) / (0.051 - 0.0275) * 0.75
-    } else if (wSquared < 0.093) {
-      return 0.25 - (wSquared - 0.051) / (0.093 - 0.051) * 0.15
-    } else if (wSquared < 0.158) {
-      return 0.10 - (wSquared - 0.093) / (0.158 - 0.093) * 0.05
-    } else if (wSquared < 0.241) {
-      return 0.05 - (wSquared - 0.158) / (0.241 - 0.158) * 0.025
-    } else if (wSquared < 0.347) {
-      return 0.025 - (wSquared - 0.241) / (0.347 - 0.241) * 0.015
-    } else if (wSquared < 0.461) {
-      return 0.01 - (wSquared - 0.347) / (0.461 - 0.347) * 0.005
-    } else {
-      // For very large values, use asymptotic approximation
-      // P ≈ exp(-W²*/2) for large W²*
-      double p = Math.exp(-wSquared / 2.0)
-      return Math.max(0.001, p)
     }
+    if (wSquared < 0.093) {
+      return 0.25 - (wSquared - 0.051) / (0.093 - 0.051) * 0.15
+    }
+    if (wSquared < 0.158) {
+      return 0.10 - (wSquared - 0.093) / (0.158 - 0.093) * 0.05
+    }
+    if (wSquared < 0.241) {
+      return 0.05 - (wSquared - 0.158) / (0.241 - 0.158) * 0.025
+    }
+    if (wSquared < 0.347) {
+      return 0.025 - (wSquared - 0.241) / (0.347 - 0.241) * 0.015
+    }
+    if (wSquared < 0.461) {
+      return 0.01 - (wSquared - 0.347) / (0.461 - 0.347) * 0.005
+    }
+    // For very large values, use asymptotic approximation
+    // P ≈ exp(-W²*/2) for large W²*
+    double p = Math.exp(-wSquared / 2.0)
+    return Math.max(0.001, p)
   }
 
   /**
@@ -143,25 +147,28 @@ class CramerVonMises {
   private static double getCriticalValue(double alpha) {
     if (alpha >= 0.25) {
       return 0.051
-    } else if (alpha >= 0.10) {
-      return 0.093
-    } else if (alpha >= 0.05) {
-      return 0.158
-    } else if (alpha >= 0.025) {
-      return 0.241
-    } else if (alpha >= 0.01) {
-      return 0.347
-    } else {
-      return 0.461  // alpha = 0.005
     }
+    if (alpha >= 0.10) {
+      return 0.093
+    }
+    if (alpha >= 0.05) {
+      return 0.158
+    }
+    if (alpha >= 0.025) {
+      return 0.241
+    }
+    if (alpha >= 0.01) {
+      return 0.347
+    }
+    return 0.461  // alpha = 0.005
   }
 
   private static void validateInput(List<? extends Number> data) {
     if (data == null) {
-      throw new IllegalArgumentException("Data cannot be null")
+      throw new IllegalArgumentException('Data cannot be null')
     }
     if (data.isEmpty()) {
-      throw new IllegalArgumentException("Data cannot be empty")
+      throw new IllegalArgumentException('Data cannot be empty')
     }
     if (data.size() < 3) {
       throw new IllegalArgumentException("Cramér-von Mises test requires at least 3 observations, got ${data.size()}")
@@ -169,7 +176,7 @@ class CramerVonMises {
     // Check for non-null values
     for (Number value : data) {
       if (value == null) {
-        throw new IllegalArgumentException("Data contains null values")
+        throw new IllegalArgumentException('Data contains null values')
       }
     }
   }
@@ -210,9 +217,8 @@ class CramerVonMises {
     String interpret() {
       if (statistic > criticalValue) {
         return "Reject H0: Data does not appear to be normally distributed (p = ${String.format('%.4f', pValue)})"
-      } else {
-        return "Fail to reject H0: Data appears to be consistent with a normal distribution (p = ${String.format('%.4f', pValue)})"
       }
+      return "Fail to reject H0: Data appears to be consistent with a normal distribution (p = ${String.format('%.4f', pValue)})"
     }
 
     /**
@@ -222,14 +228,14 @@ class CramerVonMises {
      */
     String evaluate() {
       String conclusion = statistic > criticalValue ?
-        "not normally distributed" :
-        "consistent with a normal distribution"
+        'not normally distributed' :
+        'consistent with a normal distribution'
 
       String.format(
-        "Cramér-von Mises W²*: %.4f (critical value: %.3f at %.0f%% level)\n" +
-        "p-value: %.4f\n" +
-        "Sample: n=%d, mean=%.4f, sd=%.4f\n" +
-        "Conclusion: Data appears %s",
+        'Cramér-von Mises W²*: %.4f (critical value: %.3f at %.0f%% level)\n' +
+        'p-value: %.4f\n' +
+        'Sample: n=%d, mean=%.4f, sd=%.4f\n' +
+        'Conclusion: Data appears %s',
         statistic, criticalValue, alpha * 100, pValue,
         sampleSize, mean, stdDev, conclusion
       )

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/JarqueBera.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/JarqueBera.groovy
@@ -106,7 +106,7 @@ class JarqueBera {
     validateData(data)
 
     int n = data.size()
-    double[] values = data.collect { it.doubleValue() } as double[]
+    double[] values = data*.doubleValue() as double[]
 
     // Calculate mean
     double mean = 0
@@ -156,7 +156,7 @@ class JarqueBera {
 
   private static void validateData(List<? extends Number> data) {
     if (data == null || data.isEmpty()) {
-      throw new IllegalArgumentException("Data cannot be null or empty")
+      throw new IllegalArgumentException('Data cannot be null or empty')
     }
     if (data.size() < MIN_SAMPLE_SIZE) {
       throw new IllegalArgumentException("Jarque-Bera test requires at least ${MIN_SAMPLE_SIZE} observations (got ${data.size()})")
@@ -166,7 +166,7 @@ class JarqueBera {
     double first = data[0].doubleValue()
     boolean allSame = data.every { it.doubleValue() == first }
     if (allSame) {
-      throw new IllegalArgumentException("Data has zero variance - all values are identical")
+      throw new IllegalArgumentException('Data has zero variance - all values are identical')
     }
   }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KSquared.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KSquared.groovy
@@ -104,7 +104,7 @@ class KSquared {
    */
   static KSquaredResult test(List<? extends Number> data) {
     if (data == null) {
-      throw new IllegalArgumentException("Data cannot be null")
+      throw new IllegalArgumentException('Data cannot be null')
     }
     if (data.size() < 8) {
       throw new IllegalArgumentException("Sample size must be at least 8 (got ${data.size()})")
@@ -140,7 +140,7 @@ class KSquared {
     double sd = Math.sqrt(m2)
 
     if (sd < 1e-10) {
-      throw new IllegalArgumentException("Data has zero variance")
+      throw new IllegalArgumentException('Data has zero variance')
     }
 
     // Calculate sample skewness (b1) and kurtosis (b2)
@@ -195,7 +195,7 @@ class KSquared {
    */
   static KSquaredResult test(Matrix matrix, String columnName) {
     if (matrix == null) {
-      throw new IllegalArgumentException("Matrix cannot be null")
+      throw new IllegalArgumentException('Matrix cannot be null')
     }
 
     List<?> column = matrix.column(columnName)
@@ -211,7 +211,7 @@ class KSquared {
    */
   static KSquaredResult test(Matrix matrix, int columnIndex) {
     if (matrix == null) {
-      throw new IllegalArgumentException("Matrix cannot be null")
+      throw new IllegalArgumentException('Matrix cannot be null')
     }
 
     List<?> column = matrix.column(columnIndex)
@@ -254,9 +254,8 @@ class KSquared {
       if (pValue < alphaValue) {
         String reason = determineReason()
         return "Reject H0: Data significantly departs from normality (K² = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)}) - ${reason}"
-      } else {
-        return "Fail to reject H0: Data is consistent with normality (K² = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
       }
+      return "Fail to reject H0: Data is consistent with normality (K² = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
     }
 
     /**
@@ -267,12 +266,12 @@ class KSquared {
       BigDecimal absZKurt = zKurtosis.abs()
 
       if (absZSkew > 1.96 && absZKurt > 1.96) {
-        return "both skewness and kurtosis"
-      } else if (absZSkew > absZKurt) {
-        return skewness > 0 ? "positive skewness (right tail)" : "negative skewness (left tail)"
-      } else {
-        return kurtosis > 3 ? "heavy tails (leptokurtic)" : "light tails (platykurtic)"
+        return 'both skewness and kurtosis'
       }
+      if (absZSkew > absZKurt) {
+        return skewness > 0 ? 'positive skewness (right tail)' : 'negative skewness (left tail)'
+      }
+      return kurtosis > 3 ? 'heavy tails (leptokurtic)' : 'light tails (platykurtic)'
     }
 
     /**
@@ -283,16 +282,16 @@ class KSquared {
      */
     String evaluate(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
-      String conclusion = pValue < alphaValue ? "significant departure from normality" : "consistent with normality"
+      String conclusion = pValue < alphaValue ? 'significant departure from normality' : 'consistent with normality'
 
       String.format(
         "D'Agostino's K² test:\\n" +
-        "K² statistic: %.4f\\n" +
-        "p-value: %.4f\\n" +
-        "Sample size: %d\\n" +
-        "Skewness: %.4f (Z = %.4f)\\n" +
-        "Kurtosis: %.4f (Z = %.4f)\\n" +
-        "Conclusion: Data shows %s at %.0f%% significance level",
+        'K² statistic: %.4f\\n' +
+        'p-value: %.4f\\n' +
+        'Sample size: %d\\n' +
+        'Skewness: %.4f (Z = %.4f)\\n' +
+        'Kurtosis: %.4f (Z = %.4f)\\n' +
+        'Conclusion: Data shows %s at %.0f%% significance level',
         statistic, pValue, sampleSize, skewness, zSkewness, kurtosis, zKurtosis,
         conclusion, alphaValue * 100
       )

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KolmogorovSmirnov.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KolmogorovSmirnov.groovy
@@ -104,6 +104,12 @@ import se.alipsa.matrix.stats.util.NumericConversion
  * testing with estimated parameters.</p>
  */
 class KolmogorovSmirnov {
+  private static final double ASYMPTOTIC_CORRECTION_BASE = 0.12d
+  private static final double ASYMPTOTIC_CORRECTION_SCALE = 0.11d
+  private static final double PROBABILITY_LOWER_BOUND = 0.0d
+  private static final double PROBABILITY_UPPER_BOUND = 1.0d
+  private static final double SERIES_MULTIPLIER = 2.0d
+
 
   private static final int EXACT_TWO_SAMPLE_MAX_PRODUCT = 10_000
 
@@ -118,7 +124,7 @@ class KolmogorovSmirnov {
   static KSResult testNormality(List<? extends Number> data) {
     validateData(data)
 
-    double[] values = data.collect { it.doubleValue() } as double[]
+    double[] values = data*.doubleValue() as double[]
 
     // Calculate sample mean and standard deviation
     double mean = values.sum() / values.length
@@ -131,7 +137,7 @@ class KolmogorovSmirnov {
     // Create normal distribution with sample mean and std dev
     NormalDistribution normalDist = new NormalDistribution(mean, stdDev)
 
-    testAgainstDistribution(data, normalDist, "Normality")
+    testAgainstDistribution(data, normalDist, 'Normality')
   }
 
   /**
@@ -144,7 +150,7 @@ class KolmogorovSmirnov {
   static KSResult testStandardNormality(List<? extends Number> data) {
     validateData(data)
     NormalDistribution standardNormal = new NormalDistribution(0, 1)
-    testAgainstDistribution(data, standardNormal, "Standard Normality")
+    testAgainstDistribution(data, standardNormal, 'Standard Normality')
   }
 
   /**
@@ -156,10 +162,10 @@ class KolmogorovSmirnov {
    * @return KSResult containing the D statistic and p-value
    * @throws IllegalArgumentException if data is null or has fewer than 2 observations
    */
-  static KSResult testAgainstDistribution(List<? extends Number> data, ContinuousDistribution distribution, String testName = "K-S Test") {
+  static KSResult testAgainstDistribution(List<? extends Number> data, ContinuousDistribution distribution, String testName = 'K-S Test') {
     validateData(data)
 
-    double[] values = (data.collect { it.doubleValue() } as List<Double>).sort() as double[]
+    double[] values = (data*.doubleValue() as List<Double>).sort() as double[]
     double dStatistic = calculateOneSampleStatistic(values, distribution)
     double pValue = calculateOneSamplePValue(dStatistic, values.length)
 
@@ -183,8 +189,8 @@ class KolmogorovSmirnov {
     validateData(sample1)
     validateData(sample2)
 
-    double[] values1 = sample1.collect { it.doubleValue() } as double[]
-    double[] values2 = sample2.collect { it.doubleValue() } as double[]
+    double[] values1 = sample1*.doubleValue() as double[]
+    double[] values2 = sample2*.doubleValue() as double[]
 
     // Calculate D statistic
     double dStatistic = calculateTwoSampleStatistic(values1, values2)
@@ -196,14 +202,14 @@ class KolmogorovSmirnov {
       dStatistic: BigDecimal.valueOf(dStatistic),
       pValue: BigDecimal.valueOf(pValue),
       sampleSize: values1.length + values2.length,
-      testType: "Two-Sample K-S"
+      testType: 'Two-Sample K-S'
     )
   }
 
   private static double calculateOneSampleStatistic(double[] sortedValues, ContinuousDistribution distribution) {
     int n = sortedValues.length
-    double dPlus = 0.0d
-    double dMinus = 0.0d
+    double dPlus = PROBABILITY_LOWER_BOUND
+    double dMinus = PROBABILITY_LOWER_BOUND
 
     for (int i = 0; i < n; i++) {
       double theoretical = distribution.cumulativeProbability(sortedValues[i])
@@ -217,14 +223,14 @@ class KolmogorovSmirnov {
   }
 
   private static double calculateOneSamplePValue(double dStatistic, int sampleSize) {
-    if (dStatistic <= 0.0d) {
-      return 1.0d
+    if (dStatistic <= PROBABILITY_LOWER_BOUND) {
+      return PROBABILITY_UPPER_BOUND
     }
 
     // Use Stephens' asymptotic correction for the one-sample test. This is intentionally approximate,
     // so callers and tests should not expect exact agreement with finite-sample reference tables.
     double sqrtN = Math.sqrt(sampleSize)
-    double lambda = (sqrtN + 0.12d + 0.11d / sqrtN) * dStatistic
+    double lambda = (sqrtN + ASYMPTOTIC_CORRECTION_BASE + ASYMPTOTIC_CORRECTION_SCALE / sqrtN) * dStatistic
     kolmogorovProbability(lambda)
   }
 
@@ -264,8 +270,8 @@ class KolmogorovSmirnov {
   }
 
   private static double calculateTwoSamplePValue(double dStatistic, int sampleSize1, int sampleSize2) {
-    if (dStatistic <= 0.0d) {
-      return 1.0d
+    if (dStatistic <= PROBABILITY_LOWER_BOUND) {
+      return PROBABILITY_UPPER_BOUND
     }
     if ((sampleSize1 as long) * sampleSize2 <= EXACT_TWO_SAMPLE_MAX_PRODUCT) {
       long differenceCount = Math.round(dStatistic * sampleSize1 * sampleSize2)
@@ -273,7 +279,7 @@ class KolmogorovSmirnov {
     }
 
     double effectiveSize = Math.sqrt((sampleSize1 * sampleSize2) / (double) (sampleSize1 + sampleSize2))
-    double lambda = (effectiveSize + 0.12d + 0.11d / effectiveSize) * dStatistic
+    double lambda = (effectiveSize + ASYMPTOTIC_CORRECTION_BASE + ASYMPTOTIC_CORRECTION_SCALE / effectiveSize) * dStatistic
     kolmogorovProbability(lambda)
   }
 
@@ -282,8 +288,8 @@ class KolmogorovSmirnov {
     BigInteger totalPathCount = binomial(sampleSize1 + sampleSize2, sampleSize1)
     BigDecimal cdf = new BigDecimal(validPathCount)
       .divide(new BigDecimal(totalPathCount), java.math.MathContext.DECIMAL128)
-    double pValue = 1.0d - cdf.doubleValue()
-    Math.max(0.0d, Math.min(1.0d, pValue))
+    double pValue = PROBABILITY_UPPER_BOUND - cdf.doubleValue()
+    Math.max(PROBABILITY_LOWER_BOUND, Math.min(PROBABILITY_UPPER_BOUND, pValue))
   }
 
   private static BigInteger countValidPaths(int sampleSize1, int sampleSize2, long thresholdCount) {
@@ -322,29 +328,29 @@ class KolmogorovSmirnov {
   }
 
   private static double kolmogorovProbability(double lambda) {
-    double sum = 0.0d
+    double sum = PROBABILITY_LOWER_BOUND
 
     for (int j = 1; j <= 100; j++) {
-      double term = Math.exp(-2.0d * j * j * lambda * lambda)
-      sum += (j % 2 != 0 ? 1.0d : -1.0d) * term
+      double term = Math.exp(-SERIES_MULTIPLIER * j * j * lambda * lambda)
+      sum += (j % SERIES_MULTIPLIER != 0 ? PROBABILITY_UPPER_BOUND : -PROBABILITY_UPPER_BOUND) * term
       if (term < 1e-12d) {
         break
       }
     }
 
-    Math.max(0.0d, Math.min(1.0d, 2.0d * sum))
+    Math.max(PROBABILITY_LOWER_BOUND, Math.min(PROBABILITY_UPPER_BOUND, SERIES_MULTIPLIER * sum))
   }
 
   private static void validateData(List<? extends Number> data) {
     if (data == null || data.isEmpty()) {
-      throw new IllegalArgumentException("Data cannot be null or empty")
+      throw new IllegalArgumentException('Data cannot be null or empty')
     }
     if (data.size() < 2) {
       throw new IllegalArgumentException("Kolmogorov-Smirnov test requires at least 2 observations (got ${data.size()})")
     }
     for (Number value : data) {
       if (value == null) {
-        throw new IllegalArgumentException("Data cannot contain null values")
+        throw new IllegalArgumentException('Data cannot contain null values')
       }
     }
   }
@@ -385,10 +391,10 @@ class KolmogorovSmirnov {
     @Override
     String toString() {
       String result
-      if (testType.contains("Normality")) {
-        result = isNormal() ? "Data appears normally distributed" : "Data does NOT appear normally distributed"
+      if (testType.contains('Normality')) {
+        result = isNormal() ? 'Data appears normally distributed' : 'Data does NOT appear normally distributed'
       } else {
-        result = evaluate() ? "Samples appear to differ" : "Samples do not significantly differ"
+        result = evaluate() ? 'Samples appear to differ' : 'Samples do not significantly differ'
       }
 
       """Kolmogorov-Smirnov Test Result (${testType}):

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KolmogorovSmirnov.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/KolmogorovSmirnov.groovy
@@ -103,14 +103,10 @@ import se.alipsa.matrix.stats.util.NumericConversion
  * Lilliefors test instead, which provides a corrected version of the K-S test specifically for normality
  * testing with estimated parameters.</p>
  */
+@SuppressWarnings('DuplicateNumberLiteral')
 class KolmogorovSmirnov {
   private static final double ASYMPTOTIC_CORRECTION_BASE = 0.12d
   private static final double ASYMPTOTIC_CORRECTION_SCALE = 0.11d
-  private static final double PROBABILITY_LOWER_BOUND = 0.0d
-  private static final double PROBABILITY_UPPER_BOUND = 1.0d
-  private static final double SERIES_MULTIPLIER = 2.0d
-
-
   private static final int EXACT_TWO_SAMPLE_MAX_PRODUCT = 10_000
 
   /**
@@ -208,8 +204,8 @@ class KolmogorovSmirnov {
 
   private static double calculateOneSampleStatistic(double[] sortedValues, ContinuousDistribution distribution) {
     int n = sortedValues.length
-    double dPlus = PROBABILITY_LOWER_BOUND
-    double dMinus = PROBABILITY_LOWER_BOUND
+    double dPlus = 0.0d
+    double dMinus = 0.0d
 
     for (int i = 0; i < n; i++) {
       double theoretical = distribution.cumulativeProbability(sortedValues[i])
@@ -223,8 +219,8 @@ class KolmogorovSmirnov {
   }
 
   private static double calculateOneSamplePValue(double dStatistic, int sampleSize) {
-    if (dStatistic <= PROBABILITY_LOWER_BOUND) {
-      return PROBABILITY_UPPER_BOUND
+    if (dStatistic <= 0.0d) {
+      return 1.0d
     }
 
     // Use Stephens' asymptotic correction for the one-sample test. This is intentionally approximate,
@@ -270,8 +266,8 @@ class KolmogorovSmirnov {
   }
 
   private static double calculateTwoSamplePValue(double dStatistic, int sampleSize1, int sampleSize2) {
-    if (dStatistic <= PROBABILITY_LOWER_BOUND) {
-      return PROBABILITY_UPPER_BOUND
+    if (dStatistic <= 0.0d) {
+      return 1.0d
     }
     if ((sampleSize1 as long) * sampleSize2 <= EXACT_TWO_SAMPLE_MAX_PRODUCT) {
       long differenceCount = Math.round(dStatistic * sampleSize1 * sampleSize2)
@@ -288,8 +284,8 @@ class KolmogorovSmirnov {
     BigInteger totalPathCount = binomial(sampleSize1 + sampleSize2, sampleSize1)
     BigDecimal cdf = new BigDecimal(validPathCount)
       .divide(new BigDecimal(totalPathCount), java.math.MathContext.DECIMAL128)
-    double pValue = PROBABILITY_UPPER_BOUND - cdf.doubleValue()
-    Math.max(PROBABILITY_LOWER_BOUND, Math.min(PROBABILITY_UPPER_BOUND, pValue))
+    double pValue = 1.0d - cdf.doubleValue()
+    Math.max(0.0d, Math.min(1.0d, pValue))
   }
 
   private static BigInteger countValidPaths(int sampleSize1, int sampleSize2, long thresholdCount) {
@@ -328,17 +324,17 @@ class KolmogorovSmirnov {
   }
 
   private static double kolmogorovProbability(double lambda) {
-    double sum = PROBABILITY_LOWER_BOUND
+    double sum = 0.0d
 
     for (int j = 1; j <= 100; j++) {
-      double term = Math.exp(-SERIES_MULTIPLIER * j * j * lambda * lambda)
-      sum += (j % SERIES_MULTIPLIER != 0 ? PROBABILITY_UPPER_BOUND : -PROBABILITY_UPPER_BOUND) * term
+      double term = Math.exp(-2.0d * j * j * lambda * lambda)
+      sum += (j % 2 != 0 ? 1.0d : -1.0d) * term
       if (term < 1e-12d) {
         break
       }
     }
 
-    Math.max(PROBABILITY_LOWER_BOUND, Math.min(PROBABILITY_UPPER_BOUND, SERIES_MULTIPLIER * sum))
+    Math.max(0.0d, Math.min(1.0d, 2.0d * sum))
   }
 
   private static void validateData(List<? extends Number> data) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/Lilliefors.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/Lilliefors.groovy
@@ -36,7 +36,7 @@ class Lilliefors {
     int n = data.size()
 
     // Calculate sample mean and standard deviation
-    double[] values = data.collect { it.doubleValue() } as double[]
+    double[] values = data*.doubleValue() as double[]
     double mean = values.sum() / n
     double variance = 0.0
     for (double val : values) {
@@ -117,35 +117,34 @@ class Lilliefors {
       // Approximation based on simulation studies
       if (z < 0.2) {
         return 1.0
-      } else if (z > 1.0) {
+      }
+      if (z > 1.0) {
         // For large D values, use exponential approximation
         return Math.exp(-7.01256 * z * z + 4.8 * z)
-      } else {
-        // Linear interpolation for moderate D values
-        return Math.max(0.0, 1.0 - Math.exp(-7.01256 * z * z + 4.8 * z))
       }
-    } else {
-      // For larger samples, use a different approximation
-      // Based on the asymptotic distribution
-      double sqrtN = Math.sqrt(n)
-      double zScore = d * (sqrtN - 0.01 + 0.85 / sqrtN)
-
-      if (zScore < 0.3) {
-        return 1.0
-      } else if (zScore > 1.0) {
-        return Math.exp(-2.0 * zScore * zScore)
-      } else {
-        return Math.max(0.0, 1.0 - Math.exp(-2.0 * zScore * zScore))
-      }
+      // Linear interpolation for moderate D values
+      return Math.max(0.0, 1.0 - Math.exp(-7.01256 * z * z + 4.8 * z))
     }
+    // For larger samples, use a different approximation
+    // Based on the asymptotic distribution
+    double sqrtN = Math.sqrt(n)
+    double zScore = d * (sqrtN - 0.01 + 0.85 / sqrtN)
+
+    if (zScore < 0.3) {
+      return 1.0
+    }
+    if (zScore > 1.0) {
+      return Math.exp(-2.0 * zScore * zScore)
+    }
+    return Math.max(0.0, 1.0 - Math.exp(-2.0 * zScore * zScore))
   }
 
   private static void validateInput(List<? extends Number> data) {
     if (data == null) {
-      throw new IllegalArgumentException("Data cannot be null")
+      throw new IllegalArgumentException('Data cannot be null')
     }
     if (data.isEmpty()) {
-      throw new IllegalArgumentException("Data cannot be empty")
+      throw new IllegalArgumentException('Data cannot be empty')
     }
     if (data.size() < 4) {
       throw new IllegalArgumentException("Lilliefors test requires at least 4 observations, got ${data.size()}")
@@ -153,7 +152,7 @@ class Lilliefors {
     // Check for non-null values
     for (Number value : data) {
       if (value == null) {
-        throw new IllegalArgumentException("Data contains null values")
+        throw new IllegalArgumentException('Data contains null values')
       }
     }
   }
@@ -188,22 +187,21 @@ class Lilliefors {
      */
     String evaluate() {
       if (pValue < alpha) {
-        return String.format("Reject H0: Data does not appear to be normally distributed (p = %.4f < α = %.2f)",
-                             pValue, alpha)
-      } else {
-        return String.format("Fail to reject H0: Data appears to be normally distributed (p = %.4f >= α = %.2f)",
+        return String.format('Reject H0: Data does not appear to be normally distributed (p = %.4f < α = %.2f)',
                              pValue, alpha)
       }
+      return String.format('Fail to reject H0: Data appears to be normally distributed (p = %.4f >= α = %.2f)',
+                           pValue, alpha)
     }
 
     @Override
     String toString() {
       """Lilliefors Normality Test
   Sample size: ${sampleSize}
-  Sample mean: ${String.format("%.4f", mean)}
-  Sample SD: ${String.format("%.4f", stdDev)}
-  Test statistic (D): ${String.format("%.4f", statistic)}
-  P-value: ${String.format("%.4f", pValue)}
+  Sample mean: ${String.format('%.4f', mean)}
+  Sample SD: ${String.format('%.4f', stdDev)}
+  Test statistic (D): ${String.format('%.4f', statistic)}
+  P-value: ${String.format('%.4f', pValue)}
 
   ${evaluate()}"""
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroFrancia.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroFrancia.groovy
@@ -116,14 +116,14 @@ class ShapiroFrancia {
     validateData(data)
 
     int n = data.size()
-    double[] sorted = data.collect { it.doubleValue() }.sort() as double[]
+    double[] sorted = data*.doubleValue().sort() as double[]
 
     // Calculate sample mean and variance
     double mean = StatUtils.mean(sorted)
     double variance = StatUtils.variance(sorted, mean)
 
     if (variance < 1e-10) {
-      throw new IllegalArgumentException("Data has zero variance - values are too similar or identical")
+      throw new IllegalArgumentException('Data has zero variance - values are too similar or identical')
     }
 
     // Calculate W' statistic
@@ -143,7 +143,7 @@ class ShapiroFrancia {
 
   private static void validateData(List<? extends Number> data) {
     if (data == null || data.isEmpty()) {
-      throw new IllegalArgumentException("Data cannot be null or empty")
+      throw new IllegalArgumentException('Data cannot be null or empty')
     }
     if (data.size() < MIN_SAMPLE_SIZE) {
       throw new IllegalArgumentException(
@@ -159,7 +159,7 @@ class ShapiroFrancia {
     // Check for non-null values
     for (Number value : data) {
       if (value == null) {
-        throw new IllegalArgumentException("Data contains null values")
+        throw new IllegalArgumentException('Data contains null values')
       }
     }
   }
@@ -234,29 +234,28 @@ class ShapiroFrancia {
       // So we need upper tail
       double pValue = 1.0 - normalDist.cumulativeProbability(z)
       return Math.max(0.0, Math.min(1.0, pValue))
-    } else {
-      // Larger sample approximation (based on Royston 1993)
-      double lnN = Math.log(n)
-
-      // Approximate mean of log(1-W') under H0 (normality)
-      // These parameters are calibrated so that under H0, the transformed
-      // statistic follows approximately N(0,1)
-      double mu = -1.5861 - 0.31082 * lnN - 0.083751 * lnN * lnN
-
-      // Approximate standard deviation
-      double sigma = Math.exp(-0.4803 - 0.082676 * lnN + 0.0030302 * lnN * lnN)
-
-      // Normalize: under H0 (normality), this should be approximately N(0,1)
-      double z = (logOneMinusW - mu) / sigma
-
-      // For this transformation, smaller W' → larger (less negative) log(1-W') → larger z → larger CDF
-      // We want smaller W' (non-normal) → smaller p-value
-      // So we use upper tail: p = P(Z > z) = 1 - Φ(z)
-      double pValue = normalDist.cumulativeProbability(z)
-
-      // Ensure p-value is in valid range
-      return Math.max(0.0, Math.min(1.0, pValue))
     }
+    // Larger sample approximation (based on Royston 1993)
+    double lnN = Math.log(n)
+
+    // Approximate mean of log(1-W') under H0 (normality)
+    // These parameters are calibrated so that under H0, the transformed
+    // statistic follows approximately N(0,1)
+    double mu = -1.5861 - 0.31082 * lnN - 0.083751 * lnN * lnN
+
+    // Approximate standard deviation
+    double sigma = Math.exp(-0.4803 - 0.082676 * lnN + 0.0030302 * lnN * lnN)
+
+    // Normalize: under H0 (normality), this should be approximately N(0,1)
+    double z = (logOneMinusW - mu) / sigma
+
+    // For this transformation, smaller W' → larger (less negative) log(1-W') → larger z → larger CDF
+    // We want smaller W' (non-normal) → smaller p-value
+    // So we use upper tail: p = P(Z > z) = 1 - Φ(z)
+    double pValue = normalDist.cumulativeProbability(z)
+
+    // Ensure p-value is in valid range
+    return Math.max(0.0, Math.min(1.0, pValue))
   }
 
   /**
@@ -289,9 +288,8 @@ class ShapiroFrancia {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       if (pValue < alphaValue) {
         return "Reject H0: Data does not appear to be normally distributed (W' = ${String.format('%.4f', W)}, p = ${String.format('%.4f', pValue)})"
-      } else {
-        return "Fail to reject H0: Data appears to be consistent with a normal distribution (W' = ${String.format('%.4f', W)}, p = ${String.format('%.4f', pValue)})"
       }
+      return "Fail to reject H0: Data appears to be consistent with a normal distribution (W' = ${String.format('%.4f', W)}, p = ${String.format('%.4f', pValue)})"
     }
 
     /**
@@ -302,14 +300,14 @@ class ShapiroFrancia {
     String evaluate(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       String conclusion = pValue < alphaValue ?
-        "not normally distributed" :
-        "consistent with a normal distribution"
+        'not normally distributed' :
+        'consistent with a normal distribution'
 
       String.format(
         "Shapiro-Francia W' statistic: %.4f\n" +
-        "p-value: %.4f\n" +
-        "Sample: n=%d, mean=%.4f, sd=%.4f\n" +
-        "Conclusion at %.0f%% level: Data appears %s",
+        'p-value: %.4f\n' +
+        'Sample: n=%d, mean=%.4f, sd=%.4f\n' +
+        'Conclusion at %.0f%% level: Data appears %s',
         W, pValue, sampleSize, mean, stdDev, alphaValue * 100, conclusion
       )
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroWilk.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/normality/ShapiroWilk.groovy
@@ -119,7 +119,7 @@ class ShapiroWilk {
     validateData(data)
 
     int n = data.size()
-    double[] sorted = data.collect { it.doubleValue() }.sort() as double[]
+    double[] sorted = data*.doubleValue().sort() as double[]
 
     // Calculate sample mean and variance
     double mean = StatUtils.mean(sorted)
@@ -140,7 +140,7 @@ class ShapiroWilk {
 
   private static void validateData(List<? extends Number> data) {
     if (data == null || data.isEmpty()) {
-      throw new IllegalArgumentException("Data cannot be null or empty")
+      throw new IllegalArgumentException('Data cannot be null or empty')
     }
     if (data.size() < MIN_SAMPLE_SIZE) {
       throw new IllegalArgumentException("Shapiro-Wilk test requires at least ${MIN_SAMPLE_SIZE} observations (got ${data.size()})")
@@ -153,7 +153,7 @@ class ShapiroWilk {
     double first = data[0].doubleValue()
     boolean allSame = data.every { it.doubleValue() == first }
     if (allSame) {
-      throw new IllegalArgumentException("Data has zero variance - all values are identical")
+      throw new IllegalArgumentException('Data has zero variance - all values are identical')
     }
   }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/DecisionTree.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/DecisionTree.groovy
@@ -268,18 +268,18 @@ class DecisionTree {
   private static void validateInputs(List<? extends Number> xValues, List<? extends Number> yValues,
                                      int maxDepth, int minSamplesLeaf) {
     if (xValues == null || yValues == null) {
-      throw new IllegalArgumentException("Input data cannot be null")
+      throw new IllegalArgumentException('Input data cannot be null')
     }
 
     if (xValues.size() != yValues.size()) {
       throw new IllegalArgumentException(
-        "Must have equal number of X and Y data points. " +
+        'Must have equal number of X and Y data points. ' +
         "Got ${xValues.size()} X values and ${yValues.size()} Y values."
       )
     }
 
     if (xValues.isEmpty()) {
-      throw new IllegalArgumentException("Input data cannot be empty")
+      throw new IllegalArgumentException('Input data cannot be empty')
     }
 
     if (xValues.size() < 2) {
@@ -661,21 +661,23 @@ class DecisionTree {
    */
   String summary() {
     StringBuilder sb = new StringBuilder()
-    sb.append("Decision Tree Regression\n")
-    sb.append("========================\n\n")
-    sb.append("Parameters:\n")
-    sb.append("  maxDepth: ${maxDepth}\n")
-    sb.append("  minSamplesLeaf: ${minSamplesLeaf}\n\n")
-    sb.append("Tree Structure:\n")
-    sb.append("  Actual depth: ${depth}\n")
-    sb.append("  Number of leaves: ${leafCount}\n\n")
-    sb.append("Training Metrics:\n")
-    sb.append("  R²:   ${getRSquared(4)}\n")
-    sb.append("  MSE:  ${getMse(4)}\n")
-    sb.append("  RMSE: ${getRmse(4)}\n")
-    sb.append("  MAE:  ${getMae(4)}\n\n")
-    sb.append("Tree Rules:\n")
-    appendTreeRules(sb, root, "  ", "root")
+    sb.with {
+      append('Decision Tree Regression\n')
+      append('========================\n\n')
+      append('Parameters:\n')
+      append("  maxDepth: ${maxDepth}\n")
+      append("  minSamplesLeaf: ${minSamplesLeaf}\n\n")
+      append('Tree Structure:\n')
+      append("  Actual depth: ${depth}\n")
+      append("  Number of leaves: ${leafCount}\n\n")
+      append('Training Metrics:\n')
+      append("  R²:   ${getRSquared(4)}\n")
+      append("  MSE:  ${getMse(4)}\n")
+      append("  RMSE: ${getRmse(4)}\n")
+      append("  MAE:  ${getMae(4)}\n\n")
+      append('Tree Rules:\n')
+    }
+    appendTreeRules(sb, root, '  ', 'root')
     sb.toString()
   }
 
@@ -687,8 +689,8 @@ class DecisionTree {
       sb.append("${indent}${condition}: predict ${node.value.setScale(4, RoundingMode.HALF_EVEN)}\n")
     } else {
       sb.append("${indent}${condition}:\n")
-      appendTreeRules(sb, node.left, indent + "  ", "${x} <= ${node.threshold}")
-      appendTreeRules(sb, node.right, indent + "  ", "${x} > ${node.threshold}")
+      appendTreeRules(sb, node.left, indent + '  ', "${x} <= ${node.threshold}")
+      appendTreeRules(sb, node.right, indent + '  ', "${x} > ${node.threshold}")
     }
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitDsl.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitDsl.groovy
@@ -13,6 +13,8 @@ import se.alipsa.matrix.stats.formula.dsl.GroovyFormulaSpec
  * usage such as {@code lm(data) { y | x + group }}.</p>
  */
 final class FitDsl {
+  private static final String GAM_METHOD = 'gam'
+  private static final String LOESS_METHOD = 'loess'
 
   private FitDsl() {
   }
@@ -44,7 +46,7 @@ final class FitDsl {
     @DelegatesTo(value = GroovyFormulaDsl, strategy = Closure.DELEGATE_FIRST)
     Closure<GroovyFormulaSpec> formula
   ) {
-    fit('loess', data, formula)
+    fit(LOESS_METHOD, data, formula)
   }
 
   /**
@@ -61,7 +63,7 @@ final class FitDsl {
     @DelegatesTo(value = GroovyFormulaDsl, strategy = Closure.DELEGATE_FIRST)
     Closure<GroovyFormulaSpec> formula
   ) {
-    fit('loess', data, formula, options)
+    fit(LOESS_METHOD, data, formula, options)
   }
 
   /**
@@ -76,7 +78,7 @@ final class FitDsl {
     @DelegatesTo(value = GroovyFormulaDsl, strategy = Closure.DELEGATE_FIRST)
     Closure<GroovyFormulaSpec> formula
   ) {
-    fit('gam', data, formula)
+    fit(GAM_METHOD, data, formula)
   }
 
   /**
@@ -93,7 +95,7 @@ final class FitDsl {
     @DelegatesTo(value = GroovyFormulaDsl, strategy = Closure.DELEGATE_FIRST)
     Closure<GroovyFormulaSpec> formula
   ) {
-    fit('gam', data, formula, options)
+    fit(GAM_METHOD, data, formula, options)
   }
 
   private static FitResult fit(

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
@@ -43,7 +43,7 @@ class LinearRegression {
 
   LinearRegression(List<? extends Number> x, List<? extends Number> y) {
     if (x.size() != y.size()) {
-      throw new IllegalArgumentException("Must have equal number of X and Y data points for a linear regression")
+      throw new IllegalArgumentException('Must have equal number of X and Y data points for a linear regression')
     }
 
     Integer numberOfDataValues = x.size()

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LogisticRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LogisticRegression.groovy
@@ -188,7 +188,7 @@ class LogisticRegression {
     // Validation
     if (xValues.size() != yValues.size()) {
       throw new IllegalArgumentException(
-        "Must have equal number of X and Y data points for logistic regression. " +
+        'Must have equal number of X and Y data points for logistic regression. ' +
         "Got ${xValues.size()} X values and ${yValues.size()} Y values."
       )
     }
@@ -227,8 +227,8 @@ class LogisticRegression {
     int n = xValues.size()
 
     // Convert to double arrays
-    double[] x = xValues.collect { it.doubleValue() } as double[]
-    double[] y = yValues.collect { it.doubleValue() } as double[]
+    double[] x = xValues*.doubleValue() as double[]
+    double[] y = yValues*.doubleValue() as double[]
 
     MultivariateObjective negativeLogLikelihood = { double[] coefficients ->
       double beta0 = coefficients[0]
@@ -269,8 +269,8 @@ class LogisticRegression {
 
     } catch (Exception e) {
       throw new IllegalStateException(
-        "Failed to fit logistic regression model. " +
-        "This may be due to numerical instability or perfect separation in the data. " +
+        'Failed to fit logistic regression model. ' +
+        'This may be due to numerical instability or perfect separation in the data. ' +
         "Error: ${e.message}", e
       )
     }
@@ -283,10 +283,9 @@ class LogisticRegression {
     // Use numerically stable sigmoid
     if (z >= 0) {
       return 1.0 / (1.0 + Math.exp(-z))
-    } else {
-      double expZ = Math.exp(z)
-      return expZ / (1.0 + expZ)
     }
+    double expZ = Math.exp(z)
+    return expZ / (1.0 + expZ)
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/MultipleLinearRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/MultipleLinearRegression.groovy
@@ -149,10 +149,10 @@ class MultipleLinearRegression {
 
   private static void validateInputs(double[] response, double[][] predictors) {
     if (response == null || predictors == null) {
-      throw new IllegalArgumentException("Response vector and design matrix cannot be null")
+      throw new IllegalArgumentException('Response vector and design matrix cannot be null')
     }
     if (response.length == 0) {
-      throw new IllegalArgumentException("Response vector cannot be empty")
+      throw new IllegalArgumentException('Response vector cannot be empty')
     }
     if (predictors.length != response.length) {
       throw new IllegalArgumentException(
@@ -160,7 +160,7 @@ class MultipleLinearRegression {
       )
     }
     if (predictors.length == 0 || predictors[0].length == 0) {
-      throw new IllegalArgumentException("Design matrix must contain at least one predictor")
+      throw new IllegalArgumentException('Design matrix must contain at least one predictor')
     }
 
     int columnCount = predictors[0].length
@@ -171,7 +171,7 @@ class MultipleLinearRegression {
     }
     for (double[] row : predictors) {
       if (row.length != columnCount) {
-        throw new IllegalArgumentException("Design matrix rows must all have the same length")
+        throw new IllegalArgumentException('Design matrix rows must all have the same length')
       }
     }
   }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/PolynomialRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/PolynomialRegression.groovy
@@ -45,7 +45,7 @@ class PolynomialRegression {
 
   PolynomialRegression(List<? extends Number> x, List<? extends Number> y, int degree) {
     if (x.size() != y.size()) {
-      throw new IllegalArgumentException("Must have equal number of X and Y data points")
+      throw new IllegalArgumentException('Must have equal number of X and Y data points')
     }
     if (degree < 1) {
       throw new IllegalArgumentException("Polynomial degree must be at least 1, got: $degree")
@@ -84,7 +84,7 @@ class PolynomialRegression {
     } catch (SingularMatrixException ignored) {
       int[] selectedColumns = selectIndependentColumns(design)
       if (selectedColumns.length == 0) {
-        throw new IllegalStateException("Polynomial design matrix has no independent columns")
+        throw new IllegalStateException('Polynomial design matrix has no independent columns')
       }
       double[][] reducedDesign = new double[design.length][selectedColumns.length]
       for (int row = 0; row < design.length; row++) {
@@ -254,16 +254,16 @@ class PolynomialRegression {
 
   @Override
   String toString() {
-    StringBuilder sb = new StringBuilder("Y = ")
+    StringBuilder sb = new StringBuilder('Y = ')
     for (int i = 0; i <= degree; i++) {
       BigDecimal coef = getCoefficient(i).setScale(3, RoundingMode.HALF_EVEN)
       if (i == 0) {
         sb.append(coef)
       } else {
-        sb.append(coef >= 0 ? " + " : " - ")
+        sb.append(coef >= 0 ? ' + ' : ' - ')
         sb.append(coef.abs())
         if (i == 1) {
-          sb.append("X")
+          sb.append('X')
         } else {
           sb.append("X^$i")
         }
@@ -276,9 +276,9 @@ class PolynomialRegression {
     StringBuilder sb = new StringBuilder()
     sb.append("Polynomial Regression (degree $degree)\n")
     sb.append("Equation: ${this}\n")
-    sb.append("\nCoefficients:\n")
+    sb.append('\nCoefficients:\n')
     for (int i = 0; i <= degree; i++) {
-      String term = i == 0 ? "(Intercept)" : (i == 1 ? x : "${x}^$i")
+      String term = i == 0 ? '(Intercept)' : (i == 1 ? x : "${x}^$i")
       sb.append("  $term: ${getCoefficient(i).setScale(6, RoundingMode.HALF_EVEN)}\n")
     }
     sb.append("\nR-squared: ${getRsquared(4)}\n")

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/QuantileRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/QuantileRegression.groovy
@@ -197,7 +197,7 @@ class QuantileRegression {
     // Validation
     if (xValues.size() != yValues.size()) {
       throw new IllegalArgumentException(
-        "Must have equal number of X and Y data points for quantile regression. " +
+        'Must have equal number of X and Y data points for quantile regression. ' +
         "Got ${xValues.size()} X values and ${yValues.size()} Y values."
       )
     }
@@ -288,7 +288,7 @@ class QuantileRegression {
     } catch (Exception e) {
       throw new IllegalStateException(
         "Failed to solve quantile regression for tau=${tau}. " +
-        "This may be due to numerical instability or degenerate data. " +
+        'This may be due to numerical instability or degenerate data. ' +
         "Error: ${e.message}", e
       )
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/BrentSolver.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/BrentSolver.groovy
@@ -36,16 +36,16 @@ final class BrentSolver {
       int maxIterations
   ) {
     if (function == null) {
-      throw new IllegalArgumentException("Function cannot be null")
+      throw new IllegalArgumentException('Function cannot be null')
     }
     if (min >= max) {
       throw new IllegalArgumentException("min ($min) must be smaller than max ($max)")
     }
     if (relativeAccuracy <= 0.0d || absoluteAccuracy <= 0.0d) {
-      throw new IllegalArgumentException("Accuracies must be positive")
+      throw new IllegalArgumentException('Accuracies must be positive')
     }
     if (maxIterations < 1) {
-      throw new IllegalArgumentException("maxIterations must be positive")
+      throw new IllegalArgumentException('maxIterations must be positive')
     }
 
     double a = min
@@ -61,7 +61,7 @@ final class BrentSolver {
       return new SolverResult(root: b, evaluations: evaluations, iterations: 0, lowerBound: b, upperBound: b)
     }
     if (fa * fb > 0.0d) {
-      throw new IllegalArgumentException("Function values at the interval endpoints must bracket a root")
+      throw new IllegalArgumentException('Function values at the interval endpoints must bracket a root')
     }
 
     double c = a

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/GoalSeek.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/GoalSeek.groovy
@@ -4,6 +4,8 @@ package se.alipsa.matrix.stats.solver
  * Root-finding utility that mirrors spreadsheet "goal seek" behavior for one-dimensional functions.
  */
 class GoalSeek {
+  private static final double MIDPOINT_DIVISOR = 2.0d
+  private static final double ZERO_VALUE = 0.0d
 
   /**
    * Provides similar functionality to the excel/calc goal seek function.
@@ -80,20 +82,20 @@ class GoalSeek {
     double lowValue = function.value(low)
     double highValue = function.value(high)
 
-    if (lowValue == 0.0d) {
+    if (lowValue == ZERO_VALUE) {
       return low
     }
-    if (highValue == 0.0d) {
+    if (highValue == ZERO_VALUE) {
       return high
     }
 
     for (int iteration = 0; iteration < 128 && (high - low) > absoluteAccuracy; iteration++) {
       double candidate = low - lowValue * (high - low) / (highValue - lowValue)
       if (!Double.isFinite(candidate) || candidate <= low || candidate >= high) {
-        candidate = low + (high - low) / 2.0d
+        candidate = low + (high - low) / MIDPOINT_DIVISOR
       }
       double candidateValue = function.value(candidate)
-      if (candidateValue == 0.0d) {
+      if (candidateValue == ZERO_VALUE) {
         return candidate
       }
       if (Math.signum(candidateValue) == Math.signum(lowValue)) {
@@ -104,6 +106,6 @@ class GoalSeek {
         highValue = candidateValue
       }
     }
-    low + (high - low) / 2.0d
+    low + (high - low) / MIDPOINT_DIVISOR
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/GoalSeek.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/GoalSeek.groovy
@@ -5,7 +5,7 @@ package se.alipsa.matrix.stats.solver
  */
 class GoalSeek {
   private static final double MIDPOINT_DIVISOR = 2.0d
-  private static final double ZERO_VALUE = 0.0d
+  private static final double ROOT_TARGET = 0.0d
 
   /**
    * Provides similar functionality to the excel/calc goal seek function.
@@ -82,10 +82,10 @@ class GoalSeek {
     double lowValue = function.value(low)
     double highValue = function.value(high)
 
-    if (lowValue == ZERO_VALUE) {
+    if (lowValue == ROOT_TARGET) {
       return low
     }
-    if (highValue == ZERO_VALUE) {
+    if (highValue == ROOT_TARGET) {
       return high
     }
 
@@ -95,7 +95,7 @@ class GoalSeek {
         candidate = low + (high - low) / MIDPOINT_DIVISOR
       }
       double candidateValue = function.value(candidate)
-      if (candidateValue == ZERO_VALUE) {
+      if (candidateValue == ROOT_TARGET) {
         return candidate
       }
       if (Math.signum(candidateValue) == Math.signum(lowValue)) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/LinearProgramSolver.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/LinearProgramSolver.groovy
@@ -45,7 +45,7 @@ final class LinearProgramSolver {
     PhaseState phaseOne = buildPhaseOne(normalizedConstraints, normalizedRhs)
     iterateSimplex(phaseOne, phaseOne.objective, maxIterations)
     if (phaseOne.currentObjective() < -EPSILON) {
-      throw new IllegalStateException("Linear program is infeasible")
+      throw new IllegalStateException('Linear program is infeasible')
     }
 
     PhaseState phaseTwo = removeArtificialVariables(phaseOne, variableCount)
@@ -161,7 +161,7 @@ final class LinearProgramSolver {
       }
       int leaving = selectLeavingRow(state, entering)
       if (leaving < 0) {
-        throw new IllegalStateException("Linear program is unbounded")
+        throw new IllegalStateException('Linear program is unbounded')
       }
       pivot(state.tableau, leaving, entering, state.rhsColumn)
       state.basis[leaving] = entering
@@ -222,16 +222,16 @@ final class LinearProgramSolver {
 
   private static void validateInputs(double[] objective, double[][] constraints, double[] rhs, int maxIterations) {
     if (objective == null || objective.length == 0) {
-      throw new IllegalArgumentException("Objective must contain at least one variable")
+      throw new IllegalArgumentException('Objective must contain at least one variable')
     }
     if (constraints == null || rhs == null || constraints.length == 0 || constraints.length != rhs.length) {
-      throw new IllegalArgumentException("Constraints and right-hand side must have matching non-empty sizes")
+      throw new IllegalArgumentException('Constraints and right-hand side must have matching non-empty sizes')
     }
     if (!constraints.every { double[] row -> row.length == objective.length }) {
-      throw new IllegalArgumentException("Constraint rows must match the objective dimension")
+      throw new IllegalArgumentException('Constraint rows must match the objective dimension')
     }
     if (maxIterations < 1) {
-      throw new IllegalArgumentException("maxIterations must be positive")
+      throw new IllegalArgumentException('maxIterations must be positive')
     }
   }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/NelderMeadOptimizer.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/NelderMeadOptimizer.groovy
@@ -40,16 +40,16 @@ final class NelderMeadOptimizer {
       double absoluteThreshold
   ) {
     if (objective == null) {
-      throw new IllegalArgumentException("Objective function cannot be null")
+      throw new IllegalArgumentException('Objective function cannot be null')
     }
     if (initialGuess == null || initialGuess.length == 0) {
-      throw new IllegalArgumentException("Initial guess must contain at least one dimension")
+      throw new IllegalArgumentException('Initial guess must contain at least one dimension')
     }
     if (stepSizes == null || stepSizes.length != initialGuess.length) {
-      throw new IllegalArgumentException("Step sizes must match the initial guess length")
+      throw new IllegalArgumentException('Step sizes must match the initial guess length')
     }
     if (maxEvaluations < initialGuess.length + 1) {
-      throw new IllegalArgumentException("maxEvaluations is too small for the simplex dimension")
+      throw new IllegalArgumentException('maxEvaluations is too small for the simplex dimension')
     }
 
     int dimension = initialGuess.length

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Adf.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Adf.groovy
@@ -27,17 +27,17 @@ class Adf {
    * @param type The type of test: "none" (no intercept/trend), "drift" (intercept only), or "trend" (intercept and trend)
    * @return AdfResult containing test statistic and conclusion
    */
-  static AdfResult test(List<? extends Number> data, int lags = 0, String type = "drift") {
+  static AdfResult test(List<? extends Number> data, int lags = 0, String type = 'drift') {
     validateInput(data, lags, type)
 
     int n = data.size()
-    double[] y = data.collect { it.doubleValue() } as double[]
+    double[] y = data*.doubleValue() as double[]
 
     // Check for constant series
     double yMin = y.min()
     double yMax = y.max()
     if (Math.abs(yMax - yMin) < 1e-10) {
-      throw new IllegalArgumentException("Data has no variation (constant series). Cannot perform ADF test.")
+      throw new IllegalArgumentException('Data has no variation (constant series). Cannot perform ADF test.')
     }
 
     // Calculate first differences
@@ -74,7 +74,7 @@ class Adf {
       responseVar += (r - responseMean) * (r - responseMean)
     }
     if (responseVar < 1e-10) {
-      throw new IllegalArgumentException("First differences have no variation. Cannot perform ADF test.")
+      throw new IllegalArgumentException('First differences have no variation. Cannot perform ADF test.')
     }
 
     try {
@@ -110,8 +110,8 @@ class Adf {
       )
     } catch (Exception e) {
       throw new IllegalStateException(
-        "Failed to perform ADF test. This may be due to perfect collinearity in the data " +
-        "(e.g., perfect linear trend or constant differences). " +
+        'Failed to perform ADF test. This may be due to perfect collinearity in the data ' +
+        '(e.g., perfect linear trend or constant differences). ' +
         "Try using a different lag order or test type. Error: ${e.message}", e
       )
     }
@@ -124,10 +124,10 @@ class Adf {
   private static double[][] buildDesignMatrix(double[] y, double[] dy, int lags, String type, int nObs, int n) {
     // Determine number of predictors
     int nPredictors = 1 // y_{t-1}
-    if (type == "drift" || type == "trend") {
+    if (type == 'drift' || type == 'trend') {
       nPredictors++ // constant
     }
-    if (type == "trend") {
+    if (type == 'trend') {
       nPredictors++ // time trend
     }
     nPredictors += lags // lagged differences
@@ -138,12 +138,12 @@ class Adf {
       int col = 0
 
       // Add constant if drift or trend
-      if (type == "drift" || type == "trend") {
+      if (type == 'drift' || type == 'trend') {
         X[i][col++] = 1.0
       }
 
       // Add time trend if trend (centered to reduce collinearity)
-      if (type == "trend") {
+      if (type == 'trend') {
         // Center the time trend around its mean
         double t = (lags + i + 1) - (n / 2.0)
         X[i][col++] = t
@@ -172,13 +172,13 @@ class Adf {
    * Gets the index of the γ coefficient (y_{t-1}) in the regression parameters.
    */
   private static int getGammaIndex(String type) {
-    if (type == "none") {
+    if (type == 'none') {
       return 0 // y_{t-1} is first
-    } else if (type == "drift") {
-      return 1 // constant, then y_{t-1}
-    } else { // trend
-      return 2 // constant, trend, then y_{t-1}
     }
+    if (type == 'drift') {
+      return 1 // constant, then y_{t-1}
+    }
+    return 2 // constant, trend, then y_{t-1}
   }
 
   /**
@@ -187,39 +187,41 @@ class Adf {
    */
   private static double getCriticalValue(String type, int n) {
     // Approximate 5% critical values (more accurate for larger samples)
-    if (type == "none") {
+    if (type == 'none') {
       return -1.95 // No intercept, no trend
-    } else if (type == "drift") {
+    }
+    if (type == 'drift') {
       // Use size-adjusted critical value
       if (n < 25) {
         return -3.00
-      } else if (n < 50) {
+      }
+      if (n < 50) {
         return -2.93
-      } else if (n < 100) {
+      }
+      if (n < 100) {
         return -2.89
-      } else {
-        return -2.86
       }
-    } else { // trend
-      // Use size-adjusted critical value
-      if (n < 25) {
-        return -3.60
-      } else if (n < 50) {
-        return -3.50
-      } else if (n < 100) {
-        return -3.45
-      } else {
-        return -3.41
-      }
+      return -2.86
     }
+    // trend
+    if (n < 25) {
+      return -3.60
+    }
+    if (n < 50) {
+      return -3.50
+    }
+    if (n < 100) {
+      return -3.45
+    }
+    return -3.41
   }
 
   private static void validateInput(List<? extends Number> data, int lags, String type) {
     if (data == null) {
-      throw new IllegalArgumentException("Data cannot be null")
+      throw new IllegalArgumentException('Data cannot be null')
     }
     if (data.isEmpty()) {
-      throw new IllegalArgumentException("Data cannot be empty")
+      throw new IllegalArgumentException('Data cannot be empty')
     }
     if (data.size() < 12) {
       throw new IllegalArgumentException("ADF test requires at least 12 observations, got ${data.size()}")
@@ -236,7 +238,7 @@ class Adf {
     // Check for non-null values
     for (Number value : data) {
       if (value == null) {
-        throw new IllegalArgumentException("Data contains null values")
+        throw new IllegalArgumentException('Data contains null values')
       }
     }
   }
@@ -276,10 +278,9 @@ class Adf {
      */
     String interpret() {
       if (statistic < criticalValue) {
-        return "Reject H0: Series appears to be stationary (no unit root)"
-      } else {
-        return "Fail to reject H0: Series appears to have a unit root (non-stationary)"
+        return 'Reject H0: Series appears to be stationary (no unit root)'
       }
+      return 'Fail to reject H0: Series appears to have a unit root (non-stationary)'
     }
 
     /**
@@ -289,10 +290,10 @@ class Adf {
      */
     String evaluate() {
       String conclusion = statistic < criticalValue ?
-        "stationary (no unit root)" :
-        "non-stationary (unit root present)"
+        'stationary (no unit root)' :
+        'non-stationary (unit root present)'
 
-      String.format("ADF statistic: %.4f (critical value: %.2f at 5%% level)\nγ coefficient: %.6f (SE: %.6f)\nConclusion: Series appears %s",
+      String.format('ADF statistic: %.4f (critical value: %.2f at 5%% level)\nγ coefficient: %.6f (SE: %.6f)\nConclusion: Series appears %s',
                            statistic, criticalValue, gammaCoefficient, gammaStandardError, conclusion)
     }
 
@@ -302,10 +303,10 @@ class Adf {
   Type: ${type}
   Lags: ${lag}
   Sample size: ${sampleSize} (effective: ${effectiveSize})
-  ADF statistic: ${String.format("%.4f", statistic)}
-  Critical value (5%%): ${String.format("%.2f", criticalValue)}
-  γ coefficient: ${String.format("%.6f", gammaCoefficient)}
-  Standard error: ${String.format("%.6f", gammaStandardError)}
+  ADF statistic: ${String.format('%.4f', statistic)}
+  Critical value (5%%): ${String.format('%.2f', criticalValue)}
+  γ coefficient: ${String.format('%.6f', gammaCoefficient)}
+  Standard error: ${String.format('%.6f', gammaStandardError)}
 
   ${interpret()}"""
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/AdfGls.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/AdfGls.groovy
@@ -66,15 +66,15 @@ class AdfGls {
    * @return AdfGlsResult containing test statistic and conclusion
    */
   @SuppressWarnings('MethodSize')
-  static AdfGlsResult test(double[] data, Integer lags = null, String type = "drift") {
+  static AdfGlsResult test(double[] data, Integer lags = null, String type = 'drift') {
     if (data == null) {
-      throw new IllegalArgumentException("Data cannot be null")
+      throw new IllegalArgumentException('Data cannot be null')
     }
     if (data.length < 10) {
       throw new IllegalArgumentException("Data must have at least 10 observations (got ${data.length})")
     }
 
-    if (type != "drift" && type != "trend") {
+    if (type != 'drift' && type != 'trend') {
       throw new IllegalArgumentException("Type must be 'drift' or 'trend' (got '${type}')")
     }
 
@@ -93,7 +93,7 @@ class AdfGls {
     }
 
     if (Math.abs(yMax - yMin) < 1e-10) {
-      throw new IllegalArgumentException("Data has no variation (constant series)")
+      throw new IllegalArgumentException('Data has no variation (constant series)')
     }
 
     // Auto-select lags if not provided
@@ -101,7 +101,7 @@ class AdfGls {
 
     // GLS detrending parameter: α = 1 + c/n
     // c = -7 for drift, c = -13.5 for trend
-    double c = type == "drift" ? -7.0 : -13.5
+    double c = type == 'drift' ? -7.0 : -13.5
     double alpha = 1.0 + c / n
 
     // GLS-detrend the data
@@ -119,7 +119,7 @@ class AdfGls {
     // Prepare regression
     int nObs = n - p - 1
     if (nObs < 10) {
-      throw new IllegalArgumentException("Insufficient observations after accounting for lags")
+      throw new IllegalArgumentException('Insufficient observations after accounting for lags')
     }
 
     // Build design matrix: [ỹ_{t-1}, Δỹ_{t-1}, ..., Δỹ_{t-p}]
@@ -201,8 +201,8 @@ class AdfGls {
   /**
    * Performs the ADF-GLS test on a List of numbers.
    */
-  static AdfGlsResult test(List<? extends Number> data, Integer lags = null, String type = "drift") {
-    double[] array = data.collect { it.doubleValue() } as double[]
+  static AdfGlsResult test(List<? extends Number> data, Integer lags = null, String type = 'drift') {
+    double[] array = data*.doubleValue() as double[]
     test(array, lags, type)
   }
 
@@ -222,7 +222,7 @@ class AdfGls {
     }
 
     // Build quasi-differenced deterministic terms
-    double[][] X = new double[n][type == "drift" ? 1 : 2]
+    double[][] X = new double[n][type == 'drift' ? 1 : 2]
 
     // Constant term
     X[0][0] = 1.0
@@ -231,7 +231,7 @@ class AdfGls {
     }
 
     // Trend term (if needed)
-    if (type == "trend") {
+    if (type == 'trend') {
       X[0][1] = 1.0
       for (int i = 1; i < n; i++) {
         X[i][1] = (i + 1.0) - alpha * i
@@ -245,7 +245,7 @@ class AdfGls {
     double[] fitted = new double[n]
     for (int i = 0; i < n; i++) {
       fitted[i] = beta[0]  // Constant
-      if (type == "trend") {
+      if (type == 'trend') {
         fitted[i] += beta[1] * (i + 1.0)  // Trend
       }
     }
@@ -316,7 +316,7 @@ class AdfGls {
 
     double[] params
 
-    if (type == "drift") {
+    if (type == 'drift') {
       if (significance == 0.01) {
         params = [-2.64, -1.95, -0.80, 0.00] as double[]
       } else if (significance == 0.05) {
@@ -383,9 +383,8 @@ class AdfGls {
 
       if (statistic < cv) {
         return "Reject H0: Series appears stationary (ADF-GLS = ${String.format('%.4f', statistic)}, CV = ${String.format('%.4f', cv)})"
-      } else {
-        return "Fail to reject H0: Unit root likely present, series appears non-stationary (ADF-GLS = ${String.format('%.4f', statistic)}, CV = ${String.format('%.4f', cv)})"
       }
+      return "Fail to reject H0: Unit root likely present, series appears non-stationary (ADF-GLS = ${String.format('%.4f', statistic)}, CV = ${String.format('%.4f', cv)})"
     }
 
     /**
@@ -393,16 +392,16 @@ class AdfGls {
      */
     String evaluate(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
-      String conclusion = statistic < criticalValue5pct ? "stationary" : "non-stationary (unit root present)"
+      String conclusion = statistic < criticalValue5pct ? 'stationary' : 'non-stationary (unit root present)'
 
       String.format(
-        "ADF-GLS test:\\n" +
-        "Test type: %s\\n" +
-        "Lags: %d\\n" +
-        "ADF-GLS statistic: %.4f\\n" +
-        "Critical values: 1%% = %.4f, 5%% = %.4f, 10%% = %.4f\\n" +
-        "Sample size: %d\\n" +
-        "Conclusion: Series appears %s at %.0f%% significance level",
+        'ADF-GLS test:\\n' +
+        'Test type: %s\\n' +
+        'Lags: %d\\n' +
+        'ADF-GLS statistic: %.4f\\n' +
+        'Critical values: 1%% = %.4f, 5%% = %.4f, 10%% = %.4f\\n' +
+        'Sample size: %d\\n' +
+        'Conclusion: Series appears %s at %.0f%% significance level',
         testType, lags, statistic, criticalValue1pct, criticalValue5pct, criticalValue10pct,
         sampleSize, conclusion, (alphaValue * 100) as double
       )

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Ccm.groovy
@@ -76,7 +76,7 @@ class Ccm {
    */
   static CcmResult test(double[] x, double[] y, int E = 3, int tau = 1, List<Integer> librarySizes = null) {
     if (x == null || y == null) {
-      throw new IllegalArgumentException("Time series cannot be null")
+      throw new IllegalArgumentException('Time series cannot be null')
     }
 
     if (x.length != y.length) {
@@ -454,45 +454,47 @@ class Ccm {
      */
     String interpret() {
       StringBuilder sb = new StringBuilder()
-      sb.append("Convergent Cross Mapping Results:\n")
-      sb.append("=" * 60).append("\n\n")
+      sb.with {
+        append('Convergent Cross Mapping Results:\n')
+        append('=' * 60).append('\n\n')
 
-      sb.append("Configuration:\n")
-      sb.append("  Embedding dimension (E): ${embeddingDim}\n")
-      sb.append("  Time lag (tau): ${timeLag}\n")
-      sb.append("  Series length: ${seriesLength}\n")
-      sb.append("  Library sizes: ${librarySizes.join(', ')}\n\n")
+        append('Configuration:\n')
+        append("  Embedding dimension (E): ${embeddingDim}\n")
+        append("  Time lag (tau): ${timeLag}\n")
+        append("  Series length: ${seriesLength}\n")
+        append("  Library sizes: ${librarySizes.join(', ')}\n\n")
 
-      sb.append("Cross-map Skills:\n")
-      sb.append("-" * 60).append("\n")
-      sb.append(String.format("%-15s %-20s %-20s\n", "Library Size", "X|M(Y) (Y→X)", "Y|M(X) (X→Y)"))
-      sb.append("-" * 60).append("\n")
+        append('Cross-map Skills:\n')
+        append('-' * 60).append('\n')
+        append(String.format('%-15s %-20s %-20s\n', 'Library Size', 'X|M(Y) (Y→X)', 'Y|M(X) (X→Y)'))
+        append('-' * 60).append('\n')
+      }
 
       for (int i = 0; i < librarySizes.size(); i++) {
         String xVal = xmapY[i] != null ? String.format('%.4f', xmapY[i]) : 'NaN'
         String yVal = ymapX[i] != null ? String.format('%.4f', ymapX[i]) : 'NaN'
-        sb.append(String.format("%-15d %-20s %-20s\n", librarySizes[i], xVal, yVal))
+        sb.append(String.format('%-15d %-20s %-20s\n', librarySizes[i], xVal, yVal))
       }
 
-      sb.append("\n")
-      sb.append("Interpretation:\n")
-      sb.append("-" * 60).append("\n")
+      sb.append('\n')
+      sb.append('Interpretation:\n')
+      sb.append('-' * 60).append('\n')
 
       boolean xToY = xCausesY()
       boolean yToX = yCausesX()
 
       if (xToY && yToX) {
-        sb.append("Bidirectional causality: Both X and Y appear to causally influence each other\n")
+        sb.append('Bidirectional causality: Both X and Y appear to causally influence each other\n')
       } else if (xToY) {
-        sb.append("Unidirectional causality: X appears to causally drive Y\n")
+        sb.append('Unidirectional causality: X appears to causally drive Y\n')
       } else if (yToX) {
-        sb.append("Unidirectional causality: Y appears to causally drive X\n")
+        sb.append('Unidirectional causality: Y appears to causally drive X\n')
       } else {
-        sb.append("No clear causal relationship detected\n")
+        sb.append('No clear causal relationship detected\n')
       }
 
-      sb.append("\nNote: CCM detects causality via state space reconstruction.\n")
-      sb.append("Positive, increasing cross-map skill indicates causal influence.\n")
+      sb.append('\nNote: CCM detects causality via state space reconstruction.\n')
+      sb.append('Positive, increasing cross-map skill indicates causal influence.\n')
 
       sb.toString()
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Chow.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Chow.groovy
@@ -69,7 +69,7 @@ class Chow {
    */
   static ChowResult test(double[] y, double[][] X, int breakPoint) {
     if (y == null || X == null) {
-      throw new IllegalArgumentException("Data cannot be null")
+      throw new IllegalArgumentException('Data cannot be null')
     }
 
     int n = y.length
@@ -118,7 +118,7 @@ class Chow {
     double denominator = (rss1 + rss2) / (n - 2 * k)
 
     if (denominator < 1e-10) {
-      throw new IllegalArgumentException("Denominator too small - perfect fit in sub-models")
+      throw new IllegalArgumentException('Denominator too small - perfect fit in sub-models')
     }
 
     double fStatistic = numerator / denominator
@@ -145,8 +145,8 @@ class Chow {
    * Performs the Chow test with automatic conversion of List inputs.
    */
   static ChowResult test(List<? extends Number> y, List<List<? extends Number>> X, int breakPoint) {
-    double[] yArray = y.collect { it.doubleValue() } as double[]
-    double[][] XArray = X.collect { row -> row.collect { it.doubleValue() } as double[] } as double[][]
+    double[] yArray = y*.doubleValue() as double[]
+    double[][] XArray = X.collect { row -> row*.doubleValue() as double[] } as double[][]
     test(yArray, XArray, breakPoint)
   }
 
@@ -194,9 +194,8 @@ class Chow {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       if (pValue < alphaValue) {
         return "Reject H0: Structural break detected at observation ${breakPoint} (F = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
-      } else {
-        return "Fail to reject H0: No evidence of structural break at observation ${breakPoint} (F = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
       }
+      return "Fail to reject H0: No evidence of structural break at observation ${breakPoint} (F = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
     }
 
     /**
@@ -204,19 +203,19 @@ class Chow {
      */
     String evaluate(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
-      String conclusion = pValue < alphaValue ? "structural break present" : "no structural break detected"
+      String conclusion = pValue < alphaValue ? 'structural break present' : 'no structural break detected'
 
       String.format(
-        "Chow test:\\n" +
-        "Break point: %d\\n" +
-        "F-statistic: %.4f\\n" +
-        "p-value: %.4f\\n" +
-        "Degrees of freedom: (%d, %d)\\n" +
-        "RSS full model: %.4f\\n" +
-        "RSS sub-models: %.4f + %.4f = %.4f\\n" +
-        "Sample size: %d\\n" +
-        "Number of parameters: %d\\n" +
-        "Conclusion: %s at %.0f%% significance level",
+        'Chow test:\\n' +
+        'Break point: %d\\n' +
+        'F-statistic: %.4f\\n' +
+        'p-value: %.4f\\n' +
+        'Degrees of freedom: (%d, %d)\\n' +
+        'RSS full model: %.4f\\n' +
+        'RSS sub-models: %.4f + %.4f = %.4f\\n' +
+        'Sample size: %d\\n' +
+        'Number of parameters: %d\\n' +
+        'Conclusion: %s at %.0f%% significance level',
         breakPoint, statistic, pValue, df1, df2,
         rssFull, rss1, rss2, rss1 + rss2,
         sampleSize, numParameters,

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Df.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Df.groovy
@@ -66,7 +66,7 @@ class Df {
    * @param type The type of test: "none" (no intercept/trend), "drift" (intercept only), or "trend" (intercept and trend)
    * @return DfResult containing test statistic and conclusion
    */
-  static DfResult test(double[] data, String type = "drift") {
+  static DfResult test(double[] data, String type = 'drift') {
     validateInput(data, type)
     int n = data.length
     ensureVariation(data)
@@ -120,12 +120,12 @@ class Df {
 
   private static void validateInput(double[] data, String type) {
     if (data == null) {
-      throw new IllegalArgumentException("Data cannot be null")
+      throw new IllegalArgumentException('Data cannot be null')
     }
     if (data.length < 10) {
       throw new IllegalArgumentException("Data must have at least 10 observations (got ${data.length})")
     }
-    if (!(type in ["none", "drift", "trend"])) {
+    if (!(type in ['none', 'drift', 'trend'])) {
       throw new IllegalArgumentException("Type must be 'none', 'drift', or 'trend' (got '${type}')")
     }
   }
@@ -142,7 +142,7 @@ class Df {
       }
     }
     if (Math.abs(yMax - yMin) < 1e-10) {
-      throw new IllegalArgumentException("Data has no variation (constant series)")
+      throw new IllegalArgumentException('Data has no variation (constant series)')
     }
   }
 
@@ -156,10 +156,10 @@ class Df {
 
   private static int predictorCount(String type) {
     int count = 1
-    if (type == "drift" || type == "trend") {
+    if (type == 'drift' || type == 'trend') {
       count++
     }
-    if (type == "trend") {
+    if (type == 'trend') {
       count++
     }
     count
@@ -169,10 +169,10 @@ class Df {
     double[][] designMatrix = new double[nObs][nPredictors]
     for (int i = 0; i < nObs; i++) {
       int column = 0
-      if (type == "drift" || type == "trend") {
+      if (type == 'drift' || type == 'trend') {
         designMatrix[i][column++] = 1.0
       }
-      if (type == "trend") {
+      if (type == 'trend') {
         designMatrix[i][column++] = i + 1.0
       }
       designMatrix[i][column] = data[i]
@@ -222,8 +222,8 @@ class Df {
   /**
    * Performs the Dickey-Fuller test on a List of numbers.
    */
-  static DfResult test(List<? extends Number> data, String type = "drift") {
-    double[] array = data.collect { it.doubleValue() } as double[]
+  static DfResult test(List<? extends Number> data, String type = 'drift') {
+    double[] array = data*.doubleValue() as double[]
     test(array, type)
   }
 
@@ -236,7 +236,7 @@ class Df {
     // Using MacKinnon (1996) approximation
     double[] params
 
-    if (type == "none") {
+    if (type == 'none') {
       if (significance == 0.01) {
         params = [-2.66, -2.62, -1.26, 0.00] as double[]
       } else if (significance == 0.05) {
@@ -244,7 +244,7 @@ class Df {
       } else {
         params = [-1.60, -1.62, -0.88, 0.00] as double[]  // 10%
       }
-    } else if (type == "drift") {
+    } else if (type == 'drift') {
       if (significance == 0.01) {
         params = [-3.75, -3.52, -1.79, -0.38] as double[]
       } else if (significance == 0.05) {
@@ -308,9 +308,8 @@ class Df {
 
       if (statistic != null && statistic < cv) {
         return "Reject H0: Series appears stationary (DF = ${format(statistic, '%.4f')}, CV = ${format(cv, '%.4f')})"
-      } else {
-        return "Fail to reject H0: Unit root likely present, series appears non-stationary (DF = ${format(statistic, '%.4f')}, CV = ${format(cv, '%.4f')})"
       }
+      return "Fail to reject H0: Unit root likely present, series appears non-stationary (DF = ${format(statistic, '%.4f')}, CV = ${format(cv, '%.4f')})"
     }
 
     /**
@@ -318,15 +317,15 @@ class Df {
      */
     String evaluate(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
-      String conclusion = statistic != null && statistic < criticalValue5pct ? "stationary" : "non-stationary (unit root present)"
+      String conclusion = statistic != null && statistic < criticalValue5pct ? 'stationary' : 'non-stationary (unit root present)'
 
       String.format(
-        "Dickey-Fuller test:\\n" +
-        "Test type: %s\\n" +
-        "DF statistic: %.4f\\n" +
-        "Critical values: 1%% = %.4f, 5%% = %.4f, 10%% = %.4f\\n" +
-        "Sample size: %d\\n" +
-        "Conclusion: Series appears %s at %.0f%% significance level",
+        'Dickey-Fuller test:\\n' +
+        'Test type: %s\\n' +
+        'DF statistic: %.4f\\n' +
+        'Critical values: 1%% = %.4f, 5%% = %.4f, 10%% = %.4f\\n' +
+        'Sample size: %d\\n' +
+        'Conclusion: Series appears %s at %.0f%% significance level',
         testType, statistic ?: Double.NaN, criticalValue1pct, criticalValue5pct, criticalValue10pct,
         sampleSize, conclusion, (alphaValue * 100) as double
       )

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/DurbinWatson.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/DurbinWatson.groovy
@@ -34,7 +34,7 @@ class DurbinWatson {
     validateInput(residuals)
 
     int n = residuals.size()
-    double[] res = residuals.collect { it.doubleValue() } as double[]
+    double[] res = residuals*.doubleValue() as double[]
 
     // Calculate the Durbin-Watson statistic
     double numerator = 0.0
@@ -80,10 +80,10 @@ class DurbinWatson {
 
   private static void validateInput(List<? extends Number> residuals) {
     if (residuals == null) {
-      throw new IllegalArgumentException("Residuals cannot be null")
+      throw new IllegalArgumentException('Residuals cannot be null')
     }
     if (residuals.isEmpty()) {
-      throw new IllegalArgumentException("Residuals cannot be empty")
+      throw new IllegalArgumentException('Residuals cannot be empty')
     }
     if (residuals.size() < 3) {
       throw new IllegalArgumentException("Durbin-Watson test requires at least 3 observations, got ${residuals.size()}")
@@ -91,7 +91,7 @@ class DurbinWatson {
     // Check for non-null values
     for (Number value : residuals) {
       if (value == null) {
-        throw new IllegalArgumentException("Residuals contains null values")
+        throw new IllegalArgumentException('Residuals contains null values')
       }
     }
   }
@@ -116,7 +116,7 @@ class DurbinWatson {
     int sampleSize
 
     /** The alternative hypothesis */
-    String alternative = "two.sided"
+    String alternative = 'two.sided'
 
     /**
      * Interprets the Durbin-Watson statistic.
@@ -125,16 +125,18 @@ class DurbinWatson {
      */
     String interpret() {
       if (statistic < 1.5) {
-        return "Strong positive autocorrelation (DW < 1.5)"
-      } else if (statistic < 1.8) {
-        return "Moderate positive autocorrelation (1.5 ≤ DW < 1.8)"
-      } else if (statistic < 2.2) {
-        return "No significant autocorrelation (1.8 ≤ DW ≤ 2.2)"
-      } else if (statistic < 2.5) {
-        return "Moderate negative autocorrelation (2.2 < DW ≤ 2.5)"
-      } else {
-        return "Strong negative autocorrelation (DW > 2.5)"
+        return 'Strong positive autocorrelation (DW < 1.5)'
       }
+      if (statistic < 1.8) {
+        return 'Moderate positive autocorrelation (1.5 ≤ DW < 1.8)'
+      }
+      if (statistic < 2.2) {
+        return 'No significant autocorrelation (1.8 ≤ DW ≤ 2.2)'
+      }
+      if (statistic < 2.5) {
+        return 'Moderate negative autocorrelation (2.2 < DW ≤ 2.5)'
+      }
+      return 'Strong negative autocorrelation (DW > 2.5)'
     }
 
     /**
@@ -145,14 +147,14 @@ class DurbinWatson {
     String evaluate() {
       String autocorrType
       if (autocorrelation > 0.3) {
-        autocorrType = "positive"
+        autocorrType = 'positive'
       } else if (autocorrelation < -0.3) {
-        autocorrType = "negative"
+        autocorrType = 'negative'
       } else {
-        autocorrType = "negligible"
+        autocorrType = 'negligible'
       }
 
-      String.format("Durbin-Watson statistic: %.4f (ρ ≈ %.4f, %s autocorrelation)\n%s",
+      String.format('Durbin-Watson statistic: %.4f (ρ ≈ %.4f, %s autocorrelation)\n%s',
                            statistic, autocorrelation, autocorrType, interpret())
     }
 
@@ -160,8 +162,8 @@ class DurbinWatson {
     String toString() {
       """Durbin-Watson Test
   Sample size: ${sampleSize}
-  Test statistic (DW): ${String.format("%.4f", statistic)}
-  Autocorrelation (ρ): ${String.format("%.4f", autocorrelation)}
+  Test statistic (DW): ${String.format('%.4f', statistic)}
+  Autocorrelation (ρ): ${String.format('%.4f', autocorrelation)}
   Alternative: ${alternative}
 
   ${interpret()}"""

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Granger.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Granger.groovy
@@ -83,7 +83,7 @@ class Granger {
    */
   static GrangerResult test(double[] x, double[] y, Integer maxLag = null) {
     if (x == null || y == null) {
-      throw new IllegalArgumentException("Data cannot be null")
+      throw new IllegalArgumentException('Data cannot be null')
     }
 
     if (x.length != y.length) {
@@ -147,7 +147,7 @@ class Granger {
     double denominator = rssUnrestricted / (nObs - 2 * p - 1)
 
     if (denominator < 1e-10) {
-      throw new IllegalArgumentException("Unrestricted model has perfect fit (RSS ≈ 0)")
+      throw new IllegalArgumentException('Unrestricted model has perfect fit (RSS ≈ 0)')
     }
 
     double fStatistic = numerator / denominator
@@ -175,8 +175,8 @@ class Granger {
    * Performs the Granger causality test with List inputs.
    */
   static GrangerResult test(List<? extends Number> x, List<? extends Number> y, Integer maxLag = null) {
-    double[] xArray = x.collect { it.doubleValue() } as double[]
-    double[] yArray = y.collect { it.doubleValue() } as double[]
+    double[] xArray = x*.doubleValue() as double[]
+    double[] yArray = y*.doubleValue() as double[]
     test(xArray, yArray, maxLag)
   }
 
@@ -265,9 +265,8 @@ class Granger {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       if (pValue < alphaValue) {
         return "Reject H0: X Granger-causes Y (F = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
-      } else {
-        return "Fail to reject H0: X does not Granger-cause Y (F = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
       }
+      return "Fail to reject H0: X does not Granger-cause Y (F = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
     }
 
     /**
@@ -275,18 +274,18 @@ class Granger {
      */
     String evaluate(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
-      String conclusion = pValue < alphaValue ? "X Granger-causes Y" : "X does not Granger-cause Y"
+      String conclusion = pValue < alphaValue ? 'X Granger-causes Y' : 'X does not Granger-cause Y'
 
       String.format(
-        "Granger causality test:\\n" +
-        "Lags: %d\\n" +
-        "F-statistic: %.4f\\n" +
-        "p-value: %.4f\\n" +
-        "Degrees of freedom: (%d, %d)\\n" +
-        "RSS restricted: %.4f\\n" +
-        "RSS unrestricted: %.4f\\n" +
-        "Sample size: %d (effective: %d)\\n" +
-        "Conclusion: %s at %.0f%% significance level",
+        'Granger causality test:\\n' +
+        'Lags: %d\\n' +
+        'F-statistic: %.4f\\n' +
+        'p-value: %.4f\\n' +
+        'Degrees of freedom: (%d, %d)\\n' +
+        'RSS restricted: %.4f\\n' +
+        'RSS unrestricted: %.4f\\n' +
+        'Sample size: %d (effective: %d)\\n' +
+        'Conclusion: %s at %.0f%% significance level',
         lags, statistic, pValue, df1, df2,
         rssRestricted, rssUnrestricted,
         sampleSize, effectiveSampleSize,

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Johansen.groovy
@@ -175,7 +175,7 @@ class Johansen {
 
   private static void validateInputs(List<double[]> data, int lags, String type) {
     if (data == null || data.isEmpty()) {
-      throw new IllegalArgumentException("Data cannot be null or empty")
+      throw new IllegalArgumentException('Data cannot be null or empty')
     }
     if (lags < 1) {
       throw new IllegalArgumentException("Lags must be at least 1 (got ${lags})")
@@ -187,7 +187,7 @@ class Johansen {
     int n = data[0].length
     for (int i = 1; i < data.size(); i++) {
       if (data[i].length != n) {
-        throw new IllegalArgumentException("All series must have the same length")
+        throw new IllegalArgumentException('All series must have the same length')
       }
     }
     if (n < lags + 20) {
@@ -259,7 +259,7 @@ class Johansen {
     try {
       ztZInv = MatrixAlgebra.inverse(ztZ)
     } catch (SingularMatrixException ignored) {
-      throw new IllegalArgumentException("Singular matrix in short-run regression - cannot perform Johansen test")
+      throw new IllegalArgumentException('Singular matrix in short-run regression - cannot perform Johansen test')
     }
 
     double[][] projection = MatrixAlgebra.multiply(
@@ -337,7 +337,8 @@ class Johansen {
         [0.00, 0.00, 0.00, 3.76, 15.41],     // r = 3
         [0.00, 0.00, 0.00, 0.00, 3.76]       // r = 4
       ] as double[][]
-    } else if (type == 'trend') {
+    }
+    if (type == 'trend') {
       return [
         [10.49, 22.76, 39.06, 59.14, 83.20],
         [0.00, 6.50, 22.76, 39.06, 59.14],
@@ -345,15 +346,14 @@ class Johansen {
         [0.00, 0.00, 0.00, 6.50, 22.76],
         [0.00, 0.00, 0.00, 0.00, 6.50]
       ] as double[][]
-    } else {  // 'none'
-      return [
-        [2.71, 13.33, 26.79, 44.49, 66.23],
-        [0.00, 2.71, 13.33, 26.79, 44.49],
-        [0.00, 0.00, 2.71, 13.33, 26.79],
-        [0.00, 0.00, 0.00, 2.71, 13.33],
-        [0.00, 0.00, 0.00, 0.00, 2.71]
-      ] as double[][]
     }
+    return [
+      [2.71, 13.33, 26.79, 44.49, 66.23],
+      [0.00, 2.71, 13.33, 26.79, 44.49],
+      [0.00, 0.00, 2.71, 13.33, 26.79],
+      [0.00, 0.00, 0.00, 2.71, 13.33],
+      [0.00, 0.00, 0.00, 0.00, 2.71]
+    ] as double[][]
   }
 
   /**
@@ -388,7 +388,7 @@ class Johansen {
      */
     String interpret() {
       StringBuilder sb = new StringBuilder()
-      sb.append("Johansen Cointegration Test Results:\n")
+      sb.append('Johansen Cointegration Test Results:\n')
 
       int cointRank = 0
       for (int r = 0; r < numVariables; r++) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Kpss.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Kpss.groovy
@@ -27,11 +27,11 @@ class Kpss {
    * @param lags The number of lags for long-run variance estimation (default: auto-selected based on sample size)
    * @return KpssResult containing test statistic and conclusion
    */
-  static KpssResult test(List<? extends Number> data, String type = "level", Integer lags = null) {
+  static KpssResult test(List<? extends Number> data, String type = 'level', Integer lags = null) {
     validateInput(data, type)
 
     int n = data.size()
-    double[] y = data.collect { it.doubleValue() } as double[]
+    double[] y = data*.doubleValue() as double[]
 
     // Auto-select lags if not specified
     // Rule of thumb: l = floor(4 * (T/100)^(1/4))
@@ -78,7 +78,7 @@ class Kpss {
   private static double[] detrend(double[] y, String type, int n) {
     double[] residuals = new double[n]
 
-    if (type == "level") {
+    if (type == 'level') {
       // Remove mean
       double mean = 0.0
       for (double val : y) {
@@ -151,19 +151,18 @@ class Kpss {
    * Values from Kwiatkowski et al. (1992).
    */
   private static double getCriticalValue(String type) {
-    if (type == "level") {
+    if (type == 'level') {
       return 0.463  // 5% critical value for level stationarity
-    } else { // trend
-      return 0.146  // 5% critical value for trend stationarity
     }
+    return 0.146  // 5% critical value for trend stationarity
   }
 
   private static void validateInput(List<? extends Number> data, String type) {
     if (data == null) {
-      throw new IllegalArgumentException("Data cannot be null")
+      throw new IllegalArgumentException('Data cannot be null')
     }
     if (data.isEmpty()) {
-      throw new IllegalArgumentException("Data cannot be empty")
+      throw new IllegalArgumentException('Data cannot be empty')
     }
     if (data.size() < 10) {
       throw new IllegalArgumentException("KPSS test requires at least 10 observations, got ${data.size()}")
@@ -174,7 +173,7 @@ class Kpss {
     // Check for non-null values
     for (Number value : data) {
       if (value == null) {
-        throw new IllegalArgumentException("Data contains null values")
+        throw new IllegalArgumentException('Data contains null values')
       }
     }
   }
@@ -205,10 +204,9 @@ class Kpss {
      */
     String interpret() {
       if (statistic > criticalValue) {
-        return "Reject H0: Series appears to have a unit root (non-stationary)"
-      } else {
-        return "Fail to reject H0: Series appears to be ${type}-stationary"
+        return 'Reject H0: Series appears to have a unit root (non-stationary)'
       }
+      return "Fail to reject H0: Series appears to be ${type}-stationary"
     }
 
     /**
@@ -218,10 +216,10 @@ class Kpss {
      */
     String evaluate() {
       String conclusion = statistic > criticalValue ?
-        "non-stationary (unit root present)" :
+        'non-stationary (unit root present)' :
         "${type}-stationary"
 
-      String.format("KPSS statistic: %.4f (critical value: %.3f at 5%% level)\nLags used: %d\nConclusion: Series appears %s",
+      String.format('KPSS statistic: %.4f (critical value: %.3f at 5%% level)\nLags used: %d\nConclusion: Series appears %s',
                            statistic, criticalValue, lags, conclusion)
     }
 
@@ -231,8 +229,8 @@ class Kpss {
   Type: ${type}
   Sample size: ${sampleSize}
   Lags: ${lags}
-  KPSS statistic: ${String.format("%.4f", statistic)}
-  Critical value (5%%): ${String.format("%.3f", criticalValue)}
+  KPSS statistic: ${String.format('%.4f', statistic)}
+  Critical value (5%%): ${String.format('%.3f', criticalValue)}
 
   ${interpret()}"""
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Portmanteau.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/Portmanteau.groovy
@@ -44,7 +44,7 @@ class Portmanteau {
     validateInput(data, lags, fitdf)
 
     int n = data.size()
-    double[] y = data.collect { it.doubleValue() } as double[]
+    double[] y = data*.doubleValue() as double[]
 
     // Auto-select lags if not specified
     // Common rule: min(10, n/5) or sqrt(n)
@@ -71,7 +71,7 @@ class Portmanteau {
     variance /= n
 
     if (variance < 1e-10) {
-      throw new IllegalArgumentException("Data has no variation (constant or near-constant series)")
+      throw new IllegalArgumentException('Data has no variation (constant or near-constant series)')
     }
 
     // Calculate autocorrelations for lags 1 to h
@@ -99,7 +99,7 @@ class Portmanteau {
     int degreesOfFreedom = h - fitdf
     if (degreesOfFreedom <= 0) {
       throw new IllegalArgumentException(
-        "Degrees of freedom must be positive. " +
+        'Degrees of freedom must be positive. ' +
         "Number of lags (${h}) must be greater than fit df (${fitdf})"
       )
     }
@@ -121,10 +121,10 @@ class Portmanteau {
 
   private static void validateInput(List<? extends Number> data, Integer lags, int fitdf) {
     if (data == null) {
-      throw new IllegalArgumentException("Data cannot be null")
+      throw new IllegalArgumentException('Data cannot be null')
     }
     if (data.isEmpty()) {
-      throw new IllegalArgumentException("Data cannot be empty")
+      throw new IllegalArgumentException('Data cannot be empty')
     }
     if (data.size() < 10) {
       throw new IllegalArgumentException("Ljung-Box test requires at least 10 observations, got ${data.size()}")
@@ -138,7 +138,7 @@ class Portmanteau {
     // Check for non-null values
     for (Number value : data) {
       if (value == null) {
-        throw new IllegalArgumentException("Data contains null values")
+        throw new IllegalArgumentException('Data contains null values')
       }
     }
   }
@@ -178,9 +178,8 @@ class Portmanteau {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       if (pValue < alphaValue) {
         return "Reject H0: Series shows significant autocorrelation (p = ${String.format('%.4f', pValue)})"
-      } else {
-        return "Fail to reject H0: No significant autocorrelation detected (p = ${String.format('%.4f', pValue)})"
       }
+      return "Fail to reject H0: No significant autocorrelation detected (p = ${String.format('%.4f', pValue)})"
     }
 
     /**
@@ -191,16 +190,16 @@ class Portmanteau {
     String evaluate(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       String conclusion = pValue < alphaValue ?
-        "significant autocorrelation present" :
-        "no significant autocorrelation"
+        'significant autocorrelation present' :
+        'no significant autocorrelation'
 
       StringBuilder sb = new StringBuilder()
-      sb.append(String.format("Ljung-Box Q statistic: %.4f (df: %d, p-value: %.4f)\n", statistic, degreesOfFreedom, pValue))
-      sb.append(String.format("Lags tested: %d\n", lags))
+      sb.append(String.format('Ljung-Box Q statistic: %.4f (df: %d, p-value: %.4f)\n', statistic, degreesOfFreedom, pValue))
+      sb.append(String.format('Lags tested: %d\n', lags))
       if (fitdf > 0) {
-        sb.append(String.format("Model fit df: %d\n", fitdf))
+        sb.append(String.format('Model fit df: %d\n', fitdf))
       }
-      sb.append(String.format("Conclusion: %s at %.0f%% significance level", conclusion, (alphaValue * 100) as double))
+      sb.append(String.format('Conclusion: %s at %.0f%% significance level', conclusion, (alphaValue * 100) as double))
 
       sb.toString()
     }
@@ -221,7 +220,7 @@ class Portmanteau {
     @Override
     String toString() {
       StringBuilder sb = new StringBuilder()
-      sb.append("Ljung-Box Portmanteau Test\n")
+      sb.append('Ljung-Box Portmanteau Test\n')
       sb.append("Sample size: ${sampleSize}\n")
       sb.append("Lags tested: ${lags}\n")
       if (fitdf > 0) {
@@ -231,9 +230,9 @@ class Portmanteau {
       sb.append("Degrees of freedom: ${degreesOfFreedom}\n")
       sb.append("p-value: ${String.format('%.4f', pValue)}\n")
       sb.append("\n${interpret()}\n")
-      sb.append("\nAutocorrelations:\n")
+      sb.append('\nAutocorrelations:\n')
       for (int i = 0; i < Math.min(lags, 10); i++) {
-        sb.append(String.format("  Lag %2d: %7.4f\n", i + 1, autocorrelations[i]))
+        sb.append(String.format('  Lag %2d: %7.4f\n', i + 1, autocorrelations[i]))
       }
       if (lags > 10) {
         sb.append("  ... (${lags - 10} more lags)\n")

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtils.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtils.groovy
@@ -18,6 +18,9 @@ final class TimeSeriesUtils {
 
   /** Threshold below which a pivot is treated as numerically singular. */
   private static final double SINGULARITY_THRESHOLD = 1e-14
+  private static final int AUGMENTED_MATRIX_FACTOR = 2
+  private static final String NON_EMPTY_MATRIX_MESSAGE = 'Matrix must contain at least one row and one column'
+  private static final String RECTANGULAR_MATRIX_MESSAGE = 'Matrix rows must all have the same length'
   private static final Logger log = Logger.getLogger(TimeSeriesUtils)
 
   private TimeSeriesUtils() {
@@ -37,10 +40,10 @@ final class TimeSeriesUtils {
    */
   static double[] solveLinearSystem(double[][] A, double[] b) {
     if (A == null || b == null) {
-      throw new IllegalArgumentException("Matrix and vector cannot be null")
+      throw new IllegalArgumentException('Matrix and vector cannot be null')
     }
     if (A.length == 0 || A[0].length == 0) {
-      throw new IllegalArgumentException("Matrix must contain at least one row and one column")
+      throw new IllegalArgumentException(NON_EMPTY_MATRIX_MESSAGE)
     }
     if (A.length != b.length) {
       throw new IllegalArgumentException("Matrix row count (${A.length}) must match vector length (${b.length})")
@@ -49,7 +52,7 @@ final class TimeSeriesUtils {
     int rowCount = A.length
     int columnCount = A[0].length
     if (A.any { double[] row -> row.length != columnCount }) {
-      throw new IllegalArgumentException("Matrix rows must all have the same length")
+      throw new IllegalArgumentException(RECTANGULAR_MATRIX_MESSAGE)
     }
     if (rowCount < columnCount) {
       throw new IllegalArgumentException("Underdetermined system: ${rowCount} rows for ${columnCount} columns")
@@ -116,22 +119,22 @@ final class TimeSeriesUtils {
    * @return the inverted matrix
    * @throws IllegalArgumentException if the input is invalid, the matrix is singular,
    * or the computed inverse contains non-finite values
-   */
+  */
   static double[][] invertMatrix(double[][] A) {
     if (A == null || A.length == 0 || A[0].length == 0) {
-      throw new IllegalArgumentException("Matrix must contain at least one row and one column")
+      throw new IllegalArgumentException(NON_EMPTY_MATRIX_MESSAGE)
     }
     if (A.length != A[0].length) {
-      throw new IllegalArgumentException("Only square matrices can be inverted")
+      throw new IllegalArgumentException('Only square matrices can be inverted')
     }
 
     int n = A.length
     if (A.any { double[] row -> row.length != n }) {
-      throw new IllegalArgumentException("Matrix rows must all have the same length")
+      throw new IllegalArgumentException(RECTANGULAR_MATRIX_MESSAGE)
     }
 
     double[][] result = new double[n][n]
-    double[][] augmented = new double[n][2 * n]
+    double[][] augmented = new double[n][AUGMENTED_MATRIX_FACTOR * n]
     for (int i = 0; i < n; i++) {
       for (int j = 0; j < n; j++) {
         augmented[i][j] = A[i][j]
@@ -149,14 +152,14 @@ final class TimeSeriesUtils {
         log.warn("Singular pivot at column $k while inverting ${n}x${n} matrix")
         throw new IllegalArgumentException("Singular matrix at column ${k} - cannot invert matrix")
       }
-      for (int j = 0; j < 2 * n; j++) {
+      for (int j = 0; j < AUGMENTED_MATRIX_FACTOR * n; j++) {
         augmented[k][j] /= pivot
       }
 
       for (int i = 0; i < n; i++) {
         if (i != k) {
           double factor = augmented[i][k]
-          for (int j = 0; j < 2 * n; j++) {
+          for (int j = 0; j < AUGMENTED_MATRIX_FACTOR * n; j++) {
             augmented[i][j] -= factor * augmented[k][j]
           }
         }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TurningPoint.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/TurningPoint.groovy
@@ -82,7 +82,7 @@ class TurningPoint {
    */
   static TurningPointResult test(double[] data) {
     if (data == null) {
-      throw new IllegalArgumentException("Data cannot be null")
+      throw new IllegalArgumentException('Data cannot be null')
     }
 
     int n = data.length
@@ -138,7 +138,7 @@ class TurningPoint {
    * Performs the Turning Point test with List input.
    */
   static TurningPointResult test(List<? extends Number> data) {
-    double[] array = data.collect { it.doubleValue() } as double[]
+    double[] array = data*.doubleValue() as double[]
     test(array)
   }
 
@@ -182,11 +182,10 @@ class TurningPoint {
     String interpret(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       if (pValue < alphaValue) {
-        String direction = turningPoints > expectedTurningPoints ? "more" : "fewer"
+        String direction = turningPoints > expectedTurningPoints ? 'more' : 'fewer'
         return "Reject H0: Data shows ${direction} turning points than expected under randomness (Z = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
-      } else {
-        return "Fail to reject H0: Data is consistent with randomness (Z = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
       }
+      return "Fail to reject H0: Data is consistent with randomness (Z = ${String.format('%.4f', statistic)}, p = ${String.format('%.4f', pValue)})"
     }
 
     /**
@@ -194,24 +193,24 @@ class TurningPoint {
      */
     String evaluate(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
-      String conclusion = pValue < alphaValue ? "data is not random" : "data is consistent with randomness"
-      String direction = turningPoints > expectedTurningPoints ? "cyclicity" : "trend"
+      String conclusion = pValue < alphaValue ? 'data is not random' : 'data is consistent with randomness'
+      String direction = turningPoints > expectedTurningPoints ? 'cyclicity' : 'trend'
 
       String.format(
-        "Turning Point test:\\n" +
-        "Sample size: %d\\n" +
-        "Turning points observed: %d (peaks: %d, troughs: %d)\\n" +
-        "Expected under H0: %.4f\\n" +
-        "Variance: %.4f\\n" +
-        "Z-statistic: %.4f\\n" +
-        "p-value: %.4f\\n" +
-        "Conclusion: %s at %.0f%% significance level\\n" +
-        "Note: %s turning points may suggest %s",
+        'Turning Point test:\\n' +
+        'Sample size: %d\\n' +
+        'Turning points observed: %d (peaks: %d, troughs: %d)\\n' +
+        'Expected under H0: %.4f\\n' +
+        'Variance: %.4f\\n' +
+        'Z-statistic: %.4f\\n' +
+        'p-value: %.4f\\n' +
+        'Conclusion: %s at %.0f%% significance level\\n' +
+        'Note: %s turning points may suggest %s',
         sampleSize, turningPoints, peaks, troughs,
         expectedTurningPoints, variance,
         statistic, pValue,
         conclusion, (alphaValue * 100) as double,
-        turningPoints > expectedTurningPoints ? "More" : "Fewer",
+        turningPoints > expectedTurningPoints ? 'More' : 'Fewer',
         direction
       )
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/UnitRoot.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/timeseries/UnitRoot.groovy
@@ -101,7 +101,7 @@ class UnitRoot {
    */
   static UnitRootResult test(double[] data, String type = 'drift', Integer lags = 0) {
     if (data == null) {
-      throw new IllegalArgumentException("Data cannot be null")
+      throw new IllegalArgumentException('Data cannot be null')
     }
 
     if (data.length < 10) {
@@ -144,7 +144,7 @@ class UnitRoot {
    * Runs unit root testing with List input.
    */
   static UnitRootResult test(List<? extends Number> data, String type = 'drift', Integer lags = 0) {
-    double[] array = data.collect { it.doubleValue() } as double[]
+    double[] array = data*.doubleValue() as double[]
     test(array, type, lags)
   }
 
@@ -179,44 +179,46 @@ class UnitRoot {
     String summary(Number alpha = 0.05) {
       BigDecimal alphaValue = NumericConversion.toAlpha(alpha)
       StringBuilder sb = new StringBuilder()
-      sb.append("Unit Root Test Summary\n")
-      sb.append("=" * 60).append("\n")
+      sb.append('Unit Root Test Summary\n')
+      sb.append('=' * 60).append('\n')
       sb.append("Sample size: ${sampleSize}\n")
       sb.append("Type: ${type}\n")
       sb.append("Significance level: ${alphaValue * 100}%\n")
-      sb.append("=" * 60).append("\n\n")
+      sb.append('=' * 60).append('\n\n')
 
       // DF Test
-      sb.append("1. Dickey-Fuller Test:\n")
-      sb.append("   Statistic: ${String.format('%.4f', dfResult.statistic)}\n")
-      sb.append("   Critical value (5%): ${String.format('%.4f', dfResult.criticalValue5pct)}\n")
-      sb.append("   Conclusion: ${dfResult.interpret(alphaValue)}\n\n")
+      sb.with {
+        append('1. Dickey-Fuller Test:\n')
+        append("   Statistic: ${String.format('%.4f', dfResult.statistic)}\n")
+        append("   Critical value (5%): ${String.format('%.4f', dfResult.criticalValue5pct)}\n")
+        append("   Conclusion: ${dfResult.interpret(alphaValue)}\n\n")
 
-      // ADF Test
-      sb.append("2. Augmented Dickey-Fuller Test:\n")
-      sb.append("   Lags: ${adfResult.lag}\n")
-      sb.append("   Statistic: ${String.format('%.4f', adfResult.statistic)}\n")
-      sb.append("   Critical value (5%): ${String.format('%.4f', adfResult.criticalValue)}\n")
-      sb.append("   Conclusion: ${adfResult.interpret()}\n\n")
+        // ADF Test
+        append('2. Augmented Dickey-Fuller Test:\n')
+        append("   Lags: ${adfResult.lag}\n")
+        append("   Statistic: ${String.format('%.4f', adfResult.statistic)}\n")
+        append("   Critical value (5%): ${String.format('%.4f', adfResult.criticalValue)}\n")
+        append("   Conclusion: ${adfResult.interpret()}\n\n")
 
-      // ADF-GLS Test
-      sb.append("3. ADF-GLS Test:\n")
-      sb.append("   Lags: ${adfGlsResult.lags}\n")
-      sb.append("   Statistic: ${String.format('%.4f', adfGlsResult.statistic)}\n")
-      sb.append("   Critical value (5%): ${String.format('%.4f', adfGlsResult.criticalValue5pct)}\n")
-      sb.append("   Conclusion: ${adfGlsResult.interpret(alphaValue)}\n\n")
+        // ADF-GLS Test
+        append('3. ADF-GLS Test:\n')
+        append("   Lags: ${adfGlsResult.lags}\n")
+        append("   Statistic: ${String.format('%.4f', adfGlsResult.statistic)}\n")
+        append("   Critical value (5%): ${String.format('%.4f', adfGlsResult.criticalValue5pct)}\n")
+        append("   Conclusion: ${adfGlsResult.interpret(alphaValue)}\n\n")
 
-      // KPSS Test (note: opposite null hypothesis)
-      sb.append("4. KPSS Test (tests stationarity, opposite null):\n")
-      sb.append("   Lags: ${kpssResult.lags}\n")
-      sb.append("   Statistic: ${String.format('%.4f', kpssResult.statistic)}\n")
-      sb.append("   Critical value (5%): ${String.format('%.4f', kpssResult.criticalValue)}\n")
-      sb.append("   Conclusion: ${kpssResult.interpret()}\n\n")
+        // KPSS Test (note: opposite null hypothesis)
+        append('4. KPSS Test (tests stationarity, opposite null):\n')
+        append("   Lags: ${kpssResult.lags}\n")
+        append("   Statistic: ${String.format('%.4f', kpssResult.statistic)}\n")
+        append("   Critical value (5%): ${String.format('%.4f', kpssResult.criticalValue)}\n")
+        append("   Conclusion: ${kpssResult.interpret()}\n\n")
+      }
 
       // Overall assessment
-      sb.append("=" * 60).append("\n")
-      sb.append("Overall Assessment:\n")
-      sb.append("=" * 60).append("\n")
+      sb.append('=' * 60).append('\n')
+      sb.append('Overall Assessment:\n')
+      sb.append('=' * 60).append('\n')
       sb.append(getConsensus(alphaValue))
 
       sb.toString()
@@ -255,30 +257,30 @@ class UnitRoot {
       StringBuilder consensus = new StringBuilder()
 
       if (unitRootTests >= 2 && !kpssRejectsStationarity) {
-        consensus.append("Strong evidence of STATIONARITY:\n")
+        consensus.append('Strong evidence of STATIONARITY:\n')
         consensus.append("- ${unitRootTests}/3 unit root tests reject the null hypothesis\n")
-        consensus.append("- KPSS test does not reject stationarity\n")
-        consensus.append("Conclusion: Series appears to be stationary")
+        consensus.append('- KPSS test does not reject stationarity\n')
+        consensus.append('Conclusion: Series appears to be stationary')
       } else if (unitRootTests == 0 && kpssRejectsStationarity) {
-        consensus.append("Strong evidence of UNIT ROOT (non-stationarity):\n")
-        consensus.append("- All unit root tests fail to reject the null hypothesis\n")
-        consensus.append("- KPSS test rejects stationarity\n")
-        consensus.append("Conclusion: Series appears to have a unit root")
+        consensus.append('Strong evidence of UNIT ROOT (non-stationarity):\n')
+        consensus.append('- All unit root tests fail to reject the null hypothesis\n')
+        consensus.append('- KPSS test rejects stationarity\n')
+        consensus.append('Conclusion: Series appears to have a unit root')
       } else if (unitRootTests >= 2) {
-        consensus.append("Mixed evidence, leaning toward STATIONARITY:\n")
+        consensus.append('Mixed evidence, leaning toward STATIONARITY:\n')
         consensus.append("- ${unitRootTests}/3 unit root tests reject the null hypothesis\n")
-        consensus.append("- But KPSS suggests non-stationarity\n")
-        consensus.append("Conclusion: Results are conflicting, but majority suggests stationarity")
+        consensus.append('- But KPSS suggests non-stationarity\n')
+        consensus.append('Conclusion: Results are conflicting, but majority suggests stationarity')
       } else if (kpssRejectsStationarity) {
-        consensus.append("Mixed evidence, leaning toward UNIT ROOT:\n")
+        consensus.append('Mixed evidence, leaning toward UNIT ROOT:\n')
         consensus.append("- ${unitRootTests}/3 unit root tests reject the null hypothesis\n")
-        consensus.append("- KPSS test rejects stationarity\n")
-        consensus.append("Conclusion: Results are conflicting, but evidence suggests unit root")
+        consensus.append('- KPSS test rejects stationarity\n')
+        consensus.append('Conclusion: Results are conflicting, but evidence suggests unit root')
       } else {
-        consensus.append("INCONCLUSIVE evidence:\n")
+        consensus.append('INCONCLUSIVE evidence:\n')
         consensus.append("- ${unitRootTests}/3 unit root tests reject the null hypothesis\n")
-        consensus.append("- KPSS test does not reject stationarity\n")
-        consensus.append("Conclusion: Results are mixed, consider additional analysis")
+        consensus.append('- KPSS test does not reject stationarity\n')
+        consensus.append('Conclusion: Results are mixed, consider additional analysis')
       }
 
       consensus.toString()
@@ -287,11 +289,11 @@ class UnitRoot {
     private static double getCriticalValue(AdfGls.AdfGlsResult adfGlsRes, double alpha) {
       if (alpha <= 0.01) {
         return adfGlsRes.criticalValue1pct
-      } else if (alpha <= 0.05) {
-        return adfGlsRes.criticalValue5pct
-      } else {
-        return adfGlsRes.criticalValue10pct
       }
+      if (alpha <= 0.05) {
+        return adfGlsRes.criticalValue5pct
+      }
+      return adfGlsRes.criticalValue10pct
     }
 
     private static double getCriticalValue(Adf.AdfResult adfRes) {
@@ -302,11 +304,11 @@ class UnitRoot {
     private static double getCriticalValue(Df.DfResult dfRes, double alpha) {
       if (alpha <= 0.01) {
         return dfRes.criticalValue1pct
-      } else if (alpha <= 0.05) {
-        return dfRes.criticalValue5pct
-      } else {
-        return dfRes.criticalValue10pct
       }
+      if (alpha <= 0.05) {
+        return dfRes.criticalValue5pct
+      }
+      return dfRes.criticalValue10pct
     }
 
     /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Student.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Student.groovy
@@ -51,15 +51,15 @@ class Student {
    */
   static PairedResult pairedTTest(List<? extends Number> first, List<? extends Number> second) {
     if (first == null || second == null) {
-      throw new IllegalArgumentException("Input lists cannot be null")
+      throw new IllegalArgumentException('Input lists cannot be null')
     }
     if (first.isEmpty() || second.isEmpty()) {
-      throw new IllegalArgumentException("Input lists cannot be empty")
+      throw new IllegalArgumentException('Input lists cannot be empty')
     }
     Integer n1 = first.size()
     Integer n2 = second.size()
     if (n1 != n2) {
-      throw new IllegalArgumentException("The two lists of values are of different size")
+      throw new IllegalArgumentException('The two lists of values are of different size')
     }
     if (n1 < 2) {
       throw new IllegalArgumentException("Paired t-test requires at least 2 pairs of observations, got: $n1")
@@ -83,21 +83,31 @@ class Student {
 
     // Use native TDistribution for p-value calculation
     def p = TDistribution.pValue(t as double, df as double)
-    PairedResult result = new PairedResult()
-    result.description = "Paired t-test"
-    result.tVal = t
-    result.n1 = n1
-    result.n2 = n2
-    result.mean1 = mean1.stripTrailingZeros()
-    result.mean2 = mean2.stripTrailingZeros()
-    result.var1 = var1
-    result.var2 = var2
-    result.sd = sd
-    result.sd1 = sd1
-    result.sd2 = sd2
-    result.pVal = p
-    result.df = df
-    result
+    int firstCount = n1
+    int secondCount = n2
+    BigDecimal firstMean = mean1.stripTrailingZeros()
+    BigDecimal secondMean = mean2.stripTrailingZeros()
+    BigDecimal firstVariance = var1
+    BigDecimal secondVariance = var2
+    BigDecimal pooledSd = sd
+    BigDecimal firstSd = sd1
+    BigDecimal secondSd = sd2
+    BigDecimal degreesFreedom = df
+    new PairedResult(
+      description: 'Paired t-test',
+      tVal: t,
+      n1: firstCount,
+      n2: secondCount,
+      mean1: firstMean,
+      mean2: secondMean,
+      var1: firstVariance,
+      var2: secondVariance,
+      sd: pooledSd,
+      sd1: firstSd,
+      sd2: secondSd,
+      pVal: p,
+      df: degreesFreedom
+    )
   }
 
   /**
@@ -122,10 +132,10 @@ class Student {
    */
   static Result tTest(List<? extends Number> first, List<? extends Number> second, Boolean equalVariance = null) {
     if (first == null || second == null) {
-      throw new IllegalArgumentException("Input lists cannot be null")
+      throw new IllegalArgumentException('Input lists cannot be null')
     }
     if (first.isEmpty() || second.isEmpty()) {
-      throw new IllegalArgumentException("Input lists cannot be empty")
+      throw new IllegalArgumentException('Input lists cannot be empty')
     }
     if (first.size() < 2 || second.size() < 2) {
       throw new IllegalArgumentException("Each sample must have at least 2 observations, got: first=${first.size()}, second=${second.size()}")
@@ -148,39 +158,45 @@ class Student {
       if (!isEqualVariance) {
         throw new IllegalArgumentException(
           "Student's t-test requires equal variances. Variances differ significantly (var1=${var1}, var2=${var2}). " +
-          "Use se.alipsa.matrix.stats.ttest.Welch.tTest() instead for unequal variances."
+          'Use se.alipsa.matrix.stats.ttest.Welch.tTest() instead for unequal variances.'
         )
       }
     } else if (!equalVariance) {
       throw new IllegalArgumentException(
         "Student's t-test requires equal variances (equalVariance=true). " +
-        "Use se.alipsa.matrix.stats.ttest.Welch.tTest() instead for unequal variances."
+        'Use se.alipsa.matrix.stats.ttest.Welch.tTest() instead for unequal variances.'
       )
     } else {
       isEqualVariance = true
     }
 
-    Result result = new Result()
-
     // Student's t-test with pooled variance
-    result.description = "Student's two sample t-test"
     BigDecimal pooledVar = ((n1 - 1) * var1 + (n2 - 1) * var2) / (n1 + n2 - 2)
     BigDecimal t = (mean1 - mean2) / (pooledVar * (1.0/n1 + 1.0/n2)).sqrt()
-    result.tVal = t
-    result.df = n1 + n2 - 2
-
-    result.mean1 = mean1
-    result.mean2 = mean2
-    result.var1 = var1
-    result.var2 = var2
-    result.sd1 = sd1
-    result.sd2 = sd2
-    result.n1 = n1
-    result.n2 = n2
-
-    // Use native TDistribution for p-value calculation
-    result.pVal = TDistribution.pValue(result.tVal as double, result.df as double)
-    result
+    BigDecimal degreesFreedom = n1 + n2 - 2
+    def p = TDistribution.pValue(t as double, degreesFreedom as double)
+    int firstCount = n1
+    int secondCount = n2
+    BigDecimal firstMean = mean1
+    BigDecimal secondMean = mean2
+    BigDecimal firstVariance = var1
+    BigDecimal secondVariance = var2
+    BigDecimal firstSd = sd1
+    BigDecimal secondSd = sd2
+    new Result(
+      description: "Student's two sample t-test",
+      tVal: t,
+      df: degreesFreedom,
+      mean1: firstMean,
+      mean2: secondMean,
+      var1: firstVariance,
+      var2: secondVariance,
+      sd1: firstSd,
+      sd2: secondSd,
+      n1: firstCount,
+      n2: secondCount,
+      pVal: p
+    )
   }
 
   /**
@@ -201,13 +217,13 @@ class Student {
    */
   static SingleResult tTest(List<? extends Number> values, Number comparison) {
     if (values == null) {
-      throw new IllegalArgumentException("Input list cannot be null")
+      throw new IllegalArgumentException('Input list cannot be null')
     }
     if (values.isEmpty()) {
-      throw new IllegalArgumentException("Input list cannot be empty")
+      throw new IllegalArgumentException('Input list cannot be empty')
     }
     if (comparison == null) {
-      throw new IllegalArgumentException("Comparison value cannot be null")
+      throw new IllegalArgumentException('Comparison value cannot be null')
     }
 
     int n = values.size()
@@ -219,16 +235,23 @@ class Student {
     BigDecimal sd = variance.sqrt()
     BigDecimal dividend = mean - (comparison as BigDecimal)
     BigDecimal divisor = sd / (n as BigDecimal).sqrt()
-    SingleResult result = new SingleResult("One Sample t-test")
-    result.tVal = dividend / divisor
-    result.mean = mean
-    result.var = variance
-    result.sd = sd
-    result.n = n
-    result.df = n - 1
-    // Use native TDistribution for p-value calculation
-    result.pVal = TDistribution.pValue(result.tVal as double, result.df as double)
-    result
+    BigDecimal t = dividend / divisor
+    int degreesFreedom = n - 1
+    def p = TDistribution.pValue(t as double, degreesFreedom as double)
+    BigDecimal sampleMean = mean
+    BigDecimal sampleVariance = variance
+    BigDecimal sampleSd = sd
+    int sampleSize = n
+    new SingleResult(
+      description: 'One Sample t-test',
+      tVal: t,
+      mean: sampleMean,
+      var: sampleVariance,
+      sd: sampleSd,
+      n: sampleSize,
+      df: degreesFreedom,
+      pVal: p
+    )
   }
 
   /**
@@ -248,6 +271,9 @@ class Student {
     BigDecimal pVal
     Integer df
     String description
+
+    SingleResult() {
+    }
 
     SingleResult(String description) {
       this.description = description

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Welch.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Welch.groovy
@@ -34,10 +34,10 @@ class Welch {
    */
   static TtestResult tTest(List<? extends Number> first, List<? extends Number> second) {
     if (first == null || second == null) {
-      throw new IllegalArgumentException("Input lists cannot be null")
+      throw new IllegalArgumentException('Input lists cannot be null')
     }
     if (first.isEmpty() || second.isEmpty()) {
-      throw new IllegalArgumentException("Input lists cannot be empty")
+      throw new IllegalArgumentException('Input lists cannot be empty')
     }
     if (first.size() < 2 || second.size() < 2) {
       throw new IllegalArgumentException("Each sample must have at least 2 observations, got: first=${first.size()}, second=${second.size()}")
@@ -52,12 +52,8 @@ class Welch {
     int n1 = first.size()
     int n2 = second.size()
 
-    TtestResult result = new TtestResult()
-    result.description = "Welch's two sample t-test"
-
     // Welch's t-statistic
     BigDecimal t = (mean1 - mean2) / ((var1 / n1) + (var2 / n2)).sqrt()
-    result.tVal = t
 
     // Welch-Satterthwaite degrees of freedom
     BigDecimal dividend = ((var1/n1) + (var2/n2)) ** 2
@@ -65,19 +61,30 @@ class Welch {
     BigDecimal n2Sq = (n2 as BigDecimal) ** 2
     BigDecimal divisor1 = ((var1 ** 2) as BigDecimal).divide(n1Sq * (n1-1), SCALE, RoundingMode.HALF_UP)
     BigDecimal divisor2 = ((var2 ** 2) as BigDecimal).divide(n2Sq * (n2 -1), SCALE, RoundingMode.HALF_UP)
-    result.df = dividend.divide(divisor1 + divisor2, SCALE, RoundingMode.HALF_UP)
 
-    result.mean1 = mean1
-    result.mean2 = mean2
-    result.var1 = var1
-    result.var2 = var2
-    result.sd1 = sd1
-    result.sd2 = sd2
-    result.n1 = n1
-    result.n2 = n2
-
-    // Use native TDistribution for p-value calculation
-    result.pVal = TDistribution.pValue(t as double, result.df as double)
-    result
+    BigDecimal degreesFreedom = dividend.divide(divisor1 + divisor2, SCALE, RoundingMode.HALF_UP)
+    def p = TDistribution.pValue(t as double, degreesFreedom as double)
+    BigDecimal firstMean = mean1
+    BigDecimal secondMean = mean2
+    BigDecimal firstVariance = var1
+    BigDecimal secondVariance = var2
+    BigDecimal firstSd = sd1
+    BigDecimal secondSd = sd2
+    int firstCount = n1
+    int secondCount = n2
+    new TtestResult(
+      description: "Welch's two sample t-test",
+      tVal: t,
+      df: degreesFreedom,
+      mean1: firstMean,
+      mean2: secondMean,
+      var1: firstVariance,
+      var2: secondVariance,
+      sd1: firstSd,
+      sd2: secondSd,
+      n1: firstCount,
+      n2: secondCount,
+      pVal: p
+    )
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/util/NumericConversion.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/util/NumericConversion.groovy
@@ -125,7 +125,7 @@ final class NumericConversion {
    * @since 2.4.0
    */
   static double[][] toDoubleArray(Grid<?> grid) {
-    int[] shape = validateRectangular(grid, 'grid')
+    int[] shape = validateRectangular(grid, GRID_LABEL)
     Grid<BigDecimal> numericGrid = toBigDecimalGrid(grid)
     double[][] values = new double[shape[0]][shape[1]]
     for (int row = 0; row < shape[0]; row++) {

--- a/matrix-stats/src/test/groovy/AnovaTest.groovy
+++ b/matrix-stats/src/test/groovy/AnovaTest.groovy
@@ -24,7 +24,7 @@ class AnovaTest {
     // Residuals  147  38.96   0.265
 
     def iris = Dataset.iris()
-    def speciesIdx = iris.columnIndex("Species")
+    def speciesIdx = iris.columnIndex('Species')
 
     // Group by species using subset
     def setosa = iris.subset { it[speciesIdx] == 'setosa' }['Sepal Length'] as List<Number>
@@ -51,7 +51,7 @@ class AnovaTest {
     // Residuals  147  16.96   0.115
 
     def iris = Dataset.iris()
-    def speciesIdx = iris.columnIndex("Species")
+    def speciesIdx = iris.columnIndex('Species')
 
     def setosa = iris.subset { it[speciesIdx] == 'setosa' }['Sepal Width'] as List<Number>
     def versicolor = iris.subset { it[speciesIdx] == 'versicolor' }['Sepal Width'] as List<Number>

--- a/matrix-stats/src/test/groovy/EllipseTest.groovy
+++ b/matrix-stats/src/test/groovy/EllipseTest.groovy
@@ -44,10 +44,10 @@ class EllipseTest {
 
     def result = Ellipse.calculate(xVals, yVals, 0.95, 't', 51)
 
-    assertFalse(result.x.isEmpty(), "Should generate ellipse with 3 points")
-    assertFalse(result.y.isEmpty(), "Should generate ellipse with 3 points")
-    assertEquals(51, result.x.size(), "Should generate 51 points")
-    assertEquals(51, result.y.size(), "Should generate 51 points")
+    assertFalse(result.x.isEmpty(), 'Should generate ellipse with 3 points')
+    assertFalse(result.y.isEmpty(), 'Should generate ellipse with 3 points')
+    assertEquals(51, result.x.size(), 'Should generate 51 points')
+    assertEquals(51, result.y.size(), 'Should generate 51 points')
   }
 
   @Test
@@ -62,8 +62,8 @@ class EllipseTest {
     double dx = Math.abs((result.x[0] - result.x[-1]) as double)
     double dy = Math.abs((result.y[0] - result.y[-1]) as double)
 
-    assertTrue(dx < TOLERANCE, "Ellipse X should be closed (first ≈ last)")
-    assertTrue(dy < TOLERANCE, "Ellipse Y should be closed (first ≈ last)")
+    assertTrue(dx < TOLERANCE, 'Ellipse X should be closed (first ≈ last)')
+    assertTrue(dy < TOLERANCE, 'Ellipse Y should be closed (first ≈ last)')
   }
 
   @Test
@@ -91,9 +91,9 @@ class EllipseTest {
     def maxRadius99 = calculateMaxRadius(result99.x, result99.y)
 
     // Higher confidence levels should produce larger ellipses
-    assertTrue(maxRadius50 < maxRadius90, "50% ellipse should be smaller than 90%")
-    assertTrue(maxRadius90 < maxRadius95, "90% ellipse should be smaller than 95%")
-    assertTrue(maxRadius95 < maxRadius99, "95% ellipse should be smaller than 99%")
+    assertTrue(maxRadius50 < maxRadius90, '50% ellipse should be smaller than 90%')
+    assertTrue(maxRadius90 < maxRadius95, '90% ellipse should be smaller than 95%')
+    assertTrue(maxRadius95 < maxRadius99, '95% ellipse should be smaller than 99%')
   }
 
   @Test
@@ -122,7 +122,7 @@ class EllipseTest {
     // Euclid should produce smaller ellipse than t/norm
     def maxRadiusT = calculateMaxRadius(resultT.x, resultT.y)
     def maxRadiusEuclid = calculateMaxRadius(resultEuclid.x, resultEuclid.y)
-    assertTrue(maxRadiusEuclid < maxRadiusT, "Euclid ellipse should be smaller than t-type")
+    assertTrue(maxRadiusEuclid < maxRadiusT, 'Euclid ellipse should be smaller than t-type')
   }
 
   @Test
@@ -134,8 +134,8 @@ class EllipseTest {
     def result10 = Ellipse.calculate(xVals, yVals, 0.95, 't', 10)
     def result100 = Ellipse.calculate(xVals, yVals, 0.95, 't', 100)
 
-    assertEquals(10, result10.x.size(), "Should generate 10 segments")
-    assertEquals(100, result100.x.size(), "Should generate 100 segments")
+    assertEquals(10, result10.x.size(), 'Should generate 10 segments')
+    assertEquals(100, result100.x.size(), 'Should generate 100 segments')
   }
 
   @Test
@@ -168,10 +168,10 @@ class EllipseTest {
 
     // All points should be at or very near the mean
     result.x.each { x ->
-      assertTrue(Math.abs((x - 5G) as double) < 1e-6, "X values should be near mean")
+      assertTrue(Math.abs((x - 5G) as double) < 1e-6, 'X values should be near mean')
     }
     result.y.each { y ->
-      assertTrue(Math.abs((y - 10G) as double) < 1e-6, "Y values should be near mean")
+      assertTrue(Math.abs((y - 10G) as double) < 1e-6, 'Y values should be near mean')
     }
   }
 
@@ -192,9 +192,9 @@ class EllipseTest {
 
     // Ellipse center should be very close to data mean
     assertTrue(Math.abs((ellipseCenterX - meanX) as double) < 0.1,
-               "Ellipse center X should be near data mean X")
+               'Ellipse center X should be near data mean X')
     assertTrue(Math.abs((ellipseCenterY - meanY) as double) < 0.1,
-               "Ellipse center Y should be near data mean Y")
+               'Ellipse center Y should be near data mean Y')
   }
 
   @Test
@@ -272,13 +272,13 @@ class EllipseTest {
   private void assertAllFinite(List<BigDecimal> xVals, List<BigDecimal> yVals) {
     xVals.each { x ->
       double d = x as double
-      assertFalse(Double.isNaN(d), "X value should not be NaN")
-      assertFalse(Double.isInfinite(d), "X value should not be infinite")
+      assertFalse(Double.isNaN(d), 'X value should not be NaN')
+      assertFalse(Double.isInfinite(d), 'X value should not be infinite')
     }
     yVals.each { y ->
       double d = y as double
-      assertFalse(Double.isNaN(d), "Y value should not be NaN")
-      assertFalse(Double.isInfinite(d), "Y value should not be infinite")
+      assertFalse(Double.isNaN(d), 'Y value should not be NaN')
+      assertFalse(Double.isInfinite(d), 'Y value should not be infinite')
     }
   }
 }

--- a/matrix-stats/src/test/groovy/KMeansComparisonTest.groovy
+++ b/matrix-stats/src/test/groovy/KMeansComparisonTest.groovy
@@ -29,10 +29,10 @@ class KMeansComparisonTest {
     def matrixGroups = matrixKMeans.assignment.toList().countBy { it.clusterId }
     def matrixWCSS = matrixKMeans.WCSS
 
-    println "\nMatrix KMeans:"
+    println '\nMatrix KMeans:'
     println "Group sizes: $matrixGroups"
     println "WCSS: $matrixWCSS"
-    println "Centroids: ${matrixCentroids.collect { it.toList() }}"
+    println "Centroids: ${matrixCentroids*.toList()}"
 
     // ✅ Use Smile's built-in fit method for KMeans
     def smileKMeans = KMeans.fit(points, k, 100)
@@ -41,10 +41,10 @@ class KMeansComparisonTest {
     def smileGroups = smileLabels.countBy { it }
     def smileWCSS = smileKMeans.distortion()
 
-    println "\nSMILE KMeans:"
+    println '\nSMILE KMeans:'
     println "Group sizes: $smileGroups"
     println "WCSS: $smileWCSS"
-    println "Centroids: ${smileCentroids.collect { it.toList() }}"
+    println "Centroids: ${smileCentroids*.toList()}"
 
     List<double[]> matchedSmileCentroids = []
 

--- a/matrix-stats/src/test/groovy/KMeansPlusPlusTest.groovy
+++ b/matrix-stats/src/test/groovy/KMeansPlusPlusTest.groovy
@@ -40,10 +40,10 @@ class KMeansPlusPlusTest {
 
     def groupCounts = clustering.getAssignment().toList().countBy { it.clusterId }
     //println("Assignments: " + groupCounts)
-    assertEquals(750, groupCounts[0], "Cluster 0 should have 750 points")
-    assertEquals(750, groupCounts[1], "Cluster 1 should have 750 points")
-    assertEquals(750, groupCounts[2], "Cluster 2 should have 750 points")
-    assertEquals(750, groupCounts[3], "Cluster 3 should have 750 points")
+    assertEquals(750, groupCounts[0], 'Cluster 0 should have 750 points')
+    assertEquals(750, groupCounts[1], 'Cluster 1 should have 750 points')
+    assertEquals(750, groupCounts[2], 'Cluster 2 should have 750 points')
+    assertEquals(750, groupCounts[3], 'Cluster 3 should have 750 points')
 
     Map<Integer, Matrix> clusters = clustering.getClustersById()
     clusters.each { id, matrix ->
@@ -53,10 +53,10 @@ class KMeansPlusPlusTest {
 
     // print centeroids
     // for (int i = 0; i < k; i++) println("(" + centroids[i][0] + ", " + centroids[i][1] + ")")
-    assertEquals(4, centroids.length, "Centroids should be 4")
+    assertEquals(4, centroids.length, 'Centroids should be 4')
 
-    println("The within-cluster sum-of-squares (WCSS) = " + wcss)
-    assertTrue(wcss < 250 && wcss > 230, "WCSS should be approximately 240")
+    println('The within-cluster sum-of-squares (WCSS) = ' + wcss)
+    assertTrue(wcss < 250 && wcss > 230, 'WCSS should be approximately 240')
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/KMeansTest.groovy
+++ b/matrix-stats/src/test/groovy/KMeansTest.groovy
@@ -15,70 +15,70 @@ class KMeansTest {
 
   @Test
   void testKMeansWithFixedK() {
-    Matrix m = Matrix.builder("test").columns([
-        "x": (0..<3000).collect { it % 2 == 0 ? 0.1 : 0.9 },
-        "y": (0..<3000).collect { it % 3 == 0 ? 0.1 : 0.9 }
+    Matrix m = Matrix.builder('test').columns([
+        'x': (0..<3000).collect { it % 2 == 0 ? 0.1 : 0.9 },
+        'y': (0..<3000).collect { it % 3 == 0 ? 0.1 : 0.9 }
     ]).build()
 
     KMeans kmeans = new KMeans(m)
-    List<String> features = ["x", "y"]
+    List<String> features = ['x', 'y']
     Matrix clustered = kmeans.fit(features, 2)
 
-    assertEquals(2, clustered.column("Group").toSet().size(), "Should have two clusters")
-    assertEquals(3000, clustered.rowCount(), "Should have same row count after clustering")
-    assertTrue(clustered.columnNames().contains("Group"), "Matrix should contain 'Group' column")
+    assertEquals(2, clustered.column('Group').toSet().size(), 'Should have two clusters')
+    assertEquals(3000, clustered.rowCount(), 'Should have same row count after clustering')
+    assertTrue(clustered.columnNames().contains('Group'), "Matrix should contain 'Group' column")
   }
 
   @Test
   void testKMeansWithAutoEstimation() {
-    Matrix m = Matrix.builder("test").columns([
-        "x": (0..<3000).collect { it % 4 == 0 ? 0.1 : 0.9 },
-        "y": (0..<3000).collect { it % 5 == 0 ? 0.1 : 0.9 }
+    Matrix m = Matrix.builder('test').columns([
+        'x': (0..<3000).collect { it % 4 == 0 ? 0.1 : 0.9 },
+        'y': (0..<3000).collect { it % 5 == 0 ? 0.1 : 0.9 }
     ]).build()
 
     KMeans kmeans = new KMeans(m)
-    List<String> features = ["x", "y"]
+    List<String> features = ['x', 'y']
     Matrix clustered = kmeans.fit(features, 10, GroupEstimator.CalculationMethod.ELBOW)
 
-    assertTrue(clustered.column("Group").toSet().size() >= 2, "Should have at least 2 clusters")
-    assertEquals(3000, clustered.rowCount(), "Should have same row count after clustering")
+    assertTrue(clustered.column('Group').toSet().size() >= 2, 'Should have at least 2 clusters')
+    assertEquals(3000, clustered.rowCount(), 'Should have same row count after clustering')
   }
 
   @Test
   void testNoMutationReturnsNewMatrix() {
-    Matrix m = Matrix.builder("test").columns([
-        "x": [0.1, 0.9, 0.1, 0.9],
-        "y": [0.1, 0.9, 0.9, 0.1],
-        "z": [0.42, 0.73, 0.64, 0.45] // added column
+    Matrix m = Matrix.builder('test').columns([
+        'x': [0.1, 0.9, 0.1, 0.9],
+        'y': [0.1, 0.9, 0.9, 0.1],
+        'z': [0.42, 0.73, 0.64, 0.45] // added column
     ]).types([double]*3)
         .build()
 
     KMeans kmeans = new KMeans(m)
-    List<String> features = ["x", "y", "z"]
-    Matrix result = kmeans.fit(features, 2, 20, "clusterGroup", false)
+    List<String> features = ['x', 'y', 'z']
+    Matrix result = kmeans.fit(features, 2, 20, 'clusterGroup', false)
 
     println result.content()
     // Assertions
-    assertNotSame(m, result, "Should return a new Matrix when mutate = false")
+    assertNotSame(m, result, 'Should return a new Matrix when mutate = false')
     assertEquals(m.rowCount(), result.rowCount())
-    assertTrue(result.columnNames().contains("clusterGroup"))
-    assertEquals(m.column("z"), result.column("z"), "z column should be preserved in result")
-    assertTrue(result.column("clusterGroup").every { it instanceof Integer }, "Group values should be integers")
+    assertTrue(result.columnNames().contains('clusterGroup'))
+    assertEquals(m.column('z'), result.column('z'), 'z column should be preserved in result')
+    assertTrue(result.column('clusterGroup').every { it instanceof Integer }, 'Group values should be integers')
   }
 
   @Test
   void testInvalidFeatureThrows() {
-    Matrix m = Matrix.builder("test").columns([
-        "a": [1, 2, 3],
-        "b": [4, 5, 6]
+    Matrix m = Matrix.builder('test').columns([
+        'a': [1, 2, 3],
+        'b': [4, 5, 6]
     ]).build()
 
     KMeans kmeans = new KMeans(m)
 
     IllegalArgumentException thrown = assertThrows(IllegalArgumentException) {
-      kmeans.fit(["c"], 2)
+      kmeans.fit(['c'], 2)
     }
-    assertTrue(thrown.message.contains("The following columns does not exist in the matrix: c"))
+    assertTrue(thrown.message.contains('The following columns does not exist in the matrix: c'))
   }
 
   @Test
@@ -94,11 +94,11 @@ class KMeansTest {
     }
     m = Normalize.minMaxNorm(m)
     KMeans kmeans = new KMeans(m)
-    Matrix clustered = kmeans.fit(features, 3, 50, "Group", false)
-    println "testWhiskeyDataClustering: " + kmeans.reportTime()
+    Matrix clustered = kmeans.fit(features, 3, 50, 'Group', false)
+    println 'testWhiskeyDataClustering: ' + kmeans.reportTime()
     println Stat.countBy(clustered, 'Group').content()
-    assertEquals(3, clustered.column("Group").toSet().size(), "Should have three clusters")
-    assertEquals(m.rowCount(), clustered.rowCount(), "Should have same row count after clustering")
-    assertTrue(clustered.columnNames().contains("Group"), "Matrix should contain 'Group' column")
+    assertEquals(3, clustered.column('Group').toSet().size(), 'Should have three clusters')
+    assertEquals(m.rowCount(), clustered.rowCount(), 'Should have same row count after clustering')
+    assertTrue(clustered.columnNames().contains('Group'), "Matrix should contain 'Group' column")
   }
 }

--- a/matrix-stats/src/test/groovy/LinearRegressionTest.groovy
+++ b/matrix-stats/src/test/groovy/LinearRegressionTest.groovy
@@ -64,7 +64,7 @@ class LinearRegressionTest {
 
     assertEquals(-0.98130982, model.getIntercept(8), 'Estimate intercept')
     assertEquals(1.88939547, model.getSlope(8), 'Estimate X')
-    assertEquals("Y = 1.89X - 0.98", model.toString(), 'Formula')
+    assertEquals('Y = 1.89X - 0.98', model.toString(), 'Formula')
     assertEquals(0.98034908, model.getRsquared(8), 'Multiple R-squared')
     assertEquals(0.99577407, model.getInterceptStdErr(8), 'Std error intercept')
     assertEquals(0.11962969, model.getSlopeStdErr(8), 'Stc err X')

--- a/matrix-stats/src/test/groovy/NormalizeTest.groovy
+++ b/matrix-stats/src/test/groovy/NormalizeTest.groovy
@@ -64,14 +64,14 @@ class NormalizeTest {
 
   @Test
   void testLogNormZeroes() {
-    assertIterableEquals([null]*3, Normalize.logNorm(ListConverter.convert([0, 0, 0], Byte)), "Byte should be -Infinity")
-    assertIterableEquals([null]*3, Normalize.logNorm(ListConverter.convert([0, 0, 0], Short)), "Short should be -Infinity")
-    assertIterableEquals([null]*3, Normalize.logNorm(ListConverter.toIntegers([0, 0, 0])), "Integer should be -Infinity")
-    assertIterableEquals([null]*3, Normalize.logNorm([0f, 0f, 0f]), "Float should be -Infinity")
-    assertIterableEquals([null]*3, Normalize.logNorm([0l, 0l, 0l]), "Long should be -Infinity")
-    assertIterableEquals([null]*3, Normalize.logNorm([0.0d, 0d, 0d]), "Double should be -Infinity")
-    assertIterableEquals([null]*3, Normalize.logNorm(ListConverter.convert([0, 0, 0], BigInteger)), "BigInteger should be null")
-    assertIterableEquals([null]*3, Normalize.logNorm([0.0g, 0.0g, 0.0g]), "BigDecimal should be null")
+    assertIterableEquals([null]*3, Normalize.logNorm(ListConverter.convert([0, 0, 0], Byte)), 'Byte should be -Infinity')
+    assertIterableEquals([null]*3, Normalize.logNorm(ListConverter.convert([0, 0, 0], Short)), 'Short should be -Infinity')
+    assertIterableEquals([null]*3, Normalize.logNorm(ListConverter.toIntegers([0, 0, 0])), 'Integer should be -Infinity')
+    assertIterableEquals([null]*3, Normalize.logNorm([0f, 0f, 0f]), 'Float should be -Infinity')
+    assertIterableEquals([null]*3, Normalize.logNorm([0l, 0l, 0l]), 'Long should be -Infinity')
+    assertIterableEquals([null]*3, Normalize.logNorm([0.0d, 0d, 0d]), 'Double should be -Infinity')
+    assertIterableEquals([null]*3, Normalize.logNorm(ListConverter.convert([0, 0, 0], BigInteger)), 'BigInteger should be null')
+    assertIterableEquals([null]*3, Normalize.logNorm([0.0g, 0.0g, 0.0g]), 'BigDecimal should be null')
   }
 
   @Test
@@ -114,14 +114,14 @@ class NormalizeTest {
 
   @Test
   void testMinMaxNormZeroes() {
-    assert [Float.NaN]*3 == Normalize.minMaxNorm(ListConverter.convert([0, 0, 0], Byte)) : "Byte should be NaN"
-    assert [Float.NaN]*3 == Normalize.minMaxNorm(ListConverter.convert([0, 0, 0], Short)) : "Short should be NaN"
-    assert [Double.NaN]*3 == Normalize.minMaxNorm([0i, 0i, 0i]) : "Integer should be NaN"
-    assert [Float.NaN]*3 == Normalize.minMaxNorm([0f, 0f, 0f]) : "Float should be NaN"
-    assert [Double.NaN]*3 == Normalize.minMaxNorm([0d, 0d, 0d]) : "Double should be NaN"
-    assert [Double.NaN]*3 == Normalize.minMaxNorm([0l, 0l, 0l]) : "Long should be NaN"
-    assert [null]*3 == Normalize.minMaxNorm([0G, 0G, 0G]) : "BigInteger should be null"
-    assert [null]*3 == Normalize.minMaxNorm([0.0g, 0.0g, 0.0g]) : "BigDecimal should be null"
+    assert [Float.NaN]*3 == Normalize.minMaxNorm(ListConverter.convert([0, 0, 0], Byte)) : 'Byte should be NaN'
+    assert [Float.NaN]*3 == Normalize.minMaxNorm(ListConverter.convert([0, 0, 0], Short)) : 'Short should be NaN'
+    assert [Double.NaN]*3 == Normalize.minMaxNorm([0i, 0i, 0i]) : 'Integer should be NaN'
+    assert [Float.NaN]*3 == Normalize.minMaxNorm([0f, 0f, 0f]) : 'Float should be NaN'
+    assert [Double.NaN]*3 == Normalize.minMaxNorm([0d, 0d, 0d]) : 'Double should be NaN'
+    assert [Double.NaN]*3 == Normalize.minMaxNorm([0l, 0l, 0l]) : 'Long should be NaN'
+    assert [null]*3 == Normalize.minMaxNorm([0G, 0G, 0G]) : 'BigInteger should be null'
+    assert [null]*3 == Normalize.minMaxNorm([0.0g, 0.0g, 0.0g]) : 'BigDecimal should be null'
   }
 
   @Test
@@ -194,14 +194,14 @@ class NormalizeTest {
 
   @Test
   void testStdScaleNormZeroes() {
-    assertIterableEquals([null]*3, Normalize.stdScaleNorm(ListConverter.convert([0, 0, 0], Byte)), "Byte should be -Infinity")
-    assertIterableEquals([null]*3, Normalize.stdScaleNorm(ListConverter.convert([0, 0, 0], Short)), "Short should be -Infinity")
-    assertIterableEquals([null]*3, Normalize.stdScaleNorm(ListConverter.toIntegers([0, 0, 0])), "Integer should be -Infinity")
-    assertIterableEquals([null]*3, Normalize.stdScaleNorm([0f, 0f, 0f]), "Float should be null")
-    assertIterableEquals([null]*3, Normalize.stdScaleNorm([0.0d, 0d, 0d]), "Double should be null")
-    assertIterableEquals([null]*3, Normalize.stdScaleNorm([0l, 0l, 0l]), "Long should be -Infinity")
-    assertIterableEquals([null]*3, Normalize.stdScaleNorm(ListConverter.convert([0, 0, 0], BigInteger)), "BigInteger should be null")
-    assertIterableEquals([null]*3, Normalize.stdScaleNorm([0.0g, 0.0g, 0.0g]), "BigDecimal should be null")
+    assertIterableEquals([null]*3, Normalize.stdScaleNorm(ListConverter.convert([0, 0, 0], Byte)), 'Byte should be -Infinity')
+    assertIterableEquals([null]*3, Normalize.stdScaleNorm(ListConverter.convert([0, 0, 0], Short)), 'Short should be -Infinity')
+    assertIterableEquals([null]*3, Normalize.stdScaleNorm(ListConverter.toIntegers([0, 0, 0])), 'Integer should be -Infinity')
+    assertIterableEquals([null]*3, Normalize.stdScaleNorm([0f, 0f, 0f]), 'Float should be null')
+    assertIterableEquals([null]*3, Normalize.stdScaleNorm([0.0d, 0d, 0d]), 'Double should be null')
+    assertIterableEquals([null]*3, Normalize.stdScaleNorm([0l, 0l, 0l]), 'Long should be -Infinity')
+    assertIterableEquals([null]*3, Normalize.stdScaleNorm(ListConverter.convert([0, 0, 0], BigInteger)), 'BigInteger should be null')
+    assertIterableEquals([null]*3, Normalize.stdScaleNorm([0.0g, 0.0g, 0.0g]), 'BigDecimal should be null')
   }
 
   @Test
@@ -245,14 +245,14 @@ class NormalizeTest {
 
   @Test
   void testMeanNormZeroes() {
-    assertIterableEquals([Float.NaN]*3, Normalize.meanNorm(ListConverter.convert([0, 0, 0], Byte)), "Byte should be -Infinity")
-    assertIterableEquals([Float.NaN]*3, Normalize.meanNorm(ListConverter.convert([0, 0, 0], Short)), "Short should be -Infinity")
-    assertIterableEquals([Float.NaN]*3, Normalize.meanNorm(ListConverter.toIntegers([0, 0, 0])), "Integer should be -Infinity")
-    assertIterableEquals([Float.NaN]*3, Normalize.meanNorm([0f, 0f, 0f]), "Float should be null")
-    assertIterableEquals([Double.NaN]*3, Normalize.meanNorm([0.0d, 0d, 0d]), "Double should be null")
-    assertIterableEquals([Float.NaN]*3, Normalize.meanNorm([0l, 0l, 0l]), "Long should be -Infinity")
-    assertIterableEquals([null]*3, Normalize.meanNorm(ListConverter.convert([0, 0, 0], BigInteger)), "BigInteger should be null")
-    assertIterableEquals([null]*3, Normalize.meanNorm([0.0g, 0.0g, 0.0g]), "BigDecimal should be null")
+    assertIterableEquals([Float.NaN]*3, Normalize.meanNorm(ListConverter.convert([0, 0, 0], Byte)), 'Byte should be -Infinity')
+    assertIterableEquals([Float.NaN]*3, Normalize.meanNorm(ListConverter.convert([0, 0, 0], Short)), 'Short should be -Infinity')
+    assertIterableEquals([Float.NaN]*3, Normalize.meanNorm(ListConverter.toIntegers([0, 0, 0])), 'Integer should be -Infinity')
+    assertIterableEquals([Float.NaN]*3, Normalize.meanNorm([0f, 0f, 0f]), 'Float should be null')
+    assertIterableEquals([Double.NaN]*3, Normalize.meanNorm([0.0d, 0d, 0d]), 'Double should be null')
+    assertIterableEquals([Float.NaN]*3, Normalize.meanNorm([0l, 0l, 0l]), 'Long should be -Infinity')
+    assertIterableEquals([null]*3, Normalize.meanNorm(ListConverter.convert([0, 0, 0], BigInteger)), 'BigInteger should be null')
+    assertIterableEquals([null]*3, Normalize.meanNorm([0.0g, 0.0g, 0.0g]), 'BigDecimal should be null')
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/PolynomialRegressionTest.groovy
+++ b/matrix-stats/src/test/groovy/PolynomialRegressionTest.groovy
@@ -22,7 +22,7 @@ class PolynomialRegressionTest {
     assertEquals(36.0, poly.predict(6).doubleValue(), 0.5)  // Extrapolation
 
     // R-squared should be very high for perfect fit
-    assertTrue(poly.rsquared > 0.99, "R-squared should be > 0.99 for perfect fit")
+    assertTrue(poly.rsquared > 0.99, 'R-squared should be > 0.99 for perfect fit')
 
     // Check degree
     assertEquals(2, poly.degree)
@@ -94,9 +94,9 @@ class PolynomialRegressionTest {
     def poly = new PolynomialRegression(x, y, 2)
     def summary = poly.summary()
 
-    assertTrue(summary.contains('Polynomial Regression'), "Summary should contain title")
-    assertTrue(summary.contains('R-squared'), "Summary should contain R-squared")
-    assertTrue(summary.contains('degree 2'), "Summary should mention degree")
+    assertTrue(summary.contains('Polynomial Regression'), 'Summary should contain title')
+    assertTrue(summary.contains('R-squared'), 'Summary should contain R-squared')
+    assertTrue(summary.contains('degree 2'), 'Summary should mention degree')
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/QuantileRegressionTest.groovy
+++ b/matrix-stats/src/test/groovy/QuantileRegressionTest.groovy
@@ -153,7 +153,7 @@ class QuantileRegressionTest {
       new QuantileRegression(x, y, 0.0)
     }
 
-    assertTrue(exception.message.contains("must be in the open interval (0, 1)"))
+    assertTrue(exception.message.contains('must be in the open interval (0, 1)'))
   }
 
   @Test
@@ -165,7 +165,7 @@ class QuantileRegressionTest {
       new QuantileRegression(x, y, 1.0)
     }
 
-    assertTrue(exception.message.contains("must be in the open interval (0, 1)"))
+    assertTrue(exception.message.contains('must be in the open interval (0, 1)'))
   }
 
   @Test
@@ -177,7 +177,7 @@ class QuantileRegressionTest {
       new QuantileRegression(x, y, -0.5)
     }
 
-    assertTrue(exception.message.contains("must be in the open interval (0, 1)"))
+    assertTrue(exception.message.contains('must be in the open interval (0, 1)'))
   }
 
   @Test
@@ -189,7 +189,7 @@ class QuantileRegressionTest {
       new QuantileRegression(x, y, 1.5)
     }
 
-    assertTrue(exception.message.contains("must be in the open interval (0, 1)"))
+    assertTrue(exception.message.contains('must be in the open interval (0, 1)'))
   }
 
   @Test
@@ -201,7 +201,7 @@ class QuantileRegressionTest {
       new QuantileRegression(x, y, 0.5)
     }
 
-    assertTrue(exception.message.contains("Need at least 2 data points"))
+    assertTrue(exception.message.contains('Need at least 2 data points'))
   }
 
   @Test
@@ -213,7 +213,7 @@ class QuantileRegressionTest {
       new QuantileRegression(x, y, 0.5)
     }
 
-    assertTrue(exception.message.contains("Must have equal number"))
+    assertTrue(exception.message.contains('Must have equal number'))
   }
 
   @Test
@@ -225,9 +225,9 @@ class QuantileRegressionTest {
 
     String str = qr
     assertNotNull(str)
-    assertTrue(str.contains("Y"))
-    assertTrue(str.contains("X"))
-    assertTrue(str.contains("τ=0.5") || str.contains("τ=0.50"))
+    assertTrue(str.contains('Y'))
+    assertTrue(str.contains('X'))
+    assertTrue(str.contains('τ=0.5') || str.contains('τ=0.50'))
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/StudentTest.groovy
+++ b/matrix-stats/src/test/groovy/StudentTest.groovy
@@ -26,7 +26,7 @@ class StudentTest {
   @Test
   void testTwoSample() {
     def iris = Dataset.iris()
-    def speciesIdx = iris.columnIndex("Species")
+    def speciesIdx = iris.columnIndex('Species')
     def setosa = iris.subset {
       it[speciesIdx] == 'setosa'
     }
@@ -36,12 +36,12 @@ class StudentTest {
     // R's t.test defaults to Welch's t-test, so we use Welch class
     TtestResult result = Welch.tTest(setosa['Petal Length'], virginica['Petal Length'])
     // println(result)
-    assertEquals(-49.98618626, result.getT(8), "t value")
+    assertEquals(-49.98618626, result.getT(8), 't value')
     // println("var1 = ${result.var1}, var2 = ${result.var2}")
-    assertEquals(58.60939455, result.getDf(8), "Degrees of freedom")
-    assertEquals(0.17366400, result.getSd1(8), "sd1")
-    assertEquals(0.55189470, result.getSd2(8), "sd2")
-    assertEquals(0.55189470, result.getSd2(8), "sd2")
+    assertEquals(58.60939455, result.getDf(8), 'Degrees of freedom')
+    assertEquals(0.17366400, result.getSd1(8), 'sd1')
+    assertEquals(0.55189470, result.getSd2(8), 'sd2')
+    assertEquals(0.55189470, result.getSd2(8), 'sd2')
     assertEquals(9.269628E-50, result.p, 0.0000001)
   }
 

--- a/matrix-stats/src/test/groovy/contingency/FisherTest.groovy
+++ b/matrix-stats/src/test/groovy/contingency/FisherTest.groovy
@@ -23,7 +23,7 @@ class FisherTest {
     assertNotNull(result.pValue)
     assertNotNull(result.oddsRatio)
     assertNotNull(result.confidenceInterval)
-    assertEquals("two.sided", result.alternative)
+    assertEquals('two.sided', result.alternative)
 
     // Odds ratio = (3*3)/(1*1) = 9
     assertEquals(9.0, result.oddsRatio, 0.001)
@@ -40,8 +40,8 @@ class FisherTest {
 
     assertNotNull(result)
     // This should show significant association
-    assertTrue(result.pValue < 0.05, "Should detect significant association")
-    assertTrue(result.oddsRatio > 1.0, "Odds ratio should indicate positive association")
+    assertTrue(result.pValue < 0.05, 'Should detect significant association')
+    assertTrue(result.oddsRatio > 1.0, 'Odds ratio should indicate positive association')
   }
 
   @Test
@@ -54,30 +54,30 @@ class FisherTest {
     // No association: odds ratio should be 1
     assertEquals(1.0, result.oddsRatio, 0.001)
     // p-value should be high (not significant)
-    assertTrue(result.pValue > 0.9, "Should not detect association")
+    assertTrue(result.pValue > 0.9, 'Should not detect association')
   }
 
   @Test
   void testOneSidedGreater() {
     def table = [[12, 5], [9, 11]]
-    def result = Fisher.test(table, "greater")
+    def result = Fisher.test(table, 'greater')
 
     assertNotNull(result)
-    assertEquals("greater", result.alternative)
+    assertEquals('greater', result.alternative)
     assertNotNull(result.pValue)
 
     // One-sided test should have different p-value than two-sided
-    def twoSided = Fisher.test(table, "two.sided")
+    def twoSided = Fisher.test(table, 'two.sided')
     assertNotEquals(result.pValue, twoSided.pValue)
   }
 
   @Test
   void testOneSidedLess() {
     def table = [[12, 5], [9, 11]]
-    def result = Fisher.test(table, "less")
+    def result = Fisher.test(table, 'less')
 
     assertNotNull(result)
-    assertEquals("less", result.alternative)
+    assertEquals('less', result.alternative)
     assertNotNull(result.pValue)
   }
 
@@ -90,9 +90,9 @@ class FisherTest {
     assertNotNull(result)
     assertNotNull(result.oddsRatio)
     // Should use continuity correction for odds ratio
-    assertTrue(result.oddsRatio > 0, "Odds ratio should be positive")
-    assertTrue(result.confidenceInterval[0] > 0, "Lower CI should be positive")
-    assertTrue(result.confidenceInterval[1] > 0, "Upper CI should be positive")
+    assertTrue(result.oddsRatio > 0, 'Odds ratio should be positive')
+    assertTrue(result.confidenceInterval[0] > 0, 'Lower CI should be positive')
+    assertTrue(result.confidenceInterval[1] > 0, 'Upper CI should be positive')
   }
 
   @Test
@@ -132,10 +132,10 @@ class FisherTest {
       .matrixName('test')
       .rows([[8, 4], [3, 7]])
       .build()
-    def result = Fisher.test(matrix, "greater")
+    def result = Fisher.test(matrix, 'greater')
 
     assertNotNull(result)
-    assertEquals("greater", result.alternative)
+    assertEquals('greater', result.alternative)
   }
 
   @Test
@@ -178,14 +178,14 @@ class FisherTest {
     // Significant result
     def table1 = [[18, 2], [4, 16]]
     def result1 = Fisher.test(table1)
-    assertTrue(result1.evaluate(0.05), "Should reject null at 5% level")
-    assertTrue(result1.evaluate(0.05G), "Should reject null at 5% level with BigDecimal alpha")
-    assertTrue(result1.evaluate(), "Should reject null with default alpha")
+    assertTrue(result1.evaluate(0.05), 'Should reject null at 5% level')
+    assertTrue(result1.evaluate(0.05G), 'Should reject null at 5% level with BigDecimal alpha')
+    assertTrue(result1.evaluate(), 'Should reject null with default alpha')
 
     // Non-significant result
     def table2 = [[10, 10], [10, 10]]
     def result2 = Fisher.test(table2)
-    assertFalse(result2.evaluate(0.05), "Should not reject null at 5% level")
+    assertFalse(result2.evaluate(0.05), 'Should not reject null at 5% level')
   }
 
   @Test
@@ -200,11 +200,11 @@ class FisherTest {
     BigDecimal upper = result.confidenceInterval[1]
 
     // Lower bound should be less than odds ratio
-    assertTrue(lower < result.oddsRatio, "Lower CI bound should be < odds ratio")
+    assertTrue(lower < result.oddsRatio, 'Lower CI bound should be < odds ratio')
     // Upper bound should be greater than odds ratio
-    assertTrue(upper > result.oddsRatio, "Upper CI bound should be > odds ratio")
+    assertTrue(upper > result.oddsRatio, 'Upper CI bound should be > odds ratio')
     // Lower should be less than upper
-    assertTrue(lower < upper, "Lower CI should be < upper CI")
+    assertTrue(lower < upper, 'Lower CI should be < upper CI')
   }
 
   @Test
@@ -215,10 +215,10 @@ class FisherTest {
 
     assertNotNull(str)
     assertTrue(str.contains("Fisher's Exact Test"))
-    assertTrue(str.contains("p-value"))
-    assertTrue(str.contains("odds ratio"))
-    assertTrue(str.contains("95% CI"))
-    assertTrue(str.contains("alternative"))
+    assertTrue(str.contains('p-value'))
+    assertTrue(str.contains('odds ratio'))
+    assertTrue(str.contains('95% CI'))
+    assertTrue(str.contains('alternative'))
   }
 
   @Test
@@ -255,7 +255,7 @@ class FisherTest {
     def table2 = [[10, 0], [0, 10]]
     def result2 = Fisher.test(table2)
     assertNotNull(result2)
-    assertTrue(result2.oddsRatio > 100, "Odds ratio should be very large for perfect association")
+    assertTrue(result2.oddsRatio > 100, 'Odds ratio should be very large for perfect association')
   }
 
   @Test
@@ -291,8 +291,8 @@ class FisherTest {
 
     for (def table : tables) {
       def result = Fisher.test(table)
-      assertTrue(result.pValue >= 0.0, "p-value should be >= 0")
-      assertTrue(result.pValue <= 1.0, "p-value should be <= 1")
+      assertTrue(result.pValue >= 0.0, 'p-value should be >= 0')
+      assertTrue(result.pValue <= 1.0, 'p-value should be <= 1')
     }
   }
 
@@ -300,9 +300,9 @@ class FisherTest {
   void testDifferentAlternatives() {
     def table = [[10, 5], [3, 12]]
 
-    def twoSided = Fisher.test(table, "two.sided")
-    def greater = Fisher.test(table, "greater")
-    def less = Fisher.test(table, "less")
+    def twoSided = Fisher.test(table, 'two.sided')
+    def greater = Fisher.test(table, 'greater')
+    def less = Fisher.test(table, 'less')
 
     // All should have same odds ratio
     assertEquals(twoSided.oddsRatio, greater.oddsRatio, 1e-10)
@@ -322,8 +322,8 @@ class FisherTest {
     def table = [[5, 5], [5, 5]]
     def result = Fisher.test(table)
 
-    assertEquals(1.0, result.oddsRatio, 0.001, "Symmetric table should have OR = 1")
-    assertTrue(result.pValue > 0.9, "Symmetric table should have high p-value")
+    assertEquals(1.0, result.oddsRatio, 0.001, 'Symmetric table should have OR = 1')
+    assertTrue(result.pValue > 0.9, 'Symmetric table should have high p-value')
   }
 
   @Test
@@ -335,8 +335,8 @@ class FisherTest {
     double upper = result.confidenceInterval[1]
 
     // CI should contain the point estimate
-    assertTrue(lower <= result.oddsRatio, "Lower CI should be <= odds ratio")
-    assertTrue(upper >= result.oddsRatio, "Upper CI should be >= odds ratio")
+    assertTrue(lower <= result.oddsRatio, 'Lower CI should be <= odds ratio')
+    assertTrue(upper >= result.oddsRatio, 'Upper CI should be >= odds ratio')
   }
 
   @Test
@@ -350,7 +350,7 @@ class FisherTest {
     assertNotNull(result)
     // Strong association: OR = (30*30)/(10*10) = 9
     assertEquals(9.0, result.oddsRatio, 0.001)
-    assertTrue(result.pValue < 0.05, "Should detect significant association")
+    assertTrue(result.pValue < 0.05, 'Should detect significant association')
   }
 
   @Test
@@ -361,7 +361,7 @@ class FisherTest {
 
     assertNotNull(result)
     // Odds ratio ≈ relative risk for rare diseases
-    assertTrue(result.oddsRatio > 1.5, "Should show increased risk")
+    assertTrue(result.oddsRatio > 1.5, 'Should show increased risk')
   }
 
   @Test
@@ -404,7 +404,7 @@ class FisherTest {
     def table = [[12, 5], [9, 11]]
     def result = Fisher.test(table)
 
-    assertEquals(2.933, result.oddsRatio, 0.01, "Odds ratio should match expected")
+    assertEquals(2.933, result.oddsRatio, 0.01, 'Odds ratio should match expected')
     // Two-sided p-value should be reasonable (not extremely small or large)
     assertTrue(result.pValue > 0.1 && result.pValue < 0.3,
                "p-value should be in reasonable range (got ${result.pValue})")
@@ -414,8 +414,8 @@ class FisherTest {
   void testAlternativeHypothesesConsistency() {
     def table = [[15, 5], [8, 12]]
 
-    def greater = Fisher.test(table, "greater")
-    def less = Fisher.test(table, "less")
+    def greater = Fisher.test(table, 'greater')
+    def less = Fisher.test(table, 'less')
 
     // For one-sided tests, p(greater) + p(less) should be approximately 1 + p(observed)
     // This is because they overlap at the observed value

--- a/matrix-stats/src/test/groovy/kde/KernelDensityTest.groovy
+++ b/matrix-stats/src/test/groovy/kde/KernelDensityTest.groovy
@@ -31,41 +31,41 @@ class KernelDensityTest {
   @Test
   void testKernelEvaluation() {
     // Gaussian at u=0 should be 1/sqrt(2*pi) ≈ 0.3989
-    assertEquals(0.3989422804, Kernel.GAUSSIAN.evaluate(0) as double, 1e-6, "Gaussian at u=0")
-    assertEquals(0.2419707245, Kernel.GAUSSIAN.evaluate(1) as double, 1e-6, "Gaussian at u=1")
+    assertEquals(0.3989422804, Kernel.GAUSSIAN.evaluate(0) as double, 1e-6, 'Gaussian at u=0')
+    assertEquals(0.2419707245, Kernel.GAUSSIAN.evaluate(1) as double, 1e-6, 'Gaussian at u=1')
 
     // Epanechnikov at u=0 should be 0.75
-    assertEquals(0.75, Kernel.EPANECHNIKOV.evaluate(0) as double, TOLERANCE, "Epanechnikov at u=0")
-    assertEquals(0.0, Kernel.EPANECHNIKOV.evaluate(1.5) as double, TOLERANCE, "Epanechnikov at u=1.5")
+    assertEquals(0.75, Kernel.EPANECHNIKOV.evaluate(0) as double, TOLERANCE, 'Epanechnikov at u=0')
+    assertEquals(0.0, Kernel.EPANECHNIKOV.evaluate(1.5) as double, TOLERANCE, 'Epanechnikov at u=1.5')
 
     // Uniform at u=0 should be 0.5
-    assertEquals(0.5, Kernel.UNIFORM.evaluate(0) as double, TOLERANCE, "Uniform at u=0")
-    assertEquals(0.0, Kernel.UNIFORM.evaluate(1.5) as double, TOLERANCE, "Uniform at u=1.5")
+    assertEquals(0.5, Kernel.UNIFORM.evaluate(0) as double, TOLERANCE, 'Uniform at u=0')
+    assertEquals(0.0, Kernel.UNIFORM.evaluate(1.5) as double, TOLERANCE, 'Uniform at u=1.5')
 
     // Triangular at u=0 should be 1.0
-    assertEquals(1.0, Kernel.TRIANGULAR.evaluate(0) as double, TOLERANCE, "Triangular at u=0")
-    assertEquals(0.5, Kernel.TRIANGULAR.evaluate(0.5) as double, TOLERANCE, "Triangular at u=0.5")
-    assertEquals(0.0, Kernel.TRIANGULAR.evaluate(1.5) as double, TOLERANCE, "Triangular at u=1.5")
+    assertEquals(1.0, Kernel.TRIANGULAR.evaluate(0) as double, TOLERANCE, 'Triangular at u=0')
+    assertEquals(0.5, Kernel.TRIANGULAR.evaluate(0.5) as double, TOLERANCE, 'Triangular at u=0.5')
+    assertEquals(0.0, Kernel.TRIANGULAR.evaluate(1.5) as double, TOLERANCE, 'Triangular at u=1.5')
   }
 
   @Test
   void testKernelFromString() {
-    assertEquals(Kernel.GAUSSIAN, Kernel.fromString("gaussian"))
-    assertEquals(Kernel.GAUSSIAN, Kernel.fromString("GAUSSIAN"))
-    assertEquals(Kernel.GAUSSIAN, Kernel.fromString("normal"))
-    assertEquals(Kernel.EPANECHNIKOV, Kernel.fromString("epanechnikov"))
-    assertEquals(Kernel.EPANECHNIKOV, Kernel.fromString("epan"))
-    assertEquals(Kernel.UNIFORM, Kernel.fromString("uniform"))
-    assertEquals(Kernel.UNIFORM, Kernel.fromString("rectangular"))
-    assertEquals(Kernel.TRIANGULAR, Kernel.fromString("triangular"))
-    assertEquals(Kernel.TRIANGULAR, Kernel.fromString("triangle"))
+    assertEquals(Kernel.GAUSSIAN, Kernel.fromString('gaussian'))
+    assertEquals(Kernel.GAUSSIAN, Kernel.fromString('GAUSSIAN'))
+    assertEquals(Kernel.GAUSSIAN, Kernel.fromString('normal'))
+    assertEquals(Kernel.EPANECHNIKOV, Kernel.fromString('epanechnikov'))
+    assertEquals(Kernel.EPANECHNIKOV, Kernel.fromString('epan'))
+    assertEquals(Kernel.UNIFORM, Kernel.fromString('uniform'))
+    assertEquals(Kernel.UNIFORM, Kernel.fromString('rectangular'))
+    assertEquals(Kernel.TRIANGULAR, Kernel.fromString('triangular'))
+    assertEquals(Kernel.TRIANGULAR, Kernel.fromString('triangle'))
 
     // Default for null
     assertEquals(Kernel.GAUSSIAN, Kernel.fromString(null))
 
     // Unknown kernel should throw
     assertThrows(IllegalArgumentException) {
-      Kernel.fromString("unknown")
+      Kernel.fromString('unknown')
     }
   }
 
@@ -99,14 +99,14 @@ class KernelDensityTest {
   void testBasicKDE() {
     def kde = new KernelDensity(TEST_DATA)
 
-    assertEquals(Kernel.GAUSSIAN, kde.kernel, "Default kernel should be Gaussian")
-    assertEquals(512, kde.n, "Default n should be 512")
-    assertTrue(kde.bandwidth > 0, "Bandwidth should be positive")
-    assertEquals(TEST_DATA.size(), kde.dataCount, "Data count should match")
+    assertEquals(Kernel.GAUSSIAN, kde.kernel, 'Default kernel should be Gaussian')
+    assertEquals(512, kde.n, 'Default n should be 512')
+    assertTrue(kde.bandwidth > 0, 'Bandwidth should be positive')
+    assertEquals(TEST_DATA.size(), kde.dataCount, 'Data count should match')
 
     // Density should be non-negative everywhere
     for (BigDecimal d : kde.density) {
-      assertTrue(d >= 0, "Density should be non-negative")
+      assertTrue(d >= 0, 'Density should be non-negative')
     }
 
     // Density should integrate to approximately 1 (within reason)
@@ -146,7 +146,7 @@ class KernelDensityTest {
     def kde2 = new KernelDensity(TEST_DATA, [adjust: 2.0])
 
     assertEquals((kde1.bandwidth * 2) as double, kde2.bandwidth as double, TOLERANCE,
-        "Adjust=2 should double bandwidth")
+        'Adjust=2 should double bandwidth')
   }
 
   @Test
@@ -156,12 +156,12 @@ class KernelDensityTest {
     // Density at mean should be relatively high
     BigDecimal mean = TEST_DATA.sum() / TEST_DATA.size()
     BigDecimal densityAtMean = kde.density(mean)
-    assertTrue(densityAtMean > 0, "Density at mean should be positive")
+    assertTrue(densityAtMean > 0, 'Density at mean should be positive')
 
     // Density far from data should be low
     BigDecimal densityFarAway = kde.density(100.0)
     assertTrue(densityFarAway < densityAtMean / 100,
-        "Density far from data should be much lower than at mean")
+        'Density far from data should be much lower than at mean')
   }
 
   @Test
@@ -170,16 +170,16 @@ class KernelDensityTest {
     List<BigDecimal> points = [1.0, 2.0, 3.0]
     List<BigDecimal> densities = kde.density(points)
 
-    assertEquals(points.size(), densities.size(), "Should return same number of densities as points")
+    assertEquals(points.size(), densities.size(), 'Should return same number of densities as points')
     for (BigDecimal d : densities) {
-      assertTrue(d >= 0, "All densities should be non-negative")
+      assertTrue(d >= 0, 'All densities should be non-negative')
     }
   }
 
   @Test
   void testFromMatrix() {
     Matrix m = Matrix.builder()
-        .matrixName("test")
+        .matrixName('test')
         .columns([
             'values': TEST_DATA,
             'other': [1, 2, 3, 4, 5, 6]
@@ -188,8 +188,8 @@ class KernelDensityTest {
         .build()
 
     def kde = new KernelDensity(m, 'values')
-    assertEquals(TEST_DATA.size(), kde.dataCount, "Data count should match column length")
-    assertTrue(kde.bandwidth > 0, "Bandwidth should be positive")
+    assertEquals(TEST_DATA.size(), kde.dataCount, 'Data count should match column length')
+    assertTrue(kde.bandwidth > 0, 'Bandwidth should be positive')
   }
 
   @Test
@@ -209,13 +209,13 @@ class KernelDensityTest {
     def kde = new KernelDensity(TEST_DATA, [n: 100])
     Matrix result = kde.toMatrix()
 
-    assertEquals(100, result.rowCount(), "Result should have n rows")
-    assertEquals(['x', 'density'], result.columnNames(), "Should have x and density columns")
+    assertEquals(100, result.rowCount(), 'Result should have n rows')
+    assertEquals(['x', 'density'], result.columnNames(), 'Should have x and density columns')
 
     // Verify x values are increasing
     for (int i = 1; i < result.rowCount(); i++) {
       assertTrue((result[i, 'x'] as BigDecimal) > (result[i - 1, 'x'] as BigDecimal),
-          "X values should be increasing")
+          'X values should be increasing')
     }
   }
 
@@ -224,10 +224,10 @@ class KernelDensityTest {
     def kde = new KernelDensity(TEST_DATA, [n: 50])
     List<List<BigDecimal>> points = kde.toPointList()
 
-    assertEquals(50, points.size(), "Should return n points")
+    assertEquals(50, points.size(), 'Should return n points')
     for (List<BigDecimal> pt : points) {
-      assertEquals(2, pt.size(), "Each point should be [x, density]")
-      assertTrue(pt[1] >= 0, "Density should be non-negative")
+      assertEquals(2, pt.size(), 'Each point should be [x, density]')
+      assertTrue(pt[1] >= 0, 'Density should be non-negative')
     }
   }
 
@@ -238,15 +238,15 @@ class KernelDensityTest {
 
     // Without trim, evaluation range should extend beyond data
     assertTrue(kdeNoTrim.x[0] < kdeNoTrim.dataMin,
-        "Without trim, evaluation should start before data min")
+        'Without trim, evaluation should start before data min')
     assertTrue(kdeNoTrim.x[kdeNoTrim.n - 1] > kdeNoTrim.dataMax,
-        "Without trim, evaluation should end after data max")
+        'Without trim, evaluation should end after data max')
 
     // With trim, evaluation range should match data range
     assertTrue((kdeTrim.x[0] - kdeTrim.dataMin).abs() < 0.01,
-        "With trim, evaluation should start at data min")
+        'With trim, evaluation should start at data min')
     assertTrue((kdeTrim.x[kdeTrim.n - 1] - kdeTrim.dataMax).abs() < 0.01,
-        "With trim, evaluation should end at data max")
+        'With trim, evaluation should end at data max')
   }
 
   @Test
@@ -262,8 +262,8 @@ class KernelDensityTest {
     List<BigDecimal> dataWithNulls = [1.2, null, 2.3, null, 1.8, 2.1]
     def kde = new KernelDensity(dataWithNulls)
 
-    assertEquals(4, kde.dataCount, "Should filter out nulls")
-    assertTrue(kde.bandwidth > 0, "Should compute valid bandwidth with filtered data")
+    assertEquals(4, kde.dataCount, 'Should filter out nulls')
+    assertTrue(kde.bandwidth > 0, 'Should compute valid bandwidth with filtered data')
   }
 
   @Test
@@ -287,8 +287,8 @@ class KernelDensityTest {
     // All same values - bandwidth computation should handle this
     def kde = new KernelDensity([2.0, 2.0, 2.0, 2.0, 2.0])
 
-    assertTrue(kde.bandwidth > 0, "Bandwidth should be positive even with identical values")
-    assertTrue(kde.density(2.0) > 0, "Density at the repeated value should be positive")
+    assertTrue(kde.bandwidth > 0, 'Bandwidth should be positive even with identical values')
+    assertTrue(kde.density(2.0) > 0, 'Density at the repeated value should be positive')
   }
 
   @Test
@@ -296,9 +296,9 @@ class KernelDensityTest {
     def kde = new KernelDensity(TEST_DATA)
     String summary = kde.summary()
 
-    assertTrue(summary.contains("Kernel"), "Summary should contain kernel info")
-    assertTrue(summary.contains("Bandwidth"), "Summary should contain bandwidth")
-    assertTrue(summary.contains("Data points"), "Summary should contain data count")
+    assertTrue(summary.contains('Kernel'), 'Summary should contain kernel info')
+    assertTrue(summary.contains('Bandwidth'), 'Summary should contain bandwidth')
+    assertTrue(summary.contains('Data points'), 'Summary should contain data count')
   }
 
   @Test
@@ -306,8 +306,8 @@ class KernelDensityTest {
     def kde = new KernelDensity(TEST_DATA, [kernel: Kernel.EPANECHNIKOV])
     String str = kde
 
-    assertTrue(str.contains("EPANECHNIKOV"), "toString should contain kernel name")
-    assertTrue(str.contains("bandwidth"), "toString should contain bandwidth")
+    assertTrue(str.contains('EPANECHNIKOV'), 'toString should contain kernel name')
+    assertTrue(str.contains('bandwidth'), 'toString should contain bandwidth')
   }
 
   @Test
@@ -320,7 +320,7 @@ class KernelDensityTest {
     xCopy[0] = 999.0
 
     assertEquals(originalFirst, kde.getX()[0],
-        "Modifying returned list should not affect internal state")
+        'Modifying returned list should not affect internal state')
   }
 
   @Test
@@ -328,10 +328,10 @@ class KernelDensityTest {
     def kde = new KernelDensity(TEST_DATA)
 
     BigDecimal bw4 = kde.getBandwidth(4)
-    assertEquals(4, bw4.scale(), "Bandwidth should have 4 decimal places")
+    assertEquals(4, bw4.scale(), 'Bandwidth should have 4 decimal places')
 
     BigDecimal bw2 = kde.getBandwidth(2)
-    assertEquals(2, bw2.scale(), "Bandwidth should have 2 decimal places")
+    assertEquals(2, bw2.scale(), 'Bandwidth should have 2 decimal places')
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/normality/AndersonDarlingTest.groovy
+++ b/matrix-stats/src/test/groovy/normality/AndersonDarlingTest.groovy
@@ -110,9 +110,9 @@ class AndersonDarlingTest {
   @Test
   void testDifferentSampleSizes() {
     // Test with different sample sizes
-    List<Double> small = (1..10).collect { it.doubleValue() }
-    List<Double> medium = (1..50).collect { it.doubleValue() }
-    List<Double> large = (1..100).collect { it.doubleValue() }
+    List<Double> small = (1..10)*.doubleValue()
+    List<Double> medium = (1..50)*.doubleValue()
+    List<Double> large = (1..100)*.doubleValue()
 
     def resultSmall = AndersonDarling.testNormality(small)
     def resultMedium = AndersonDarling.testNormality(medium)

--- a/matrix-stats/src/test/groovy/normality/LillieforsTest.groovy
+++ b/matrix-stats/src/test/groovy/normality/LillieforsTest.groovy
@@ -67,9 +67,9 @@ class LillieforsTest {
   @Test
   void testDifferentSampleSizes() {
     // Test with different sample sizes
-    List<Double> small = (1..10).collect { it.doubleValue() }
-    List<Double> medium = (1..50).collect { it.doubleValue() }
-    List<Double> large = (1..100).collect { it.doubleValue() }
+    List<Double> small = (1..10)*.doubleValue()
+    List<Double> medium = (1..50)*.doubleValue()
+    List<Double> large = (1..100)*.doubleValue()
 
     def resultSmall = Lilliefors.testNormality(small)
     def resultMedium = Lilliefors.testNormality(medium)

--- a/matrix-stats/src/test/groovy/normality/ShapiroFranciaTest.groovy
+++ b/matrix-stats/src/test/groovy/normality/ShapiroFranciaTest.groovy
@@ -96,7 +96,7 @@ class ShapiroFranciaTest {
     }
 
     // Too many observations
-    List<Double> tooManyData = (1..6000).collect { it.doubleValue() }
+    List<Double> tooManyData = (1..6000)*.doubleValue()
     assertThrows(IllegalArgumentException) {
       ShapiroFrancia.test(tooManyData)
     }

--- a/matrix-stats/src/test/groovy/regression/LogisticRegressionTest.groovy
+++ b/matrix-stats/src/test/groovy/regression/LogisticRegressionTest.groovy
@@ -234,8 +234,8 @@ class LogisticRegressionTest {
 
   private static double[] apacheLogisticFit(List<? extends Number> xValues, List<? extends Number> yValues) {
     int n = xValues.size()
-    double[] x = xValues.collect { it.doubleValue() } as double[]
-    double[] y = yValues.collect { it.doubleValue() } as double[]
+    double[] x = xValues*.doubleValue() as double[]
+    double[] y = yValues*.doubleValue() as double[]
 
     MultivariateFunction negativeLogLikelihood = new MultivariateFunction() {
       @Override

--- a/matrix-stats/src/test/groovy/se/alipsa/matrix/stats/timeseries/Section45BenchmarkTest.groovy
+++ b/matrix-stats/src/test/groovy/se/alipsa/matrix/stats/timeseries/Section45BenchmarkTest.groovy
@@ -221,7 +221,7 @@ class Section45BenchmarkTest {
     int columnCount = values[0].length
     Matrix.builder()
       .columnNames((0..<columnCount).collect { int idx -> "c${idx}" })
-      .rows(values.collect { double[] row -> row.toList() })
+      .rows(values*.toList())
       .types((0..<columnCount).collect { Double })
       .build()
   }

--- a/matrix-stats/src/test/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtilsTest.groovy
+++ b/matrix-stats/src/test/groovy/se/alipsa/matrix/stats/timeseries/TimeSeriesUtilsTest.groovy
@@ -57,7 +57,7 @@ class TimeSeriesUtilsTest {
       TimeSeriesUtils.solveLinearSystem(a, b)
     }
 
-    assertEquals("Singular matrix at column 1 - cannot solve linear system", exception.message)
+    assertEquals('Singular matrix at column 1 - cannot solve linear system', exception.message)
   }
 
   @Test
@@ -74,7 +74,7 @@ class TimeSeriesUtilsTest {
       TimeSeriesUtils.solveLinearSystem(a, b)
     }
 
-    assertEquals("Singular matrix at column 1 - cannot solve linear system", exception.message)
+    assertEquals('Singular matrix at column 1 - cannot solve linear system', exception.message)
   }
 
   @Test
@@ -103,7 +103,7 @@ class TimeSeriesUtilsTest {
       TimeSeriesUtils.invertMatrix(a)
     }
 
-    assertEquals("Singular matrix at column 1 - cannot invert matrix", exception.message)
+    assertEquals('Singular matrix at column 1 - cannot invert matrix', exception.message)
   }
 
   @Test
@@ -179,6 +179,6 @@ class TimeSeriesUtilsTest {
       TimeSeriesUtils.calculateRSS(y, x, beta)
     }
 
-    assertEquals("Design matrix rows must all have the same length", exception.message)
+    assertEquals('Design matrix rows must all have the same length', exception.message)
   }
 }

--- a/matrix-stats/src/test/groovy/timeseries/AdfGlsTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/AdfGlsTest.groovy
@@ -20,11 +20,11 @@ class AdfGlsTest {
       125, 124, 126, 128, 130, 132, 131, 133, 135, 137
     ] as double[]
 
-    def result = AdfGls.test(data, 0, "drift")
+    def result = AdfGls.test(data, 0, 'drift')
 
     assertNotNull(result, 'Result should not be null')
     assertEquals(30, result.sampleSize)
-    assertEquals("drift", result.testType)
+    assertEquals('drift', result.testType)
     assertEquals(0, result.lags)
 
     // Random walk should fail to reject unit root
@@ -41,7 +41,7 @@ class AdfGlsTest {
       99, 100, 102, 98, 100, 101, 99, 100, 101, 99
     ] as double[]
 
-    def result = AdfGls.test(data, 0, "drift")
+    def result = AdfGls.test(data, 0, 'drift')
 
     assertNotNull(result, 'Result should not be null')
     assertTrue(result.statistic <= 0, 'ADF-GLS statistic should be negative')
@@ -55,10 +55,10 @@ class AdfGlsTest {
       data[i] = 100 + i * 0.5 + Math.sin(i * 0.3) * 2
     }
 
-    def result = AdfGls.test(data, 0, "trend")
+    def result = AdfGls.test(data, 0, 'trend')
 
     assertNotNull(result, 'Result should not be null')
-    assertEquals("trend", result.testType)
+    assertEquals('trend', result.testType)
     assertTrue(result.statistic <= 0, 'ADF-GLS statistic should be negative')
   }
 
@@ -71,7 +71,7 @@ class AdfGlsTest {
       data[i] = 100 + Math.sin(i * 0.2) * 10 + (rnd.nextDouble() - 0.5) * 3
     }
 
-    def result = AdfGls.test(data, 2, "drift")
+    def result = AdfGls.test(data, 2, 'drift')
 
     assertNotNull(result, 'Result should not be null')
     assertEquals(2, result.lags, 'Lags should be 2')
@@ -85,7 +85,7 @@ class AdfGlsTest {
       data[i] = 100 + i * 0.3 + Math.sin(i * 0.2) * 5
     }
 
-    def result = AdfGls.test(data, null as Integer, "drift")
+    def result = AdfGls.test(data, null as Integer, 'drift')
 
     assertNotNull(result, 'Result should not be null')
     assertTrue(result.lags >= 0, 'Lags should be non-negative')
@@ -99,7 +99,7 @@ class AdfGlsTest {
       101, 99, 100, 102, 98, 100, 101, 99, 100, 101
     ]
 
-    def result = AdfGls.test(data, 0, "drift")
+    def result = AdfGls.test(data, 0, 'drift')
 
     assertNotNull(result, 'Result should not be null')
     assertEquals(20, result.sampleSize)
@@ -109,13 +109,13 @@ class AdfGlsTest {
   void testValidation() {
     // Null data
     assertThrows(IllegalArgumentException) {
-      AdfGls.test(null as double[], 0, "drift")
+      AdfGls.test(null as double[], 0, 'drift')
     }
 
     // Too few observations
     double[] tooSmall = [1, 2, 3, 4, 5, 6, 7, 8, 9] as double[]
     assertThrows(IllegalArgumentException) {
-      AdfGls.test(tooSmall, 0, "drift")
+      AdfGls.test(tooSmall, 0, 'drift')
     }
 
     // Constant series
@@ -124,13 +124,13 @@ class AdfGlsTest {
       constant[i] = 100.0
     }
     assertThrows(IllegalArgumentException) {
-      AdfGls.test(constant, 0, "drift")
+      AdfGls.test(constant, 0, 'drift')
     }
 
     // Invalid type
     double[] data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as double[]
     assertThrows(IllegalArgumentException) {
-      AdfGls.test(data, 0, "invalid")
+      AdfGls.test(data, 0, 'invalid')
     }
   }
 
@@ -142,7 +142,7 @@ class AdfGlsTest {
     }
 
     IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
-      AdfGls.test(data, null as Integer, "trend")
+      AdfGls.test(data, null as Integer, 'trend')
     }
 
     assertTrue(exception.message.contains('Unable to select ADF-GLS lag'))
@@ -156,7 +156,7 @@ class AdfGlsTest {
       data[i] = 100 + i * 0.1 + Math.sin(i * 0.2) * 2
     }
 
-    def result = AdfGls.test(data, 0, "drift")
+    def result = AdfGls.test(data, 0, 'drift')
 
     // Critical values should be negative and ordered: 1% < 5% < 10%
     assertTrue(result.criticalValue1pct < result.criticalValue5pct,
@@ -174,7 +174,7 @@ class AdfGlsTest {
       101, 99, 100, 102, 98, 100, 101, 99, 100, 101
     ] as double[]
 
-    def result = AdfGls.test(data, 0, "drift")
+    def result = AdfGls.test(data, 0, 'drift')
 
     String interpretation = result.interpret(0.05)
     assertNotNull(interpretation, 'Interpretation should not be null')
@@ -190,7 +190,7 @@ class AdfGlsTest {
       data[i] = 100 + i + Math.sin(i * 0.3) * 3
     }
 
-    def result = AdfGls.test(data, 0, "trend")
+    def result = AdfGls.test(data, 0, 'trend')
 
     String evaluation = result.evaluate()
     assertNotNull(evaluation, 'Evaluation should not be null')
@@ -207,7 +207,7 @@ class AdfGlsTest {
       data[i] = 100 + Math.sin(i * 0.5) * 10
     }
 
-    def result = AdfGls.test(data, 0, "drift")
+    def result = AdfGls.test(data, 0, 'drift')
 
     String str = result
     assertTrue(str.contains('ADF-GLS'), 'Should contain test name')
@@ -225,14 +225,14 @@ class AdfGlsTest {
     }
 
     // Test both types
-    def driftResult = AdfGls.test(data, 0, "drift")
-    def trendResult = AdfGls.test(data, 0, "trend")
+    def driftResult = AdfGls.test(data, 0, 'drift')
+    def trendResult = AdfGls.test(data, 0, 'trend')
 
     assertNotNull(driftResult)
     assertNotNull(trendResult)
 
-    assertEquals("drift", driftResult.testType)
-    assertEquals("trend", trendResult.testType)
+    assertEquals('drift', driftResult.testType)
+    assertEquals('trend', trendResult.testType)
 
     // Critical values should differ by type
     // Trend critical values are more negative
@@ -250,7 +250,7 @@ class AdfGlsTest {
       randomWalk[i] = randomWalk[i - 1] + (rnd.nextDouble() - 0.5)
     }
 
-    def result = AdfGls.test(randomWalk, 0, "drift")
+    def result = AdfGls.test(randomWalk, 0, 'drift')
 
     // Gamma should be small (close to 0) for unit root process
     assertTrue(Math.abs(result.gamma) < 0.5,
@@ -267,7 +267,7 @@ class AdfGlsTest {
     ]
 
     for (double[] data : testData) {
-      def result = AdfGls.test(data, 0, "drift")
+      def result = AdfGls.test(data, 0, 'drift')
 
       // Statistics should be finite and in a reasonable range
       assertFalse(Double.isNaN(result.statistic), 'Statistic should not be NaN')
@@ -284,7 +284,7 @@ class AdfGlsTest {
     // Test with minimum allowed sample size (15 to account for lag computations)
     double[] data = [100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114] as double[]
 
-    def result = AdfGls.test(data, 0, "drift")
+    def result = AdfGls.test(data, 0, 'drift')
 
     assertNotNull(result, 'Should handle minimum sample size')
     assertEquals(15, result.sampleSize)
@@ -297,7 +297,7 @@ class AdfGlsTest {
       data[i] = 100 + Math.sin(i * 0.2) * 10
     }
 
-    def result = AdfGls.test(data, 0, "drift")
+    def result = AdfGls.test(data, 0, 'drift')
 
     String interp01 = result.interpret(0.01)
     String interp05 = result.interpret(0.05)
@@ -315,7 +315,7 @@ class AdfGlsTest {
       data[i] = 100 + i + Math.sin(i * 0.3) * 2
     }
 
-    def result = AdfGls.test(data, 0, "drift")
+    def result = AdfGls.test(data, 0, 'drift')
 
     // Standard error should be positive
     assertTrue(result.standardError > 0,
@@ -334,9 +334,9 @@ class AdfGlsTest {
       data[i] = 100 + i * 0.2 + Math.sin(i * 0.3) * 5
     }
 
-    def result0 = AdfGls.test(data, 0, "drift")
-    def result1 = AdfGls.test(data, 1, "drift")
-    def result2 = AdfGls.test(data, 2, "drift")
+    def result0 = AdfGls.test(data, 0, 'drift')
+    def result1 = AdfGls.test(data, 1, 'drift')
+    def result2 = AdfGls.test(data, 2, 'drift')
 
     assertEquals(0, result0.lags)
     assertEquals(1, result1.lags)
@@ -359,7 +359,7 @@ class AdfGlsTest {
       trendSeries[i] = 100 + i * 2 + Math.sin(i * 0.5) * 3
     }
 
-    def result = AdfGls.test(trendSeries, 0, "trend")
+    def result = AdfGls.test(trendSeries, 0, 'trend')
 
     assertNotNull(result, 'Result should not be null')
     // For trend-stationary series, should generally reject unit root
@@ -373,7 +373,7 @@ class AdfGlsTest {
       101, 99, 100, 102, 98, 100, 101, 99, 100, 101
     ] as double[]
 
-    def result = AdfGls.test(data, 0, "drift")
+    def result = AdfGls.test(data, 0, 'drift')
 
     assertNotNull(result.interpret(0.10G))
     assertNotNull(result.evaluate(0.10G))

--- a/matrix-stats/src/test/groovy/timeseries/AdfTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/AdfTest.groovy
@@ -27,7 +27,7 @@ class AdfTest {
     assertNotNull(result, 'Result should not be null')
     assertEquals(50, result.sampleSize, 'Sample size')
     assertEquals(0, result.lag, 'Default lag')
-    assertEquals("drift", result.type, 'Default type')
+    assertEquals('drift', result.type, 'Default type')
     assertTrue(result.statistic != 0, 'Statistic should be non-zero')
   }
 
@@ -88,7 +88,7 @@ class AdfTest {
 
     // Invalid type
     assertThrows(IllegalArgumentException) {
-      Adf.test(validData, 0, "invalid")
+      Adf.test(validData, 0, 'invalid')
     }
   }
 
@@ -101,13 +101,13 @@ class AdfTest {
       data.add(i * 0.5 + rnd.nextGaussian() * 2.0)
     }
 
-    def resultDrift = Adf.test(data, 0, "drift")
-    def resultTrend = Adf.test(data, 0, "trend")
-    def resultNone = Adf.test(data, 0, "none")
+    def resultDrift = Adf.test(data, 0, 'drift')
+    def resultTrend = Adf.test(data, 0, 'trend')
+    def resultNone = Adf.test(data, 0, 'none')
 
-    assertEquals("drift", resultDrift.type, 'Type should be drift')
-    assertEquals("trend", resultTrend.type, 'Type should be trend')
-    assertEquals("none", resultNone.type, 'Type should be none')
+    assertEquals('drift', resultDrift.type, 'Type should be drift')
+    assertEquals('trend', resultTrend.type, 'Type should be trend')
+    assertEquals('none', resultNone.type, 'Type should be none')
 
     // Critical values should be different for different types
     assertTrue(resultNone.criticalValue > resultDrift.criticalValue,
@@ -152,10 +152,10 @@ class AdfTest {
       data.add(value)
     }
 
-    def result = Adf.test(data, 1, "trend")
+    def result = Adf.test(data, 1, 'trend')
 
     assertEquals(1, result.lag, 'Lag')
-    assertEquals("trend", result.type, 'Type')
+    assertEquals('trend', result.type, 'Type')
     assertEquals(50, result.sampleSize, 'Sample size')
     assertNotNull(result.statistic, 'Statistic should not be null')
     assertNotNull(result.gammaCoefficient, 'Gamma coefficient should not be null')
@@ -265,8 +265,8 @@ class AdfTest {
       largeSample.add(val)
     }
 
-    def resultSmall = Adf.test(smallSample, 0, "drift")
-    def resultLarge = Adf.test(largeSample, 0, "drift")
+    def resultSmall = Adf.test(smallSample, 0, 'drift')
+    def resultLarge = Adf.test(largeSample, 0, 'drift')
 
     // Small sample should have more negative critical value
     assertTrue(resultSmall.criticalValue < resultLarge.criticalValue,

--- a/matrix-stats/src/test/groovy/timeseries/CcmTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/CcmTest.groovy
@@ -42,7 +42,7 @@ class CcmTest {
 
     // X drives Y, so Y|M(X) should show cross-map skill
     // Note: Due to randomness in library selection, exact causality detection may vary
-    assertFalse(result.ymapX.isEmpty(), "Should compute cross-map skills")
+    assertFalse(result.ymapX.isEmpty(), 'Should compute cross-map skills')
   }
 
   @Test
@@ -281,11 +281,11 @@ class CcmTest {
     String interpretation = result.interpret()
 
     assertNotNull(interpretation)
-    assertTrue(interpretation.contains("Convergent Cross Mapping"))
-    assertTrue(interpretation.contains("Embedding dimension"))
-    assertTrue(interpretation.contains("Time lag"))
-    assertTrue(interpretation.contains("Library sizes"))
-    assertTrue(interpretation.contains("Cross-map Skills"))
+    assertTrue(interpretation.contains('Convergent Cross Mapping'))
+    assertTrue(interpretation.contains('Embedding dimension'))
+    assertTrue(interpretation.contains('Time lag'))
+    assertTrue(interpretation.contains('Library sizes'))
+    assertTrue(interpretation.contains('Cross-map Skills'))
   }
 
   @Test
@@ -327,7 +327,7 @@ class CcmTest {
     // Library sizes should be sorted
     for (int i = 0; i < result.librarySizes.size() - 1; i++) {
       assertTrue(result.librarySizes[i] < result.librarySizes[i + 1],
-                 "Library sizes should be increasing")
+                 'Library sizes should be increasing')
     }
   }
 
@@ -448,8 +448,8 @@ class CcmTest {
 
     assertNotNull(result)
     // White noise should show low cross-map skills
-    assertFalse(result.xCausesY(0.8), "White noise should not show strong causality")
-    assertFalse(result.yCausesX(0.8), "White noise should not show strong causality")
+    assertFalse(result.xCausesY(0.8), 'White noise should not show strong causality')
+    assertFalse(result.yCausesX(0.8), 'White noise should not show strong causality')
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/timeseries/DfTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/DfTest.groovy
@@ -19,11 +19,11 @@ class DfTest {
       111, 113, 115, 114, 116, 118, 120, 122, 121, 123
     ] as double[]
 
-    def result = Df.test(data, "drift")
+    def result = Df.test(data, 'drift')
 
     assertNotNull(result, 'Result should not be null')
     assertEquals(20, result.sampleSize)
-    assertEquals("drift", result.testType)
+    assertEquals('drift', result.testType)
 
     // Random walk should fail to reject unit root
     assertTrue(result.statistic > result.criticalValue5pct,
@@ -38,7 +38,7 @@ class DfTest {
       101, 99, 100, 102, 98, 100, 101, 99, 100, 101
     ] as double[]
 
-    def result = Df.test(data, "drift")
+    def result = Df.test(data, 'drift')
 
     assertNotNull(result, 'Result should not be null')
 
@@ -55,10 +55,10 @@ class DfTest {
       data[i] = 100 + i * 0.5 + Math.sin(i * 0.3) * 2
     }
 
-    def result = Df.test(data, "trend")
+    def result = Df.test(data, 'trend')
 
     assertNotNull(result, 'Result should not be null')
-    assertEquals("trend", result.testType)
+    assertEquals('trend', result.testType)
     assertTrue(result.statistic <= 0, 'DF statistic should be negative')
   }
 
@@ -70,10 +70,10 @@ class DfTest {
       1.1, 0.9, 1.0, 1.2, 0.8, 1.0, 1.1, 0.9, 1.0, 1.1
     ] as double[]
 
-    def result = Df.test(data, "none")
+    def result = Df.test(data, 'none')
 
     assertNotNull(result, 'Result should not be null')
-    assertEquals("none", result.testType)
+    assertEquals('none', result.testType)
     assertTrue(result.statistic <= 0, 'DF statistic should be negative')
   }
 
@@ -85,7 +85,7 @@ class DfTest {
       101, 99, 100, 102, 98, 100, 101, 99, 100, 101
     ]
 
-    def result = Df.test(data, "drift")
+    def result = Df.test(data, 'drift')
 
     assertNotNull(result, 'Result should not be null')
     assertEquals(20, result.sampleSize)
@@ -95,13 +95,13 @@ class DfTest {
   void testValidation() {
     // Null data
     assertThrows(IllegalArgumentException) {
-      Df.test(null as double[], "drift")
+      Df.test(null as double[], 'drift')
     }
 
     // Too few observations
     double[] tooSmall = [1, 2, 3, 4, 5, 6, 7, 8, 9] as double[]
     assertThrows(IllegalArgumentException) {
-      Df.test(tooSmall, "drift")
+      Df.test(tooSmall, 'drift')
     }
 
     // Constant series
@@ -110,13 +110,13 @@ class DfTest {
       constant[i] = 100.0
     }
     assertThrows(IllegalArgumentException) {
-      Df.test(constant, "drift")
+      Df.test(constant, 'drift')
     }
 
     // Invalid type
     double[] data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as double[]
     assertThrows(IllegalArgumentException) {
-      Df.test(data, "invalid")
+      Df.test(data, 'invalid')
     }
   }
 
@@ -128,7 +128,7 @@ class DfTest {
       data[i] = 100 + i * 0.1
     }
 
-    def result = Df.test(data, "drift")
+    def result = Df.test(data, 'drift')
 
     // Critical values should be negative and ordered: 1% < 5% < 10%
     assertTrue(result.criticalValue1pct < result.criticalValue5pct,
@@ -146,7 +146,7 @@ class DfTest {
       101, 99, 100, 102, 98, 100, 101, 99, 100, 101
     ] as double[]
 
-    def result = Df.test(data, "drift")
+    def result = Df.test(data, 'drift')
 
     String interpretation = result.interpret(0.05)
     assertNotNull(interpretation, 'Interpretation should not be null')
@@ -162,7 +162,7 @@ class DfTest {
       data[i] = 100 + i
     }
 
-    def result = Df.test(data, "trend")
+    def result = Df.test(data, 'trend')
 
     String evaluation = result.evaluate()
     assertNotNull(evaluation, 'Evaluation should not be null')
@@ -179,7 +179,7 @@ class DfTest {
       data[i] = 100 + Math.sin(i * 0.5) * 10
     }
 
-    def result = Df.test(data, "drift")
+    def result = Df.test(data, 'drift')
 
     String str = result
     assertTrue(str.contains('Dickey-Fuller'), 'Should contain test name')
@@ -196,17 +196,17 @@ class DfTest {
     }
 
     // Test all three types
-    def noneResult = Df.test(data, "none")
-    def driftResult = Df.test(data, "drift")
-    def trendResult = Df.test(data, "trend")
+    def noneResult = Df.test(data, 'none')
+    def driftResult = Df.test(data, 'drift')
+    def trendResult = Df.test(data, 'trend')
 
     assertNotNull(noneResult)
     assertNotNull(driftResult)
     assertNotNull(trendResult)
 
-    assertEquals("none", noneResult.testType)
-    assertEquals("drift", driftResult.testType)
-    assertEquals("trend", trendResult.testType)
+    assertEquals('none', noneResult.testType)
+    assertEquals('drift', driftResult.testType)
+    assertEquals('trend', trendResult.testType)
 
     // Critical values should differ by type
     // Trend is most negative, none is least negative
@@ -224,7 +224,7 @@ class DfTest {
       randomWalk[i] = randomWalk[i - 1] + (rnd.nextDouble() - 0.5)
     }
 
-    def result = Df.test(randomWalk, "drift")
+    def result = Df.test(randomWalk, 'drift')
 
     // Gamma should be small (close to 0) for unit root process
     assertTrue(Math.abs(result.gamma) < 0.5,
@@ -242,7 +242,7 @@ class DfTest {
     ]
 
     for (double[] data : testData) {
-      def result = Df.test(data, "drift")
+      def result = Df.test(data, 'drift')
 
       // DF statistic should be negative
       assertTrue(result.statistic <= 0,
@@ -259,7 +259,7 @@ class DfTest {
     // Test with minimum allowed sample size (10)
     double[] data = [100, 101, 102, 103, 104, 105, 106, 107, 108, 109] as double[]
 
-    def result = Df.test(data, "drift")
+    def result = Df.test(data, 'drift')
 
     assertNotNull(result, 'Should handle minimum sample size')
     assertEquals(10, result.sampleSize)
@@ -272,7 +272,7 @@ class DfTest {
       data[i] = 100 + Math.sin(i * 0.2) * 10
     }
 
-    def result = Df.test(data, "drift")
+    def result = Df.test(data, 'drift')
 
     String interp01 = result.interpret(0.01)
     String interp05 = result.interpret(0.05)
@@ -290,7 +290,7 @@ class DfTest {
       data[i] = 100 + i + Math.sin(i * 0.3) * 2
     }
 
-    def result = Df.test(data, "drift")
+    def result = Df.test(data, 'drift')
 
     // Standard error should be positive
     assertTrue(result.standardError > 0,
@@ -308,7 +308,7 @@ class DfTest {
       101, 99, 100, 102, 98, 100, 101, 99, 100, 101
     ] as double[]
 
-    def result = Df.test(data, "drift")
+    def result = Df.test(data, 'drift')
 
     assertNotNull(result.interpret(0.10G))
     assertNotNull(result.evaluate(0.10G))

--- a/matrix-stats/src/test/groovy/timeseries/DurbinWatsonTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/DurbinWatsonTest.groovy
@@ -78,17 +78,17 @@ class DurbinWatsonTest {
     List<Double> residuals = [1.0, 1.1, 1.2, 1.3, 1.4, 1.5]
 
     // Test with different alternatives
-    def resultTwoSided = DurbinWatson.test(residuals, "two.sided")
-    def resultGreater = DurbinWatson.test(residuals, "greater")
-    def resultLess = DurbinWatson.test(residuals, "less")
+    def resultTwoSided = DurbinWatson.test(residuals, 'two.sided')
+    def resultGreater = DurbinWatson.test(residuals, 'greater')
+    def resultLess = DurbinWatson.test(residuals, 'less')
 
-    assertEquals("two.sided", resultTwoSided.alternative, 'Two-sided alternative')
-    assertEquals("greater", resultGreater.alternative, 'Greater alternative')
-    assertEquals("less", resultLess.alternative, 'Less alternative')
+    assertEquals('two.sided', resultTwoSided.alternative, 'Two-sided alternative')
+    assertEquals('greater', resultGreater.alternative, 'Greater alternative')
+    assertEquals('less', resultLess.alternative, 'Less alternative')
 
     // Invalid alternative
     assertThrows(IllegalArgumentException) {
-      DurbinWatson.test(residuals, "invalid")
+      DurbinWatson.test(residuals, 'invalid')
     }
   }
 

--- a/matrix-stats/src/test/groovy/timeseries/JohansenTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/JohansenTest.groovy
@@ -270,7 +270,7 @@ class JohansenTest {
     // Eigenvalues should be sorted in descending order
     for (int i = 0; i < result.eigenvalues.size() - 1; i++) {
       assertTrue(result.eigenvalues[i] >= result.eigenvalues[i+1],
-                 "Eigenvalues should be in descending order")
+                 'Eigenvalues should be in descending order')
     }
   }
 
@@ -294,7 +294,7 @@ class JohansenTest {
     // Trace statistics should decrease as r increases
     for (int i = 0; i < result.traceStatistics.size() - 1; i++) {
       assertTrue(result.traceStatistics[i] >= result.traceStatistics[i+1],
-                 "Trace statistics should be non-increasing")
+                 'Trace statistics should be non-increasing')
     }
   }
 
@@ -389,7 +389,7 @@ class JohansenTest {
 
     assertEquals(5, result.lags)
     assertNotNull(result.eigenvalues)
-    assertTrue(result.sampleSize < n, "Effective sample size should be less than n")
+    assertTrue(result.sampleSize < n, 'Effective sample size should be less than n')
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/timeseries/KpssTest.groovy
+++ b/matrix-stats/src/test/groovy/timeseries/KpssTest.groovy
@@ -22,10 +22,10 @@ class KpssTest {
       data.add(y + 10.0)  // Add constant level
     }
 
-    def result = Kpss.test(data, "level")
+    def result = Kpss.test(data, 'level')
 
     assertNotNull(result, 'Result should not be null')
-    assertEquals("level", result.type, 'Type should be level')
+    assertEquals('level', result.type, 'Type should be level')
     assertEquals(100, result.sampleSize, 'Sample size')
     assertTrue(result.statistic >= 0, 'KPSS statistic should be non-negative')
   }
@@ -39,10 +39,10 @@ class KpssTest {
       data.add(i * 0.5 + rnd.nextGaussian())  // Linear trend + noise
     }
 
-    def result = Kpss.test(data, "trend")
+    def result = Kpss.test(data, 'trend')
 
     assertNotNull(result, 'Result should not be null')
-    assertEquals("trend", result.type, 'Type should be trend')
+    assertEquals('trend', result.type, 'Type should be trend')
     assertTrue(result.statistic >= 0, 'KPSS statistic should be non-negative')
   }
 
@@ -57,7 +57,7 @@ class KpssTest {
       data.add(value)
     }
 
-    def result = Kpss.test(data, "level")
+    def result = Kpss.test(data, 'level')
 
     assertNotNull(result, 'Result should not be null')
     // For random walk, we expect higher KPSS statistic
@@ -84,7 +84,7 @@ class KpssTest {
     // Invalid type
     List<Double> validData = (1..50).collect { it + Math.random() }
     assertThrows(IllegalArgumentException) {
-      Kpss.test(validData, "invalid")
+      Kpss.test(validData, 'invalid')
     }
   }
 
@@ -96,11 +96,11 @@ class KpssTest {
       data.add(i * 0.3 + rnd.nextGaussian())
     }
 
-    def resultLevel = Kpss.test(data, "level")
-    def resultTrend = Kpss.test(data, "trend")
+    def resultLevel = Kpss.test(data, 'level')
+    def resultTrend = Kpss.test(data, 'trend')
 
-    assertEquals("level", resultLevel.type, 'Level type')
-    assertEquals("trend", resultTrend.type, 'Trend type')
+    assertEquals('level', resultLevel.type, 'Level type')
+    assertEquals('trend', resultTrend.type, 'Trend type')
 
     // Critical values should be different
     assertTrue(resultLevel.criticalValue > resultTrend.criticalValue,
@@ -117,8 +117,8 @@ class KpssTest {
       data.add(y)
     }
 
-    def result1 = Kpss.test(data, "level", 1)
-    def result2 = Kpss.test(data, "level", 5)
+    def result1 = Kpss.test(data, 'level', 1)
+    def result2 = Kpss.test(data, 'level', 5)
 
     assertEquals(1, result1.lags, 'Should use 1 lag')
     assertEquals(5, result2.lags, 'Should use 5 lags')
@@ -134,7 +134,7 @@ class KpssTest {
       data.add(y)
     }
 
-    def result = Kpss.test(data, "level")
+    def result = Kpss.test(data, 'level')
 
     assertTrue(result.lags > 0, 'Auto-selected lags should be positive')
     assertTrue(result.lags < 100, 'Auto-selected lags should be reasonable')
@@ -225,9 +225,9 @@ class KpssTest {
       data.add(y)
     }
 
-    def kpssResult = Kpss.test(data, "level")
+    def kpssResult = Kpss.test(data, 'level')
 
     assertNotNull(kpssResult, 'KPSS result should not be null')
-    assertEquals("level", kpssResult.type, 'Type should be level')
+    assertEquals('level', kpssResult.type, 'Type should be level')
   }
 }

--- a/matrix-stats/src/test/groovy/ttest/StudentEqualVarianceTest.groovy
+++ b/matrix-stats/src/test/groovy/ttest/StudentEqualVarianceTest.groovy
@@ -39,17 +39,17 @@ class StudentEqualVarianceTest {
     assertEquals("Student's two sample t-test", result.description)
 
     // Verify degrees of freedom (n1 + n2 - 2 = 8 + 8 - 2 = 14)
-    assertEquals(14, result.df as int, "Degrees of freedom")
+    assertEquals(14, result.df as int, 'Degrees of freedom')
 
     // Verify t-statistic (from R reference)
-    assertEquals(0.84731855, result.getT(8), "t-statistic")
+    assertEquals(0.84731855, result.getT(8), 't-statistic')
 
     // Verify p-value (from R reference: 0.4111, allowing small tolerance for numerical precision)
-    assertEquals(0.4111, result.pVal, 0.001, "p-value")
+    assertEquals(0.4111, result.pVal, 0.001, 'p-value')
 
     // Verify means
-    assertEquals(5.0, result.getMean1(1), "mean1")
-    assertEquals(4.0, result.getMean2(1), "mean2")
+    assertEquals(5.0, result.getMean1(1), 'mean1')
+    assertEquals(4.0, result.getMean2(1), 'mean2')
   }
 
   /**
@@ -79,19 +79,19 @@ class StudentEqualVarianceTest {
     assertEquals("Student's two sample t-test", result.description)
 
     // Verify degrees of freedom
-    assertEquals(6, result.df as int, "df should be n1+n2-2 = 4+4-2 = 6")
+    assertEquals(6, result.df as int, 'df should be n1+n2-2 = 4+4-2 = 6')
 
     // Both groups have equal variance (approximately 2.666667)
-    assertEquals(2.66666667, result.getVar1(8), "var1")
-    assertEquals(2.66666667, result.getVar2(8), "var2")
+    assertEquals(2.66666667, result.getVar1(8), 'var1')
+    assertEquals(2.66666667, result.getVar2(8), 'var2')
 
     // Verify t-statistic is negative (group1 mean < group2 mean)
-    assertTrue(result.t < 0, "t should be negative")
+    assertTrue(result.t < 0, 't should be negative')
 
     // With equal variances and equal sample sizes, the pooled variance
     // should equal the individual variances
     // t = (10-15) / sqrt(2.666667 * (1/4 + 1/4)) = -5 / sqrt(1.333333) = -4.33
-    assertEquals(-4.33012702, result.getT(8), "t-statistic")
+    assertEquals(-4.33012702, result.getT(8), 't-statistic')
   }
 
   /**
@@ -115,7 +115,7 @@ class StudentEqualVarianceTest {
     assertEquals("Welch's two sample t-test", welchResult.description)
 
     // With truly equal variances, t-statistics should be very close
-    assertEquals(studentResult.t, welchResult.t, 0.01, "t-statistics should be similar")
+    assertEquals(studentResult.t, welchResult.t, 0.01, 't-statistics should be similar')
 
     // But degrees of freedom will differ
     assertTrue(Math.abs(studentResult.df - welchResult.df) < 0.5,
@@ -135,9 +135,9 @@ class StudentEqualVarianceTest {
     def result = Student.tTest(group1, group2, null)
 
     // Should detect equal variance and use Student's t-test
-    assertTrue(result.description.contains("equal variance") ||
+    assertTrue(result.description.contains('equal variance') ||
                result.df == (group1.size() + group2.size() - 2),
-               "Should auto-detect equal variance")
+               'Should auto-detect equal variance')
   }
 
   /**
@@ -152,9 +152,9 @@ class StudentEqualVarianceTest {
     def result = Student.tTest(group1, group2, true)
 
     // Verify df = n1 + n2 - 2 = 3 + 5 - 2 = 6
-    assertEquals(6, result.df as int, "df should be n1+n2-2 = 6")
-    assertEquals(3, result.n1, "n1")
-    assertEquals(5, result.n2, "n2")
+    assertEquals(6, result.df as int, 'df should be n1+n2-2 = 6')
+    assertEquals(3, result.n1, 'n1')
+    assertEquals(5, result.n2, 'n2')
     assertEquals("Student's two sample t-test", result.description)
   }
 
@@ -169,13 +169,13 @@ class StudentEqualVarianceTest {
     def result = Student.tTest(group1, group2, true)
 
     // Verify result is both Student.Result and TtestResult
-    assertTrue(result instanceof Student.Result, "Should be Student.Result")
-    assertTrue(result instanceof TtestResult, "Should also be TtestResult (via inheritance)")
+    assertTrue(result instanceof Student.Result, 'Should be Student.Result')
+    assertTrue(result instanceof TtestResult, 'Should also be TtestResult (via inheritance)')
 
     // Verify backwards compatibility - Student.Result can be assigned to TtestResult
     TtestResult ttestResult = result
-    assertNotNull(ttestResult, "Should be assignable to TtestResult")
-    assertEquals(result.tVal, ttestResult.tVal, "tVal should match")
+    assertNotNull(ttestResult, 'Should be assignable to TtestResult')
+    assertEquals(result.tVal, ttestResult.tVal, 'tVal should match')
   }
 
   /**
@@ -191,10 +191,10 @@ class StudentEqualVarianceTest {
       Student.tTest(group1, group2, false)
     }
 
-    assertTrue(exception.message.contains("Welch.tTest()"),
-               "Exception should direct user to Welch.tTest()")
-    assertTrue(exception.message.contains("equal variances"),
-               "Exception should mention equal variance requirement")
+    assertTrue(exception.message.contains('Welch.tTest()'),
+               'Exception should direct user to Welch.tTest()')
+    assertTrue(exception.message.contains('equal variances'),
+               'Exception should mention equal variance requirement')
   }
 
   /**
@@ -210,9 +210,9 @@ class StudentEqualVarianceTest {
       Student.tTest(group1, group2, null)
     }
 
-    assertTrue(exception.message.contains("Welch.tTest()"),
-               "Exception should direct user to Welch.tTest()")
-    assertTrue(exception.message.contains("differ significantly"),
-               "Exception should mention variances differ")
+    assertTrue(exception.message.contains('Welch.tTest()'),
+               'Exception should direct user to Welch.tTest()')
+    assertTrue(exception.message.contains('differ significantly'),
+               'Exception should mention variances differ')
   }
 }

--- a/matrix-stats/src/test/groovy/ttest/WelchTest.groovy
+++ b/matrix-stats/src/test/groovy/ttest/WelchTest.groovy
@@ -17,7 +17,7 @@ class WelchTest {
   void testWelchTwoSample() {
     // Same test as StudentTest but using Welch class with simpler API
     def iris = Dataset.iris()
-    def speciesIdx = iris.columnIndex("Species")
+    def speciesIdx = iris.columnIndex('Species')
     def setosa = iris.subset {
       it[speciesIdx] == 'setosa'
     }
@@ -29,10 +29,10 @@ class WelchTest {
     def result = Welch.tTest(setosa['Petal Length'], virginica['Petal Length'])
 
     // Verify same results as Student.tTest with equalVariance=false
-    assertEquals(-49.98618626, result.getT(8), "t value")
-    assertEquals(58.60939455, result.getDf(8), "Degrees of freedom")
-    assertEquals(0.17366400, result.getSd1(8), "sd1")
-    assertEquals(0.55189470, result.getSd2(8), "sd2")
+    assertEquals(-49.98618626, result.getT(8), 't value')
+    assertEquals(58.60939455, result.getDf(8), 'Degrees of freedom')
+    assertEquals(0.17366400, result.getSd1(8), 'sd1')
+    assertEquals(0.55189470, result.getSd2(8), 'sd2')
     assertEquals(9.269628E-50, result.p, 0.0000001)
     assertEquals("Welch's two sample t-test", result.description)
   }
@@ -47,8 +47,8 @@ class WelchTest {
     // Should handle different sample sizes correctly
     assertEquals(5, result.n1)
     assertEquals(7, result.n2)
-    assertTrue(result.pVal < 0.05, "Should detect difference")
-    assertTrue(result.df > 0, "df should be positive")
+    assertTrue(result.pVal < 0.05, 'Should detect difference')
+    assertTrue(result.df > 0, 'df should be positive')
     // Welch-Satterthwaite df should be fractional
     assertNotEquals(result.df as int, result.df, "df should be fractional for Welch's test")
   }
@@ -90,8 +90,8 @@ class WelchTest {
     def welchResult = Welch.tTest(sample1, sample2)
 
     // With equal variance and equal sample sizes, results should be very close
-    assertTrue(welchResult.pVal < 0.001, "Should detect clear difference")
-    assertTrue(Math.abs(welchResult.t) > 10, "t-statistic should be large")
+    assertTrue(welchResult.pVal < 0.001, 'Should detect clear difference')
+    assertTrue(Math.abs(welchResult.t) > 10, 't-statistic should be large')
   }
 
   @Test
@@ -112,14 +112,14 @@ class WelchTest {
     def result = Welch.tTest(sample1, sample2)
 
     // Verify result is TtestResult type
-    assertTrue(result instanceof TtestResult, "Welch.tTest() should return TtestResult")
+    assertTrue(result instanceof TtestResult, 'Welch.tTest() should return TtestResult')
 
     // Verify all expected properties are accessible
-    assertNotNull(result.tVal, "tVal should be set")
-    assertNotNull(result.pVal, "pVal should be set")
-    assertNotNull(result.df, "df should be set")
-    assertNotNull(result.mean1, "mean1 should be set")
-    assertNotNull(result.mean2, "mean2 should be set")
-    assertNotNull(result.description, "description should be set")
+    assertNotNull(result.tVal, 'tVal should be set')
+    assertNotNull(result.pVal, 'pVal should be set')
+    assertNotNull(result.df, 'df should be set')
+    assertNotNull(result.mean1, 'mean1 should be set')
+    assertNotNull(result.mean2, 'mean2 should be set')
+    assertNotNull(result.description, 'description should be set')
   }
 }

--- a/matrix-stats/src/test/groovy/util/LeastSquaresKernelTest.groovy
+++ b/matrix-stats/src/test/groovy/util/LeastSquaresKernelTest.groovy
@@ -87,6 +87,6 @@ class LeastSquaresKernelTest {
       LeastSquaresKernel.calculateResidualSumOfSquares(response, predictors, coefficients)
     }
 
-    assertEquals("Design matrix rows must all have the same length", exception.message)
+    assertEquals('Design matrix rows must all have the same length', exception.message)
   }
 }

--- a/matrix-stats/src/test/groovy/util/NumericConversionTest.groovy
+++ b/matrix-stats/src/test/groovy/util/NumericConversionTest.groovy
@@ -79,8 +79,8 @@ class NumericConversionTest {
       [3.0, 4.0],
     ])
 
-    assertEquals([[1.0d, 2.0d], [3.0d, 4.0d]], NumericConversion.toDoubleArray(matrix).collect { it.toList() })
-    assertEquals([[1.0d, 2.0d], [3.0d, 4.0d]], NumericConversion.toDoubleArray(grid).collect { it.toList() })
+    assertEquals([[1.0d, 2.0d], [3.0d, 4.0d]], NumericConversion.toDoubleArray(matrix)*.toList())
+    assertEquals([[1.0d, 2.0d], [3.0d, 4.0d]], NumericConversion.toDoubleArray(grid)*.toList())
   }
 
   @Test

--- a/req/codenarc-consolidation-2.md
+++ b/req/codenarc-consolidation-2.md
@@ -267,7 +267,7 @@ matrix-stats has `ignoreFailures = true` on the entire `codenarc` block. The vio
 
 ### 4.1 Audit
 
-- [ ] **4.1.1 Generate fresh reports and read them**
+- [x] **4.1.1 Generate fresh reports and read them**
 
   ```bash
   # Generate reports (ignoreFailures is still true so both tasks succeed)
@@ -288,19 +288,25 @@ matrix-stats has `ignoreFailures = true` on the entire `codenarc` block. The vio
 
   Cross-reference against the counts in the scope table above to confirm alignment; discrepancies indicate the source changed since this plan was written.
 
+  Completed verification:
+  ```bash
+  ./gradlew :matrix-stats:codenarcMain :matrix-stats:codenarcTest
+  ```
+  Initial report counts were 615 main violations and 394 test violations.
+
 ### 4.2 Fix UnnecessaryGString (430 main + 380 test)
 
-- [ ] **4.2.1 Fix in main sources**
+- [x] **4.2.1 Fix in main sources**
 
   For each file, replace uninterpolated `"string"` → `'string'`. Use the HTML report (`matrix-stats/build/reports/codenarc/main.html`) to navigate to exact line numbers.
 
-- [ ] **4.2.2 Fix in test sources**
+- [x] **4.2.2 Fix in test sources**
 
   Same mechanical change across all test files.
 
 ### 4.3 Fix UnnecessaryObjectReferences (46 main)
 
-- [ ] **4.3.1 Consolidate repeated property assignments using `with()`**
+- [x] **4.3.1 Consolidate repeated property assignments using `with()`**
 
   CodeNarc fires when consecutive statements call methods or set properties on the same object. Refactor to a `with()` block:
   ```groovy
@@ -352,7 +358,7 @@ matrix-stats has `ignoreFailures = true` on the entire `codenarc` block. The vio
 
 ### 4.4 Fix DuplicateStringLiteral (46 main)
 
-- [ ] **4.4.1 Extract repeated string labels to `static final` constants**
+- [x] **4.4.1 Extract repeated string labels to `static final` constants**
 
   For each file, identify which string is repeated and extract to a constant at the top of the class:
   ```groovy
@@ -362,7 +368,7 @@ matrix-stats has `ignoreFailures = true` on the entire `codenarc` block. The vio
 
 ### 4.5 Fix UnnecessaryElseStatement (39 main)
 
-- [ ] **4.5.1 Remove unnecessary else branches**
+- [x] **4.5.1 Remove unnecessary else branches**
 
   ```groovy
   // Before
@@ -380,7 +386,7 @@ matrix-stats has `ignoreFailures = true` on the entire `codenarc` block. The vio
 
 ### 4.6 Fix UnnecessaryCollectCall (30 main + 14 test)
 
-- [ ] **4.6.1 Remove no-op collect calls**
+- [x] **4.6.1 Remove no-op collect calls**
 
   ```groovy
   // Before
@@ -391,7 +397,7 @@ matrix-stats has `ignoreFailures = true` on the entire `codenarc` block. The vio
 
 ### 4.7 Fix DuplicateNumberLiteral (22 main)
 
-- [ ] **4.7.1 Extract repeated numeric literals to named constants**
+- [x] **4.7.1 Extract repeated numeric literals to named constants**
 
   Statistical and mathematical constants all have meaningful names. Extract each repeated literal to a `private static final` (or shared constants class for cross-file values):
   ```groovy
@@ -403,7 +409,7 @@ matrix-stats has `ignoreFailures = true` on the entire `codenarc` block. The vio
 
 ### 4.8 Fix DuplicateListLiteral (2 main)
 
-- [ ] **4.8.1 Extract the repeated list to a constant or inline it**
+- [x] **4.8.1 Extract the repeated list to a constant or inline it**
 
   ```groovy
   // Before - same literal twice
@@ -413,7 +419,7 @@ matrix-stats has `ignoreFailures = true` on the entire `codenarc` block. The vio
   // After — either extract to constant or use a single definition
   ```
 
-- [ ] **4.9 Remove the codenarc override from matrix-stats/build.gradle**
+- [x] **4.9 Remove the codenarc override from matrix-stats/build.gradle**
 
   Delete lines 16–19:
   ```groovy
@@ -423,7 +429,7 @@ matrix-stats has `ignoreFailures = true` on the entire `codenarc` block. The vio
   }
   ```
 
-- [ ] **4.10 Verify — confirm 0 violations remain**
+- [x] **4.10 Verify — confirm 0 violations remain**
 
   ```bash
   ./gradlew :matrix-stats:codenarcMain
@@ -431,6 +437,19 @@ matrix-stats has `ignoreFailures = true` on the entire `codenarc` block. The vio
   ./gradlew :matrix-stats:test
   ```
   Expected: all tasks pass.
+
+  Completed verification:
+  ```bash
+  ./gradlew :matrix-stats:compileGroovy
+  ./gradlew :matrix-stats:codenarcMain
+  ./gradlew :matrix-stats:codenarcTest
+  ./gradlew :matrix-stats:spotlessCheck
+  ./gradlew :matrix-stats:test --tests 'StudentTest' --tests 'ttest.StudentEqualVarianceTest' --tests 'ttest.WelchTest'
+  ./gradlew :matrix-stats:test
+  ./gradlew test
+  git diff --check
+  ```
+  Final CodeNarc XML reports contain 0 main violations and 0 test violations.
 
 - [ ] **4.11 Commit (after user confirmation)**
 


### PR DESCRIPTION
## Summary

- Remove the module-level CodeNarc `ignoreFailures` override from `matrix-stats`.
- Fix `matrix-stats` main and test CodeNarc violations across unnecessary GStrings, unnecessary collect calls, unnecessary else branches, repeated object references, and duplicate literals.
- Update `req/codenarc-consolidation-2.md` task 4 with completed checkboxes and validation notes.

## Modules touched

- `matrix-stats`
- `req`

## Validation

- `./gradlew :matrix-stats:compileGroovy`
- `./gradlew :matrix-stats:codenarcMain`
- `./gradlew :matrix-stats:codenarcTest`
- `./gradlew :matrix-stats:spotlessCheck`
- `./gradlew :matrix-stats:test --tests 'StudentTest' --tests 'ttest.StudentEqualVarianceTest' --tests 'ttest.WelchTest'`
- `./gradlew :matrix-stats:test`
- `./gradlew test`
- `git diff --check`

Final CodeNarc XML reports contain 0 main violations and 0 test violations for `matrix-stats`.