### PR TITLE
[codex] Add FitResult value accessors

### DIFF
--- a/matrix-stats/README.md
+++ b/matrix-stats/README.md
@@ -248,6 +248,7 @@ def frame = ModelFrame.of('y ~ x + group', data)
 
 def lm = FitRegistry.instance().get('lm').fit(frame)
 assert lm.fittedValues.length == data.rowCount()
+assert lm.fittedList.size() == data.rowCount()
 ```
 
 Supported fit methods through `FitRegistry`:

--- a/matrix-stats/req/v2.5.0-plan.md
+++ b/matrix-stats/req/v2.5.0-plan.md
@@ -102,21 +102,22 @@ A task is only complete when its tests have passed and the exact test command ha
 
 ## 5. FitResult Usability and Defensive Access
 
-5.1 [ ] Add tests in `matrix-stats/src/test/groovy/regression/FitDslTest.groovy` or a dedicated `FitResultTest.groovy` for BigDecimal/list convenience accessors, and keep coverage that confirms the existing constructor-side array cloning remains intact.
+5.1 [x] Add tests in `matrix-stats/src/test/groovy/regression/FitDslTest.groovy` or a dedicated `FitResultTest.groovy` for BigDecimal/list convenience accessors, and keep coverage that confirms the existing constructor-side array cloning remains intact.
 
-5.2 [ ] Add list/BigDecimal accessors consistent with `MultipleLinearRegression`; do not frame this as adding defensive getters, because `FitResult` already clones `coefficients`, `standardErrors`, `fittedValues`, and `residuals` in its constructor.
+5.2 [x] Add list/BigDecimal accessors consistent with `MultipleLinearRegression`; do not frame this as adding defensive getters, because `FitResult` already clones `coefficients`, `standardErrors`, `fittedValues`, and `residuals` in its constructor.
 
-5.3 [ ] Add getters named `getCoefficientList()`, `getStandardErrorList()`, `getFittedList()`, and `getResidualList()` returning immutable `List<BigDecimal>` values, plus `getRSquaredValue()` for a `BigDecimal` `rSquared` accessor.
+5.3 [x] Add getters named `getCoefficientList()`, `getStandardErrorList()`, `getFittedList()`, and `getResidualList()` returning immutable `List<BigDecimal>` values, plus `getRSquaredValue()` for a `BigDecimal` `rSquared` accessor.
 
-5.4 [ ] Ensure local methods such as loess still represent missing coefficient vectors clearly with empty immutable lists/arrays.
+5.4 [x] Ensure local methods such as loess still represent missing coefficient vectors clearly with empty immutable lists/arrays.
 
-5.5 [ ] Update README or GroovyDoc examples if public result access changes.
+5.5 [x] Update README or GroovyDoc examples if public result access changes.
 
-5.6 [ ] Run and record verification:
-- `./gradlew :matrix-stats:codenarcMain`
-- `./gradlew :matrix-stats:spotlessCheck`
-- `./gradlew :matrix-stats:test --tests 'regression.*Fit*'`
-- `./gradlew :matrix-stats:test`
+5.6 [x] Run and record verification:
+- [x] `./gradlew :matrix-stats:codenarcMain`
+- [x] `./gradlew :matrix-stats:spotlessCheck`
+- [x] `./gradlew :matrix-stats:test --tests 'regression.*Fit*'`
+- [x] `./gradlew :matrix-stats:test`
+- [x] `./gradlew test` (additional full regression verification)
 
 ---
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitResult.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitResult.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.stats.regression
 
+import se.alipsa.matrix.stats.util.NumericConversion
+
 /**
  * Immutable result of a model fit, containing coefficients, diagnostics, and fitted values.
  *
@@ -40,5 +42,50 @@ final class FitResult {
     this.residuals = residuals.clone()
     this.rSquared = rSquared
     this.predictorNames = List.copyOf(predictorNames)
+  }
+
+  /**
+   * Returns the fitted coefficients as immutable {@code BigDecimal} values.
+   *
+   * @return the coefficient values, or an empty immutable list for local methods without global coefficients
+   */
+  List<BigDecimal> getCoefficientList() {
+    NumericConversion.toBigDecimalList(coefficients, 'coefficients')
+  }
+
+  /**
+   * Returns the coefficient standard errors as immutable {@code BigDecimal} values.
+   *
+   * @return the standard-error values, or an empty immutable list when standard errors are not available
+   */
+  List<BigDecimal> getStandardErrorList() {
+    NumericConversion.toBigDecimalList(standardErrors, 'standardErrors')
+  }
+
+  /**
+   * Returns the fitted values as immutable {@code BigDecimal} values.
+   *
+   * @return the fitted values
+   */
+  List<BigDecimal> getFittedList() {
+    NumericConversion.toBigDecimalList(fittedValues, 'fittedValues')
+  }
+
+  /**
+   * Returns the residuals as immutable {@code BigDecimal} values.
+   *
+   * @return the residual values
+   */
+  List<BigDecimal> getResidualList() {
+    NumericConversion.toBigDecimalList(residuals, 'residuals')
+  }
+
+  /**
+   * Returns the coefficient of determination as a {@code BigDecimal}.
+   *
+   * @return the R-squared value
+   */
+  BigDecimal getRSquaredValue() {
+    BigDecimal.valueOf(rSquared)
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitResult.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/FitResult.groovy
@@ -86,6 +86,6 @@ final class FitResult {
    * @return the R-squared value
    */
   BigDecimal getRSquaredValue() {
-    BigDecimal.valueOf(rSquared)
+    NumericConversion.toBigDecimal(rSquared, 'rSquared')
   }
 }

--- a/matrix-stats/src/test/groovy/regression/FitResultTest.groovy
+++ b/matrix-stats/src/test/groovy/regression/FitResultTest.groovy
@@ -107,4 +107,21 @@ class FitResultTest {
       result.coefficientList.add(1.0G)
     }
   }
+
+  @Test
+  void testRSquaredValueRejectsNonFiniteValues() {
+    FitResult result = new FitResult(
+      [] as double[],
+      [] as double[],
+      [] as double[],
+      [] as double[],
+      Double.NaN,
+      []
+    )
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      result.RSquaredValue
+    }
+    assertTrue(exception.message.contains('must be finite'))
+  }
 }

--- a/matrix-stats/src/test/groovy/regression/FitResultTest.groovy
+++ b/matrix-stats/src/test/groovy/regression/FitResultTest.groovy
@@ -1,0 +1,110 @@
+package regression
+
+import static org.junit.jupiter.api.Assertions.*
+
+import groovy.transform.CompileStatic
+
+import org.junit.jupiter.api.Test
+
+import se.alipsa.matrix.stats.regression.FitResult
+
+/**
+ * Tests for fit result value accessors.
+ */
+@CompileStatic
+class FitResultTest {
+
+  @Test
+  void testBigDecimalListAccessors() {
+    FitResult result = new FitResult(
+      [1.5d, 2.0d] as double[],
+      [0.1d, 0.2d] as double[],
+      [3.5d, 5.5d] as double[],
+      [0.5d, -0.5d] as double[],
+      0.95d,
+      ['(Intercept)', 'x']
+    )
+
+    assertEquals([1.5G, 2.0G], result.coefficientList)
+    assertEquals([0.1G, 0.2G], result.standardErrorList)
+    assertEquals([3.5G, 5.5G], result.fittedList)
+    assertEquals([0.5G, -0.5G], result.residualList)
+    assertEquals(0.95G, result.RSquaredValue)
+  }
+
+  @Test
+  void testListAccessorsAreImmutable() {
+    FitResult result = new FitResult(
+      [1.5d] as double[],
+      [0.1d] as double[],
+      [3.5d] as double[],
+      [0.5d] as double[],
+      0.95d,
+      ['(Intercept)']
+    )
+
+    assertThrows(UnsupportedOperationException) {
+      result.coefficientList.add(9.0G)
+    }
+    assertThrows(UnsupportedOperationException) {
+      result.standardErrorList.add(9.0G)
+    }
+    assertThrows(UnsupportedOperationException) {
+      result.fittedList.add(9.0G)
+    }
+    assertThrows(UnsupportedOperationException) {
+      result.residualList.add(9.0G)
+    }
+  }
+
+  @Test
+  void testConstructorClonesArrayInputs() {
+    double[] coefficients = [1.5d, 2.0d] as double[]
+    double[] standardErrors = [0.1d, 0.2d] as double[]
+    double[] fittedValues = [3.5d, 5.5d] as double[]
+    double[] residuals = [0.5d, -0.5d] as double[]
+
+    FitResult result = new FitResult(
+      coefficients,
+      standardErrors,
+      fittedValues,
+      residuals,
+      0.95d,
+      ['(Intercept)', 'x']
+    )
+
+    coefficients[0] = 999.0d
+    standardErrors[0] = 999.0d
+    fittedValues[0] = 999.0d
+    residuals[0] = 999.0d
+
+    assertEquals(1.5d, result.coefficients[0], 1e-10d)
+    assertEquals(0.1d, result.standardErrors[0], 1e-10d)
+    assertEquals(3.5d, result.fittedValues[0], 1e-10d)
+    assertEquals(0.5d, result.residuals[0], 1e-10d)
+    assertEquals(1.5G, result.coefficientList[0])
+    assertEquals(0.1G, result.standardErrorList[0])
+    assertEquals(3.5G, result.fittedList[0])
+    assertEquals(0.5G, result.residualList[0])
+  }
+
+  @Test
+  void testEmptyCoefficientVectorsReturnEmptyImmutableLists() {
+    FitResult result = new FitResult(
+      [] as double[],
+      [] as double[],
+      [1.0d, 2.0d] as double[],
+      [0.0d, 0.0d] as double[],
+      1.0d,
+      []
+    )
+
+    assertTrue(result.coefficientList.isEmpty())
+    assertTrue(result.standardErrorList.isEmpty())
+    assertEquals([1.0G, 2.0G], result.fittedList)
+    assertEquals([0.0G, 0.0G], result.residualList)
+    assertThrows(UnsupportedOperationException) {
+      result.coefficientList.add(1.0G)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add immutable BigDecimal list accessors to `FitResult` for coefficients, standard errors, fitted values, and residuals.
- Add `RSquaredValue` for BigDecimal-oriented result access.
- Cover the new accessors, immutable list behavior, constructor-side array cloning, and empty local-method coefficient vectors in `FitResultTest`.
- Update the README fit example and mark phase 5 complete in `matrix-stats/req/v2.5.0-plan.md`.

## Modules touched

- `matrix-stats`

## Verification

- `./gradlew :matrix-stats:codenarcMain`
- `./gradlew :matrix-stats:spotlessCheck`
- `./gradlew :matrix-stats:test --tests 'regression.*Fit*'`
- `./gradlew :matrix-stats:test`
- `./gradlew test`