### PR TITLE
Close out matrix-stats v2.5.0 plan

### DIFF
--- a/matrix-stats/release.md
+++ b/matrix-stats/release.md
@@ -1,5 +1,26 @@
 # Matrix stats release history
 
+## v2.5.0, unreleased
+**Review follow-up fixes and typed result API cleanup**
+
+### Bug Fixes and Robustness
+- Fix `LinearProgramSolver` infeasible equality-form handling so contradictory constraints throw `IllegalStateException('Linear program is infeasible')` instead of leaking pivot-table errors.
+- Validate `Fisher.test(...)` alternatives and reject unsupported values instead of silently treating them as two-sided tests.
+- Avoid integer overflow in Fisher odds-ratio and confidence-interval arithmetic for large contingency tables.
+- Make matrix-level normalization consistently select numeric columns by declared/non-null numeric content, preserve nonnumeric columns, and update transformed numeric column metadata.
+- Harden `LinearRegression` input validation for empty, mismatched, underdetermined, and constant-predictor inputs with clearer `IllegalArgumentException` messages.
+- Correct Brent-Dekker interpolation acceptance in `BrentSolver` so secant and inverse quadratic steps use consistent sign normalization and the standard `2 * p` acceptance bound.
+
+### API Additions and Usability
+- Add BigDecimal/list convenience accessors to `FitResult`, including coefficient, standard-error, fitted-value, residual, and `rSquared` accessors.
+- Add typed `GoalSeek.Result` values with BigDecimal accessors for computed value, result, and difference.
+- Preserve explicit `GoalSeek.Result as Map` compatibility for callers migrating from the previous map-shaped result.
+- Add Groovy-facing `Number` overloads for `GoalSeek` target, bracket, threshold, and max-iteration arguments.
+
+### Tests and Documentation
+- Add focused regression coverage for solver infeasibility, Fisher validation and large-count arithmetic, normalization column selection, linear-regression validation, FitResult accessors, GoalSeek typed result behavior, and Brent/GoalSeek iteration behavior.
+- Refresh solver README examples and GroovyDoc for typed GoalSeek result usage and iteration semantics.
+
 ## v2.4.0, 2026-04-23
 **Native runtime cleanup and idiomatic Groovy API expansion**
 

--- a/matrix-stats/release.md
+++ b/matrix-stats/release.md
@@ -13,9 +13,10 @@
 
 ### API Additions and Usability
 - Add BigDecimal/list convenience accessors to `FitResult`, including coefficient, standard-error, fitted-value, residual, and `rSquared` accessors.
-- Add typed `GoalSeek.Result` values with BigDecimal accessors for computed value, result, and difference.
-- Preserve explicit `GoalSeek.Result as Map` compatibility for callers migrating from the previous map-shaped result.
 - Add Groovy-facing `Number` overloads for `GoalSeek` target, bracket, threshold, and max-iteration arguments.
+
+### Breaking Changes
+- Replace the raw `Map` return type of `GoalSeek.solve()` with typed `GoalSeek.Result`, including BigDecimal accessors for computed value, result, and difference. Existing callers can restore the previous map-shaped result with `GoalSeek.solve(...) as Map`.
 
 ### Tests and Documentation
 - Add focused regression coverage for solver infeasibility, Fisher validation and large-count arithmetic, normalization column selection, linear-regression validation, FitResult accessors, GoalSeek typed result behavior, and Brent/GoalSeek iteration behavior.

--- a/matrix-stats/req/v2.5.0-plan.md
+++ b/matrix-stats/req/v2.5.0-plan.md
@@ -148,18 +148,18 @@ A task is only complete when its tests have passed and the exact test command ha
 
 ## 7. Final Verification and Documentation Close-out
 
-7.1 [ ] Run module verification in the repository-required order:
-- `./gradlew :matrix-stats:codenarcMain`
-- `./gradlew :matrix-stats:spotlessCheck`
-- `./gradlew :matrix-stats:test`
+7.1 [x] Run module verification in the repository-required order:
+- [x] `./gradlew :matrix-stats:codenarcMain`
+- [x] `./gradlew :matrix-stats:spotlessCheck`
+- [x] `./gradlew :matrix-stats:test`
 
-7.2 [ ] Run full regression verification before release/merge:
-- `./gradlew test`
+7.2 [x] Run full regression verification before release/merge:
+- [x] `./gradlew test`
 
-7.3 [ ] Record all exact passing commands in this plan or in the PR description before marking any implementation section complete.
+7.3 [x] Record all exact passing commands in this plan or in the PR description before marking any implementation section complete.
 
-7.4 [ ] Update `matrix-stats/README.md` if any public API behavior or examples changed.
+7.4 [x] Update `matrix-stats/README.md` if any public API behavior or examples changed. Existing solver README examples already use the typed `GoalSeek` result API, so no additional README edit was needed for this close-out.
 
-7.5 [ ] Update release notes in `matrix-stats/release.md` with the v2.5.0 bug fixes and API additions.
+7.5 [x] Update release notes in `matrix-stats/release.md` with the v2.5.0 bug fixes and API additions.
 
-7.6 [ ] Confirm no unrelated generated artifacts or local build outputs are included in the PR.
+7.6 [x] Confirm no unrelated generated artifacts or local build outputs are included in the PR.


### PR DESCRIPTION
## Summary
- Add v2.5.0 release notes for the completed matrix-stats review follow-up work.
- Mark phase 7 of `matrix-stats/req/v2.5.0-plan.md` complete with the exact verification commands.
- Note that the existing README solver examples already use the typed GoalSeek result API.

## Modules touched
- `matrix-stats`

## Validation
- `./gradlew :matrix-stats:codenarcMain`
- `./gradlew :matrix-stats:spotlessCheck`
- `./gradlew :matrix-stats:test`
- `./gradlew test`
- `git diff --check`