### PR TITLE
[codex] Improve matrix-csv usability

### DIFF
--- a/matrix-bom/bom.xml
+++ b/matrix-bom/bom.xml
@@ -37,7 +37,7 @@
     <matrixBigQueryVersion>0.6.1</matrixBigQueryVersion>
     <matrixChartsVersion>0.5.0-SNAPSHOT</matrixChartsVersion>
     <matrixCoreVersion>3.8.0</matrixCoreVersion>
-    <matrixCsvVersion>2.3.1-SNAPSHOT</matrixCsvVersion>
+    <matrixCsvVersion>2.4.0-SNAPSHOT</matrixCsvVersion>
     <matrixDatasetsVersion>2.2.0</matrixDatasetsVersion>
     <matrixGgplotVersion>0.5.0-SNAPSHOT</matrixGgplotVersion>
     <matrixGroovyExtVersion>0.2.0</matrixGroovyExtVersion>

--- a/matrix-csv/README.md
+++ b/matrix-csv/README.md
@@ -78,6 +78,7 @@ Write defaults:
 - quote defaults to `"`
 - header output is enabled by default
 - charset defaults to UTF-8 for file/path targets
+- fluent writes can set file/path encoding with `charset(...)`
 - `.tsv` and `.tab` targets auto-select tab delimiters for typed direct writes and SPI writes unless the delimiter was explicitly configured
 
 Preset behavior:
@@ -156,6 +157,10 @@ CsvWriter.write(matrix)
     .to(new File('data-no-header.csv'))
 
 CsvWriter.write(matrix)
+    .charset('ISO-8859-1')
+    .to(new File('latin1.csv'))
+
+CsvWriter.write(matrix)
     .excel()
     .to(new File('report.csv'))
 
@@ -171,6 +176,7 @@ Supported write-time fluent configuration is intentionally limited to options wi
 - `escapeCharacter(...)`
 - `nullString(...)`
 - `recordSeparator(...)`
+- `charset(...)`
 - `withHeader(...)`
 - preset helpers such as `excel()`, `tsv()`, and `rfc4180()`
 
@@ -341,6 +347,7 @@ def matrix = CsvReader.read().delimiter(';').from(file)
 
 | Method | Default | Notes |
 |--------|---------|-------|
+| `charset(...)` | `UTF-8` | File/Path output only |
 | `withHeader(...)` | `true` | Write only |
 
 ### Presets

--- a/matrix-csv/build.gradle
+++ b/matrix-csv/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = 'se.alipsa.matrix'
-version = '2.3.1-SNAPSHOT'
+version = '2.4.0-SNAPSHOT'
 description = "Groovy library for importing structured text into a matrix"
 
 ext.nexusReleaseUrl = version.contains("SNAPSHOT")

--- a/matrix-csv/checkDependencies.sh
+++ b/matrix-csv/checkDependencies.sh
@@ -1,1 +1,1 @@
-./gradlew dependencyUpdates -Drevision=release
+./gradlew dependencyUpdates -Drevision=release --no-configuration-cache

--- a/matrix-csv/release.md
+++ b/matrix-csv/release.md
@@ -1,5 +1,11 @@
 # Release history
 
+## v2.4.0, 2026-06-18
+- preserve column names when reading header-only CSV files through the fluent API and SPI
+- use the default matrix name `matrix` for fluent string, reader, and stream reads unless explicitly overridden
+- add fluent file/path charset support for `CsvWriter.write(matrix).charset(...).to(...)`
+- refresh deprecated `CsvImporter` and `CsvExporter` migration guidance for the current `CsvReader` / `CsvWriter` APIs
+
 ## v2.3.0, 2026-03-26
 - clean up deprecated `CsvImporter` dead code and suppress legacy enum naming violations without breaking backward compatibility
 - fix remaining CodeNarc priority 2 issues across `matrix-csv`, including builder field naming and deprecated Reader charset documentation

--- a/matrix-csv/src/main/groovy/se/alipsa/matrix/csv/CsvExporter.groovy
+++ b/matrix-csv/src/main/groovy/se/alipsa/matrix/csv/CsvExporter.groovy
@@ -10,10 +10,10 @@ import se.alipsa.matrix.core.Matrix
 /**
  * Exports a Matrix to a CSV using apache commons csv.
  *
- * @deprecated Use {@link CsvWriter} instead. This class will be removed in v2.0.
+ * @deprecated Use {@link CsvWriter} instead. This class will be removed in a future major release.
  * <p>Migration guide:</p>
  * <ul>
- *   <li>{@code CsvExporter.exportToCsv(matrix, file)} → {@code CsvWriter.write(matrix, file)}</li>
+ *   <li>{@code CsvExporter.exportToCsv(matrix, file)} → {@code CsvWriter.write(matrix).to(file)}</li>
  *   <li>{@code CsvExporter.exportToExcelCsv(matrix, file)} → {@code CsvWriter.writeExcelCsv(matrix, file)}</li>
  *   <li>{@code CsvExporter.exportToTsv(matrix, file)} → {@code CsvWriter.writeTsv(matrix, file)}</li>
  * </ul>
@@ -31,7 +31,7 @@ class CsvExporter {
    * @param table the matrix to export
    * @param out the file to write to or a directory to write to
    * @param withHeader whether to include the columns names in the first row, default is true
-   * @deprecated Use {@link CsvWriter#write(Matrix, File, CSVFormat, boolean)} instead
+   * @deprecated Use {@code CsvWriter.write(table).withHeader(withHeader).to(out)} instead
    */
   @Deprecated
   static void exportToCsv(Matrix table, File out, boolean withHeader = true) {
@@ -46,7 +46,7 @@ class CsvExporter {
    * @param format the CSVFormat to use
    * @param out the file to write to or a directory to write to
    * @param withHeader whether to include the columns names in the first row, default is true
-   * @deprecated Use {@link CsvWriter#write(Matrix, File, CSVFormat, boolean)} instead
+   * @deprecated Use {@code CsvWriter.write(table).to(out)} with fluent format configuration instead
    */
   @Deprecated
   static void exportToCsv(Matrix table, CSVFormat format, File out, boolean withHeader = true) {
@@ -60,7 +60,7 @@ class CsvExporter {
    * @param format the CSVFormat to use
    * @param out the writer to write to
    * @param withHeader whether to include the columns names in the first row, default is true
-   * @deprecated Use {@link CsvWriter#write(Matrix, Writer, CSVFormat, boolean)} instead
+   * @deprecated Use {@code CsvWriter.write(table).to(out)} with fluent format configuration instead
    */
   @Deprecated
   static void exportToCsv(Matrix table, CSVFormat format = CSVFormat.DEFAULT, Writer out, boolean withHeader = true) {
@@ -74,7 +74,7 @@ class CsvExporter {
    * @param format the CSVFormat to use
    * @param out the print writer to write to
    * @param withHeader whether to include the columns names in the first row, default is true
-   * @deprecated Use {@link CsvWriter#write(Matrix, CSVFormat, PrintWriter, boolean)} instead
+   * @deprecated Use {@code CsvWriter.write(table).to(out)} with fluent format configuration instead
    */
   @Deprecated
   static void exportToCsv(Matrix table, CSVFormat format = CSVFormat.DEFAULT, PrintWriter out, boolean withHeader = true) {
@@ -87,7 +87,7 @@ class CsvExporter {
    * @param table the matrix to export
    * @param printer the CSVPrinter to use
    * @param withHeader whether to include the columns names in the first row, default is true
-   * @deprecated Use {@link CsvWriter#write(Matrix, CSVPrinter, boolean)} instead
+   * @deprecated Use {@code CsvWriter.write(table).to(writer)} instead
    */
   @Deprecated
   static void exportToCsv(Matrix table, CSVPrinter printer, boolean withHeader = true) {

--- a/matrix-csv/src/main/groovy/se/alipsa/matrix/csv/CsvExporter.groovy
+++ b/matrix-csv/src/main/groovy/se/alipsa/matrix/csv/CsvExporter.groovy
@@ -87,7 +87,7 @@ class CsvExporter {
    * @param table the matrix to export
    * @param printer the CSVPrinter to use
    * @param withHeader whether to include the columns names in the first row, default is true
-   * @deprecated Use {@code CsvWriter.write(table).to(writer)} instead
+   * @deprecated Use {@code CsvWriter.write(table, printer, withHeader)} instead
    */
   @Deprecated
   static void exportToCsv(Matrix table, CSVPrinter printer, boolean withHeader = true) {

--- a/matrix-csv/src/main/groovy/se/alipsa/matrix/csv/CsvImporter.groovy
+++ b/matrix-csv/src/main/groovy/se/alipsa/matrix/csv/CsvImporter.groovy
@@ -13,12 +13,12 @@ import java.nio.file.Path
 /**
  * Imports CSV files into Matrix objects using Apache Commons CSV.
  *
- * @deprecated Use {@link CsvReader} instead. This class will be removed in v2.0.
+ * @deprecated Use {@link CsvReader} instead. This class will be removed in a future major release.
  * <p>Migration guide:</p>
  * <ul>
- *   <li>{@code CsvImporter.importCsv(file)} → {@code CsvReader.read(file)}</li>
- *   <li>{@code CsvImporter.importCsvString(content)} → {@code CsvReader.readString(content)}</li>
- *   <li>{@code CsvImporter.importCsvFromFile(path)} → {@code CsvReader.readFile(path)}</li>
+ *   <li>{@code CsvImporter.importCsv(file)} → {@code CsvReader.read().from(file)}</li>
+ *   <li>{@code CsvImporter.importCsvString(content)} → {@code CsvReader.read().fromString(content)}</li>
+ *   <li>{@code CsvImporter.importCsvFromFile(path)} → {@code CsvReader.read().fromFile(path)}</li>
  * </ul>
  *
  * <p>Provides flexible CSV parsing with support for multiple input sources
@@ -36,7 +36,7 @@ class CsvImporter {
   /**
    * Configuration options for CSV parsing.
    *
-   * @deprecated Use {@link CsvOption} instead. This enum will be removed in v2.0.
+   * @deprecated Use {@link CsvOption} instead. This enum will be removed in a future major release.
    */
   @Deprecated
   @SuppressWarnings('FieldName')
@@ -295,7 +295,7 @@ class CsvImporter {
    * @return Matrix containing the imported data with default settings
    * @throws IOException if reading the file fails or file not found
    * @throws IllegalArgumentException if columns are mismatched between rows
-   * @deprecated Use {@link CsvReader#readFile(String)} instead
+   * @deprecated Use {@code CsvReader.read().fromFile(filePath)} instead
    */
   @Deprecated
   static Matrix importCsvFromFile(String filePath) throws IOException {

--- a/matrix-csv/src/main/groovy/se/alipsa/matrix/csv/CsvReader.groovy
+++ b/matrix-csv/src/main/groovy/se/alipsa/matrix/csv/CsvReader.groovy
@@ -696,7 +696,14 @@ class CsvReader {
     /** Sets the character encoding (default: UTF-8). */
     ReadBuilder charset(Charset cs) { charset = cs; this }
 
-    /** Sets the name for the resulting Matrix. */
+    /** Sets the character encoding by name (default: UTF-8). */
+    ReadBuilder charset(String cs) { charset = Charset.forName(cs); this }
+
+    /**
+     * Sets the name for the resulting Matrix.
+     * Defaults to the source-derived name for file and URL reads, or {@code matrix}
+     * for stream, reader, and string reads.
+     */
     ReadBuilder matrixName(String name) { matrixName = name; this }
 
     /** Sets how duplicate header names are handled when header parsing is enabled. */

--- a/matrix-csv/src/main/groovy/se/alipsa/matrix/csv/CsvReader.groovy
+++ b/matrix-csv/src/main/groovy/se/alipsa/matrix/csv/CsvReader.groovy
@@ -436,9 +436,17 @@ class CsvReader {
    */
   private static Matrix parse(String matrixName, CSVParser parser, boolean firstRowAsHeader) {
     List<List<String>> rows = parser.records*.toList()
+    List<String> headerRow = parserHeaderRow(parser, rows.isEmpty() ? 0 : rows[0].size())
 
     // Handle empty CSV file
     if (rows.isEmpty()) {
+      if (!headerRow.isEmpty()) {
+        return Matrix.builder()
+            .matrixName(matrixName ?: DEFAULT_MATRIX_NAME)
+            .columnNames(headerRow)
+            .types([String] * headerRow.size())
+            .build()
+      }
       return Matrix.builder()
           .matrixName(matrixName ?: DEFAULT_MATRIX_NAME)
           .build()
@@ -452,24 +460,9 @@ class CsvReader {
       }
       rowCount++
     }
-    List<String> headerRow = []
-    if (parser.headerNames != null && parser.headerNames.size() > 0) {
-      headerRow = parser.headerNames
-      if (headerRow.size() != ncols) {
-        List<String> resolvedHeaderRow = [''] * ncols
-        Map<String, Integer> headerMap = parser.headerMap
-        if (headerMap != null) {
-          headerMap.each { String name, Integer index ->
-            if (index != null && index >= 0 && index < ncols) {
-              resolvedHeaderRow[index] = name ?: ''
-            }
-          }
-        }
-        headerRow = resolvedHeaderRow
-      }
-    } else if (firstRowAsHeader) {
+    if (headerRow.isEmpty() && firstRowAsHeader) {
       headerRow = rows.remove(0)
-    } else {
+    } else if (headerRow.isEmpty()) {
       for (int i = 0; i < ncols; i++) {
         headerRow << 'c' + i
       }
@@ -481,6 +474,26 @@ class CsvReader {
         .rows(rows)
         .types(types)
         .build()
+  }
+
+  private static List<String> parserHeaderRow(CSVParser parser, int ncols) {
+    if (parser.headerNames == null || parser.headerNames.isEmpty()) {
+      return []
+    }
+    List<String> headerRow = parser.headerNames
+    if (ncols == 0 || headerRow.size() == ncols) {
+      return headerRow
+    }
+    List<String> resolvedHeaderRow = [''] * ncols
+    Map<String, Integer> headerMap = parser.headerMap
+    if (headerMap != null) {
+      headerMap.each { String name, Integer index ->
+        if (index != null && index >= 0 && index < ncols) {
+          resolvedHeaderRow[index] = name ?: ''
+        }
+      }
+    }
+    resolvedHeaderRow
   }
 
   /**
@@ -592,7 +605,7 @@ class CsvReader {
     private boolean firstRowAsHeader = true
     private List<String> header = null
     private Charset charset = StandardCharsets.UTF_8
-    private String matrixName = ''
+    private String matrixName = null
     private List<Class> types = null
     private String dateTimeFormat = null
     private NumberFormat numberFormat = null
@@ -683,7 +696,7 @@ class CsvReader {
     /** Sets the character encoding (default: UTF-8). */
     ReadBuilder charset(Charset cs) { charset = cs; this }
 
-    /** Sets the name for the resulting Matrix (default: empty string). */
+    /** Sets the name for the resulting Matrix. */
     ReadBuilder matrixName(String name) { matrixName = name; this }
 
     /** Sets how duplicate header names are handled when header parsing is enabled. */
@@ -828,7 +841,7 @@ class CsvReader {
     Matrix from(InputStream is) throws IOException {
       CSVFormat apacheFormat = buildCSVFormat()
       try (CSVParser parser = CSVParser.parse(CloseShieldInputStream.wrap(is), charset, apacheFormat)) {
-        convertIfNeeded(parse(matrixName, parser, firstRowAsHeader))
+        convertIfNeeded(parse(matrixName ?: DEFAULT_MATRIX_NAME, parser, firstRowAsHeader))
       }
     }
 
@@ -842,7 +855,7 @@ class CsvReader {
     Matrix from(Reader reader) throws IOException {
       CSVFormat apacheFormat = buildCSVFormat()
       try (CSVParser parser = CSVParser.parse(CloseShieldReader.wrap(reader), apacheFormat)) {
-        convertIfNeeded(parse(matrixName, parser, firstRowAsHeader))
+        convertIfNeeded(parse(matrixName ?: DEFAULT_MATRIX_NAME, parser, firstRowAsHeader))
       }
     }
 

--- a/matrix-csv/src/main/groovy/se/alipsa/matrix/csv/CsvWriter.groovy
+++ b/matrix-csv/src/main/groovy/se/alipsa/matrix/csv/CsvWriter.groovy
@@ -10,6 +10,7 @@ import org.apache.commons.io.output.CloseShieldWriter
 import se.alipsa.matrix.core.Matrix
 
 import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 
 /**
@@ -394,6 +395,7 @@ class CsvWriter {
     private QuoteMode quoteMode = null
     private boolean allowMissingColumnNames = false
     private boolean withHeaderValue = true
+    private Charset charset = StandardCharsets.UTF_8
 
     private WriteBuilder(Matrix matrix) {
       this.matrix = matrix
@@ -448,6 +450,12 @@ class CsvWriter {
     /** Sets whether to include column names in the first row (default: true). */
     WriteBuilder withHeader(boolean b) { withHeaderValue = b; this }
 
+    /** Sets the character encoding for File and Path output. */
+    WriteBuilder charset(Charset cs) { charset = cs; this }
+
+    /** Sets the character encoding by name for File and Path output. */
+    WriteBuilder charset(String cs) { charset = Charset.forName(cs); this }
+
     // ── Preset methods ────────────────────────────────────────
 
     /** Configures Apache Excel-compatible CSV format, including CRLF output and {@link QuoteMode#ALL_NON_NULL}. */
@@ -467,11 +475,7 @@ class CsvWriter {
      * @param out the file to write to (or a directory)
      */
     void to(File out) {
-      validateMatrix(matrix)
-      out = ensureFileOutput(matrix, out)
-      try (PrintWriter pw = new PrintWriter(out)) {
-        to(pw)
-      }
+      to(out, charset)
     }
 
     /**

--- a/matrix-csv/src/main/groovy/se/alipsa/matrix/csv/CsvWriter.groovy
+++ b/matrix-csv/src/main/groovy/se/alipsa/matrix/csv/CsvWriter.groovy
@@ -213,7 +213,8 @@ class CsvWriter {
    * @param matrix the matrix to write
    * @param printer the CSVPrinter to use
    * @param withHeader whether to include the columns names in the first row (default: true)
-   * @deprecated Use {@code CsvWriter.write(matrix).to(writer)} instead
+   * @deprecated Prefer {@code CsvWriter.write(matrix).to(writer)} when a Writer is available.
+   * Use this compatibility overload when an existing CSVPrinter must be reused.
    */
   @Deprecated
   static void write(Matrix matrix, CSVPrinter printer, boolean withHeader = true) {

--- a/matrix-csv/src/test/groovy/CsvFormatTest.groovy
+++ b/matrix-csv/src/test/groovy/CsvFormatTest.groovy
@@ -9,6 +9,7 @@ import se.alipsa.matrix.csv.CsvReader
 import se.alipsa.matrix.csv.CsvWriter
 
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.nio.file.Path
 import java.text.NumberFormat
 import java.time.LocalDate
@@ -151,6 +152,43 @@ Bob,25'''
     assertNotNull(matrix, 'Matrix should not be null')
     assertEquals(0, matrix.rowCount(), 'Empty CSV should have 0 rows')
     assertEquals(0, matrix.columnCount(), 'Empty CSV should have 0 columns')
+  }
+
+  @Test
+  void readHeaderOnlyCsvWithFluentApi() {
+    Matrix matrix = CsvReader.read().fromString('id,name,amount')
+
+    assertEquals('matrix', matrix.matrixName)
+    assertEquals(0, matrix.rowCount(), 'Header-only CSV should have 0 data rows')
+    assertEquals(3, matrix.columnCount(), 'Header-only CSV should preserve columns')
+    assertEquals(['id', 'name', 'amount'], matrix.columnNames(), 'Column names')
+  }
+
+  @Test
+  void readHeaderOnlyCsvWithSpi() {
+    File file = tempDir.resolve('header-only.csv').toFile()
+    file.text = 'id,name,amount'
+
+    Matrix matrix = Matrix.read(file)
+
+    assertEquals(0, matrix.rowCount(), 'Header-only CSV should have 0 data rows')
+    assertEquals(3, matrix.columnCount(), 'Header-only CSV should preserve columns')
+    assertEquals(['id', 'name', 'amount'], matrix.columnNames(), 'Column names')
+  }
+
+  @Test
+  void fluentStringReaderAndStreamReadsUseDefaultMatrixName() {
+    String csvContent = 'name,age\nAlice,30\n'
+
+    Matrix fromString = CsvReader.read().fromString(csvContent)
+    Matrix fromReader = CsvReader.read().from(new StringReader(csvContent))
+    Matrix fromStream = CsvReader.read().from(new ByteArrayInputStream(csvContent.bytes))
+    Matrix explicitName = CsvReader.read().matrixName('people').fromString(csvContent)
+
+    assertEquals('matrix', fromString.matrixName)
+    assertEquals('matrix', fromReader.matrixName)
+    assertEquals('matrix', fromStream.matrixName)
+    assertEquals('people', explicitName.matrixName)
   }
 
   // ── Read: presets ──────────────────────────────────────────
@@ -361,6 +399,32 @@ Alice,30'''
     assertTrue(csvContent.contains('col1,col2'), 'Should contain header')
     assertTrue(csvContent.contains('a,b'), 'Should contain first row')
     assertTrue(csvContent.contains('c,d'), 'Should contain second row')
+  }
+
+  @Test
+  void writeToFileWithFluentCharset() {
+    Matrix matrix = Matrix.builder()
+        .columnNames(['name'])
+        .rows([
+            ['Åsa'],
+            ['Élodie']
+        ])
+        .build()
+
+    File outputFile = tempDir.resolve('latin1.csv').toFile()
+    CsvWriter.write(matrix)
+        .charset('ISO-8859-1')
+        .to(outputFile)
+
+    String content = Files.readString(outputFile.toPath(), StandardCharsets.ISO_8859_1)
+    Matrix reloaded = CsvReader.read()
+        .charset(StandardCharsets.ISO_8859_1)
+        .from(outputFile)
+
+    assertTrue(content.contains('Åsa'))
+    assertTrue(content.contains('Élodie'))
+    assertEquals(['Åsa'], reloaded.row(0))
+    assertEquals(['Élodie'], reloaded.row(1))
   }
 
   // ── Write: presets ─────────────────────────────────────────

--- a/matrix-csv/src/test/groovy/CsvFormatTest.groovy
+++ b/matrix-csv/src/test/groovy/CsvFormatTest.groovy
@@ -276,6 +276,19 @@ Bob,Göteborg'''
   }
 
   @Test
+  void readFromFileWithStringCharset() {
+    File inputFile = tempDir.resolve('latin1-read.csv').toFile()
+    inputFile.write('name\nÅsa\nÉlodie\n', 'ISO-8859-1')
+
+    Matrix matrix = CsvReader.read()
+        .charset('ISO-8859-1')
+        .from(inputFile)
+
+    assertEquals(['Åsa'], matrix.row(0))
+    assertEquals(['Élodie'], matrix.row(1))
+  }
+
+  @Test
   void readWithMatrixName() {
     String csvContent = '''name,age
 Alice,30'''


### PR DESCRIPTION
## Summary
- Preserve columns when reading header-only CSV files through the fluent/SPI reader path.
- Normalize default matrix names for fluent stream, reader, and string reads.
- Add fluent file/path charset support for `CsvWriter` and document the new API.
- Update `matrix-csv` and the BOM CSV entry to `2.4.0-SNAPSHOT`.
- Refresh stale CSV importer/exporter deprecation migration guidance.

## Modules touched
- `matrix-csv`
- `matrix-bom`

## Root cause
The fluent reader parsed records before considering `CSVParser.headerNames`, so files with only a header row produced an empty matrix with no columns. Fluent non-file reads also passed an unset matrix name through to parsing, which diverged from the typed/SPI fallback behavior documented as `matrix`.

## Tests
- `./gradlew :matrix-csv:codenarcMain`
- `./gradlew :matrix-csv:spotlessCheck`
- `./gradlew :matrix-csv:test`