### PR TITLE
Remove redundant CodeNarc suppressions

### DIFF
--- a/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/Bq.groovy
+++ b/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/Bq.groovy
@@ -94,7 +94,7 @@ import java.time.temporal.ChronoUnit
  * @see Matrix
  * @see TypeMapper
  */
-@SuppressWarnings(['ClassSize', 'Instanceof', 'NestedForLoop'])
+@SuppressWarnings('ClassSize')
 @CompileStatic
 class Bq {
 

--- a/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/GetTableInfoQueryConfigurationTest.groovy
+++ b/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/GetTableInfoQueryConfigurationTest.groovy
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test
  * usual `test.alipsa.matrix.bigquery` package so it can access the `@PackageScope`
  * helpers added for query configuration verification.</p>
  */
-@SuppressWarnings('ClassEndsWithBlankLine')
 @CompileStatic
 class GetTableInfoQueryConfigurationTest {
 

--- a/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/InsertAppendSemanticsTest.groovy
+++ b/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/InsertAppendSemanticsTest.groovy
@@ -35,7 +35,6 @@ import java.lang.reflect.Method
  * These tests live in `se.alipsa.matrix.bigquery` so they can exercise package-scope
  * routing helpers without invoking the real BigQuery write channel.
  */
-@SuppressWarnings('ClassEndsWithBlankLine')
 @CompileStatic
 class InsertAppendSemanticsTest {
 
@@ -216,7 +215,7 @@ class InsertAppendSemanticsTest {
     }
   }
 
-  @SuppressWarnings(['ClassName', 'ClassStartsWithBlankLine', 'ClassEndsWithBlankLine'])
+  @SuppressWarnings('ClassName')
   private static class RecordingInsertClient extends Bq {
     boolean throwConnectionError
     Boolean lastAppendValue
@@ -236,7 +235,7 @@ class InsertAppendSemanticsTest {
     }
   }
 
-  @SuppressWarnings(['ClassName', 'ClassStartsWithBlankLine', 'ClassEndsWithBlankLine'])
+  @SuppressWarnings('ClassName')
   private static final class InsertAllTestState {
     final TableId tableId
     boolean initializeTable = true

--- a/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/ProgressBarConfigurationTest.groovy
+++ b/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/ProgressBarConfigurationTest.groovy
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test
  * These tests live in `se.alipsa.matrix.bigquery` so they can exercise
  * package-scope progress-bar configuration helpers directly.
  */
-@SuppressWarnings('ClassEndsWithBlankLine')
 @CompileStatic
 class ProgressBarConfigurationTest {
 

--- a/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/ProjectScopedIdTest.groovy
+++ b/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/ProjectScopedIdTest.groovy
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test
  * These tests live in `se.alipsa.matrix.bigquery` so they can access the
  * `@PackageScope` ID helpers used to keep dataset and table operations scoped to `projectId`.
  */
-@SuppressWarnings('ClassEndsWithBlankLine')
 @CompileStatic
 class ProjectScopedIdTest {
 

--- a/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/SaveToBigQueryValidationTest.groovy
+++ b/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/SaveToBigQueryValidationTest.groovy
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test
  * These tests live in `se.alipsa.matrix.bigquery` so they can access the
  * `@PackageScope` validation helpers used by `saveToBigQuery`.
  */
-@SuppressWarnings('ClassEndsWithBlankLine')
 @CompileStatic
 class SaveToBigQueryValidationTest {
 

--- a/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/BqDataTypesTest.groovy
+++ b/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/BqDataTypesTest.groovy
@@ -27,18 +27,7 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 
 @Tag("external")
-@SuppressWarnings([
-    'BlockEndsWithBlankLine',
-    'ClassEndsWithBlankLine',
-    'ConsecutiveBlankLines',
-    'NestedForLoop',
-    'SpaceAfterComma',
-    'SpaceAfterCommentDelimiter',
-    'SpaceAroundOperator',
-    'UnnecessaryBigDecimalInstantiation',
-    'UnnecessaryBigIntegerInstantiation',
-    'UnnecessaryGString'
-])
+@SuppressWarnings(['UnnecessaryBigDecimalInstantiation', 'UnnecessaryBigIntegerInstantiation', 'UnnecessaryGString'])
 @CompileStatic
 class BqDataTypesTest {
 

--- a/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/BqTest.groovy
+++ b/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/BqTest.groovy
@@ -26,15 +26,7 @@ import se.alipsa.matrix.datasets.Dataset
  * Performance optimization: Uses shared dataset and Bq instance to minimize network round-trips.
  */
 @Tag("external")
-@SuppressWarnings([
-    'ClassEndsWithBlankLine',
-    'SpaceAfterComma',
-    'SpaceAfterCommentDelimiter',
-    'SpaceAfterOpeningBrace',
-    'SpaceBeforeClosingBrace',
-    'SpaceBeforeOpeningBrace',
-    'UnnecessaryGString'
-])
+@SuppressWarnings(['SpaceBeforeOpeningBrace', 'UnnecessaryGString'])
 @CompileStatic
 class BqTest {
 

--- a/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/BqTestContainerTest.groovy
+++ b/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/BqTestContainerTest.groovy
@@ -20,12 +20,7 @@ import se.alipsa.matrix.datasets.Dataset
 
 @Testcontainers
 @Tag("flaky")  // BigQuery emulator testcontainer has threading issues - see issue #XXX
-@SuppressWarnings([
-    'BlockEndsWithBlankLine',
-    'ClassEndsWithBlankLine',
-    'UnnecessaryDotClass',
-    'UnnecessaryGString'
-])
+@SuppressWarnings(['UnnecessaryDotClass', 'UnnecessaryGString'])
 class BqTestContainerTest {
 
   // https://github.com/goccy/bigquery-emulator/pkgs/container/bigquery-emulator

--- a/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/BqUnitTest.groovy
+++ b/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/BqUnitTest.groovy
@@ -20,12 +20,7 @@ import java.time.ZonedDateTime
  * Unit tests for Bq utility methods that don't require BigQuery connections.
  * These tests can run in CI without external dependencies.
  */
-@SuppressWarnings([
-    'ClassEndsWithBlankLine',
-    'UnnecessaryBigDecimalInstantiation',
-    'UnnecessaryBigIntegerInstantiation',
-    'UnnecessaryGString'
-])
+@SuppressWarnings(['UnnecessaryBigDecimalInstantiation', 'UnnecessaryBigIntegerInstantiation', 'UnnecessaryGString'])
 @CompileStatic
 class BqUnitTest {
 

--- a/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/ConvertObjectValueTest.groovy
+++ b/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/ConvertObjectValueTest.groovy
@@ -19,12 +19,7 @@ import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
-@SuppressWarnings([
-    'ClassEndsWithBlankLine',
-    'UnnecessaryBigDecimalInstantiation',
-    'UnnecessaryBigIntegerInstantiation',
-    'UnnecessaryGString'
-])
+@SuppressWarnings(['UnnecessaryBigDecimalInstantiation', 'UnnecessaryBigIntegerInstantiation', 'UnnecessaryGString'])
 @CompileStatic
 class ConvertObjectValueTest {
 

--- a/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/SanitizeStringTest.groovy
+++ b/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/SanitizeStringTest.groovy
@@ -13,10 +13,7 @@ import org.junit.jupiter.api.Test
 
 import se.alipsa.matrix.bigquery.Bq
 
-@SuppressWarnings([
-    'ClassEndsWithBlankLine',
-    'UnnecessaryGString'
-])
+@SuppressWarnings('UnnecessaryGString')
 @CompileStatic
 class SanitizeStringTest {
 

--- a/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/SchemaCreationTest.groovy
+++ b/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/SchemaCreationTest.groovy
@@ -19,11 +19,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 
-@SuppressWarnings([
-    'ClassEndsWithBlankLine',
-    'UnnecessaryBigDecimalInstantiation',
-    'UnnecessaryGString'
-])
+@SuppressWarnings(['UnnecessaryBigDecimalInstantiation', 'UnnecessaryGString'])
 @CompileStatic
 class SchemaCreationTest {
 

--- a/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/TypeMapperTest.groovy
+++ b/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/TypeMapperTest.groovy
@@ -21,11 +21,7 @@ import java.time.ZonedDateTime
  * Unit tests for TypeMapper conversion logic.
  * These tests do not require external BigQuery connections and can run in CI.
  */
-@SuppressWarnings([
-    'ClassEndsWithBlankLine',
-    'UnnecessaryBigDecimalInstantiation',
-    'UnnecessaryGString'
-])
+@SuppressWarnings(['UnnecessaryBigDecimalInstantiation', 'UnnecessaryGString'])
 @CompileStatic
 class TypeMapperTest {
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/AnnotationConstants.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/AnnotationConstants.groovy
@@ -5,8 +5,7 @@ import se.alipsa.matrix.core.Matrix
 /**
  * Shared constants and utility methods for annotation implementations.
  */
-@SuppressWarnings('DuplicateStringLiteral')
-@SuppressWarnings('UnnecessaryCast')
+@SuppressWarnings(['DuplicateStringLiteral', 'UnnecessaryCast'])
 class AnnotationConstants {
 
   /**

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/AnnotationConstants.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/AnnotationConstants.groovy
@@ -6,7 +6,6 @@ import se.alipsa.matrix.core.Matrix
  * Shared constants and utility methods for annotation implementations.
  */
 @SuppressWarnings('DuplicateStringLiteral')
-@SuppressWarnings('Instanceof')
 @SuppressWarnings('UnnecessaryCast')
 class AnnotationConstants {
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Chart.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Chart.groovy
@@ -13,7 +13,7 @@ import se.alipsa.matrix.core.Matrix
 /**
  * Immutable compiled Charm chart.
  */
-@SuppressWarnings(value = ['DuplicateNumberLiteral', 'DuplicateStringLiteral', 'IfStatementBraces', 'Instanceof', 'ParameterCount', 'UnnecessaryCollectCall', 'UnnecessaryGString'])
+@SuppressWarnings(['DuplicateNumberLiteral', 'DuplicateStringLiteral', 'IfStatementBraces', 'ParameterCount', 'UnnecessaryCollectCall', 'UnnecessaryGString'])
 class Chart {
 
   private final Matrix data

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Charts.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Charts.groovy
@@ -6,7 +6,6 @@ import se.alipsa.matrix.core.Row
 /**
  * Static DSL entry points for Charm chart specifications.
  */
-@SuppressWarnings('Instanceof')
 class Charts {
 
   /**

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/GuideUtils.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/GuideUtils.groovy
@@ -3,7 +3,6 @@ package se.alipsa.matrix.charm
 /**
  * Utility methods for normalizing guide configuration values.
  */
-@SuppressWarnings('Instanceof')
 final class GuideUtils {
 
   private GuideUtils() {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/LayerDsl.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/LayerDsl.groovy
@@ -11,7 +11,7 @@ import groovy.transform.CompileDynamic
  * {@code method}, {@code se}, {@code bins}) still fall through to
  * {@link LayerParams#propertyMissing(String, Object) propertyMissing}.</p>
  */
-@SuppressWarnings(['IfStatementBraces', 'Instanceof', 'UnnecessaryOverridingMethod'])
+@SuppressWarnings(['IfStatementBraces', 'UnnecessaryOverridingMethod'])
 class LayerDsl extends LayerParams {
 
   /** Point/line size. */

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/LegendDirection.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/LegendDirection.groovy
@@ -3,7 +3,6 @@ package se.alipsa.matrix.charm
 /**
  * Typed legend direction constants.
  */
-@SuppressWarnings('Instanceof')
 enum LegendDirection {
 
   VERTICAL, HORIZONTAL

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/LegendPosition.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/LegendPosition.groovy
@@ -7,7 +7,6 @@ package se.alipsa.matrix.charm
  * compile-time safety. Absolute positioning via {@code [x, y]} lists is
  * supported by the separate {@link Theme#legendPositionCoords} field.</p>
  */
-@SuppressWarnings('Instanceof')
 enum LegendPosition {
 
   RIGHT, LEFT, TOP, BOTTOM, NONE

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/LinetypeName.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/LinetypeName.groovy
@@ -6,7 +6,6 @@ package se.alipsa.matrix.charm
  * <p>Use these in {@code geomLine().linetype(LinetypeName.DASHED)} or inside
  * the {@code layers {}} DSL where the constants are directly available.</p>
  */
-@SuppressWarnings('Instanceof')
 enum LinetypeName {
 
   SOLID, DASHED, DOTTED, DOTDASH, LONGDASH, TWODASH

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Scale.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Scale.groovy
@@ -7,7 +7,6 @@ import groovy.transform.stc.SimpleType
  * Scale configuration for one aesthetic axis/channel.
  */
 @SuppressWarnings('DuplicateStringLiteral')
-@SuppressWarnings('Instanceof')
 class Scale {
 
   private ScaleType type = ScaleType.CONTINUOUS

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/ScaleTransform.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/ScaleTransform.groovy
@@ -6,7 +6,6 @@ import groovy.transform.stc.SimpleType
 /**
  * Transformation strategy for Charm scales.
  */
-@SuppressWarnings('Instanceof')
 interface ScaleTransform {
 
   /**

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/ShapeName.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/ShapeName.groovy
@@ -6,7 +6,6 @@ package se.alipsa.matrix.charm
  * <p>Use these in {@code geomPoint().shape(ShapeName.CIRCLE)} or inside
  * the {@code layers {}} DSL where the constants are directly available.</p>
  */
-@SuppressWarnings('Instanceof')
 enum ShapeName {
 
   CIRCLE, SQUARE, TRIANGLE, DIAMOND, PLUS, X, CROSS

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Theme.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Theme.groovy
@@ -10,9 +10,7 @@ import se.alipsa.matrix.charm.theme.ElementText
  * Replaces the previous map-based approach with strongly typed element classes
  * for plot, panel, axis, legend, strip, and text styling.
  */
-@SuppressWarnings('AbcMetric')
-@SuppressWarnings('DuplicateNumberLiteral')
-@SuppressWarnings('UnnecessaryObjectReferences')
+@SuppressWarnings(['AbcMetric', 'DuplicateNumberLiteral', 'UnnecessaryObjectReferences'])
 class Theme {
 
   // ============ Plot-level elements ============

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Theme.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/Theme.groovy
@@ -12,7 +12,6 @@ import se.alipsa.matrix.charm.theme.ElementText
  */
 @SuppressWarnings('AbcMetric')
 @SuppressWarnings('DuplicateNumberLiteral')
-@SuppressWarnings('Instanceof')
 @SuppressWarnings('UnnecessaryObjectReferences')
 class Theme {
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/LayerBuilder.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/geom/LayerBuilder.groovy
@@ -21,7 +21,7 @@ import se.alipsa.matrix.core.Matrix
  * geom-specific fluent setters. Common concerns (mapping, position,
  * inherit-mapping) are handled here.</p>
  */
-@SuppressWarnings(['Instanceof', 'DuplicateStringLiteral'])
+@SuppressWarnings('DuplicateStringLiteral')
 abstract class LayerBuilder {
 
   protected Mapping layerMapping

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/AxisRenderer.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/AxisRenderer.groovy
@@ -24,9 +24,7 @@ import java.math.RoundingMode
 @SuppressWarnings('DuplicateNumberLiteral')
 @SuppressWarnings('DuplicateStringLiteral')
 @SuppressWarnings('IfStatementBraces')
-@SuppressWarnings('Instanceof')
 @SuppressWarnings('MethodSize')
-@SuppressWarnings('NestedForLoop')
 @SuppressWarnings('ParameterCount')
 @SuppressWarnings('UnnecessaryToString')
 class AxisRenderer {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/CharmRenderer.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/CharmRenderer.groovy
@@ -39,7 +39,6 @@ import java.math.RoundingMode
 @SuppressWarnings('CyclomaticComplexity')
 @SuppressWarnings('DuplicateNumberLiteral')
 @SuppressWarnings('DuplicateStringLiteral')
-@SuppressWarnings('Instanceof')
 @SuppressWarnings('MethodSize')
 @SuppressWarnings('UnnecessaryCollectCall')
 @SuppressWarnings('UnnecessaryObjectReferences')

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/FacetRenderer.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/FacetRenderer.groovy
@@ -15,8 +15,6 @@ import se.alipsa.matrix.core.Matrix
 @SuppressWarnings('DuplicateStringLiteral')
 @SuppressWarnings('IfStatementBraces')
 @SuppressWarnings('ImplementationAsType')
-@SuppressWarnings('Instanceof')
-@SuppressWarnings('NestedForLoop')
 @SuppressWarnings('ParameterCount')
 @SuppressWarnings('UnnecessaryCast')
 @SuppressWarnings('UnnecessaryCollectCall')

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/LayerDataRowAccess.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/LayerDataRowAccess.groovy
@@ -5,7 +5,6 @@ import se.alipsa.matrix.core.Matrix
 /**
  * Lightweight row access helpers for LayerData metadata.
  */
-@SuppressWarnings('Instanceof')
 class LayerDataRowAccess {
 
   private LayerDataRowAccess() {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/PlotGridRenderer.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/PlotGridRenderer.groovy
@@ -21,7 +21,6 @@ import java.util.regex.Pattern
  */
 @SuppressWarnings('DuplicateNumberLiteral')
 @SuppressWarnings('DuplicateStringLiteral')
-@SuppressWarnings('NestedForLoop')
 @SuppressWarnings('UnnecessaryCast')
 class PlotGridRenderer {
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/SpokeSupport.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/SpokeSupport.groovy
@@ -5,7 +5,6 @@ import se.alipsa.matrix.core.ValueConverter
 /**
  * Shared parameter resolution for spoke stat/geom behavior.
  */
-@SuppressWarnings('Instanceof')
 class SpokeSupport {
 
   /**

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/coord/TransCoord.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/coord/TransCoord.groovy
@@ -11,7 +11,6 @@ import se.alipsa.matrix.core.ValueConverter
 /**
  * Coordinate transform applying named transforms to x/y.
  */
-@SuppressWarnings('Instanceof')
 class TransCoord {
 
   static List<LayerData> compute(CoordSpec coordSpec, List<LayerData> data) {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/geom/BarRenderer.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/geom/BarRenderer.groovy
@@ -11,7 +11,6 @@ import se.alipsa.matrix.core.ValueConverter
  * Renders bar/col geometry.
  */
 @SuppressWarnings('AbcMetric')
-@SuppressWarnings('Instanceof')
 class BarRenderer {
 
   /**

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/geom/BoxplotRenderer.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/geom/BoxplotRenderer.groovy
@@ -15,7 +15,6 @@ import se.alipsa.matrix.core.ValueConverter
 @SuppressWarnings('CyclomaticComplexity')
 @SuppressWarnings('DuplicateNumberLiteral')
 @SuppressWarnings('DuplicateStringLiteral')
-@SuppressWarnings('Instanceof')
 @SuppressWarnings('MethodSize')
 class BoxplotRenderer {
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/geom/ViolinRenderer.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/geom/ViolinRenderer.groovy
@@ -12,7 +12,6 @@ import se.alipsa.matrix.core.ValueConverter
  */
 @SuppressWarnings('AbcMetric')
 @SuppressWarnings('DuplicateNumberLiteral')
-@SuppressWarnings('Instanceof')
 class ViolinRenderer {
 
   /**

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/scale/ContinuousCharmScale.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/scale/ContinuousCharmScale.groovy
@@ -16,8 +16,6 @@ import java.math.RoundingMode
  */
 @SuppressWarnings('DuplicateNumberLiteral')
 @SuppressWarnings('IfStatementBraces')
-@SuppressWarnings('Instanceof')
-@SuppressWarnings('NestedForLoop')
 @SuppressWarnings('UnnecessaryCast')
 @SuppressWarnings('UnnecessaryToString')
 class ContinuousCharmScale extends CharmScale {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/scale/ScaleEngine.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/scale/ScaleEngine.groovy
@@ -18,7 +18,6 @@ import se.alipsa.matrix.core.ValueConverter
 @SuppressWarnings('DuplicateStringLiteral')
 @SuppressWarnings('IfStatementBraces')
 @SuppressWarnings('ImplementationAsType')
-@SuppressWarnings('Instanceof')
 @SuppressWarnings('ParameterCount')
 @SuppressWarnings('UnnecessaryCollectCall')
 class ScaleEngine {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/FunctionStat.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/FunctionStat.groovy
@@ -8,7 +8,6 @@ import se.alipsa.matrix.core.ValueConverter
  * Function stat evaluates y = f(x) over a range.
  */
 @SuppressWarnings('DuplicateNumberLiteral')
-@SuppressWarnings('Instanceof')
 class FunctionStat {
 
   static List<LayerData> compute(LayerSpec layer, List<LayerData> data) {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/QuantileStat.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/QuantileStat.groovy
@@ -9,7 +9,6 @@ import se.alipsa.matrix.stats.regression.QuantileRegression
  * Quantile regression stat producing fitted lines for one or more quantiles.
  */
 @SuppressWarnings('DuplicateNumberLiteral')
-@SuppressWarnings('Instanceof')
 @SuppressWarnings('UnnecessaryCast')
 class QuantileStat {
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/SfStatSupport.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/SfStatSupport.groovy
@@ -9,7 +9,6 @@ import se.alipsa.matrix.charm.sf.WktReader
  * Shared helpers for SF-related stats.
  */
 @SuppressWarnings('DuplicateStringLiteral')
-@SuppressWarnings('Instanceof')
 @SuppressWarnings('UnnecessaryToString')
 class SfStatSupport {
 

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/SfStatSupport.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/render/stat/SfStatSupport.groovy
@@ -8,8 +8,7 @@ import se.alipsa.matrix.charm.sf.WktReader
 /**
  * Shared helpers for SF-related stats.
  */
-@SuppressWarnings('DuplicateStringLiteral')
-@SuppressWarnings('UnnecessaryToString')
+@SuppressWarnings(['DuplicateStringLiteral', 'UnnecessaryToString'])
 class SfStatSupport {
 
   private SfStatSupport() {

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/theme/ElementBlank.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/theme/ElementBlank.groovy
@@ -6,6 +6,6 @@ package se.alipsa.matrix.charm.theme
  * Presence of this class indicates the element should not be drawn.
  * Used when a theme explicitly removes an element via element_blank().
  */
-@SuppressWarnings(['EmptyClass', 'ClassEndsWithBlankLine', 'ClassStartsWithBlankLine'])
+@SuppressWarnings('EmptyClass')
 class ElementBlank {
 }

--- a/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/util/ColorUtil.groovy
+++ b/matrix-charts/src/main/groovy/se/alipsa/matrix/charm/util/ColorUtil.groovy
@@ -6,7 +6,6 @@ import java.math.RoundingMode
 /** Utility methods for color conversion and parsing. */
 @SuppressWarnings('DuplicateNumberLiteral')
 @SuppressWarnings('DuplicateStringLiteral')
-@SuppressWarnings('Instanceof')
 class ColorUtil {
 
     static String asHexString(Color color, String defaultIfNull='none') {

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Column.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Column.groovy
@@ -20,7 +20,6 @@ import se.alipsa.matrix.core.util.ShiftHelper
  *       preserved from the source.</li>
  * </ul>
  */
-@SuppressWarnings('Instanceof')
 class Column extends ArrayList {
 
   String name

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Grid.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Grid.groovy
@@ -13,7 +13,6 @@ import java.text.NumberFormat
  *
  * @param <T> the grid element type
  */
-@SuppressWarnings(['Instanceof', 'NestedForLoop'])
 class Grid<T> implements Iterable<List<T>> {
 
   List<List<T>> data

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/GroupedMatrix.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/GroupedMatrix.groovy
@@ -180,7 +180,6 @@ class GroupedMatrix {
    * @param aggregations map of source column name to aggregation closure
    * @return a new Matrix with group columns and aggregated values
    */
-  @SuppressWarnings('NestedForLoop')
   Matrix agg(Map<String, Closure> aggregations) {
     if (aggregations == null) {
       throw new IllegalArgumentException('aggregations must not be null')

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Joiner.groovy
@@ -235,7 +235,7 @@ class Joiner {
     indices
   }
 
-  @SuppressWarnings(['Instanceof', 'DuplicateStringLiteral'])
+  @SuppressWarnings('DuplicateStringLiteral')
   private static List<List<String>> normalizeKeys(Map<String, Object> by) {
     if (!by.containsKey('x') || !by.containsKey('y')) {
       throw new IllegalArgumentException("Join key map must contain both 'x' and 'y' entries")

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/ListConverter.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/ListConverter.groovy
@@ -26,7 +26,6 @@ class ListConverter {
     convert(list, type, valueIfNull, dateTimeFormat, NumberFormat.getInstance(numberFormat))
   }
 
-  @SuppressWarnings('Instanceof')
   static <T> List<T> convert(Collection<?> list, @NotNull Class<T> type, T valueIfNull = null,
                              String dateTimeFormat = null, NumberFormat numberFormat = null) {
     List<T> c = []

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Matrix.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Matrix.groovy
@@ -44,31 +44,7 @@ import java.time.LocalDateTime
  * or to assign / create a column <code> myMatrix['bar'] = [1..12]</code> to assign the range 1 to 12 to the column bar
  *
  */
-@SuppressWarnings([
-    'JavadocEmptyLastLine',
-    'ClassSize',
-    'ClassStartsWithBlankLine',
-    'SpaceAroundOperator',
-    'SpaceAfterMethodCallName',
-    'UnnecessaryGString',
-    'Instanceof',
-    'NestedForLoop',
-    'UnnecessaryCollectCall',
-    'SpaceAfterOpeningBrace',
-    'SpaceBeforeClosingBrace',
-    'SpaceBeforeOpeningBrace',
-    'JavadocMissingParamDescription',
-    'JavadocEmptyReturnTag',
-    'JavadocEmptyFirstLine',
-    'ConsecutiveBlankLines',
-    'BlockStartsWithBlankLine',
-    'SpaceAfterComma',
-    'UnnecessaryElseStatement',
-    'SpaceAfterCommentDelimiter',
-    'DuplicateListLiteral',
-    'DuplicateNumberLiteral',
-    'MethodCount'
-])
+@SuppressWarnings(['JavadocEmptyLastLine', 'ClassSize', 'UnnecessaryGString', 'UnnecessaryCollectCall', 'SpaceBeforeOpeningBrace', 'JavadocMissingParamDescription', 'JavadocEmptyReturnTag', 'JavadocEmptyFirstLine', 'UnnecessaryElseStatement', 'DuplicateListLiteral', 'DuplicateNumberLiteral', 'MethodCount'])
 class Matrix implements Iterable<Row>, Cloneable {
   private static final String ANONYMOUS_COLUMN_PREFIX = 'c'
   private static final String FILE_CANNOT_BE_NULL = 'file cannot be null'
@@ -1655,7 +1631,6 @@ class Matrix implements Iterable<Row>, Cloneable {
     }
   }
 
-  @SuppressWarnings('Instanceof')
   private static boolean valuesAreDifferent(Object entry, Object thatVal, BigDecimal allowedDiff) {
     if (entry instanceof Number) {
       if (thatVal instanceof Number) {

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/RollingMatrix.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/RollingMatrix.groovy
@@ -127,7 +127,6 @@ class RollingMatrix {
     result
   }
 
-  @SuppressWarnings(['Instanceof', 'NestedForLoop'])
   private Matrix aggregateNumericColumns(boolean decimalResult = true, Closure<?> function) {
     Matrix result = source.clone()
     source.columnNames().eachWithIndex { String columnName, int index ->

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/Stat.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/Stat.groovy
@@ -14,14 +14,7 @@ import java.math.RoundingMode
  * For statistical test functions, see the matrix-stat-tests library
  *
  */
-@SuppressWarnings([
-    'JavadocEmptyLastLine',
-    'MissingBlankLineBeforeAnnotatedField',
-    'UnnecessaryGString',
-    'Instanceof',
-    'NestedForLoop',
-    'UnnecessaryNullCheckBeforeInstanceOf'
-])
+@SuppressWarnings(['JavadocEmptyLastLine', 'MissingBlankLineBeforeAnnotatedField', 'UnnecessaryGString', 'UnnecessaryNullCheckBeforeInstanceOf'])
 class Stat {
 
     private static final Logger log = Logger.getLogger(Stat)

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/ext/ColumnExtension.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/ext/ColumnExtension.groovy
@@ -24,7 +24,6 @@ class ColumnExtension {
     self
   }
 
-  @SuppressWarnings('Instanceof')
   static Object getAt(Column self, Collection indices) {
     if (indices.size() == 2 && indices[1] instanceof Class) {
       return self.getAt(indices[0] as Number, indices[1] as Class)

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/ext/RowExtension.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/ext/RowExtension.groovy
@@ -6,7 +6,6 @@ import se.alipsa.matrix.core.Row
  * Overrides DefaultGroovyMethods so we can define our own getAt and putAt
  * see resources/META-INF.groovy
  */
-@SuppressWarnings('Instanceof')
 class RowExtension {
 
   static Object getAt(Row self, String[] colNames) {

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/spi/FormatRegistry.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/spi/FormatRegistry.groovy
@@ -225,7 +225,6 @@ class FormatRegistry {
     }
   }
 
-  @SuppressWarnings('NestedForLoop')
   private Map<String, MatrixFormatProvider> loadProviders() {
     Map<String, MatrixFormatProvider> loadedProviders = [:]
     ServiceLoader<MatrixFormatProvider> loader = ServiceLoader.load(MatrixFormatProvider)

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/ClassUtils.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/ClassUtils.groovy
@@ -131,7 +131,6 @@ class ClassUtils {
     return NEAREST_TYPE_MAP.get(key, Number)
   }
 
-  @SuppressWarnings('Instanceof')
   static GroovyClassLoader findGroovyClassLoader(Object obj) {
     ClassLoader cl = obj.class.classLoader
     while (cl != null && !(cl instanceof GroovyClassLoader)) {

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/ComparisonHelper.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/ComparisonHelper.groovy
@@ -27,7 +27,6 @@ class ComparisonHelper {
    * @param row the row values to inspect
    * @return true if at least one value is non-null, otherwise false
    */
-  @SuppressWarnings('Instanceof')
   static boolean containsValues(Iterable row) {
     for (def element in row) {
       if (element != null && (!(element instanceof CharSequence) || !element.toString().isBlank())) {

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/CsvHelper.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/CsvHelper.groovy
@@ -69,7 +69,6 @@ class CsvHelper {
     type.name
   }
 
-  @SuppressWarnings('Instanceof')
   static String serializeMetadataValue(Object value) {
     if (value == null) {
       return ''

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/CumulativeHelper.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/CumulativeHelper.groovy
@@ -138,7 +138,6 @@ class CumulativeHelper {
     }
   }
 
-  @SuppressWarnings('Instanceof')
   private static void requireComparable(Column source, String operationName) {
     if (source == null) {
       throw new IllegalArgumentException("${operationName} requires a non-null column")
@@ -151,7 +150,7 @@ class CumulativeHelper {
     }
   }
 
-  @SuppressWarnings(['ExplicitCallToCompareToMethod', 'Instanceof'])
+  @SuppressWarnings('ExplicitCallToCompareToMethod')
   private static int compareValues(Comparable left, Comparable right, String operationName, Column source) {
     if (left instanceof Number && right instanceof Number) {
       BigDecimal leftValue = numericValue(left, source, operationName)
@@ -168,7 +167,6 @@ class CumulativeHelper {
     }
   }
 
-  @SuppressWarnings('Instanceof')
   static BigDecimal numericValue(Object element, Column source, String operationName) {
     if (!(element instanceof Number)) {
       throw new IllegalArgumentException(

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/MatrixPrinter.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/MatrixPrinter.groovy
@@ -59,7 +59,6 @@ class MatrixPrinter {
   /**
    * Used to pretty print (e.g. to console) a row
    */
-  @SuppressWarnings('Instanceof')
   static List<String> padRow(Matrix m, List row, List<Integer> columnLengths) {
     List<String> stringRow = []
     for (int c = 0; c < m.columns().size(); c++) {

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/RollingNumericAccumulator.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/RollingNumericAccumulator.groovy
@@ -67,7 +67,6 @@ class RollingNumericAccumulator {
     numericCount--
   }
 
-  @SuppressWarnings('Instanceof')
   private static BigDecimal numericValue(Object value) {
     value instanceof Number ? ValueConverter.asBigDecimal(value as Number) : null
   }

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/RollingWindowHelper.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/RollingWindowHelper.groovy
@@ -85,7 +85,6 @@ class RollingWindowHelper {
    * @param values the raw window values
    * @return the numeric values
    */
-  @SuppressWarnings('Instanceof')
   static List<Number> nonNullNumbers(List<?> values) {
     values.findAll { it instanceof Number } as List<Number>
   }
@@ -96,7 +95,6 @@ class RollingWindowHelper {
    * @param column the column to inspect
    * @return true when the column is numeric
    */
-  @SuppressWarnings('Instanceof')
   static boolean isNumericColumn(Column column) {
     if (column == null) {
       return false

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/RollingWindowOptions.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/RollingWindowOptions.groovy
@@ -88,7 +88,6 @@ class RollingWindowOptions {
     new RollingWindowOptions(window, minPeriods, center, by)
   }
 
-  @SuppressWarnings('Instanceof')
   private static int intValue(Object value, String name) {
     if (!(value instanceof Number)) {
       throw new IllegalArgumentException("rolling ${name} must be a number but was ${value}")
@@ -100,7 +99,6 @@ class RollingWindowOptions {
     }
   }
 
-  @SuppressWarnings('Instanceof')
   private static boolean booleanValue(Object value, String name) {
     if (!(value instanceof Boolean)) {
       throw new IllegalArgumentException("rolling ${name} must be a boolean but was ${value}")

--- a/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/RowComparator.groovy
+++ b/matrix-core/src/main/groovy/se/alipsa/matrix/core/util/RowComparator.groovy
@@ -40,7 +40,6 @@ class RowComparator<T> implements Comparator<List<T>> {
     return 0
   }
 
-  @SuppressWarnings('Instanceof')
   private static int compareValues(Object v1, Object v2) {
     if (v1 == v2) {
       return 0

--- a/matrix-core/src/test/groovy/GridTest.groovy
+++ b/matrix-core/src/test/groovy/GridTest.groovy
@@ -9,20 +9,7 @@ import se.alipsa.matrix.core.Matrix
 
 import java.text.DecimalFormat
 
-@SuppressWarnings([
-    'UnnecessaryGString',
-    'SpaceAfterComma',
-    'BlockEndsWithBlankLine',
-    'UnnecessaryDotClass',
-    'ClosureStatementOnOpeningLineOfMultipleLineClosure',
-    'SpaceAfterClosingBrace',
-    'SpaceBeforeClosingBrace',
-    'ClosureAsLastMethodParameter',
-    'UnnecessarySemicolon',
-    'SpaceAfterFor',
-    'SpaceAfterCommentDelimiter',
-    'ClassEndsWithBlankLine'
-])
+@SuppressWarnings(['UnnecessaryGString', 'UnnecessaryDotClass', 'ClosureStatementOnOpeningLineOfMultipleLineClosure', 'SpaceAfterClosingBrace', 'ClosureAsLastMethodParameter', 'UnnecessarySemicolon', 'SpaceAfterFor'])
 class GridTest {
 
     @Test

--- a/matrix-core/src/test/groovy/LoggerTest.groovy
+++ b/matrix-core/src/test/groovy/LoggerTest.groovy
@@ -8,7 +8,7 @@ import se.alipsa.matrix.core.util.Logger
 
 import java.lang.reflect.Method
 
-@SuppressWarnings(['UnnecessaryGroovyImport', 'UnnecessaryGString', 'ClassEndsWithBlankLine'])
+@SuppressWarnings(['UnnecessaryGroovyImport', 'UnnecessaryGString'])
 class LoggerTest {
 
   private static final Method FORMAT_MESSAGE = Logger.getDeclaredMethod('formatMessage', String, Object[])

--- a/matrix-core/src/test/groovy/MatrixBuilderTest.groovy
+++ b/matrix-core/src/test/groovy/MatrixBuilderTest.groovy
@@ -19,16 +19,7 @@ import java.time.LocalDate
  * Note the calls to content() is a decent way to check the integrity of the matrix and is there to ensure
  * there is no exception from doing that
  */
-@SuppressWarnings([
-    'ConsecutiveBlankLines',
-    'UnnecessaryGString',
-    'SpaceAfterComma',
-    'SpaceAroundOperator',
-    'SpaceAfterCommentDelimiter',
-    'MethodSize',
-    'ClassStartsWithBlankLine',
-    'ClassEndsWithBlankLine'
-])
+@SuppressWarnings(['UnnecessaryGString', 'MethodSize'])
 class MatrixBuilderTest {
 
 

--- a/matrix-core/src/test/groovy/MatrixTest.groovy
+++ b/matrix-core/src/test/groovy/MatrixTest.groovy
@@ -19,18 +19,7 @@ import java.time.LocalDateTime
 import java.time.YearMonth
 import java.time.temporal.TemporalAccessor
 
-@SuppressWarnings([
-    'ConsecutiveBlankLines',
-    'ClassSize',
-    'UnnecessaryGString',
-    'ClosureAsLastMethodParameter',
-    'SpaceAfterCommentDelimiter',
-    'BlockEndsWithBlankLine',
-    'UnnecessaryBigDecimalInstantiation',
-    'UnnecessaryCollectCall',
-    'UnnecessaryDotClass',
-    'ClassEndsWithBlankLine'
-])
+@SuppressWarnings(['ClassSize', 'UnnecessaryGString', 'ClosureAsLastMethodParameter', 'UnnecessaryBigDecimalInstantiation', 'UnnecessaryCollectCall', 'UnnecessaryDotClass'])
 class MatrixTest {
 
   @Test

--- a/matrix-core/src/test/groovy/StatTest.groovy
+++ b/matrix-core/src/test/groovy/StatTest.groovy
@@ -15,13 +15,7 @@ import java.math.RoundingMode
 import java.time.LocalDate
 import java.time.YearMonth
 
-@SuppressWarnings([
-    'UnnecessaryGString',
-    'SpaceAfterComma',
-    'SpaceAroundOperator',
-    'SpaceAfterCommentDelimiter',
-    'ClassEndsWithBlankLine'
-])
+@SuppressWarnings('UnnecessaryGString')
 class StatTest {
 
   @Test

--- a/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
+++ b/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
@@ -8,8 +8,6 @@ import java.math.RoundingMode
 /** Histogram chart for visualizing the frequency distribution of numerical data. */
 @SuppressWarnings('DuplicateNumberLiteral')
 @SuppressWarnings('ExplicitCallToCompareToMethod')
-@SuppressWarnings('Instanceof')
-@SuppressWarnings('NestedForLoop')
 class Histogram extends Chart<Histogram> {
 
   List<? extends Number> originalData = []

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/Gsmile.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/Gsmile.groovy
@@ -222,7 +222,6 @@ class Gsmile {
    * @param args the slicing arguments (first is row range, rest are column names)
    * @return a new DataFrame with the selected subset
    */
-  @SuppressWarnings('Instanceof')
   static DataFrame getAt(DataFrame self, Collection args) {
     if (args.isEmpty()) {
       return self

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/SmileUtil.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/SmileUtil.groovy
@@ -155,7 +155,6 @@ class SmileUtil {
    * @return 2D array of double values
    * @throws IllegalArgumentException if any column contains a null value
    */
-  @SuppressWarnings('NestedForLoop')
   static double[][] matrixToArray(Matrix matrix) {
     int rows = matrix.rowCount()
     int cols = matrix.columnCount()

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileData.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileData.groovy
@@ -315,7 +315,6 @@ class SmileData {
    * @param random the Random instance to use
    * @return a list of n bootstrap sample matrices
    */
-  @SuppressWarnings('NestedForLoop')
   static List<Matrix> bootstrap(Matrix matrix, int n, int sampleSize, Random random) {
     if (n < 1) {
       throw new IllegalArgumentException("n must be at least 1: was $n")

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileFeatures.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/data/SmileFeatures.groovy
@@ -159,7 +159,6 @@ class SmileFeatures {
    * @param columns the column names to transform
    * @return a new Matrix with log-transformed columns
    */
-  @SuppressWarnings('NestedForLoop')
   static Matrix logTransform(Matrix matrix, List<String> columns) {
     Map<String, List<?>> newData = [:]
     List<Class<?>> newTypes = []
@@ -208,7 +207,6 @@ class SmileFeatures {
    * @param columns the column names to transform
    * @return a new Matrix with sqrt-transformed columns
    */
-  @SuppressWarnings('NestedForLoop')
   static Matrix sqrtTransform(Matrix matrix, List<String> columns) {
     Map<String, List<?>> newData = [:]
     List<Class<?>> newTypes = []
@@ -974,7 +972,6 @@ class SmileFeatures {
      * @throws IllegalStateException if the encoder has not been fitted
      * @throws IllegalArgumentException if a value is unseen or null, or if generated column names collide
      */
-    @SuppressWarnings('NestedForLoop')
     Matrix transform(Matrix matrix, String column, boolean dropOriginal = true) {
       if (!fitted) {
         throw new IllegalStateException('Encoder must be fitted before transforming')

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/ml/SmileClassifier.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/ml/SmileClassifier.groovy
@@ -165,7 +165,6 @@ class SmileClassifier {
    * @param testMatrix the test data with actual labels
    * @return a Matrix representing the confusion matrix
    */
-  @SuppressWarnings('NestedForLoop')
   Matrix confusionMatrix(Matrix testMatrix) {
     SmileUtil.validateTestMatrix(testMatrix, targetColumn)
     int[] actual = extractTargetAsInt(testMatrix, targetColumn, classLabels)
@@ -204,7 +203,6 @@ class SmileClassifier {
    * @param testMatrix the test data with actual labels
    * @return a Matrix with precision, recall, f1 for each class
    */
-  @SuppressWarnings('NestedForLoop')
   Matrix evaluate(Matrix testMatrix) {
     SmileUtil.validateTestMatrix(testMatrix, targetColumn)
     int[] actual = extractTargetAsInt(testMatrix, targetColumn, classLabels)

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/ml/SmileCluster.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/ml/SmileCluster.groovy
@@ -174,7 +174,6 @@ class SmileCluster {
    * @return a Matrix containing the cluster centroids
    * @throws UnsupportedOperationException if the algorithm does not produce centroids
    */
-  @SuppressWarnings('NestedForLoop')
   Matrix getCentroidsMatrix() {
     double[][] centroids = getCentroids()
 
@@ -250,7 +249,6 @@ class SmileCluster {
 
   // Helper methods
 
-  @SuppressWarnings('NestedForLoop')
   private static double calculateSilhouette(double[][] data, int[] labels) {
     int n = data.length
     if (n < MIN_CLUSTERS) { return ZERO }
@@ -298,7 +296,6 @@ class SmileCluster {
     validPoints > 0 ? totalSilhouette / validPoints : 0.0d
   }
 
-  @SuppressWarnings('NestedForLoop')
   private static double meanDistanceToCluster(double[][] data, int[] labels, int pointIndex, int cluster) {
     double sumDist = ZERO
     int count = 0

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/ml/SmileDimensionality.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/ml/SmileDimensionality.groovy
@@ -151,7 +151,6 @@ class SmileDimensionality {
    *
    * @return a Matrix with loadings (features x components)
    */
-  @SuppressWarnings('NestedForLoop')
   Matrix getLoadingsMatrix() {
     double[][] loadings = getLoadings()
 
@@ -236,7 +235,6 @@ class SmileDimensionality {
 
   // Helper methods
 
-  @SuppressWarnings('NestedForLoop')
   private static Matrix arrayToMatrix(double[][] data, int numComponents) {
     Map<String, List<?>> result = [:]
     List<Class<?>> types = []

--- a/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/stats/SmileStats.groovy
+++ b/matrix-smile/src/main/groovy/se/alipsa/matrix/smile/stats/SmileStats.groovy
@@ -749,7 +749,6 @@ class SmileStats {
    * @param method correlation method
    * @return a Map with "correlation" and "pvalue" matrices
    */
-  @SuppressWarnings('NestedForLoop')
   static Map<String, Matrix> correlationWithSignificance(Matrix matrix, List<String> columns = null, CorrelationMethod method = CorrelationMethod.PEARSON) {
     List<String> numericCols = columns ?: SmileUtil.getNumericColumnNames(matrix)
     int n = numericCols.size()
@@ -995,7 +994,6 @@ class SmileStats {
     buf
   }
 
-  @SuppressWarnings('NestedForLoop')
   private static Matrix matrixFromCorrelation(List<String> columnNames, double[][] data) {
     Map<String, List<?>> matrixData = [:]
 

--- a/matrix-smile/src/test/groovy/SmileDataTest.groovy
+++ b/matrix-smile/src/test/groovy/SmileDataTest.groovy
@@ -168,7 +168,6 @@ class SmileDataTest {
     assertEquals(2.0d, firstFold.validation.row(1)[0])
   }
 
-  @SuppressWarnings('NestedForLoop')
   @Test
   void testKFoldWithSeed() {
     Matrix data = createTestMatrix()
@@ -218,7 +217,6 @@ class SmileDataTest {
     }
   }
 
-  @SuppressWarnings('NestedForLoop')
   @Test
   void testKFoldCoverageComplete() {
     Matrix data = createTestMatrix()
@@ -342,7 +340,6 @@ class SmileDataTest {
     }
   }
 
-  @SuppressWarnings('NestedForLoop')
   @Test
   void testBootstrapWithSeed() {
     Matrix data = createTestMatrix()

--- a/matrix-spreadsheet/src/main/groovy/se/alipsa/matrix/spreadsheet/fastexcel/FExcelReader.groovy
+++ b/matrix-spreadsheet/src/main/groovy/se/alipsa/matrix/spreadsheet/fastexcel/FExcelReader.groovy
@@ -15,7 +15,7 @@ import java.util.stream.Stream
  * Provides read access to Excel (.xlsx) workbook metadata such as sheet names, row counts,
  * and column counts using the FastExcel reader library.
  */
-@SuppressWarnings(['UnusedObject', 'CloseWithoutCloseable'])
+@SuppressWarnings('UnusedObject')
 class FExcelReader implements SpreadsheetReader {
 
   private static final int NOT_FOUND = -1

--- a/matrix-spreadsheet/src/main/groovy/se/alipsa/matrix/spreadsheet/fastods/FOdsReader.groovy
+++ b/matrix-spreadsheet/src/main/groovy/se/alipsa/matrix/spreadsheet/fastods/FOdsReader.groovy
@@ -14,7 +14,6 @@ import javax.xml.stream.XMLStreamReader
 /**
  * Extract various information from a Calc (ods) file using fastods streaming.
  */
-@SuppressWarnings('CloseWithoutCloseable')
 class FOdsReader implements SpreadsheetReader {
 
   private static final int NOT_FOUND = -1

--- a/matrix-spreadsheet/src/test/groovy/spreadsheet/SpreadsheetFormatProviderTest.groovy
+++ b/matrix-spreadsheet/src/test/groovy/spreadsheet/SpreadsheetFormatProviderTest.groovy
@@ -241,7 +241,6 @@ class SpreadsheetFormatProviderTest {
     method.invoke(null, reader, options) as int
   }
 
-  @SuppressWarnings('CloseWithoutCloseable')
   private static class StubSpreadsheetReader implements SpreadsheetReader {
 
     private final int lastRow

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixResultSet.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/MatrixResultSet.groovy
@@ -172,7 +172,6 @@ class MatrixResultSet implements ResultSet {
    *
    * @throws SQLException if a database access error occurs
    */
-  @SuppressWarnings('CloseWithoutCloseable')
   @Override
   void close() throws SQLException {
     matrix = null

--- a/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlGenerator.groovy
+++ b/matrix-sql/src/main/groovy/se/alipsa/matrix/sql/SqlGenerator.groovy
@@ -6,7 +6,6 @@ import se.alipsa.matrix.core.Row
 /**
  * Generates prepared SQL statements (INSERT, UPDATE) for {@link Matrix} and {@link Row} data.
  */
-@SuppressWarnings('SpaceInsideParentheses')
 class SqlGenerator {
 
   private static final String COMMA_SEP = ', '

--- a/matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/gtable/Gtable.groovy
+++ b/matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/gtable/Gtable.groovy
@@ -345,7 +345,7 @@ class Gtable extends Table {
    * @param columnIndex the columnIndex
    * @param value the value
    */
-  @SuppressWarnings(['unchecked', 'Instanceof'])
+  @SuppressWarnings('unchecked')
   void putAt(int rowIndex, int columnIndex, Object value) {
     Column col = (Column) column(columnIndex)
     if (value == null) {

--- a/req/codenarc-consolidation-2.md
+++ b/req/codenarc-consolidation-2.md
@@ -796,7 +796,7 @@ Confirmed redundant suppressions found in the codebase (representative list; ste
 | `matrix-spreadsheet/src/test/groovy/spreadsheet/SpreadsheetFormatProviderTest.groovy:244` | `@SuppressWarnings('CloseWithoutCloseable')` → remove whole annotation |
 | `matrix-tablesaw/src/main/groovy/.../Gtable.groovy:348` | `['unchecked', 'Instanceof']` → remove only `Instanceof`, keep `unchecked` |
 
-- [ ] **6.1 Find all redundant suppressions (multiline-aware)**
+- [x] **6.1 Find all redundant suppressions (multiline-aware)**
 
   `@SuppressWarnings` annotations in this codebase sometimes span multiple lines (e.g. `Matrix.groovy:47`, `Stat.groovy:17` put the rule names on separate lines), so a simple two-stage grep misses them. Use the Python script below which reads each file as a whole and matches across newlines:
 
@@ -846,7 +846,7 @@ Confirmed redundant suppressions found in the codebase (representative list; ste
   EOF
   ```
 
-- [ ] **6.2 For each hit: remove only the globally-excluded rule from the annotation**
+- [x] **6.2 For each hit: remove only the globally-excluded rule from the annotation**
 
   - If the annotation suppresses only globally-excluded rules: delete the whole `@SuppressWarnings(...)` line.
   - If the annotation is a list that mixes excluded and still-active rules: remove only the excluded entries from the list. When a list is reduced to a single entry, convert from list syntax to string syntax:
@@ -857,7 +857,7 @@ Confirmed redundant suppressions found in the codebase (representative list; ste
     @SuppressWarnings('DuplicateStringLiteral')
     ```
 
-- [ ] **6.3 Verify CodeNarc passes on each affected module**
+- [x] **6.3 Verify CodeNarc passes on each affected module**
 
   ```bash
   ./gradlew :matrix-smile:codenarcMain :matrix-smile:codenarcTest
@@ -919,8 +919,28 @@ Confirmed redundant suppressions found in the codebase (representative list; ste
   EOF
   ```
 
-- [ ] **6.4 Verify tests pass for affected modules**
+  Completed verification:
+  ```bash
+  ./gradlew :matrix-smile:codenarcMain :matrix-smile:codenarcTest :matrix-core:codenarcMain :matrix-core:codenarcTest :matrix-charts:codenarcMain :matrix-charts:codenarcTest
+  ./gradlew :matrix-pict:codenarcMain :matrix-pict:codenarcTest :matrix-bigquery:codenarcMain :matrix-bigquery:codenarcTest :matrix-sql:codenarcMain :matrix-sql:codenarcTest :matrix-spreadsheet:codenarcMain :matrix-spreadsheet:codenarcTest :matrix-tablesaw:codenarcMain :matrix-tablesaw:codenarcTest
+  python - << 'EOF'
+  # Full Step 6.1 redundant-suppression audit script from this section
+  EOF
+  # Output: OK — no redundant @SuppressWarnings remaining.
+  ./gradlew :matrix-smile:spotlessCheck :matrix-core:spotlessCheck :matrix-charts:spotlessCheck :matrix-pict:spotlessCheck :matrix-bigquery:spotlessCheck :matrix-sql:spotlessCheck :matrix-spreadsheet:spotlessCheck :matrix-tablesaw:spotlessCheck
+  git diff --check
+  ```
 
+- [x] **6.4 Verify tests pass for affected modules**
+
+  ```bash
+  ./gradlew :matrix-smile:test :matrix-core:test
+  ./gradlew :matrix-charts:test -Pheadless=true
+  ./gradlew :matrix-pict:test :matrix-sql:test
+  ./gradlew :matrix-bigquery:test :matrix-spreadsheet:test :matrix-tablesaw:test
+  ```
+
+  Completed verification:
   ```bash
   ./gradlew :matrix-smile:test :matrix-core:test
   ./gradlew :matrix-charts:test -Pheadless=true


### PR DESCRIPTION
## Summary
- Remove redundant `@SuppressWarnings` entries for CodeNarc rules that are now globally excluded by the consolidated root ruleset.
- Preserve active suppressions in mixed annotations and delete annotations that only contained globally excluded rules.
- Update `req/codenarc-consolidation-2.md` task 6 status and verification notes.

## Modules touched
- matrix-bigquery
- matrix-charts
- matrix-core
- matrix-pict
- matrix-smile
- matrix-spreadsheet
- matrix-sql
- matrix-tablesaw

## Verification
- `./gradlew :matrix-smile:codenarcMain :matrix-smile:codenarcTest :matrix-core:codenarcMain :matrix-core:codenarcTest :matrix-charts:codenarcMain :matrix-charts:codenarcTest`
- `./gradlew :matrix-pict:codenarcMain :matrix-pict:codenarcTest :matrix-bigquery:codenarcMain :matrix-bigquery:codenarcTest :matrix-sql:codenarcMain :matrix-sql:codenarcTest :matrix-spreadsheet:codenarcMain :matrix-spreadsheet:codenarcTest :matrix-tablesaw:codenarcMain :matrix-tablesaw:codenarcTest`
- Redundant-suppression audit script: `OK — no redundant @SuppressWarnings remaining.`
- `./gradlew :matrix-smile:spotlessCheck :matrix-core:spotlessCheck :matrix-charts:spotlessCheck :matrix-pict:spotlessCheck :matrix-bigquery:spotlessCheck :matrix-sql:spotlessCheck :matrix-spreadsheet:spotlessCheck :matrix-tablesaw:spotlessCheck`
- `./gradlew :matrix-smile:test :matrix-core:test`
- `./gradlew :matrix-charts:test -Pheadless=true`
- `./gradlew :matrix-pict:test :matrix-sql:test`
- `./gradlew :matrix-bigquery:test :matrix-spreadsheet:test :matrix-tablesaw:test`
- `git diff --check`