### PR TITLE
[codex] Validate linear regression inputs

### DIFF
--- a/matrix-stats/req/v2.5.0-plan.md
+++ b/matrix-stats/req/v2.5.0-plan.md
@@ -81,21 +81,22 @@ A task is only complete when its tests have passed and the exact test command ha
 
 ## 4. LinearRegression Input Validation
 
-4.1 [ ] Add tests in `matrix-stats/src/test/groovy/LinearRegressionTest.groovy` for empty inputs, mismatched inputs, two-observation exact fits, constant `x`, and zero-variance `y` if the behavior needs to be defined.
+4.1 [x] Add tests in `matrix-stats/src/test/groovy/LinearRegressionTest.groovy` for empty inputs, mismatched inputs, two-observation exact fits, constant `x`, and zero-variance `y` if the behavior needs to be defined.
 
-4.2 [ ] Reject empty input and require enough observations before standard-error calculations. If exact two-point fits should be supported, document and test how `r2`, residual variance, and standard errors behave; otherwise require at least three observations.
+4.2 [x] Reject empty input and require enough observations before standard-error calculations. If exact two-point fits should be supported, document and test how `r2`, residual variance, and standard errors behave; otherwise require at least three observations.
 
-4.3 [ ] Reject constant predictors before calculating the slope denominator.
+4.3 [x] Reject constant predictors before calculating the slope denominator.
 
-4.4 [ ] Return descriptive `IllegalArgumentException` messages for invalid input instead of leaking `ArithmeticException: Division undefined`.
+4.4 [x] Return descriptive `IllegalArgumentException` messages for invalid input instead of leaking `ArithmeticException: Division undefined`.
 
-4.5 [ ] Ensure `LinearRegression(Matrix, String, String)` reports invalid or nonnumeric columns clearly.
+4.5 [x] Ensure `LinearRegression(Matrix, String, String)` reports invalid or nonnumeric columns clearly.
 
-4.6 [ ] Run and record verification:
-- `./gradlew :matrix-stats:codenarcMain`
-- `./gradlew :matrix-stats:spotlessCheck`
-- `./gradlew :matrix-stats:test --tests 'LinearRegressionTest'`
-- `./gradlew :matrix-stats:test`
+4.6 [x] Run and record verification:
+- [x] `./gradlew :matrix-stats:codenarcMain`
+- [x] `./gradlew :matrix-stats:spotlessCheck`
+- [x] `./gradlew :matrix-stats:test --tests 'LinearRegressionTest'`
+- [x] `./gradlew :matrix-stats:test`
+- [x] `./gradlew test` (additional full regression verification)
 
 ---
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
@@ -234,8 +234,10 @@ Multiple R-squared: ${getRsquared(3)}
   }
 
   private static RegressionData listData(List<? extends Number> x, List<? extends Number> y) {
-    validateShape(x, y)
-    new RegressionData(numericValues(x, 'x'), numericValues(y, 'y'))
+    new RegressionData(
+      x == null ? null : numericValues(x, 'x'),
+      y == null ? null : numericValues(y, 'y')
+    )
   }
 
   private static RegressionData matrixData(Matrix table, String xColumn, String yColumn) {
@@ -264,8 +266,9 @@ Multiple R-squared: ${getRsquared(3)}
   }
 
   private static List<BigDecimal> columnValues(Matrix table, String columnName) {
+    List column = table.column(columnName)
     (0 ..< table.rowCount()).collect { int row ->
-      NumericConversion.toBigDecimal(table.column(columnName)[row], "matrix value at row ${row}, column '${columnName}'")
+      NumericConversion.toBigDecimal(column[row], "matrix value at row ${row}, column '${columnName}'")
     } as List<BigDecimal>
   }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
@@ -2,6 +2,7 @@ package se.alipsa.matrix.stats.regression
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Stat
+import se.alipsa.matrix.stats.util.NumericConversion
 
 import java.math.MathContext
 import java.math.RoundingMode
@@ -35,27 +36,44 @@ class LinearRegression {
   String x = 'X'
   String y = 'Y'
 
+  /**
+   * Fits a simple linear regression from two numeric matrix columns.
+   *
+   * @param table the source matrix
+   * @param x the predictor column name
+   * @param y the response column name
+   * @throws IllegalArgumentException if the columns are missing, nonnumeric, or not estimable
+   */
   LinearRegression(Matrix table, String x, String y) {
-    this(table[x] as List<? extends Number>, table[y] as List<? extends Number>)
+    this(columnValues(table, x), columnValues(table, y))
     this.x = x
     this.y = y
   }
 
+  /**
+   * Fits a simple linear regression from predictor and response values.
+   *
+   * @param x the predictor values
+   * @param y the response values
+   * @throws IllegalArgumentException if the inputs are invalid or not estimable
+   */
   LinearRegression(List<? extends Number> x, List<? extends Number> y) {
-    if (x.size() != y.size()) {
-      throw new IllegalArgumentException('Must have equal number of X and Y data points for a linear regression')
-    }
+    validateShape(x, y)
 
-    Integer numberOfDataValues = x.size()
+    List<BigDecimal> xValues = numericValues(x, 'x')
+    List<BigDecimal> yValues = numericValues(y, 'y')
+    validateVariation(xValues)
 
-    List<? extends Number> xSquared = x.collect {it * it }
+    Integer numberOfDataValues = xValues.size()
+
+    List<BigDecimal> xSquared = xValues.collect { BigDecimal value -> value * value }
 
     List<BigDecimal> xMultipliedByY = (0 ..< numberOfDataValues).collect {
-      i -> (x.get(i) * y.get(i)) as BigDecimal
+      i -> xValues[i] * yValues[i]
     }
 
-    BigDecimal xSummed = Stat.sum(x)
-    BigDecimal ySummed = Stat.sum(y)
+    BigDecimal xSummed = Stat.sum(xValues) as BigDecimal
+    BigDecimal ySummed = Stat.sum(yValues) as BigDecimal
     BigDecimal sumOfXSquared = Stat.sum(xSquared)
     BigDecimal sumOfXMultipliedByY = Stat.sum(xMultipliedByY)
 
@@ -74,15 +92,15 @@ class LinearRegression {
     BigDecimal rss = 0.0     // residual sum of squares
     BigDecimal ssr = 0.0     // regression sum of squares
     for (int i = 0; i < numberOfDataValues; i++) {
-      xxbar += (x[i] - xBar) ** 2
-      yybar += (y[i] - yBar) ** 2
-      xybar += (x[i] - xBar) * (y[i] - yBar)
-      BigDecimal fit = predict(x[i])
-      rss += (fit - y[i]) ** 2
+      xxbar += (xValues[i] - xBar) ** 2
+      yybar += (yValues[i] - yBar) ** 2
+      xybar += (xValues[i] - xBar) * (yValues[i] - yBar)
+      BigDecimal fit = predict(xValues[i])
+      rss += (fit - yValues[i]) ** 2
       ssr += (fit - yBar) ** 2
     }
     int degreesOfFreedom = numberOfDataValues - 2
-    r2 = ssr / yybar
+    r2 = yybar == 0 ? 1.0G : ssr / yybar
     BigDecimal svar  = rss / degreesOfFreedom
     BigDecimal slopeVar = svar / xxbar
     slopeStdErr = slopeVar.sqrt(MathContext.DECIMAL128)
@@ -210,5 +228,36 @@ ${coefficients.content()}
 
 Multiple R-squared: ${getRsquared(3)}
 """.stripIndent()
+  }
+
+  private static List<BigDecimal> columnValues(Matrix table, String columnName) {
+    NumericConversion.toBigDecimalColumn(table, columnName)
+  }
+
+  private static void validateShape(List<? extends Number> x, List<? extends Number> y) {
+    if (x == null || y == null) {
+      throw new IllegalArgumentException('X and Y data points cannot be null')
+    }
+    if (x.size() != y.size()) {
+      throw new IllegalArgumentException('Must have equal number of X and Y data points for a linear regression')
+    }
+    if (x.size() < 3) {
+      throw new IllegalArgumentException(
+        "Linear regression requires at least three observations, got ${x.size()}"
+      )
+    }
+  }
+
+  private static List<BigDecimal> numericValues(List<?> values, String label) {
+    values.withIndex().collect { Object value, int index ->
+      NumericConversion.toBigDecimal(value, "${label} value at index ${index}")
+    } as List<BigDecimal>
+  }
+
+  private static void validateVariation(List<BigDecimal> xValues) {
+    BigDecimal first = xValues[0]
+    if (xValues.every { BigDecimal value -> value == first }) {
+      throw new IllegalArgumentException('Linear regression requires at least two distinct X values')
+    }
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
@@ -234,10 +234,10 @@ Multiple R-squared: ${getRsquared(3)}
   }
 
   private static RegressionData listData(List<? extends Number> x, List<? extends Number> y) {
-    new RegressionData(
-      x == null ? null : numericValues(x, 'x'),
-      y == null ? null : numericValues(y, 'y')
-    )
+    if (x == null || y == null) {
+      return new RegressionData(null, null)
+    }
+    new RegressionData(numericValues(x, 'x'), numericValues(y, 'y'))
   }
 
   private static RegressionData matrixData(Matrix table, String xColumn, String yColumn) {

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
@@ -45,7 +45,7 @@ class LinearRegression {
    * @throws IllegalArgumentException if the columns are missing, nonnumeric, or not estimable
    */
   LinearRegression(Matrix table, String x, String y) {
-    this(columnValues(table, x), columnValues(table, y))
+    this(matrixData(table, x, y))
     this.x = x
     this.y = y
   }
@@ -58,10 +58,13 @@ class LinearRegression {
    * @throws IllegalArgumentException if the inputs are invalid or not estimable
    */
   LinearRegression(List<? extends Number> x, List<? extends Number> y) {
-    validateShape(x, y)
+    this(listData(x, y))
+  }
 
-    List<BigDecimal> xValues = numericValues(x, 'x')
-    List<BigDecimal> yValues = numericValues(y, 'y')
+  private LinearRegression(RegressionData data) {
+    validateShape(data.xValues, data.yValues)
+    List<BigDecimal> xValues = data.xValues
+    List<BigDecimal> yValues = data.yValues
     validateVariation(xValues)
 
     Integer numberOfDataValues = xValues.size()
@@ -230,8 +233,40 @@ Multiple R-squared: ${getRsquared(3)}
 """.stripIndent()
   }
 
+  private static RegressionData listData(List<? extends Number> x, List<? extends Number> y) {
+    validateShape(x, y)
+    new RegressionData(numericValues(x, 'x'), numericValues(y, 'y'))
+  }
+
+  private static RegressionData matrixData(Matrix table, String xColumn, String yColumn) {
+    validateMatrixColumns(table, xColumn, yColumn)
+    new RegressionData(
+      columnValues(table, xColumn),
+      columnValues(table, yColumn)
+    )
+  }
+
+  private static void validateMatrixColumns(Matrix table, String xColumn, String yColumn) {
+    if (table == null) {
+      throw new IllegalArgumentException('Matrix cannot be null')
+    }
+    validateMatrixColumn(table, xColumn)
+    validateMatrixColumn(table, yColumn)
+  }
+
+  private static void validateMatrixColumn(Matrix table, String columnName) {
+    if (columnName == null) {
+      throw new IllegalArgumentException('Column name cannot be null')
+    }
+    if (!table.columnNames().contains(columnName)) {
+      throw new IllegalArgumentException("Matrix does not contain column '${columnName}'")
+    }
+  }
+
   private static List<BigDecimal> columnValues(Matrix table, String columnName) {
-    NumericConversion.toBigDecimalColumn(table, columnName)
+    (0 ..< table.rowCount()).collect { int row ->
+      NumericConversion.toBigDecimal(table.column(columnName)[row], "matrix value at row ${row}, column '${columnName}'")
+    } as List<BigDecimal>
   }
 
   private static void validateShape(List<? extends Number> x, List<? extends Number> y) {
@@ -258,6 +293,16 @@ Multiple R-squared: ${getRsquared(3)}
     BigDecimal first = xValues[0]
     if (xValues.every { BigDecimal value -> value == first }) {
       throw new IllegalArgumentException('Linear regression requires at least two distinct X values')
+    }
+  }
+
+  private static class RegressionData {
+    final List<BigDecimal> xValues
+    final List<BigDecimal> yValues
+
+    RegressionData(List<BigDecimal> xValues, List<BigDecimal> yValues) {
+      this.xValues = xValues
+      this.yValues = yValues
     }
   }
 }

--- a/matrix-stats/src/test/groovy/LinearRegressionTest.groovy
+++ b/matrix-stats/src/test/groovy/LinearRegressionTest.groovy
@@ -95,6 +95,15 @@ class LinearRegressionTest {
   }
 
   @Test
+  void testRejectsNullInputsBeforeConvertingOtherValues() {
+    def exception = assertThrows(IllegalArgumentException) {
+      new LinearRegression(null, ['a', 'b', 'c'])
+    }
+
+    assertEquals('X and Y data points cannot be null', exception.message)
+  }
+
+  @Test
   void testRejectsMismatchedInputs() {
     def exception = assertThrows(IllegalArgumentException) {
       new LinearRegression([1, 2, 3], [1, 2])

--- a/matrix-stats/src/test/groovy/LinearRegressionTest.groovy
+++ b/matrix-stats/src/test/groovy/LinearRegressionTest.groovy
@@ -75,4 +75,79 @@ class LinearRegressionTest {
     assertEquals(23.58083123, model.predict(13, 8))
     assertEquals(model.predict([-1, 15])[0], model.predict(-1))
   }
+
+  @Test
+  void testRejectsEmptyInputs() {
+    def exception = assertThrows(IllegalArgumentException) {
+      new LinearRegression([], [])
+    }
+
+    assertEquals('Linear regression requires at least three observations, got 0', exception.message)
+  }
+
+  @Test
+  void testRejectsMismatchedInputs() {
+    def exception = assertThrows(IllegalArgumentException) {
+      new LinearRegression([1, 2, 3], [1, 2])
+    }
+
+    assertEquals('Must have equal number of X and Y data points for a linear regression', exception.message)
+  }
+
+  @Test
+  void testRejectsTwoObservationExactFit() {
+    def exception = assertThrows(IllegalArgumentException) {
+      new LinearRegression([1, 2], [2, 4])
+    }
+
+    assertEquals('Linear regression requires at least three observations, got 2', exception.message)
+  }
+
+  @Test
+  void testRejectsConstantPredictor() {
+    def exception = assertThrows(IllegalArgumentException) {
+      new LinearRegression([2, 2, 2], [1, 2, 3])
+    }
+
+    assertEquals('Linear regression requires at least two distinct X values', exception.message)
+  }
+
+  @Test
+  void testSupportsZeroVarianceResponse() {
+    def model = new LinearRegression([1, 2, 3], [5, 5, 5])
+
+    assertEquals(0.0, model.slope as double, 1e-12)
+    assertEquals(5.0, model.intercept as double, 1e-12)
+    assertEquals(1.0, model.r2 as double, 1e-12)
+    assertEquals(0.0, model.slopeStdErr as double, 1e-12)
+    assertEquals(0.0, model.interceptStdErr as double, 1e-12)
+  }
+
+  @Test
+  void testRejectsMissingMatrixColumnClearly() {
+    def table = Matrix.builder().data(
+      x: [1, 2, 3],
+      y: [2, 4, 6]
+    ).build()
+
+    def exception = assertThrows(IllegalArgumentException) {
+      new LinearRegression(table, 'missing', 'y')
+    }
+
+    assertEquals("Matrix does not contain column 'missing'", exception.message)
+  }
+
+  @Test
+  void testRejectsNonnumericMatrixColumnClearly() {
+    def table = Matrix.builder().data(
+      x: [1, 2, 3],
+      y: ['a', 'b', 'c']
+    ).build()
+
+    def exception = assertThrows(IllegalArgumentException) {
+      new LinearRegression(table, 'x', 'y')
+    }
+
+    assertEquals("Matrix value at row 0, column 'y' must be numeric", exception.message)
+  }
 }

--- a/matrix-stats/src/test/groovy/LinearRegressionTest.groovy
+++ b/matrix-stats/src/test/groovy/LinearRegressionTest.groovy
@@ -86,6 +86,15 @@ class LinearRegressionTest {
   }
 
   @Test
+  void testRejectsNullInputs() {
+    def exception = assertThrows(IllegalArgumentException) {
+      new LinearRegression(null, [1, 2, 3])
+    }
+
+    assertEquals('X and Y data points cannot be null', exception.message)
+  }
+
+  @Test
   void testRejectsMismatchedInputs() {
     def exception = assertThrows(IllegalArgumentException) {
       new LinearRegression([1, 2, 3], [1, 2])
@@ -135,6 +144,21 @@ class LinearRegressionTest {
     }
 
     assertEquals("Matrix does not contain column 'missing'", exception.message)
+  }
+
+  @Test
+  void testRejectsEmptyMatrixWithObservationCountMessage() {
+    def table = Matrix.builder()
+      .columnNames('x', 'y')
+      .columns([[], []])
+      .types(BigDecimal, BigDecimal)
+      .build()
+
+    def exception = assertThrows(IllegalArgumentException) {
+      new LinearRegression(table, 'x', 'y')
+    }
+
+    assertEquals('Linear regression requires at least three observations, got 0', exception.message)
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Validate `LinearRegression` list and matrix inputs before coefficient and standard-error calculations.
- Reject empty, under-sized, mismatched, nonnumeric, and constant-predictor inputs with descriptive `IllegalArgumentException` messages.
- Define the constant-response exact fit case as `r2 = 1` and add focused regression coverage.
- Mark phase 4 complete in `matrix-stats/req/v2.5.0-plan.md`.

## Modules touched

- `matrix-stats`

## Verification

- `./gradlew :matrix-stats:codenarcMain`
- `./gradlew :matrix-stats:spotlessCheck`
- `./gradlew :matrix-stats:test --tests 'LinearRegressionTest'`
- `./gradlew :matrix-stats:test`
- `./gradlew test`