### PR TITLE
Implement matrix-stats Normalize phase 3

### DIFF
--- a/matrix-stats/release.md
+++ b/matrix-stats/release.md
@@ -147,6 +147,7 @@
 #### DRY Refactoring
 - refactored Normalize.groovy: consolidated 4 functions × 6-7 overloads from 800+ lines to ~350 lines
 - extracted common normalization logic for logNorm, minMaxNorm, meanNorm, stdScaleNorm variants
+- note: logNorm(List) now returns mixed non-numeric lists unchanged, aligning it with minMaxNorm(List), meanNorm(List), and stdScaleNorm(List)
 - simplified Result class getters across Student.groovy
 
 #### Performance & Type Safety

--- a/matrix-stats/req/v2.5.0-plan.md
+++ b/matrix-stats/req/v2.5.0-plan.md
@@ -58,24 +58,24 @@ A task is only complete when its tests have passed and the exact test command ha
 
 ## 3. Normalize Matrix Column Selection and Type Metadata
 
-3.1 [ ] Add tests in `matrix-stats/src/test/groovy/NormalizeTest.groovy` for matrix normalization with:
+3.1 [x] Add tests in `matrix-stats/src/test/groovy/NormalizeTest.groovy` for matrix normalization with:
 - nonnumeric columns whose first value is `null`
 - numeric integer columns transformed to fractional values
 - mixed numeric and categorical columns
 
-3.2 [ ] Change matrix-level `Normalize.logNorm`, `minMaxNorm`, `meanNorm`, and `stdScaleNorm` to apply transformations only to numeric columns. Use declared matrix types and/or non-null values; specifically, stop relying on the `values[0]` string shortcut in `minMaxNorm(List)`, `meanNorm(List)`, and `stdScaleNorm(List)`, and add equivalent declared-type filtering for the `logNorm(Matrix)` path.
+3.2 [x] Change matrix-level `Normalize.logNorm`, `minMaxNorm`, `meanNorm`, and `stdScaleNorm` to apply transformations only to numeric columns. Use declared matrix types and/or non-null values; specifically, stop relying on the `values[0]` string shortcut in `minMaxNorm(List)`, `meanNorm(List)`, and `stdScaleNorm(List)`, and add equivalent declared-type filtering for the `logNorm(Matrix)` path.
 
-3.3 [ ] Preserve nonnumeric columns unchanged, including columns with leading nulls.
+3.3 [x] Preserve nonnumeric columns unchanged, including columns with leading nulls.
 
-3.4 [ ] Update output matrix type metadata for transformed numeric columns. If integer inputs are upgraded to `Float`, `Double`, or `BigDecimal`, the matrix `types()` must reflect the transformed value type.
+3.4 [x] Update output matrix type metadata for transformed numeric columns. If integer inputs are upgraded to `Float`, `Double`, or `BigDecimal`, the matrix `types()` must reflect the transformed value type.
 
-3.5 [ ] Consolidate shared matrix-column normalization logic to avoid duplicating skip/type-update behavior across all four normalization methods.
+3.5 [x] Consolidate shared matrix-column normalization logic to avoid duplicating skip/type-update behavior across all four normalization methods.
 
-3.6 [ ] Run and record verification:
-- `./gradlew :matrix-stats:codenarcMain`
-- `./gradlew :matrix-stats:spotlessCheck`
-- `./gradlew :matrix-stats:test --tests 'NormalizeTest'`
-- `./gradlew :matrix-stats:test`
+3.6 [x] Run and record verification:
+- [x] `./gradlew :matrix-stats:codenarcMain`
+- [x] `./gradlew :matrix-stats:spotlessCheck`
+- [x] `./gradlew :matrix-stats:test --tests 'NormalizeTest'`
+- [x] `./gradlew :matrix-stats:test`
 
 ---
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
@@ -251,6 +251,7 @@ class Normalize {
       return values
     }
 
+    // nulls are excluded from stats but preserved in output via scalar null-handling
     List<Number> numbers = numericValues(values)
     BigDecimal mean = Stat.mean(numbers)
     Number min = numbers.min()
@@ -334,6 +335,7 @@ class Normalize {
       return values
     }
 
+    // nulls are excluded from stats but preserved in output via scalar null-handling
     List<Number> numbers = numericValues(values)
     BigDecimal mean = Stat.mean(numbers)
     BigDecimal stdDev = Stat.sd(numbers)
@@ -390,19 +392,21 @@ class Normalize {
       case MIN_MAX -> minMaxNorm(values, decimals)
       case MEAN -> meanNorm(values, decimals)
       case STD_SCALE -> stdScaleNorm(values, decimals)
-      default -> throw new IllegalArgumentException("Unsupported normalization: $normalization")
     }
   }
 
   private static boolean isNumericColumn(Column col) {
     List nonNullValues = col.findAll { it != null }
+    if (nonNullValues.isEmpty()) {
+      return false
+    }
     if (!nonNullValues.every { it instanceof Number }) {
       return false
     }
     if (col.type != null && Number.isAssignableFrom(col.type)) {
       return true
     }
-    (col.type == null || col.type == Object) && !nonNullValues.isEmpty()
+    col.type == null || col.type == Object
   }
 
   private static boolean containsOnlyNumbers(List values) {
@@ -414,6 +418,8 @@ class Normalize {
     values.findAll { it instanceof Number } as List<Number>
   }
 
+  // Scalar normalization functions preserve per-element type, so the first non-null value reliably
+  // represents the output type for the whole column.
   private static Class transformedType(List values, Class fallbackType) {
     def transformedValue = values.find { it != null }
     transformedValue == null ? fallbackType : transformedValue.class

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
@@ -229,12 +229,17 @@ class Normalize {
       return []
     }
 
-    List<T> list = values.toList()
-    BigDecimal mean = Stat.mean(list)
-    T min = list.min()
-    T max = list.max()
+    List<T> numbers = values.findAll { it != null } as List<T>
+    Class arrayComponentType = values.getClass().getComponentType()
+    if (numbers.isEmpty()) {
+      return values.collect { meanNormNullValue(arrayComponentType) as T }
+    }
+    BigDecimal mean = Stat.mean(numbers)
+    T min = numbers.min()
+    T max = numbers.max()
+    Class nullValueType = numbers.first().class
 
-    values.collect { meanNorm(it, mean, min, max, decimals) }
+    values.collect { it == null ? meanNormNullValue(nullValueType) as T : meanNorm(it, mean, min, max, decimals) }
   }
 
   /**
@@ -248,13 +253,14 @@ class Normalize {
       return values
     }
 
-    // nulls are excluded from stats but preserved in output via scalar null-handling
+    // nulls are excluded from stats and yield NaN/null according to the non-null value type
     List<Number> numbers = numericValues(values)
     BigDecimal mean = Stat.mean(numbers)
     Number min = numbers.min()
     Number max = numbers.max()
+    Class nullValueType = numbers.first().class
 
-    values.collect { meanNorm(it as Number, mean, min, max, decimals) }
+    values.collect { it == null ? meanNormNullValue(nullValueType) : meanNorm(it as Number, mean, min, max, decimals) }
   }
 
   /**
@@ -413,8 +419,16 @@ class Normalize {
   }
 
   private static boolean containsOnlyNumbers(List values) {
-    List nonNullValues = values.findAll { it != null }
-    !nonNullValues.isEmpty() && nonNullValues.every { it instanceof Number }
+    boolean hasNonNullValue = false
+    boolean allValuesAreNumeric = values.every { value ->
+      if (value == null) {
+        true
+      } else {
+        hasNonNullValue = true
+        value instanceof Number
+      }
+    }
+    hasNonNullValue && allValuesAreNumeric
   }
 
   private static List<Number> numericValues(List values) {
@@ -454,6 +468,16 @@ class Normalize {
     }
     // Byte, Short, Integer, Long, Float
     Float.NaN as T
+  }
+
+  private static Number meanNormNullValue(Class sampleType) {
+    if (sampleType == BigDecimal || sampleType == BigInteger) {
+      return null
+    }
+    if (sampleType == Double) {
+      return Double.NaN
+    }
+    Float.NaN
   }
 
   /**

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
@@ -385,19 +385,13 @@ class Normalize {
   }
 
   private static List normalizeList(List values, Normalization normalization, int... decimals) {
-    if (normalization == Normalization.LOG) {
-      return logNorm(values, decimals)
+    switch (normalization) {
+      case LOG -> logNorm(values, decimals)
+      case MIN_MAX -> minMaxNorm(values, decimals)
+      case MEAN -> meanNorm(values, decimals)
+      case STD_SCALE -> stdScaleNorm(values, decimals)
+      default -> throw new IllegalArgumentException("Unsupported normalization: $normalization")
     }
-    if (normalization == Normalization.MIN_MAX) {
-      return minMaxNorm(values, decimals)
-    }
-    if (normalization == Normalization.MEAN) {
-      return meanNorm(values, decimals)
-    }
-    if (normalization == Normalization.STD_SCALE) {
-      return stdScaleNorm(values, decimals)
-    }
-    throw new IllegalArgumentException("Unsupported normalization: $normalization")
   }
 
   private static boolean isNumericColumn(Column col) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
@@ -63,12 +63,10 @@ class Normalize {
    * Apply logarithmic normalization to a list of values.
    */
   static List logNorm(List values, int... decimals) {
-    List result = values.collect { val ->
-      if (val instanceof String) {
-        return val
-      }
-      logNorm(val as Number, decimals)
+    if (!containsOnlyNumbers(values)) {
+      return values
     }
+    List result = values.collect { val -> logNorm(val as Number, decimals) }
     // Force BigDecimal preservation - if any input was BigDecimal, ensure outputs stay BigDecimal
     if (values.any { it instanceof BigDecimal }) {
       result = result.collect { val ->
@@ -103,15 +101,7 @@ class Normalize {
    * Apply logarithmic normalization to all numeric columns in a Matrix.
    */
   static Matrix logNorm(Matrix table, int... decimals) {
-    List<List> columns = []
-    for (Column col in table.columns()) {
-      columns << logNorm(col as List, decimals)
-    }
-    Matrix.builder(table.matrixName)
-        .columnNames(table.columnNames())
-        .columns(columns)
-        .types(table.types())
-        .build()
+    normalizeMatrix(table, Normalization.LOG, decimals)
   }
 
   // ===== MIN-MAX NORMALIZATION =====
@@ -171,12 +161,13 @@ class Normalize {
     if (values.isEmpty()) {
       return []
     }
-    if (values[0] instanceof String) {
-      return values  // Return strings as-is
+    if (!containsOnlyNumbers(values)) {
+      return values
     }
 
-    Number min = values.min() as Number
-    Number max = values.max() as Number
+    List<Number> numbers = numericValues(values)
+    Number min = numbers.min()
+    Number max = numbers.max()
 
     values.collect { minMaxNorm(it as Number, min, max, decimals) }
   }
@@ -192,15 +183,7 @@ class Normalize {
    * Apply min-max normalization to all numeric columns in a Matrix.
    */
   static Matrix minMaxNorm(Matrix table, int... decimals) {
-    List<List> columns = []
-    for (Column col in table.columns()) {
-      columns << minMaxNorm(col as List, decimals)
-    }
-    Matrix.builder(table.matrixName)
-        .columnNames(table.columnNames())
-        .columns(columns)
-        .types(table.types())
-        .build()
+    normalizeMatrix(table, Normalization.MIN_MAX, decimals)
   }
 
   // ===== MEAN NORMALIZATION =====
@@ -264,13 +247,14 @@ class Normalize {
     if (values.isEmpty()) {
       return []
     }
-    if (values[0] instanceof String) {
-      return values  // Return strings as-is
+    if (!containsOnlyNumbers(values)) {
+      return values
     }
 
-    BigDecimal mean = Stat.mean(values)
-    Number min = values.min() as Number
-    Number max = values.max() as Number
+    List<Number> numbers = numericValues(values)
+    BigDecimal mean = Stat.mean(numbers)
+    Number min = numbers.min()
+    Number max = numbers.max()
 
     values.collect { meanNorm(it as Number, mean, min, max, decimals) }
   }
@@ -286,12 +270,7 @@ class Normalize {
    * Apply mean normalization to all numeric columns in a Matrix.
    */
   static Matrix meanNorm(Matrix table, int... decimals) {
-    List<List> columns = table.columns().collect { Column col -> meanNorm(col as List, decimals) }
-    Matrix.builder(table.matrixName)
-        .columnNames(table.columnNames())
-        .columns(columns)
-        .types(table.types())
-        .build()
+    normalizeMatrix(table, Normalization.MEAN, decimals)
   }
 
   // ===== STANDARD DEVIATION NORMALIZATION (Z-SCORE) =====
@@ -351,12 +330,13 @@ class Normalize {
     if (values.isEmpty()) {
       return []
     }
-    if (values[0] instanceof String) {
-      return values  // Return strings as-is
+    if (!containsOnlyNumbers(values)) {
+      return values
     }
 
-    BigDecimal mean = Stat.mean(values)
-    BigDecimal stdDev = Stat.sd(values)
+    List<Number> numbers = numericValues(values)
+    BigDecimal mean = Stat.mean(numbers)
+    BigDecimal stdDev = Stat.sd(numbers)
 
     values.collect { stdScaleNorm(it as Number, mean, stdDev, decimals) }
   }
@@ -372,18 +352,78 @@ class Normalize {
    * Apply standard deviation normalization to all numeric columns in a Matrix.
    */
   static Matrix stdScaleNorm(Matrix table, int... decimals) {
+    normalizeMatrix(table, Normalization.STD_SCALE, decimals)
+  }
+
+  // ===== HELPER METHODS =====
+
+  private enum Normalization {
+    LOG,
+    MIN_MAX,
+    MEAN,
+    STD_SCALE
+  }
+
+  private static Matrix normalizeMatrix(Matrix table, Normalization normalization, int... decimals) {
     List<List> columns = []
+    List<Class> types = []
     for (Column col in table.columns()) {
-      columns << stdScaleNorm(col as List, decimals)
+      if (isNumericColumn(col)) {
+        List normalized = normalizeList(col as List, normalization, decimals)
+        columns << normalized
+        types << transformedType(normalized, col.type)
+      } else {
+        columns << col.collect()
+        types << col.type
+      }
     }
     Matrix.builder(table.matrixName)
         .columnNames(table.columnNames())
         .columns(columns)
-        .types(table.types())
+        .types(types)
         .build()
   }
 
-  // ===== HELPER METHODS =====
+  private static List normalizeList(List values, Normalization normalization, int... decimals) {
+    if (normalization == Normalization.LOG) {
+      return logNorm(values, decimals)
+    }
+    if (normalization == Normalization.MIN_MAX) {
+      return minMaxNorm(values, decimals)
+    }
+    if (normalization == Normalization.MEAN) {
+      return meanNorm(values, decimals)
+    }
+    if (normalization == Normalization.STD_SCALE) {
+      return stdScaleNorm(values, decimals)
+    }
+    throw new IllegalArgumentException("Unsupported normalization: $normalization")
+  }
+
+  private static boolean isNumericColumn(Column col) {
+    List nonNullValues = col.findAll { it != null }
+    if (!nonNullValues.every { it instanceof Number }) {
+      return false
+    }
+    if (col.type != null && Number.isAssignableFrom(col.type)) {
+      return true
+    }
+    (col.type == null || col.type == Object) && !nonNullValues.isEmpty()
+  }
+
+  private static boolean containsOnlyNumbers(List values) {
+    List nonNullValues = values.findAll { it != null }
+    !nonNullValues.isEmpty() && nonNullValues.every { it instanceof Number }
+  }
+
+  private static List<Number> numericValues(List values) {
+    values.findAll { it instanceof Number } as List<Number>
+  }
+
+  private static Class transformedType(List values, Class fallbackType) {
+    def transformedValue = values.find { it != null }
+    transformedValue == null ? fallbackType : transformedValue.class
+  }
 
   /**
    * Returns null/NaN for minMaxNorm: Float.NaN for Byte/Short/Float, Double.NaN for Integer/Long/Double, null for BigInteger/BigDecimal

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
@@ -73,9 +73,6 @@ class Normalize {
         if (val == null) {
           return null
         }
-        if (val instanceof String) {
-          return val
-        }
         if (val instanceof BigInteger) {
           // Convert BigInteger back to BigDecimal (Groovy may have auto-converted)
           return new BigDecimal(val).setScale(decimals.length > 0 ? decimals[0] : 6, RoundingMode.HALF_EVEN)
@@ -392,15 +389,21 @@ class Normalize {
       case MIN_MAX -> minMaxNorm(values, decimals)
       case MEAN -> meanNorm(values, decimals)
       case STD_SCALE -> stdScaleNorm(values, decimals)
+      default -> throw new IllegalArgumentException("Unsupported normalization: $normalization")
     }
   }
 
   private static boolean isNumericColumn(Column col) {
-    List nonNullValues = col.findAll { it != null }
-    if (nonNullValues.isEmpty()) {
-      return false
+    boolean hasNonNullValue = false
+    boolean allValuesAreNumeric = col.every { value ->
+      if (value == null) {
+        true
+      } else {
+        hasNonNullValue = true
+        value instanceof Number
+      }
     }
-    if (!nonNullValues.every { it instanceof Number }) {
+    if (!hasNonNullValue || !allValuesAreNumeric) {
       return false
     }
     if (col.type != null && Number.isAssignableFrom(col.type)) {

--- a/matrix-stats/src/test/groovy/NormalizeTest.groovy
+++ b/matrix-stats/src/test/groovy/NormalizeTest.groovy
@@ -346,8 +346,10 @@ class NormalizeTest {
 
     List meanResult = Normalize.meanNorm(values, 6)
     assertEquals(5, meanResult.size())
-    assertTrue((meanResult[0] as Number).floatValue().isNaN())
-    assertTrue((meanResult[3] as Number).floatValue().isNaN())
+    assertTrue(meanResult[0] instanceof Double)
+    assertTrue((meanResult[0] as Double).isNaN())
+    assertTrue(meanResult[3] instanceof Double)
+    assertTrue((meanResult[3] as Double).isNaN())
     // mean=20, min=10, max=30: (x-20)/(30-10)
     assertEquals(-0.5d, meanResult[1] as Double, 1e-6d)
     assertEquals(0.0d, meanResult[2] as Double, 1e-6d)

--- a/matrix-stats/src/test/groovy/NormalizeTest.groovy
+++ b/matrix-stats/src/test/groovy/NormalizeTest.groovy
@@ -332,6 +332,7 @@ class NormalizeTest {
   void testListNormalizationPreservesNonnumericValuesWithLeadingNulls() {
     List values = [null, 'alpha', 'beta']
 
+    assertIterableEquals(values, Normalize.logNorm(values))
     assertIterableEquals(values, Normalize.minMaxNorm(values))
     assertIterableEquals(values, Normalize.meanNorm(values))
     assertIterableEquals(values, Normalize.stdScaleNorm(values))

--- a/matrix-stats/src/test/groovy/NormalizeTest.groovy
+++ b/matrix-stats/src/test/groovy/NormalizeTest.groovy
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 import se.alipsa.matrix.core.ListConverter
+import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.datasets.Dataset
 import se.alipsa.matrix.stats.Normalize
 
@@ -260,5 +261,79 @@ class NormalizeTest {
     def mtcars = Dataset.mtcars()
     def m = Normalize.stdScaleNorm(mtcars)
     assert mtcars['model'] == m['model']
+  }
+
+  @Test
+  void testMatrixNormalizationPreservesNonnumericColumnsWithLeadingNulls() {
+    Matrix source = Matrix.builder('leadingNullCategory')
+        .columnNames(['category', 'value'])
+        .columns([
+          [null, 'alpha', 'beta'],
+          [1d, 2d, 4d]
+        ])
+        .types([String, Double])
+        .build()
+
+    [Normalize.logNorm(source, 4),
+     Normalize.minMaxNorm(source, 4),
+     Normalize.meanNorm(source, 4),
+     Normalize.stdScaleNorm(source, 4)].each { Matrix normalized ->
+      assertIterableEquals(source['category'], normalized['category'])
+      assertEquals(String, normalized.type('category'))
+      assertEquals(Double, normalized.type('value'))
+    }
+  }
+
+  @Test
+  void testMatrixNormalizationUpdatesIntegerColumnType() {
+    Matrix source = Matrix.builder('integerMetadata')
+        .columnNames(['count', 'category'])
+        .columns([
+          [10, 20, 30],
+          ['low', 'medium', 'high']
+        ])
+        .types([Integer, String])
+        .build()
+
+    Matrix normalized = Normalize.minMaxNorm(source, 2)
+
+    assertIterableEquals([0.0f, 0.5f, 1.0f], normalized['count'])
+    assertEquals(Float, normalized.type('count'))
+    assertIterableEquals(source['category'], normalized['category'])
+    assertEquals(String, normalized.type('category'))
+  }
+
+  @Test
+  void testMatrixNormalizationHandlesMixedNumericAndCategoricalColumns() {
+    Matrix source = Matrix.builder('mixedColumns')
+        .columnNames(['group', 'score', 'amount', 'note'])
+        .columns([
+          ['a', 'b', 'c'],
+          [1, 2, 3],
+          [2.0g, 4.0g, 8.0g],
+          [null, 'keep', 'also keep']
+        ])
+        .types([String, Integer, BigDecimal, String])
+        .build()
+
+    Matrix normalized = Normalize.stdScaleNorm(source, 6)
+
+    assertIterableEquals(source['group'], normalized['group'])
+    assertIterableEquals(source['note'], normalized['note'])
+    assertEquals(String, normalized.type('group'))
+    assertEquals(String, normalized.type('note'))
+    assertEquals(Float, normalized.type('score'))
+    assertEquals(BigDecimal, normalized.type('amount'))
+    assertTrue(normalized['score'].every { it instanceof Float })
+    assertTrue(normalized['amount'].every { it instanceof BigDecimal })
+  }
+
+  @Test
+  void testListNormalizationPreservesNonnumericValuesWithLeadingNulls() {
+    List values = [null, 'alpha', 'beta']
+
+    assertIterableEquals(values, Normalize.minMaxNorm(values))
+    assertIterableEquals(values, Normalize.meanNorm(values))
+    assertIterableEquals(values, Normalize.stdScaleNorm(values))
   }
 }

--- a/matrix-stats/src/test/groovy/NormalizeTest.groovy
+++ b/matrix-stats/src/test/groovy/NormalizeTest.groovy
@@ -220,6 +220,32 @@ class NormalizeTest {
   }
 
   @Test
+  void testMeanNormDoubleArrayWithInterspersedNulls() {
+    Double[] values = [null, 10.0d, 20.0d, null, 30.0d] as Double[]
+
+    List<Double> meanResult = Normalize.meanNorm(values, 6)
+
+    assertEquals(5, meanResult.size())
+    assertTrue(meanResult[0] instanceof Double)
+    assertTrue(meanResult[0].isNaN())
+    assertTrue(meanResult[3] instanceof Double)
+    assertTrue(meanResult[3].isNaN())
+    assertEquals(-0.5d, meanResult[1], 1e-6d)
+    assertEquals(0.0d, meanResult[2], 1e-6d)
+    assertEquals(0.5d, meanResult[4], 1e-6d)
+  }
+
+  @Test
+  void testMeanNormAllNullDoubleArrayUsesComponentType() {
+    Double[] values = [null, null, null] as Double[]
+
+    List<Double> meanResult = Normalize.meanNorm(values, 6)
+
+    assertEquals(3, meanResult.size())
+    assertTrue(meanResult.every { it instanceof Double && it.isNaN() })
+  }
+
+  @Test
   void testMeanNormFloat() {
     assertEquals(-0.150526076f, Normalize.meanNorm(1211f, 6412.428571428572f, 12f, 34567f, 9 ))
 

--- a/matrix-stats/src/test/groovy/NormalizeTest.groovy
+++ b/matrix-stats/src/test/groovy/NormalizeTest.groovy
@@ -337,4 +337,23 @@ class NormalizeTest {
     assertIterableEquals(values, Normalize.meanNorm(values))
     assertIterableEquals(values, Normalize.stdScaleNorm(values))
   }
+
+  @Test
+  void testListMeanAndStdScaleNormWithInterspersedNulls() {
+    // Stats must be computed from non-null values only; nulls must not be treated as zero
+    List values = [null, 10.0d, 20.0d, null, 30.0d]
+
+    List meanResult = Normalize.meanNorm(values, 6)
+    assertEquals(5, meanResult.size())
+    // mean=20, min=10, max=30: (x-20)/(30-10)
+    assertEquals(-0.5d, meanResult[1] as Double, 1e-6d)
+    assertEquals(0.0d, meanResult[2] as Double, 1e-6d)
+    assertEquals(0.5d, meanResult[4] as Double, 1e-6d)
+
+    List stdResult = Normalize.stdScaleNorm(values, 6)
+    assertEquals(5, stdResult.size())
+    assertTrue(stdResult[1] instanceof Number)
+    assertTrue(stdResult[2] instanceof Number)
+    assertTrue(stdResult[4] instanceof Number)
+  }
 }

--- a/matrix-stats/src/test/groovy/NormalizeTest.groovy
+++ b/matrix-stats/src/test/groovy/NormalizeTest.groovy
@@ -1,5 +1,6 @@
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertIterableEquals
+import static org.junit.jupiter.api.Assertions.assertNull
 import static org.junit.jupiter.api.Assertions.assertTrue
 
 import org.junit.jupiter.api.Test
@@ -345,6 +346,8 @@ class NormalizeTest {
 
     List meanResult = Normalize.meanNorm(values, 6)
     assertEquals(5, meanResult.size())
+    assertTrue((meanResult[0] as Number).floatValue().isNaN())
+    assertTrue((meanResult[3] as Number).floatValue().isNaN())
     // mean=20, min=10, max=30: (x-20)/(30-10)
     assertEquals(-0.5d, meanResult[1] as Double, 1e-6d)
     assertEquals(0.0d, meanResult[2] as Double, 1e-6d)
@@ -352,8 +355,10 @@ class NormalizeTest {
 
     List stdResult = Normalize.stdScaleNorm(values, 6)
     assertEquals(5, stdResult.size())
-    assertTrue(stdResult[1] instanceof Number)
-    assertTrue(stdResult[2] instanceof Number)
-    assertTrue(stdResult[4] instanceof Number)
+    assertNull(stdResult[0])
+    assertNull(stdResult[3])
+    assertEquals(-1.0d, stdResult[1] as Double, 1e-6d)
+    assertEquals(0.0d, stdResult[2] as Double, 1e-6d)
+    assertEquals(1.0d, stdResult[4] as Double, 1e-6d)
   }
 }


### PR DESCRIPTION
## Summary
- Normalize matrix-level column handling now skips nonnumeric columns based on declared type and non-null values.
- Preserve categorical columns with leading nulls unchanged.
- Update transformed numeric column metadata from the normalized result type.
- Add regression coverage for leading-null categorical columns, integer-to-fraction type updates, mixed numeric/categorical matrices, and list normalization with leading null nonnumeric values.

## Modules touched
- matrix-stats

## Tests
- `./gradlew :matrix-stats:codenarcMain`
- `./gradlew :matrix-stats:spotlessCheck`
- `./gradlew :matrix-stats:test --tests 'NormalizeTest'`
- `./gradlew :matrix-stats:test`