### PR TITLE
[codex] Implement matrix-stats 2.5.0 phase 2

### DIFF
--- a/matrix-stats/req/v2.5.0-plan.md
+++ b/matrix-stats/req/v2.5.0-plan.md
@@ -38,21 +38,21 @@ A task is only complete when its tests have passed and the exact test command ha
 
 ## 2. Fisher Exact Test Validation and Numeric Safety
 
-2.1 [ ] Add tests in `matrix-stats/src/test/groovy/contingency/FisherTest.groovy` proving invalid alternatives are rejected.
+2.1 [x] Add tests in `matrix-stats/src/test/groovy/contingency/FisherTest.groovy` proving invalid alternatives are rejected.
 
-2.2 [ ] Validate `alternative` in both `Fisher.test(List<List<Integer>>, String)` and `Fisher.test(Matrix, String)` before calculating the p-value. Keep accepting `two.sided`, `greater`, and `less`; reject and throw on unrecognized alternatives instead of silently treating them as two-sided.
+2.2 [x] Validate `alternative` in both `Fisher.test(List<List<Integer>>, String)` and `Fisher.test(Matrix, String)` before calculating the p-value. Keep accepting `two.sided`, `greater`, and `less`; reject and throw on unrecognized alternatives instead of silently treating them as two-sided.
 
-2.3 [ ] Consider adding a typed enum overload, for example `Fisher.Alternative`, while keeping the existing string overload as an API boundary.
+2.3 [x] Consider adding a typed enum overload, for example `Fisher.Alternative`, while keeping the existing string overload as an API boundary.
 
-2.4 [ ] Replace integer product arithmetic in odds-ratio and confidence-interval calculations with `BigDecimal` or `long`-safe arithmetic so large count tables do not overflow before conversion.
+2.4 [x] Replace integer product arithmetic in odds-ratio and confidence-interval calculations with `BigDecimal` or `long`-safe arithmetic so large count tables do not overflow before conversion.
 
-2.5 [ ] Add a large-count regression test where products exceed `Integer.MAX_VALUE`, for example cell counts around `50_000`.
+2.5 [x] Add a large-count regression test where products exceed `Integer.MAX_VALUE`, for example cell counts around `50_000`.
 
-2.6 [ ] Run and record verification:
-- `./gradlew :matrix-stats:codenarcMain`
-- `./gradlew :matrix-stats:spotlessCheck`
-- `./gradlew :matrix-stats:test --tests 'contingency.FisherTest'`
-- `./gradlew :matrix-stats:test`
+2.6 [x] Run and record verification:
+- [x] `./gradlew :matrix-stats:codenarcMain`
+- [x] `./gradlew :matrix-stats:spotlessCheck`
+- [x] `./gradlew :matrix-stats:test --tests 'contingency.FisherTest'`
+- [x] `./gradlew :matrix-stats:test`
 
 ---
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
@@ -4,6 +4,8 @@ import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.distribution.HypergeometricDistribution
 import se.alipsa.matrix.stats.util.NumericConversion
 
+import java.util.Locale
+
 /**
  * Fisher's exact test is a statistical significance test used in the analysis of contingency tables.
  * Although in practice it is employed when sample sizes are small, it is valid for all sample sizes.
@@ -68,7 +70,10 @@ class Fisher {
    * @throws IllegalArgumentException if table is not 2×2 or contains negative values
    */
   static FisherResult test(List<List<Integer>> table, Alternative alternative) {
-    test(table, alternative?.label)
+    if (alternative == null) {
+      throw new IllegalArgumentException('Alternative must not be null')
+    }
+    test(table, alternative.label)
   }
 
   /**
@@ -101,7 +106,10 @@ class Fisher {
    * @throws IllegalArgumentException if table is not 2×2 or contains negative values
    */
   static FisherResult test(Matrix table, Alternative alternative) {
-    test(table, alternative?.label)
+    if (alternative == null) {
+      throw new IllegalArgumentException('Alternative must not be null')
+    }
+    test(table, alternative.label)
   }
 
   private static void validateTable(List<List<Integer>> table) {
@@ -121,8 +129,6 @@ class Fisher {
   }
 
   private static FisherResult calculateFisherTest(int a, int b, int c, int d, String alternative) {
-    validateAlternative(alternative)
-
     int n = a + b + c + d
     int rowSum1 = a + b
     int colSum1 = a + c
@@ -136,7 +142,8 @@ class Fisher {
     // with colSum1 successes
     HypergeometricDistribution dist = new HypergeometricDistribution(n, colSum1, rowSum1)
 
-    double pValue = switch (alternative.toLowerCase()) {
+    String normalizedAlternative = alternative == null ? '' : alternative.toLowerCase(Locale.ROOT)
+    double pValue = switch (normalizedAlternative) {
       case 'greater' -> dist.upperCumulativeProbability(a)       // P(X >= a)
       case 'less' -> dist.cumulativeProbability(a)               // P(X <= a)
       case 'two.sided' -> calculateTwoSidedPValue(dist, a)       // two-sided
@@ -152,12 +159,6 @@ class Fisher {
       confidenceInterval: NumericConversion.toBigDecimalList(confInt, 'confidenceInterval'),
       alternative: alternative
     )
-  }
-
-  private static void validateAlternative(String alternative) {
-    if (!(alternative in ['two.sided', 'greater', 'less'])) {
-      throw new IllegalArgumentException("Alternative must be 'two.sided', 'greater', or 'less', got: ${alternative}")
-    }
   }
 
   private static double calculateOddsRatio(int a, int b, int c, int d) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
@@ -4,8 +4,6 @@ import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.distribution.HypergeometricDistribution
 import se.alipsa.matrix.stats.util.NumericConversion
 
-import java.util.Locale
-
 /**
  * Fisher's exact test is a statistical significance test used in the analysis of contingency tables.
  * Although in practice it is employed when sample sizes are small, it is valid for all sample sizes.
@@ -170,8 +168,8 @@ class Fisher {
   }
 
   private static double productRatio(int numeratorLeft, int numeratorRight, int denominatorLeft, int denominatorRight) {
-    long numerator = (long) numeratorLeft * (long) numeratorRight
-    long denominator = (long) denominatorLeft * (long) denominatorRight
+    long numerator = (numeratorLeft as long) * (numeratorRight as long)
+    long denominator = (denominatorLeft as long) * (denominatorRight as long)
     (numerator as double) / (denominator as double)
   }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/contingency/Fisher.groovy
@@ -26,6 +26,21 @@ import se.alipsa.matrix.stats.util.NumericConversion
 class Fisher {
 
   /**
+   * Alternative hypothesis options for Fisher's exact test.
+   */
+  enum Alternative {
+    TWO_SIDED('two.sided'),
+    GREATER('greater'),
+    LESS('less')
+
+    final String label
+
+    private Alternative(String label) {
+      this.label = label
+    }
+  }
+
+  /**
    * Performs Fisher's exact test on a 2×2 contingency table.
    *
    * @param table A 2×2 contingency table as a List of Lists: [[a, b], [c, d]]
@@ -42,6 +57,18 @@ class Fisher {
     int d = table[1][1]
 
     calculateFisherTest(a, b, c, d, alternative)
+  }
+
+  /**
+   * Performs Fisher's exact test on a 2×2 contingency table.
+   *
+   * @param table A 2×2 contingency table as a List of Lists: [[a, b], [c, d]]
+   * @param alternative The alternative hypothesis
+   * @return FisherResult containing p-value, odds ratio, and confidence interval
+   * @throws IllegalArgumentException if table is not 2×2 or contains negative values
+   */
+  static FisherResult test(List<List<Integer>> table, Alternative alternative) {
+    test(table, alternative?.label)
   }
 
   /**
@@ -65,6 +92,18 @@ class Fisher {
     calculateFisherTest(a, b, c, d, alternative)
   }
 
+  /**
+   * Performs Fisher's exact test on a Matrix (2×2 contingency table).
+   *
+   * @param table A 2×2 Matrix
+   * @param alternative The alternative hypothesis
+   * @return FisherResult containing p-value, odds ratio, and confidence interval
+   * @throws IllegalArgumentException if table is not 2×2 or contains negative values
+   */
+  static FisherResult test(Matrix table, Alternative alternative) {
+    test(table, alternative?.label)
+  }
+
   private static void validateTable(List<List<Integer>> table) {
     if (table == null || table.size() != 2) {
       throw new IllegalArgumentException("Fisher's exact test requires a 2×2 table (got ${table?.size() ?: 0} rows)")
@@ -82,6 +121,8 @@ class Fisher {
   }
 
   private static FisherResult calculateFisherTest(int a, int b, int c, int d, String alternative) {
+    validateAlternative(alternative)
+
     int n = a + b + c + d
     int rowSum1 = a + b
     int colSum1 = a + c
@@ -98,7 +139,8 @@ class Fisher {
     double pValue = switch (alternative.toLowerCase()) {
       case 'greater' -> dist.upperCumulativeProbability(a)       // P(X >= a)
       case 'less' -> dist.cumulativeProbability(a)               // P(X <= a)
-      default -> calculateTwoSidedPValue(dist, a)                // two-sided
+      case 'two.sided' -> calculateTwoSidedPValue(dist, a)       // two-sided
+      default -> throw new IllegalArgumentException("Alternative must be 'two.sided', 'greater', or 'less', got: ${alternative}")
     }
 
     // Calculate confidence interval for odds ratio (95% by default)
@@ -112,12 +154,24 @@ class Fisher {
     )
   }
 
+  private static void validateAlternative(String alternative) {
+    if (!(alternative in ['two.sided', 'greater', 'less'])) {
+      throw new IllegalArgumentException("Alternative must be 'two.sided', 'greater', or 'less', got: ${alternative}")
+    }
+  }
+
   private static double calculateOddsRatio(int a, int b, int c, int d) {
     if (b == 0 || c == 0) {
       // Avoid division by zero - add 0.5 to all cells (Haldane-Anscombe correction)
       return ((a + 0.5) * (d + 0.5)) / ((b + 0.5) * (c + 0.5))
     }
-    (a * d) / (b * c) as double
+    productRatio(a, d, b, c)
+  }
+
+  private static double productRatio(int numeratorLeft, int numeratorRight, int denominatorLeft, int denominatorRight) {
+    long numerator = (long) numeratorLeft * (long) numeratorRight
+    long denominator = (long) denominatorLeft * (long) denominatorRight
+    (numerator as double) / (denominator as double)
   }
 
   private static double calculateTwoSidedPValue(HypergeometricDistribution dist, int observed) {
@@ -152,7 +206,7 @@ class Fisher {
     }
 
     // Normal approximation for non-zero cells
-    double logOddsRatio = Math.log((a * d) / (b * c) as double)
+    double logOddsRatio = Math.log(productRatio(a, d, b, c))
     double se = Math.sqrt(1.0/a + 1.0/b + 1.0/c + 1.0/d)
     double alpha = 1.0 - confidenceLevel
     double z = getZScore(alpha / 2.0)

--- a/matrix-stats/src/test/groovy/contingency/FisherTest.groovy
+++ b/matrix-stats/src/test/groovy/contingency/FisherTest.groovy
@@ -92,6 +92,26 @@ class FisherTest {
   }
 
   @Test
+  void testUppercaseAlternativesRemainAccepted() {
+    def table = [[12, 5], [9, 11]]
+    def listResult = Fisher.test(table, 'GREATER')
+
+    assertNotNull(listResult)
+    assertEquals('GREATER', listResult.alternative)
+    assertNotNull(listResult.pValue)
+
+    def matrix = Matrix.builder()
+      .matrixName('test')
+      .rows(table)
+      .build()
+    def matrixResult = Fisher.test(matrix, 'TWO.SIDED')
+
+    assertNotNull(matrixResult)
+    assertEquals('TWO.SIDED', matrixResult.alternative)
+    assertNotNull(matrixResult.pValue)
+  }
+
+  @Test
   void testWithZeroCell() {
     // Table with one zero cell
     def table = [[10, 0], [5, 8]]
@@ -199,6 +219,16 @@ class FisherTest {
       Fisher.test(matrix, 'invalid')
     }
     assertEquals("Alternative must be 'two.sided', 'greater', or 'less', got: invalid", matrixException.message)
+
+    IllegalArgumentException listEnumException = assertThrows(IllegalArgumentException) {
+      Fisher.test([[1, 2], [3, 4]], null as Fisher.Alternative)
+    }
+    assertEquals('Alternative must not be null', listEnumException.message)
+
+    IllegalArgumentException matrixEnumException = assertThrows(IllegalArgumentException) {
+      Fisher.test(matrix, null as Fisher.Alternative)
+    }
+    assertEquals('Alternative must not be null', matrixEnumException.message)
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/contingency/FisherTest.groovy
+++ b/matrix-stats/src/test/groovy/contingency/FisherTest.groovy
@@ -220,6 +220,16 @@ class FisherTest {
     }
     assertEquals("Alternative must be 'two.sided', 'greater', or 'less', got: invalid", matrixException.message)
 
+    IllegalArgumentException listNullStringException = assertThrows(IllegalArgumentException) {
+      Fisher.test([[1, 2], [3, 4]], null as String)
+    }
+    assertEquals("Alternative must be 'two.sided', 'greater', or 'less', got: null", listNullStringException.message)
+
+    IllegalArgumentException matrixNullStringException = assertThrows(IllegalArgumentException) {
+      Fisher.test(matrix, null as String)
+    }
+    assertEquals("Alternative must be 'two.sided', 'greater', or 'less', got: null", matrixNullStringException.message)
+
     IllegalArgumentException listEnumException = assertThrows(IllegalArgumentException) {
       Fisher.test([[1, 2], [3, 4]], null as Fisher.Alternative)
     }

--- a/matrix-stats/src/test/groovy/contingency/FisherTest.groovy
+++ b/matrix-stats/src/test/groovy/contingency/FisherTest.groovy
@@ -94,21 +94,21 @@ class FisherTest {
   @Test
   void testUppercaseAlternativesRemainAccepted() {
     def table = [[12, 5], [9, 11]]
+    def expectedListResult = Fisher.test(table, 'greater')
     def listResult = Fisher.test(table, 'GREATER')
 
-    assertNotNull(listResult)
+    assertEquals(expectedListResult.pValue, listResult.pValue)
     assertEquals('GREATER', listResult.alternative)
-    assertNotNull(listResult.pValue)
 
     def matrix = Matrix.builder()
       .matrixName('test')
       .rows(table)
       .build()
+    def expectedMatrixResult = Fisher.test(matrix, 'two.sided')
     def matrixResult = Fisher.test(matrix, 'TWO.SIDED')
 
-    assertNotNull(matrixResult)
+    assertEquals(expectedMatrixResult.pValue, matrixResult.pValue)
     assertEquals('TWO.SIDED', matrixResult.alternative)
-    assertNotNull(matrixResult.pValue)
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/contingency/FisherTest.groovy
+++ b/matrix-stats/src/test/groovy/contingency/FisherTest.groovy
@@ -82,6 +82,16 @@ class FisherTest {
   }
 
   @Test
+  void testAlternativeEnumOverload() {
+    def table = [[12, 5], [9, 11]]
+    def result = Fisher.test(table, Fisher.Alternative.GREATER)
+
+    assertNotNull(result)
+    assertEquals('greater', result.alternative)
+    assertNotNull(result.pValue)
+  }
+
+  @Test
   void testWithZeroCell() {
     // Table with one zero cell
     def table = [[10, 0], [5, 8]]
@@ -174,6 +184,24 @@ class FisherTest {
   }
 
   @Test
+  void testInvalidAlternativesRejected() {
+    IllegalArgumentException listException = assertThrows(IllegalArgumentException) {
+      Fisher.test([[1, 2], [3, 4]], 'invalid')
+    }
+    assertEquals("Alternative must be 'two.sided', 'greater', or 'less', got: invalid", listException.message)
+
+    def matrix = Matrix.builder()
+      .matrixName('test')
+      .rows([[1, 2], [3, 4]])
+      .build()
+
+    IllegalArgumentException matrixException = assertThrows(IllegalArgumentException) {
+      Fisher.test(matrix, 'invalid')
+    }
+    assertEquals("Alternative must be 'two.sided', 'greater', or 'less', got: invalid", matrixException.message)
+  }
+
+  @Test
   void testEvaluateMethod() {
     // Significant result
     def table1 = [[18, 2], [4, 16]]
@@ -242,6 +270,18 @@ class FisherTest {
     assertNotNull(result)
     assertNotNull(result.pValue)
     assertNotNull(result.oddsRatio)
+  }
+
+  @Test
+  void testLargeCountOddsRatioDoesNotOverflow() {
+    def table = [[50_000, 1], [1, 50_000]]
+    def result = Fisher.test(table, 'greater')
+
+    assertNotNull(result)
+    assertEquals(2_500_000_000.0d, result.oddsRatio as double, 0.5d)
+    assertTrue(result.confidenceInterval[0] > 0G)
+    assertTrue(result.confidenceInterval[1] > result.oddsRatio)
+    assertTrue(result.pValue >= 0G && result.pValue <= 1G)
   }
 
   @Test


### PR DESCRIPTION
## Summary

Implements phase 2 of the matrix-stats v2.5.0 follow-up plan.

- Validates Fisher exact test alternatives before p-value calculation and rejects unknown values instead of treating them as two-sided.
- Adds `Fisher.Alternative` typed overloads while keeping the existing string overloads as API boundaries.
- Uses widened product arithmetic for odds-ratio and confidence-interval log-odds calculations so large integer cell counts do not overflow before conversion.
- Adds regression coverage for invalid alternatives, enum overload usage, and large-count odds-ratio calculations.
- Marks phase 2 complete in `matrix-stats/req/v2.5.0-plan.md` with the exact verification commands.

## Root Cause

`Fisher.test(...)` used the default switch branch for every unrecognized alternative, which silently selected the two-sided calculation. Odds-ratio calculations also multiplied `int` cell counts before converting to floating point, so large tables could overflow before the division.

## Validation

- `./gradlew :matrix-stats:codenarcMain`
- `./gradlew :matrix-stats:spotlessCheck`
- `./gradlew :matrix-stats:test --tests 'contingency.FisherTest'`
- `./gradlew :matrix-stats:test`