### PR TITLE
matrix-parquet: implement v0.6.0 phase 1 foundation

### DIFF
--- a/matrix-parquet/build.gradle
+++ b/matrix-parquet/build.gradle
@@ -10,11 +10,6 @@ group = 'se.alipsa.matrix'
 version = '0.6.0-SNAPSHOT'
 description = "Groovy library for importing and exporting parquet files to and from a Matrix"
 
-ext.nexusUrl = version.toString().endsWith("SNAPSHOT")
-    ? "https://oss.sonatype.org/content/repositories/snapshots/"
-    : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-
-
 JavaCompile javaCompile = compileJava {
     options.release = 21
     options.deprecation = true
@@ -23,7 +18,6 @@ JavaCompile javaCompile = compileJava {
 
 compileGroovy {
     options.deprecation = true
-    groovyOptions.configurationScript = rootProject.file('config/groovy/compileStatic.groovy')
 }
 
 dependencies {
@@ -111,7 +105,6 @@ publishing {
                     username = sonatypeUsername
                     password = sonatypePassword
                 }
-                url = nexusUrl
             }
         }
     }

--- a/matrix-parquet/build.gradle
+++ b/matrix-parquet/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'se.alipsa.matrix'
-version = '0.5.1-SNAPSHOT'
+version = '0.6.0-SNAPSHOT'
 description = "Groovy library for importing and exporting parquet files to and from a Matrix"
 
 ext.nexusUrl = version.toString().endsWith("SNAPSHOT")

--- a/matrix-parquet/release.md
+++ b/matrix-parquet/release.md
@@ -1,6 +1,6 @@
 # Matrix-parquet Release History
 
-## v0.5.1, 2026-06-19
+## v0.6.0, 2026-06-19
 - Upgrade dependencies
   - org.apache.parquet:parquet-column 1.17.0 -> 1.17.1
   - org.apache.parquet:parquet-hadoop 1.17.0 -> 1.17.1 

--- a/matrix-parquet/req/v0.6.0-plan.md
+++ b/matrix-parquet/req/v0.6.0-plan.md
@@ -1,0 +1,2061 @@
+# matrix-parquet v0.6.0 Implementation Plan
+
+> **For agentic workers:** This plan is executed **inline, in the current session** — this repository's `CLAUDE.md` mandates "Use skills and plugins inline; NEVER use subagents." Use `superpowers:executing-plans` for batch execution with checkpoints. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship matrix-parquet 0.6.0: add Parquet compression codec support, fix the `BigInteger` truncation bug by remapping it from `INT64` to `BINARY`+`DECIMAL(p,0)`, and fix/clean up the remaining issues found during review.
+
+**Architecture:** All changes are localized to `MatrixParquetWriter.groovy` (schema building, value writing, metadata writing, compression wiring), `MatrixParquetReader.groovy` (value reading, metadata reading, stream-derived matrix naming), and `ParquetWriteOptions.groovy` (new `compressionCodec` option and normalized decimal metadata). No new classes, no new dependencies — `snappy-java`, `aircompressor`, and `zstd-jni` are already transitively present on the runtime classpath (verified via `./gradlew :matrix-parquet:dependencies`).
+
+**Tech Stack:** Groovy 5 (statically compiled module-wide via Gradle config, not per-class annotations), Apache Parquet 1.17.1 (`parquet-column`, `parquet-hadoop`), JUnit 5 (`groovier-junit` assertions), Gradle.
+
+## Global Constraints
+
+- JDK 21 maximum for this module (Hadoop 3.4.x ceiling) — do not introduce JDK 22+ APIs.
+- Static compilation is enforced globally for this module via `config/groovy/compileStatic.groovy` (`ast(CompileStatic)`, wired in via `groovyOptions.configurationScript` in the root `build.gradle`'s `subprojects` block — every subproject's `compileGroovy` task gets it automatically, so the module `build.gradle` does not need its own copy) — every new/modified method must type-check statically. Do **not** add explicit `@CompileStatic` annotations or `import groovy.transform.CompileStatic` to any class; they are redundant (Task 2 Step 5 removes the existing ones). `@CompileDynamic` remains the correct, real opt-out for genuinely dynamic code, used where needed.
+- Use `se.alipsa.matrix.core.util.Logger` (already imported as `log` in both files) for any new logging — never `println`.
+- Prefer `BigDecimal`/`BigInteger` over primitive numeric types at API boundaries; this plan exists specifically to fix a `BigInteger` precision bug, so no step may reintroduce silent truncation.
+- No new third-party dependencies — compression codecs are already on the classpath.
+- Verification order for every task: `codenarcMain`/`codenarcTest` → `spotlessCheck` → `test`. Run `./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest :matrix-parquet:spotlessCheck :matrix-parquet:test` (or the relevant subset) after each task.
+- Module version must be `0.6.0-SNAPSHOT` before any other change in this plan lands (per project convention: bump to SNAPSHOT before touching code).
+- Never commit/push to `main` without explicit user confirmation; per `AGENTS.md`, do this work on a separate branch (e.g. `feature/parquet-0.6.0`) and let the user confirm before any push.
+
+## Execution Phases
+
+The 11 tasks below are grouped into 7 sequential phases. Each phase is one branch and one PR — branch from `main` only after the previous phase's PR has merged (every phase after Phase 1 touches files Phase 1 also touches, so branching off a stale `main` risks avoidable conflicts). Tasks keep their original numbering for cross-reference; phases do not reorder any task's content.
+
+| Phase | Tasks | Branch | Why grouped | Depends on |
+|---|---|---|---|---|
+| 1 | 1, 2 | `feature/parquet-0.6.0-foundation` | Version bump (hard prerequisite for everything else, per project SNAPSHOT convention) + dead-code/`@CompileStatic` cleanup — both mechanical, low-risk, touch every other file that later phases will also touch | none |
+| 2 | 3, 4 | `feature/parquet-0.6.0-compression-and-binary-read` | BigDecimal-from-plain-`BINARY` read fallback fix + compression codec support — both independent, both land before the larger BigInteger rework | Phase 1 |
+| 3 | 5 | `feature/parquet-0.6.0-biginteger-binary` | BigInteger `INT64`→`BINARY`+`DECIMAL(p,0)` remapping — the largest, highest-risk fix in this plan; kept solo rather than padded with unrelated work | Phase 1 |
+| 4 | 6, 7 | `feature/parquet-0.6.0-writer-fixes` | Writer-closes-on-failure fix + `java.util.Date` round-trip — both touch `buildPrimitiveType`'s type-dispatch switch; Task 7 explicitly assumes Task 5 has already removed `BigInteger` from the `INT64` case | Phase 3 |
+| 5 | 8 | `feature/parquet-0.6.0-decimal-meta` | Decimal metadata normalization/validation — touches the same `buildSchema`/`decimalMeta` call sites as Phase 3 but no hard ordering dependency; sequenced after to avoid two phases editing `buildSchema` concurrently | Phase 3 |
+| 6 | 9, 10 | `feature/parquet-0.6.0-reader-metadata` | Stream/byte-array/URL matrix-naming fix + structured-JSON index metadata — both are `MatrixParquetReader` internals (the `read` refactor and `restoreIndex`) | Phase 1 |
+| 7 | 11 | `feature/parquet-0.6.0-final-verification` | Final consolidation: full regression run, release notes consolidation, README pass — must be last since it verifies the cumulative result of every other phase | Phases 1-6 |
+
+Within each multi-task phase, complete and commit the lower-numbered task's steps before starting the next task's steps (e.g. in Phase 1, finish Task 1's Step 1-3 and commit, then do Task 2's Step 1-9) — this preserves the bite-sized, TDD, frequent-commit structure of the underlying tasks even though several land in one PR.
+
+---
+
+## Phase 1: Foundation (Tasks 1-2)
+
+**Branch:** `feature/parquet-0.6.0-foundation`, cut from `main`. **Depends on:** nothing — branch first.
+
+### Task 1: Bump module version to 0.6.0-SNAPSHOT and retitle the release notes entry
+
+**Files:**
+- Modify: `matrix-parquet/build.gradle` (version line)
+- Modify: `matrix-parquet/release.md:3` (header)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `version = '0.6.0-SNAPSHOT'` is now the module version every later task builds against. The `## v0.6.0, 2026-06-19` header in `release.md` is the section every later task appends its changelog bullet to.
+
+- [ ] **Step 1: Bump the Gradle version**
+
+In `matrix-parquet/build.gradle`, change:
+```groovy
+version = '0.5.1-SNAPSHOT'
+```
+to:
+```groovy
+version = '0.6.0-SNAPSHOT'
+```
+
+- [ ] **Step 2: Retitle the release notes entry**
+
+In `matrix-parquet/release.md`, the existing top entry already documents the 1.17.1 dependency bump but was never released (build.gradle was still on `0.5.1-SNAPSHOT`). Fold it into the new 0.6.0 release instead of cutting a separate 0.5.1. Change:
+```markdown
+## v0.5.1, 2026-06-19
+- Upgrade dependencies
+  - org.apache.parquet:parquet-column 1.17.0 -> 1.17.1
+  - org.apache.parquet:parquet-hadoop 1.17.0 -> 1.17.1 
+```
+to:
+```markdown
+## v0.6.0, 2026-06-19
+- Upgrade dependencies
+  - org.apache.parquet:parquet-column 1.17.0 -> 1.17.1
+  - org.apache.parquet:parquet-hadoop 1.17.0 -> 1.17.1 
+```
+(Later tasks append their own bullets directly below the dependency-upgrade bullet, above the `## v0.5.0` entry.)
+
+- [ ] **Step 3: Verify and commit**
+
+Run: `grep version matrix-parquet/build.gradle | head -1`
+Expected: `version = '0.6.0-SNAPSHOT'`
+
+```bash
+git add matrix-parquet/build.gradle matrix-parquet/release.md
+git commit -m "matrix-parquet: bump version to 0.6.0-SNAPSHOT"
+```
+
+---
+
+### Task 2: Remove dead/redundant code
+
+Four unrelated pieces of dead/redundant code found during review, all safe pure deletions verified by the existing test suite (no new tests needed beyond one new empty-list-value test).
+
+**Files:**
+- Modify: `matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy:734-739` (dead commented-out lines in `buildPrimitiveType`)
+- Modify: `matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy:1054-1058` (redundant empty-collection branch in `writeList`)
+- Modify: all 7 production files under `matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/` (redundant `@CompileStatic` annotations/imports, Step 5)
+- Modify: `matrix-parquet/build.gradle` (unused `nexusUrl`, redundant `compileGroovy` configuration script, Step 6)
+- Test: `matrix-parquet/src/test/groovy/MatrixParquetTest.groovy`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: no API change — `writeList(Group, String, GroupType, Object)` keeps its signature; behavior for empty collections is unchanged (still round-trips to `[]`), only the redundant special case is removed (`group.addGroup(fieldName)` is already what `Group listGroup = group.addGroup(fieldName)` does on the next line for an empty collection, since the subsequent `.each` is then a no-op).
+
+- [ ] **Step 1: Write the failing/characterization test for empty list values**
+
+Add to `MatrixParquetTest.groovy` (mirrors the existing `testNestedStructures`-style pattern already in the file):
+
+```groovy
+@Test
+void testEmptyListValueRoundTrip() {
+  def data = Matrix.builder('emptyListTest').data(
+      id: [1, 2],
+      tags: [['a', 'b'], []]
+  ).types([Integer, List]).build()
+
+  File file = tempDir.resolve('empty_list_value.parquet').toFile()
+  MatrixParquetWriter.write(data, file)
+  Matrix matrix = MatrixParquetReader.read(file)
+
+  assertEquals(['a', 'b'], matrix.tags[0])
+  assertEquals([], matrix.tags[1])
+}
+```
+
+- [ ] **Step 2: Run it to confirm it currently passes (characterization, not a bug fix)**
+
+Run: `./gradlew :matrix-parquet:test --tests "MatrixParquetTest.testEmptyListValueRoundTrip"`
+Expected: `BUILD SUCCESSFUL` — this test passes both before and after Step 3; it exists to prove the cleanup in Step 3 doesn't change behavior.
+
+- [ ] **Step 3: Remove the dead comment lines in `buildPrimitiveType`**
+
+In `MatrixParquetWriter.groovy`, change:
+```groovy
+    if (clazz == BigDecimal) {
+      if (decimalMeta != null && decimalMeta.length == 2) {
+        // int precision = decimalMeta[0] ?: 10 // BUGGY: what if 0 is passed? (though inference prevents this)
+        // int scale = decimalMeta[1] ?: 2     // BUGGY: 0 ?: 2 becomes 2
+
+        int precision = decimalMeta[0]
+        int scale = decimalMeta[1]
+```
+to:
+```groovy
+    if (clazz == BigDecimal) {
+      if (decimalMeta != null && decimalMeta.length == 2) {
+        int precision = decimalMeta[0]
+        int scale = decimalMeta[1]
+```
+
+- [ ] **Step 4: Remove the redundant empty-collection branch in `writeList`**
+
+In `MatrixParquetWriter.groovy`, change:
+```groovy
+  private static void writeList(Group group, String fieldName, GroupType groupType, Object value) {
+    if (!(value instanceof Collection)) {
+      throw new IllegalArgumentException(
+          "Cannot write field '$fieldName' as Parquet LIST: expected a Collection (List, Set, etc.) " +
+          "but got ${value.class.simpleName}. Value: ${truncateForError(value)}")
+    }
+    Collection<?> collection = (Collection<?>) value
+    if (collection.isEmpty()) {
+      group.addGroup(fieldName)
+      return
+    }
+    Group listGroup = group.addGroup(fieldName)
+    GroupType repeatedType = groupType.getType(0).asGroupType()
+    Type elementType = repeatedType.getType(0)
+    collection.each { Object element ->
+      Group entry = listGroup.addGroup(FIELD_LIST)
+      writeValue(entry, elementType.name, elementType, element)
+    }
+  }
+```
+to:
+```groovy
+  private static void writeList(Group group, String fieldName, GroupType groupType, Object value) {
+    if (!(value instanceof Collection)) {
+      throw new IllegalArgumentException(
+          "Cannot write field '$fieldName' as Parquet LIST: expected a Collection (List, Set, etc.) " +
+          "but got ${value.class.simpleName}. Value: ${truncateForError(value)}")
+    }
+    Collection<?> collection = (Collection<?>) value
+    Group listGroup = group.addGroup(fieldName)
+    GroupType repeatedType = groupType.getType(0).asGroupType()
+    Type elementType = repeatedType.getType(0)
+    collection.each { Object element ->
+      Group entry = listGroup.addGroup(FIELD_LIST)
+      writeValue(entry, elementType.name, elementType, element)
+    }
+  }
+```
+
+- [ ] **Step 5: Remove redundant `@CompileStatic` annotations**
+
+`config/groovy/compileStatic.groovy` (the `groovyOptions.configurationScript` wired into the root `build.gradle:108`'s `subprojects` block, applied automatically to every module — see Step 6 below, which removes matrix-parquet's own now-redundant copy of this wiring) already does:
+```groovy
+import groovy.transform.CompileStatic
+
+withConfig(configuration) {
+  ast(CompileStatic)
+}
+```
+This applies the `@CompileStatic` AST transform to every class compiled in this module (and every other module using the same configuration script) automatically — explicit `@CompileStatic` annotations and their imports in matrix-parquet's own production sources are therefore dead weight, not an opt-in. (`@CompileDynamic` remains a meaningful, real opt-out where genuinely needed — this step does not touch any `@CompileDynamic` usage, and matrix-parquet currently has none.)
+
+Remove the `import groovy.transform.CompileStatic` line and every `@CompileStatic` annotation from these 7 files:
+
+- `ParquetFormatProvider.groovy`: remove `import groovy.transform.CompileStatic` (line 3) and `@CompileStatic` (line 12, on the class).
+- `InMemoryOutputFile.groovy`: remove the import (line 3) and `@CompileStatic` (line 49, on the class).
+- `InMemoryPositionOutputStream.groovy`: remove the import (line 3) and `@CompileStatic` (line 31, on the class).
+- `ParquetWriteOptions.groovy`: remove the import (line 3) and `@CompileStatic` (line 13, on the class).
+- `ParquetReadOptions.groovy`: remove the import (line 3) and `@CompileStatic` (line 13, on the class).
+- `MatrixParquetReader.groovy`: remove the import (line 3) and **both** `@CompileStatic` occurrences — line 89 (on the top-level class) and line 154 (on the nested `static class ReaderBuilder`).
+- `MatrixParquetWriter.groovy`: remove the import (line 3) and **both** `@CompileStatic` occurrences — line 89 (on the top-level class) and line 183 (on the nested `static class WriterBuilder`).
+
+In each case the pattern is the same, e.g. for `ParquetWriteOptions.groovy`, change:
+```groovy
+package se.alipsa.matrix.parquet
+
+import groovy.transform.CompileStatic
+
+import se.alipsa.matrix.core.spi.OptionDescriptor
+import se.alipsa.matrix.core.spi.OptionMaps
+
+import java.time.ZoneId
+
+/**
+ * Typed options for Parquet write operations via the SPI.
+ */
+@CompileStatic
+class ParquetWriteOptions {
+```
+to:
+```groovy
+package se.alipsa.matrix.parquet
+
+import se.alipsa.matrix.core.spi.OptionDescriptor
+import se.alipsa.matrix.core.spi.OptionMaps
+
+import java.time.ZoneId
+
+/**
+ * Typed options for Parquet write operations via the SPI.
+ */
+class ParquetWriteOptions {
+```
+Apply the same import-removal-plus-annotation-removal pattern to the other 6 files, including both nested-class occurrences in `MatrixParquetReader.groovy` and `MatrixParquetWriter.groovy`.
+
+- [ ] **Step 6: Clean up `matrix-parquet/build.gradle`: remove unused `nexusUrl` and the redundant `compileGroovy` config**
+
+`ext.nexusUrl` (lines 13-15) is resolved by the `alipsaNexusRelease` plugin itself once `nexusReleasePlugin { mavenPublication = publishing.publications.maven }` is configured (see the bottom of the file) — `matrix-core/build.gradle`'s equivalent `repositories { maven { ... } }` block already has its `url` assignment commented out for this reason. Keeping a manual `url = nexusUrl` assignment in `publishing.repositories.maven` (line 114) duplicates what the plugin does and risks drifting out of sync with it, so remove both the variable and its only use.
+
+Separately, `compileGroovy`'s `groovyOptions.configurationScript = rootProject.file('config/groovy/compileStatic.groovy')` (line 26) is redundant: the root `build.gradle`'s `subprojects` block (`build.gradle:107-109`) already applies this exact configuration script to every module's `compileGroovy` task automatically. Remove the module-level line; only `options.deprecation = true` is module-specific and needs to stay.
+
+In `matrix-parquet/build.gradle`, change:
+```groovy
+group = 'se.alipsa.matrix'
+version = '0.6.0-SNAPSHOT'
+description = "Groovy library for importing and exporting parquet files to and from a Matrix"
+
+ext.nexusUrl = version.toString().endsWith("SNAPSHOT")
+    ? "https://oss.sonatype.org/content/repositories/snapshots/"
+    : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+
+
+JavaCompile javaCompile = compileJava {
+    options.release = 21
+    options.deprecation = true
+    options.compilerArgs << "-Xlint:unchecked"
+}
+
+compileGroovy {
+    options.deprecation = true
+    groovyOptions.configurationScript = rootProject.file('config/groovy/compileStatic.groovy')
+}
+```
+to:
+```groovy
+group = 'se.alipsa.matrix'
+version = '0.6.0-SNAPSHOT'
+description = "Groovy library for importing and exporting parquet files to and from a Matrix"
+
+JavaCompile javaCompile = compileJava {
+    options.release = 21
+    options.deprecation = true
+    options.compilerArgs << "-Xlint:unchecked"
+}
+
+compileGroovy {
+    options.deprecation = true
+}
+```
+and change:
+```groovy
+    if (project.ext.properties.sonatypeUsername) {
+        repositories {
+            maven {
+                credentials {
+                    username = sonatypeUsername
+                    password = sonatypePassword
+                }
+                url = nexusUrl
+            }
+        }
+    }
+```
+to:
+```groovy
+    if (project.ext.properties.sonatypeUsername) {
+        repositories {
+            maven {
+                credentials {
+                    username = sonatypeUsername
+                    password = sonatypePassword
+                }
+            }
+        }
+    }
+```
+
+Run: `./gradlew :matrix-parquet:compileGroovy`
+Expected: `BUILD SUCCESSFUL` — confirms the module still compiles (and is still statically compiled, via the root-level wiring) without its own `configurationScript` line, and that no other build logic referenced `nexusUrl`.
+
+- [ ] **Step 7: Verify CodeNarc finds no issues after the removal**
+
+Run: `./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest`
+Expected: `BUILD SUCCESSFUL` — confirms no class lost static type-checking (the module-wide `ast(CompileStatic)` config still applies to all of them) and no new CodeNarc violations (e.g. unused-import) were introduced by the removal.
+
+- [ ] **Step 8: Run the full test suite to confirm no regression**
+
+Run: `./gradlew :matrix-parquet:test`
+Expected: `BUILD SUCCESSFUL`, all tests including `testEmptyListValueRoundTrip` and the existing nested-structure tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add matrix-parquet/build.gradle \
+        matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy \
+        matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy \
+        matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetFormatProvider.groovy \
+        matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/InMemoryOutputFile.groovy \
+        matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/InMemoryPositionOutputStream.groovy \
+        matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetWriteOptions.groovy \
+        matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetReadOptions.groovy \
+        matrix-parquet/src/test/groovy/MatrixParquetTest.groovy
+git commit -m "matrix-parquet: remove dead comment, redundant empty-collection branch, redundant @CompileStatic annotations, and unused/duplicate build.gradle config"
+```
+
+---
+
+## Phase 2: Compression + binary-read fix (Tasks 3-4)
+
+**Branch:** `feature/parquet-0.6.0-compression-and-binary-read`, cut from `main` after Phase 1 merges. **Depends on:** Phase 1.
+
+### Task 3: Fix broken BigDecimal-from-plain-BINARY read fallback
+
+**Bug:** `MatrixParquetReader.readPrimitive` has a fallback branch for a `BINARY`/`FIXED_LEN_BYTE_ARRAY` field with no `DecimalLogicalTypeAnnotation`, used when Matrix metadata says the expected type is `BigDecimal` but the physical column has no decimal annotation (e.g. an externally-written file where a string-encoded number was stored as plain `BINARY`). The current code calls `group.getDouble(fieldName, 0)` — `getDouble` only works on a `DOUBLE`-typed column and throws/misbehaves on `BINARY`. This branch is currently unreachable for any file written by `MatrixParquetWriter` itself, but it is live and broken for external files.
+
+**Files:**
+- Modify: `matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy:969-970`
+- Test: `matrix-parquet/src/test/groovy/MatrixParquetTest.groovy`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: no API change — `readPrimitive` keeps its signature; the fix only changes what is returned in this one fallback branch (a correctly parsed `BigDecimal` instead of a `getDouble` call that misreads `BINARY` bytes).
+
+- [ ] **Step 1: Write the failing test**
+
+This constructs a Parquet file directly with the raw Parquet API (bypassing `MatrixParquetWriter`) to reproduce the "external file" scenario: a plain `BINARY` column holding the UTF-8 string `"123.45"`, with Matrix metadata claiming the column type is `BigDecimal`.
+
+Add these imports to `MatrixParquetTest.groovy` (alongside the existing imports):
+```groovy
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.example.data.simple.SimpleGroupFactory
+import org.apache.parquet.hadoop.example.ExampleParquetWriter
+import org.apache.parquet.schema.MessageType
+import org.apache.parquet.schema.PrimitiveType
+import org.apache.parquet.schema.Types
+```
+
+Add the test:
+```groovy
+@Test
+void testBigDecimalFallbackFromPlainBinaryColumn() {
+  // Simulates a file not written by MatrixParquetWriter: Matrix metadata
+  // claims a BigDecimal column, but the physical Parquet column is plain
+  // BINARY with no DECIMAL logical annotation (e.g. a string-encoded number).
+  MessageType schema = Types.buildMessage()
+      .optional(PrimitiveType.PrimitiveTypeName.BINARY).named('amount')
+      .named('ExternalSchema')
+
+  File file = tempDir.resolve('external_plain_binary.parquet').toFile()
+  Map<String, String> extraMeta = [(MatrixParquetReader.METADATA_COLUMN_TYPES): 'java.math.BigDecimal']
+
+  def writer = ExampleParquetWriter.builder(new Path(file.toURI()))
+      .withConf(new Configuration())
+      .withType(schema)
+      .withExtraMetaData(extraMeta)
+      .build()
+  def group = new SimpleGroupFactory(schema).newGroup()
+  group.append('amount', '123.45')
+  writer.write(group)
+  writer.close()
+
+  Matrix matrix = MatrixParquetReader.read(file)
+  assertEquals(new BigDecimal('123.45'), matrix.amount[0])
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `./gradlew :matrix-parquet:test --tests "MatrixParquetTest.testBigDecimalFallbackFromPlainBinaryColumn"`
+Expected: FAIL — either a `ClassCastException`/wrong-type error from `group.getDouble` being called on a `BINARY` field, or an assertion failure showing the wrong value (the exact exception depends on `parquet-column`'s internal validation, but the test must not pass as-is).
+
+- [ ] **Step 3: Fix the fallback branch**
+
+In `MatrixParquetReader.groovy`, change:
+```groovy
+        if (expectedType == BigDecimal) {
+          return BigDecimal.valueOf(group.getDouble(fieldName, 0))
+        }
+        return group.getBinary(fieldName, 0).toStringUsingUTF8()
+```
+to:
+```groovy
+        if (expectedType == BigDecimal) {
+          return new BigDecimal(group.getBinary(fieldName, 0).toStringUsingUTF8())
+        }
+        return group.getBinary(fieldName, 0).toStringUsingUTF8()
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./gradlew :matrix-parquet:test --tests "MatrixParquetTest.testBigDecimalFallbackFromPlainBinaryColumn"`
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy matrix-parquet/src/test/groovy/MatrixParquetTest.groovy
+git commit -m "matrix-parquet: fix broken BigDecimal fallback when reading plain BINARY columns"
+```
+
+---
+
+### Task 4: Add Parquet compression codec support
+
+**Design decision:** Default the codec to `SNAPPY` (industry-standard default, already on the classpath via transitive `snappy-java`/`aircompressor` deps — confirmed via `./gradlew :matrix-parquet:dependencies`). This applies to every write path, including the legacy non-`ParquetWriteOptions` overloads, by giving `writeInternal`/`writeBytesInternal` a default parameter. Compression is fully transparent on read — Parquet readers auto-detect the codec from file footer metadata, so `MatrixParquetReader` needs no changes.
+
+**Files:**
+- Modify: `matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetWriteOptions.groovy` (new `compressionCodec` field/builder/validate/toMap/fromMap/descriptors)
+- Modify: `matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy` (import, `WriterBuilder.compressionCodec(...)`, `writeInternal`/`writeBytesInternal` default param, `write(options)`/`writeBytes(options)` call sites)
+- Modify: `matrix-parquet/readme.md` (Default Behavior + new Compression section)
+- Test: `matrix-parquet/src/test/groovy/MatrixParquetTest.groovy`
+- Test: `matrix-parquet/src/test/groovy/ParquetFormatProviderTest.groovy`
+
+**Interfaces:**
+- Consumes: `org.apache.parquet.hadoop.metadata.CompressionCodecName` (existing parquet-hadoop enum: `UNCOMPRESSED`, `SNAPPY`, `GZIP`, `ZSTD`, `LZ4`, etc.)
+- Produces:
+  - `ParquetWriteOptions.compressionCodec` field (default `CompressionCodecName.SNAPPY`), `ParquetWriteOptions compressionCodec(CompressionCodecName)`, `ParquetWriteOptions compressionCodec(String)`.
+  - `MatrixParquetWriter.WriterBuilder.compressionCodec(CompressionCodecName)` / `.compressionCodec(String)`.
+  - SPI map key `compressionCodec` (string, e.g. `"GZIP"`) usable via `Matrix.write([compressionCodec: 'GZIP'], file)`.
+
+- [ ] **Step 1: Write the failing test for the default codec**
+
+Add to `MatrixParquetTest.groovy` (add these imports alongside existing ones if not already present):
+```groovy
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
+```
+
+```groovy
+@Test
+void testCompressionDefaultIsSnappy() {
+  def data = Matrix.builder('compressedDefault').data(
+      id: 1..50,
+      name: (1..50).collect { "name$it" }
+  ).types([Integer, String]).build()
+
+  File file = tempDir.resolve('compressed_default.parquet').toFile()
+  MatrixParquetWriter.write(data, file)
+
+  def footer = ParquetFileReader.readFooter(new Configuration(), new Path(file.toURI()))
+  def codec = footer.blocks[0].columns[0].codec
+  assertEquals(CompressionCodecName.SNAPPY, codec)
+
+  Matrix matrix = MatrixParquetReader.read(file)
+  assertEquals(data.rowCount(), matrix.rowCount())
+  assertEquals(data.id, matrix.id)
+  assertEquals(data.name, matrix.name)
+}
+
+@Test
+void testCompressionCodecOverrideViaBuilder() {
+  def data = Matrix.builder('gzipTest').data(
+      id: [1, 2, 3],
+      value: ['a', 'b', 'c']
+  ).types([Integer, String]).build()
+
+  File file = tempDir.resolve('gzip.parquet').toFile()
+  MatrixParquetWriter.builder(data)
+      .compressionCodec(CompressionCodecName.GZIP)
+      .write(file)
+
+  def footer = ParquetFileReader.readFooter(new Configuration(), new Path(file.toURI()))
+  assertEquals(CompressionCodecName.GZIP, footer.blocks[0].columns[0].codec)
+
+  Matrix matrix = MatrixParquetReader.read(file)
+  assertEquals(data.id, matrix.id)
+  assertEquals(data.value, matrix.value)
+}
+
+@Test
+void testCompressionCodecUncompressedViaStringAndBytes() {
+  def data = Matrix.builder('uncompressedTest').data(id: [1, 2]).types([Integer]).build()
+
+  byte[] bytes = MatrixParquetWriter.builder(data)
+      .compressionCodec('UNCOMPRESSED')
+      .writeBytes()
+
+  Matrix matrix = MatrixParquetReader.read(bytes)
+  assertEquals(data.id, matrix.id)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./gradlew :matrix-parquet:test --tests "MatrixParquetTest.testCompressionDefaultIsSnappy" --tests "MatrixParquetTest.testCompressionCodecOverrideViaBuilder" --tests "MatrixParquetTest.testCompressionCodecUncompressedViaStringAndBytes"`
+Expected: FAIL — `compressionCodec` is not a recognized method on `WriterBuilder`, compilation error.
+
+- [ ] **Step 3: Add `compressionCodec` to `ParquetWriteOptions`**
+
+In `ParquetWriteOptions.groovy`, add the import:
+```groovy
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
+```
+
+Add the field next to `zoneId`:
+```groovy
+  boolean inferPrecisionAndScale = true
+  Integer precision = null
+  Integer scale = null
+  Map<String, int[]> decimalMeta = [:]
+  ZoneId zoneId = null
+  CompressionCodecName compressionCodec = CompressionCodecName.SNAPPY
+```
+
+Add builder methods next to `zoneId(String value)`. AGENTS.md requires GroovyDoc on public methods, so document both:
+```groovy
+  /**
+   * Sets the compression codec for the Parquet file (default: {@code SNAPPY}).
+   *
+   * @param value the compression codec
+   * @return this options instance
+   */
+  ParquetWriteOptions compressionCodec(CompressionCodecName value) {
+    this.compressionCodec = value
+    this
+  }
+
+  /**
+   * Sets the compression codec from its name (default: {@code "SNAPPY"}).
+   *
+   * @param value the codec name, e.g. "GZIP", "ZSTD", "UNCOMPRESSED"
+   * @return this options instance
+   * @throws IllegalArgumentException if value is not a recognized codec name
+   */
+  ParquetWriteOptions compressionCodec(String value) {
+    this.compressionCodec = CompressionCodecName.valueOf(value.toUpperCase())
+    this
+  }
+```
+
+Add a null check in `validate()` (after the existing `validateDecimalMeta(decimalMeta)` line):
+```groovy
+    validateDecimalMeta(decimalMeta)
+    if (compressionCodec == null) {
+      throw new IllegalArgumentException('compressionCodec cannot be null')
+    }
+```
+
+Add it to `toMap()` (it always has a non-null default, so always include it, same pattern as `inferPrecisionAndScale`):
+```groovy
+  Map<String, ?> toMap() {
+    Map<String, Object> result = [inferPrecisionAndScale: inferPrecisionAndScale, compressionCodec: compressionCodec.name()]
+```
+
+Add it to `fromMap()` (after the `zoneid` block, before `result.validate()`):
+```groovy
+    if (normalized.containsKey('compressioncodec')) {
+      def value = normalized.compressioncodec
+      if (value instanceof CompressionCodecName) {
+        result.compressionCodec(value as CompressionCodecName)
+      } else if (value != null) {
+        result.compressionCodec(String.valueOf(value))
+      }
+    }
+```
+
+Add it to `descriptors()`:
+```groovy
+  static List<OptionDescriptor> descriptors() {
+    [
+        new OptionDescriptor('inferPrecisionAndScale', Boolean, Boolean.TRUE.toString(), 'Infer precision and scale for BigDecimal columns'),
+        new OptionDescriptor(KEY_PRECISION, Integer, null, 'Uniform precision for all BigDecimal columns'),
+        new OptionDescriptor(KEY_SCALE, Integer, null, 'Uniform scale for all BigDecimal columns'),
+        new OptionDescriptor('decimalMeta', Map, null, 'Map of column names to [precision, scale] arrays'),
+        new OptionDescriptor('zoneId', ZoneId, null, 'Time zone to use when writing timestamp values'),
+        new OptionDescriptor('compressionCodec', CompressionCodecName, CompressionCodecName.SNAPPY.name(), 'Compression codec for the Parquet file (e.g. SNAPPY, GZIP, ZSTD, UNCOMPRESSED)')
+    ]
+  }
+```
+
+- [ ] **Step 4: Thread `compressionCodec` through `MatrixParquetWriter`**
+
+Add the import:
+```groovy
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
+```
+
+Add builder methods to `WriterBuilder` (next to `zoneId(String value)`):
+```groovy
+    /**
+     * Sets the compression codec for the Parquet file (default: {@code SNAPPY}).
+     *
+     * @param value the compression codec
+     * @return this builder
+     */
+    WriterBuilder compressionCodec(CompressionCodecName value) {
+      options.compressionCodec(value)
+      this
+    }
+
+    /**
+     * Sets the compression codec for the Parquet file (default: {@code SNAPPY}).
+     *
+     * @param value the compression codec name, e.g. "GZIP", "SNAPPY", "ZSTD", "UNCOMPRESSED"
+     * @return this builder
+     */
+    WriterBuilder compressionCodec(String value) {
+      options.compressionCodec(value)
+      this
+    }
+```
+
+Change `writeInternal` to accept and apply a codec, defaulting to `SNAPPY`:
+```groovy
+  private static File writeInternal(Matrix matrix, File file, MessageType schema, CompressionCodecName compressionCodec = CompressionCodecName.SNAPPY) {
+    def conf = new Configuration()
+    def extraMeta = new HashMap<String, String>()
+    extraMeta.put(METADATA_COLUMN_TYPES, matrix.types().collect { it.name }.join(','))
+    if (matrix.hasIndex()) {
+      extraMeta.put(METADATA_INDEX_COLUMNS, matrix.indexedColumns().join(','))
+    }
+
+    def writer = ExampleParquetWriter.builder(new Path(file.toURI()))
+        .withConf(conf)
+        .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
+        .withType(schema)
+        .withCompressionCodec(compressionCodec)
+        .withExtraMetaData(extraMeta)
+        .build()
+```
+(rest of the method body unchanged)
+
+Change `writeBytesInternal` the same way:
+```groovy
+  private static byte[] writeBytesInternal(Matrix matrix, MessageType schema, CompressionCodecName compressionCodec = CompressionCodecName.SNAPPY) {
+    def conf = new Configuration()
+    def extraMeta = new HashMap<String, String>()
+    extraMeta.put(METADATA_COLUMN_TYPES, matrix.types().collect { it.name }.join(','))
+    if (matrix.hasIndex()) {
+      extraMeta.put(METADATA_INDEX_COLUMNS, matrix.indexedColumns().join(','))
+    }
+
+    InMemoryOutputFile outputFile = new InMemoryOutputFile()
+
+    def writer = ExampleParquetWriter.builder(outputFile)
+        .withConf(conf)
+        .withType(schema)
+        .withCompressionCodec(compressionCodec)
+        .withExtraMetaData(extraMeta)
+        .build()
+```
+(rest of the method body unchanged)
+
+Update the two `ParquetWriteOptions`-driven call sites to pass `options.compressionCodec` explicitly (the legacy overloads need no change — they already call `writeInternal(matrix, file, schema)`/`writeBytesInternal(matrix, schema)` with 3/2 args, and the new default parameter value `SNAPPY` applies automatically):
+
+In `write(Matrix matrix, File fileOrDir, ParquetWriteOptions options)`, change:
+```groovy
+    if (options.zoneId != null) {
+      try {
+        ZONE_ID_HOLDER.set(options.zoneId)
+        return writeInternal(matrix, file, schema)
+      } finally {
+        ZONE_ID_HOLDER.remove()
+      }
+    }
+    return writeInternal(matrix, file, schema)
+```
+to:
+```groovy
+    if (options.zoneId != null) {
+      try {
+        ZONE_ID_HOLDER.set(options.zoneId)
+        return writeInternal(matrix, file, schema, options.compressionCodec)
+      } finally {
+        ZONE_ID_HOLDER.remove()
+      }
+    }
+    return writeInternal(matrix, file, schema, options.compressionCodec)
+```
+
+In `writeBytes(Matrix matrix, ParquetWriteOptions options)`, change:
+```groovy
+    if (options.zoneId != null) {
+      try {
+        ZONE_ID_HOLDER.set(options.zoneId)
+        return writeBytesInternal(matrix, schema)
+      } finally {
+        ZONE_ID_HOLDER.remove()
+      }
+    }
+    return writeBytesInternal(matrix, schema)
+```
+to:
+```groovy
+    if (options.zoneId != null) {
+      try {
+        ZONE_ID_HOLDER.set(options.zoneId)
+        return writeBytesInternal(matrix, schema, options.compressionCodec)
+      } finally {
+        ZONE_ID_HOLDER.remove()
+      }
+    }
+    return writeBytesInternal(matrix, schema, options.compressionCodec)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `./gradlew :matrix-parquet:test --tests "MatrixParquetTest.testCompressionDefaultIsSnappy" --tests "MatrixParquetTest.testCompressionCodecOverrideViaBuilder" --tests "MatrixParquetTest.testCompressionCodecUncompressedViaStringAndBytes"`
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 6: Add an SPI-level test**
+
+Add to `ParquetFormatProviderTest.groovy`:
+```groovy
+@Test
+void testCompressionCodecViaOptionsMap() {
+  Matrix source = Matrix.builder('compressedSpi')
+      .columns(id: [1, 2, 3], name: ['a', 'b', 'c'])
+      .types([Integer, String])
+      .build()
+
+  File file = tempDir.resolve('spi_compressed.parquet').toFile()
+  source.write([compressionCodec: 'GZIP'], file)
+
+  def footer = org.apache.parquet.hadoop.ParquetFileReader.readFooter(
+      new org.apache.hadoop.conf.Configuration(), new org.apache.hadoop.fs.Path(file.toURI()))
+  assertEquals(org.apache.parquet.hadoop.metadata.CompressionCodecName.GZIP, footer.blocks[0].columns[0].codec)
+
+  Matrix matrix = Matrix.read(file)
+  assertEquals(source.id, matrix.id)
+}
+```
+
+Run: `./gradlew :matrix-parquet:test --tests "ParquetFormatProviderTest.testCompressionCodecViaOptionsMap"`
+Expected: `BUILD SUCCESSFUL`
+
+Also add to `MatrixParquetTest.groovy`, pinning the rejection of an unrecognized codec name (`CompressionCodecName.valueOf` throws `IllegalArgumentException` for unknown names):
+```groovy
+@Test
+void testCompressionCodecRejectsInvalidName() {
+  def data = Matrix.builder('badCodec').data(id: [1]).types([Integer]).build()
+  assertThrows(IllegalArgumentException) {
+    MatrixParquetWriter.builder(data).compressionCodec('NOT_A_CODEC').writeBytes()
+  }
+}
+```
+
+Run: `./gradlew :matrix-parquet:test --tests "MatrixParquetTest.testCompressionCodecRejectsInvalidName"`
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 7: Document compression in the README**
+
+In `matrix-parquet/readme.md`, update the **API Surface** section (lines 18-24) as well as the **Writing** bullet list under `## Default Behavior` (line 36-40):
+```markdown
+- `MatrixParquetWriter.builder(matrix)` — fluent writer with `.precision()`, `.scale()`, `.decimalMeta()`, `.compressionCodec()`, `.zoneId()`, `.inferPrecisionAndScale()`, `.write(File/Path/OutputStream)`, `.writeBytes()`
+```
+```markdown
+- `matrix.write(options, file)` — options map with keys `inferPrecisionAndScale`, `precision`, `scale`, `decimalMeta`, `compressionCodec`, `zoneId`
+```
+
+Then add a compression bullet to **Writing**:
+```markdown
+**Writing**
+- Parquet message type name: `matrix.matrixName` when present, otherwise `MatrixSchema`
+- BigDecimal: precision and scale are inferred from the data by default (`inferPrecisionAndScale = true`)
+- Compression: `SNAPPY` by default; override with the `compressionCodec` option (e.g. `GZIP`, `ZSTD`, `UNCOMPRESSED`)
+- Timezone: system default; override with `zoneId` option
+- Nested Map columns: stored as MAP when value types are homogeneous, as STRUCT when heterogeneous
+```
+
+Add a new section after `## Timezone Handling` (before `## Known Limitations`):
+```markdown
+## Compression
+
+Parquet files are compressed with `SNAPPY` by default. Override per write:
+
+\`\`\`groovy
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
+
+// Builder API
+MatrixParquetWriter.builder(data)
+    .compressionCodec(CompressionCodecName.GZIP)
+    .write(file)
+
+// String form (also accepted)
+MatrixParquetWriter.builder(data)
+    .compressionCodec('ZSTD')
+    .write(file)
+
+// SPI options map
+data.write([compressionCodec: 'UNCOMPRESSED'], file)
+\`\`\`
+
+Supported codec names: `UNCOMPRESSED`, `SNAPPY`, `GZIP`, `ZSTD`, `LZ4_RAW` (any value of `org.apache.parquet.hadoop.metadata.CompressionCodecName`). Compression is transparent on read — `MatrixParquetReader` auto-detects the codec from the file footer, no reader-side configuration is needed.
+```
+
+- [ ] **Step 8: Run full verification and commit**
+
+Run: `./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest :matrix-parquet:spotlessCheck :matrix-parquet:test`
+Expected: `BUILD SUCCESSFUL`
+
+```bash
+git add matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetWriteOptions.groovy \
+        matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy \
+        matrix-parquet/src/test/groovy/MatrixParquetTest.groovy \
+        matrix-parquet/src/test/groovy/ParquetFormatProviderTest.groovy \
+        matrix-parquet/readme.md
+git commit -m "matrix-parquet: add Parquet compression codec support (default SNAPPY)"
+```
+
+- [ ] **Step 9: Append to release notes**
+
+In `matrix-parquet/release.md`, add a bullet under the `## v0.6.0, 2026-06-19` header (below the dependency-upgrade bullets):
+```markdown
+- Add compression codec support: `ParquetWriteOptions.compressionCodec` / `WriterBuilder.compressionCodec(...)` / SPI `compressionCodec` option; default changed from `UNCOMPRESSED` to `SNAPPY`
+```
+
+```bash
+git add matrix-parquet/release.md
+git commit -m "matrix-parquet: document compression support in release notes"
+```
+
+---
+
+## Phase 3: BigInteger BINARY remapping (Task 5)
+
+**Branch:** `feature/parquet-0.6.0-biginteger-binary`, cut from `main` after Phase 1 merges (does not need Phase 2). **Depends on:** Phase 1.
+
+### Task 5: Switch BigInteger mapping from INT64 to BINARY+DECIMAL(p,0)
+
+**Bug being fixed:** `BigInteger` columns are currently mapped to Parquet `INT64` and written via `((Number) value).longValue()` (`MatrixParquetWriter.groovy:995`). Any `BigInteger` value outside `Long` range (`[-2^63, 2^63-1]`) silently truncates with no error. This task remaps `BigInteger` to `BINARY` with a `DecimalLogicalTypeAnnotation(scale=0, precision)`, mirroring the existing `BigDecimal`-as-decimal approach but using `BigInteger.toByteArray()` directly (no fixed-width padding needed — `BINARY` is variable-length, unlike `BigDecimal`'s `FIXED_LEN_BYTE_ARRAY`). Precision is required by the Parquet `DECIMAL` logical type regardless of physical encoding, so it must be inferred for every `BigInteger` column (there is no safe non-overflowing default — unlike `BigDecimal`, `BigInteger` has no "fall back to double" escape hatch).
+
+**Files:**
+- Modify: `matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy` (`buildPrimitiveType`, `buildSchema(Matrix, Map)`, new `withBigIntegerPrecision`/`inferBigIntegerPrecision` helpers, `writePrimitiveValue`)
+- Modify: `matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy:963-967` (`readPrimitive` decimal branch)
+- Modify: `matrix-parquet/readme.md` (Supported Data Types table + Known Limitations note)
+- Test: `matrix-parquet/src/test/groovy/MatrixParquetTest.groovy`
+
+**Interfaces:**
+- Consumes: `org.apache.parquet.schema.LogicalTypeAnnotation.decimalType(int scale, int precision)` (already imported in `MatrixParquetWriter.groovy`), `org.apache.parquet.io.api.Binary.fromConstantByteArray(byte[])` (already imported).
+- Produces: `MatrixParquetWriter.buildSchema(Matrix, Map<String, int[]>)` now always returns decimal-annotated `BINARY` schema entries for `BigInteger` columns even when the caller passes no `decimalMeta` for them. `MatrixParquetReader.readPrimitive` returns a `BigInteger` (not `BigDecimal`) when `expectedType == BigInteger` for a `BINARY`/`FIXED_LEN_BYTE_ARRAY` decimal-annotated column.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `MatrixParquetTest.groovy`:
+```groovy
+@Test
+void testBigIntegerRoundTrip() {
+  def data = Matrix.builder('bigIntTest').data(
+      id: [1, 2, 3],
+      big: [BigInteger.TEN, BigInteger.valueOf(-12345), BigInteger.ZERO]
+  ).types([Integer, BigInteger]).build()
+
+  File file = tempDir.resolve('bigint.parquet').toFile()
+  MatrixParquetWriter.write(data, file)
+  Matrix matrix = MatrixParquetReader.read(file)
+
+  assertEquals(BigInteger.TEN, matrix.big[0])
+  assertEquals(BigInteger.valueOf(-12345), matrix.big[1])
+  assertEquals(BigInteger.ZERO, matrix.big[2])
+  assertEquals(BigInteger, matrix.types()[1])
+}
+
+@Test
+void testBigIntegerBeyondLongRangeRoundTrip() {
+  // 10^30 is far beyond Long.MAX_VALUE (~9.2 x 10^18). This used to silently
+  // truncate via .longValue() when BigInteger was mapped to INT64.
+  BigInteger huge = BigInteger.TEN.pow(30)
+  BigInteger hugeNegative = huge.negate().subtract(BigInteger.ONE)
+
+  def data = Matrix.builder('hugeBigInt').data(
+      id: [1, 2],
+      big: [huge, hugeNegative]
+  ).types([Integer, BigInteger]).build()
+
+  File file = tempDir.resolve('huge_bigint.parquet').toFile()
+  MatrixParquetWriter.write(data, file)
+  Matrix matrix = MatrixParquetReader.read(file)
+
+  assertEquals(huge, matrix.big[0])
+  assertEquals(hugeNegative, matrix.big[1])
+}
+
+@Test
+void testBigIntegerExplicitDecimalMetaWrongScaleThrows() {
+  def data = Matrix.builder('badMeta').data(big: [BigInteger.ONE]).types([BigInteger]).build()
+  File file = tempDir.resolve('bad_bigint_meta.parquet').toFile()
+
+  IllegalArgumentException ex = assertThrows(IllegalArgumentException) {
+    MatrixParquetWriter.write(data, file, [big: [10, 2] as int[]])
+  }
+  assertTrue(ex.message.contains('scale must be 0'))
+}
+
+@Test
+void testBigIntegerExplicitDecimalMetaPrecisionHonored() {
+  def data = Matrix.builder('explicitMeta').data(big: [BigInteger.valueOf(42)]).types([BigInteger]).build()
+  File file = tempDir.resolve('explicit_bigint_meta.parquet').toFile()
+
+  MatrixParquetWriter.write(data, file, [big: [5, 0] as int[]])
+  Matrix matrix = MatrixParquetReader.read(file)
+  assertEquals(BigInteger.valueOf(42), matrix.big[0])
+}
+
+@Test
+void testBigIntegerWithNullsRoundTrip() {
+  def data = Matrix.builder('bigIntNulls').data(
+      id: [1, 2, 3],
+      big: [BigInteger.valueOf(7), null, BigInteger.valueOf(-9)]
+  ).types([Integer, BigInteger]).build()
+
+  File file = tempDir.resolve('bigint_nulls.parquet').toFile()
+  MatrixParquetWriter.write(data, file)
+  Matrix matrix = MatrixParquetReader.read(file)
+
+  assertEquals(BigInteger.valueOf(7), matrix.big[0])
+  assertNull(matrix.big[1])
+  assertEquals(BigInteger.valueOf(-9), matrix.big[2])
+}
+
+@Test
+void testBigIntegerExplicitPrecisionTooSmallThrows() {
+  // 9999 needs 4 digits; declaring precision 3 is insufficient. Unlike BigDecimal's
+  // FIXED_LEN_BYTE_ARRAY encoding, BINARY does not reject oversized values at write
+  // time on its own (verified empirically: parquet-mr happily writes and reads back
+  // a BINARY decimal whose byte length implies more digits than the declared
+  // precision). withBigIntegerPrecision must therefore validate this explicitly.
+  def data = Matrix.builder('smallPrecision').data(big: [BigInteger.valueOf(9999)]).types([BigInteger]).build()
+  File file = tempDir.resolve('small_precision.parquet').toFile()
+
+  IllegalArgumentException ex = assertThrows(IllegalArgumentException) {
+    MatrixParquetWriter.write(data, file, [big: [3, 0] as int[]])
+  }
+  assertTrue(ex.message.contains('too small'))
+}
+
+@Test
+void testNestedBigIntegerListPrecisionFallsBackTo38() {
+  // Nested List<BigInteger> elements bypass withBigIntegerPrecision (which only
+  // inspects top-level matrix columns: see buildSchema/withBigIntegerPrecision
+  // above), so buildParquetType always receives decimalMeta=null for them and
+  // falls back to the hardcoded precision of 38 added in Step 4. This does NOT
+  // truncate or corrupt the underlying numeric value on round-trip: BINARY is
+  // variable-length and parquet-mr does not enforce the declared precision
+  // against the actual byte length at write time (proven by
+  // testBigIntegerExplicitPrecisionTooSmallThrows needing its own explicit
+  // validation rather than relying on parquet-mr to reject it).
+  //
+  // It DOES change the round-tripped Groovy type, though: readList (Step 6)
+  // always calls readValue(..., expectedType = null) for list elements, since
+  // there is no Matrix-level type metadata for nested elements (only the
+  // top-level "List" column type is stored). readPrimitive's decimal branch
+  // only returns BigInteger when expectedType == BigInteger; with expectedType
+  // null it falls through to BigDecimal(unscaled, scale=0). So nested
+  // BigInteger elements come back as numerically-equal BigDecimal values, not
+  // BigInteger -- the same ambiguity already documented for top-level
+  // BigInteger columns read without Matrix metadata (Step 9's first new
+  // Known Limitations bullet), just unconditional here since nested elements
+  // never have expectedType metadata available at all. Propagating an
+  // expected element type through readList is a real but separate
+  // enhancement, out of scope for this bugfix-focused task.
+  BigInteger huge = BigInteger.TEN.pow(30)
+  def data = Matrix.builder('nestedBigInt').data(
+      id: [1],
+      bigs: [[huge, BigInteger.ONE]]
+  ).types([Integer, List]).build()
+
+  File file = tempDir.resolve('nested_bigint.parquet').toFile()
+  MatrixParquetWriter.write(data, file)
+  Matrix matrix = MatrixParquetReader.read(file)
+
+  assertEquals([huge as BigDecimal, BigInteger.ONE as BigDecimal], matrix.bigs[0])
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `./gradlew :matrix-parquet:test --tests "MatrixParquetTest.testBigIntegerRoundTrip" --tests "MatrixParquetTest.testBigIntegerBeyondLongRangeRoundTrip" --tests "MatrixParquetTest.testBigIntegerExplicitDecimalMetaWrongScaleThrows" --tests "MatrixParquetTest.testBigIntegerExplicitDecimalMetaPrecisionHonored" --tests "MatrixParquetTest.testBigIntegerWithNullsRoundTrip" --tests "MatrixParquetTest.testBigIntegerExplicitPrecisionTooSmallThrows"`
+Expected: `testBigIntegerBeyondLongRangeRoundTrip` FAILs (truncated value via `.longValue()`); `testBigIntegerExplicitDecimalMetaWrongScaleThrows` and `testBigIntegerExplicitPrecisionTooSmallThrows` FAIL (no such validation exists yet — no exception thrown). `testBigIntegerRoundTrip`, `testBigIntegerExplicitDecimalMetaPrecisionHonored`, and `testBigIntegerWithNullsRoundTrip` currently pass by coincidence (small values fit in `Long`, and nulls are already skipped by the generic null-check in the write-row loop) but must keep passing after the change.
+
+- [ ] **Step 3: Add `BigInteger` precision inference and merge it into `buildSchema`**
+
+In `MatrixParquetWriter.groovy`, change `buildSchema(Matrix matrix, Map<String, int[]> explicitDecimalMeta)`:
+```groovy
+  private static MessageType buildSchema(Matrix matrix, Map<String, int[]> explicitDecimalMeta) {
+    def builder = Types.buildMessage()
+    matrix.columnNames().each { col ->
+      def type = matrix.type(col)
+      def meta = explicitDecimalMeta?.get(col)
+      log.debug("Building schema for column '$col' of type $type with decimal meta: $meta")
+      builder.addField(buildParquetType(col, matrix.column(col), type, meta))
+    }
+    return builder.named(matrix.matrixName ?: "MatrixSchema" )
+  }
+```
+to:
+```groovy
+  private static MessageType buildSchema(Matrix matrix, Map<String, int[]> explicitDecimalMeta) {
+    Map<String, int[]> decimalMeta = withBigIntegerPrecision(matrix, explicitDecimalMeta)
+    def builder = Types.buildMessage()
+    matrix.columnNames().each { col ->
+      def type = matrix.type(col)
+      def meta = decimalMeta?.get(col)
+      log.debug("Building schema for column '$col' of type $type with decimal meta: $meta")
+      builder.addField(buildParquetType(col, matrix.column(col), type, meta))
+    }
+    return builder.named(matrix.matrixName ?: "MatrixSchema" )
+  }
+
+  /**
+   * Ensures every BigInteger column has decimal metadata {@code [precision, 0]}.
+   * Explicit caller-supplied metadata wins after validating its scale is 0
+   * (BigInteger has no fractional part) and that its precision is large enough
+   * to hold every value in the column; otherwise precision is inferred from
+   * the column's actual values.
+   *
+   * <p>The precision-sufficiency check matters because, unlike {@code BigDecimal}'s
+   * {@code FIXED_LEN_BYTE_ARRAY} encoding, the variable-length {@code BINARY}
+   * encoding used for {@code BigInteger} is not rejected by parquet-mr at write
+   * time when the byte length implies more digits than the declared precision —
+   * an undersized explicit precision would otherwise be written and read back
+   * successfully with no error, silently leaving inaccurate schema metadata.
+   */
+  private static Map<String, int[]> withBigIntegerPrecision(Matrix matrix, Map<String, int[]> explicitDecimalMeta) {
+    Map<String, int[]> merged = explicitDecimalMeta != null ? new LinkedHashMap<>(explicitDecimalMeta) : new LinkedHashMap<>()
+    matrix.columnNames().each { col ->
+      if (matrix.type(col) != BigInteger) {
+        return
+      }
+      int[] existing = merged[col]
+      if (existing != null) {
+        if (existing[1] != 0) {
+          throw new IllegalArgumentException(
+              "decimalMeta['$col'] scale must be 0 for BigInteger columns but was ${existing[1]}")
+        }
+        int requiredPrecision = inferBigIntegerPrecision(matrix, col)
+        if (existing[0] < requiredPrecision) {
+          throw new IllegalArgumentException(
+              "decimalMeta['$col'] precision (${existing[0]}) is too small to hold the data in this " +
+              "column (requires at least $requiredPrecision digits)")
+        }
+      } else {
+        merged[col] = [inferBigIntegerPrecision(matrix, col), 0] as int[]
+      }
+    }
+    merged
+  }
+
+  /**
+   * Infers the minimum decimal precision (digit count) needed to represent
+   * every BigInteger value in the given column, so the column can be stored
+   * as a Parquet DECIMAL(precision, 0) without truncation.
+   */
+  private static int inferBigIntegerPrecision(Matrix matrix, String col) {
+    int maxDigits = 1
+    (0..<matrix.rowCount()).each { i ->
+      def value = matrix[i, col]
+      if (value instanceof BigInteger) {
+        int digits = ((BigInteger) value).abs().toString().length()
+        maxDigits = Math.max(maxDigits, digits)
+      }
+    }
+    maxDigits
+  }
+```
+
+- [ ] **Step 4: Map `BigInteger` to `BINARY`+`DECIMAL(0, precision)` in `buildPrimitiveType`**
+
+In `MatrixParquetWriter.groovy`, change:
+```groovy
+  private static PrimitiveType buildPrimitiveType(String name, Class clazz, int[] decimalMeta = null, boolean required = false) {
+    if (clazz == BigDecimal) {
+```
+to:
+```groovy
+  private static PrimitiveType buildPrimitiveType(String name, Class clazz, int[] decimalMeta = null, boolean required = false) {
+    if (clazz == BigInteger) {
+      int precision = (decimalMeta != null && decimalMeta.length == 2 && decimalMeta[0] > 0) ? decimalMeta[0] : 38
+      def builder = required ? Types.required(PrimitiveTypeName.BINARY) : Types.optional(PrimitiveTypeName.BINARY)
+      return builder.as(LogicalTypeAnnotation.decimalType(0, precision)).named(name)
+    }
+
+    if (clazz == BigDecimal) {
+```
+
+Then remove `BigInteger` from the `Long` case in the same method's `switch`:
+```groovy
+      case Long, long, BigInteger -> primitive = PrimitiveTypeName.INT64
+```
+to:
+```groovy
+      case Long, long -> primitive = PrimitiveTypeName.INT64
+```
+
+- [ ] **Step 5: Write `BigInteger` values as `BINARY` in `writePrimitiveValue`**
+
+In `MatrixParquetWriter.groovy`, change:
+```groovy
+      case Integer, int -> group.append(fieldName, (int) value)
+      case Long, long, BigInteger -> group.append(fieldName, ((Number) value).longValue())
+```
+to:
+```groovy
+      case Integer, int -> group.append(fieldName, (int) value)
+      case Long, long -> group.append(fieldName, ((Number) value).longValue())
+      case BigInteger -> group.add(fieldName, Binary.fromConstantByteArray(((BigInteger) value).toByteArray()))
+```
+
+- [ ] **Step 6: Differentiate `BigInteger` from `BigDecimal` when reading a decimal-annotated column**
+
+In `MatrixParquetReader.groovy`, change:
+```groovy
+      case PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY:
+      case PrimitiveTypeName.BINARY:
+        if (logical instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
+          def scale = logical.scale
+          def binary = group.getBinary(fieldName, 0)
+          def unscaled = new BigInteger(binary.getBytes())
+          return new BigDecimal(unscaled, scale)
+        }
+```
+to:
+```groovy
+      case PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY:
+      case PrimitiveTypeName.BINARY:
+        if (logical instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
+          def scale = logical.scale
+          def binary = group.getBinary(fieldName, 0)
+          def unscaled = new BigInteger(binary.getBytes())
+          if (expectedType == BigInteger) {
+            return unscaled
+          }
+          return new BigDecimal(unscaled, scale)
+        }
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `./gradlew :matrix-parquet:test --tests "MatrixParquetTest.testBigIntegerRoundTrip" --tests "MatrixParquetTest.testBigIntegerBeyondLongRangeRoundTrip" --tests "MatrixParquetTest.testBigIntegerExplicitDecimalMetaWrongScaleThrows" --tests "MatrixParquetTest.testBigIntegerExplicitDecimalMetaPrecisionHonored" --tests "MatrixParquetTest.testBigIntegerWithNullsRoundTrip" --tests "MatrixParquetTest.testBigIntegerExplicitPrecisionTooSmallThrows" --tests "MatrixParquetTest.testNestedBigIntegerListPrecisionFallsBackTo38"`
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 8: Run the full test suite to confirm no regressions, especially in existing BigDecimal tests**
+
+Run: `./gradlew :matrix-parquet:test`
+Expected: `BUILD SUCCESSFUL` — in particular `testLargeBigDecimalValues`, `testNegativeBigDecimalRoundTrip`, `testMatrixParquetPrecisionOverflow`, `testWriterBuilderWithUniformPrecision`, `testWriterBuilderWithPrecisionAndScale` must still pass unchanged, since this task does not touch the `BigDecimal` physical encoding (`FIXED_LEN_BYTE_ARRAY` stays as-is).
+
+- [ ] **Step 9: Update the README**
+
+In `matrix-parquet/readme.md`, change the Supported Data Types table row:
+```markdown
+| BigInteger         | INT64                          |                                                   |
+```
+to:
+```markdown
+| BigInteger         | BINARY (DECIMAL, scale=0)      | Precision auto-inferred from data; no `Long` range limit |
+```
+
+Add bullets under `### Type Metadata` in `## Known Limitations`:
+```markdown
+- `BigInteger` columns read without Matrix metadata (e.g. external files) are inferred as `BigDecimal` with scale 0, since both the Parquet schema and the inference logic only see a generic `DECIMAL` logical annotation
+- `BigInteger` values nested inside `List`/`Map` columns always get a declared precision of 38 regardless of their actual digit count (top-level column precision inference does not extend into nested structures), and round-trip back as numerically-equal `BigDecimal` values rather than `BigInteger` (nested elements carry no expected-type metadata, unlike top-level columns). This does not cause data loss or truncation, but external Parquet readers that validate `DECIMAL` precision against declared metadata rather than actual byte length may reject or misinterpret values with more than 38 digits
+```
+
+- [ ] **Step 10: Run full verification and commit**
+
+Run: `./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest :matrix-parquet:spotlessCheck :matrix-parquet:test`
+Expected: `BUILD SUCCESSFUL`
+
+```bash
+git add matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy \
+        matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy \
+        matrix-parquet/src/test/groovy/MatrixParquetTest.groovy \
+        matrix-parquet/readme.md
+git commit -m "matrix-parquet: map BigInteger to BINARY+DECIMAL(p,0), fixing silent truncation beyond Long range"
+```
+
+- [ ] **Step 11: Append to release notes**
+
+In `matrix-parquet/release.md`, add a bullet under `## v0.6.0, 2026-06-19`:
+```markdown
+- Fix bug: `BigInteger` columns silently truncated when their value exceeded `Long` range (mapped to `INT64` via `.longValue()`); now mapped to `BINARY` with a `DECIMAL(precision, 0)` logical annotation, with precision auto-inferred from the data
+```
+
+```bash
+git add matrix-parquet/release.md
+git commit -m "matrix-parquet: document BigInteger fix in release notes"
+```
+
+---
+
+## Phase 4: Writer fixes (Tasks 6-7)
+
+**Branch:** `feature/parquet-0.6.0-writer-fixes`, cut from `main` after Phase 3 merges. **Depends on:** Phase 3 (Task 7 assumes `BigInteger` is already removed from the `INT64` case in `buildPrimitiveType`'s switch — see Task 7 Step 2's ordering note).
+
+### Task 6: Close Parquet writers safely when row writing fails
+
+**Bug being fixed:** `writeInternal` and `writeBytesInternal` call `writer.close()` only after the row loop completes. If `writeValue(...)` or `writer.write(...)` throws, the writer is not closed. This can leak file handles and leave partially-written output in an inconsistent state.
+
+**Files:**
+- Modify: `matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy` (`writeInternal`, `writeBytesInternal`)
+- Test: `matrix-parquet/src/test/groovy/MatrixParquetTest.groovy`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: no API change — failure paths now close the underlying `ParquetWriter` before propagating the original exception.
+
+- [ ] **Step 1: Add a regression test for failed file writes**
+
+Add a test that triggers the existing precision-overflow path, then immediately overwrites the same target file with valid data and reads it back:
+
+```groovy
+@Test
+void testWriterClosesFileWhenRowWriteFails() {
+  def invalid = Matrix.builder('invalidDecimal').data(amount: [623.30]).types([BigDecimal]).build()
+  File file = tempDir.resolve('failed_write_reuse.parquet').toFile()
+
+  assertThrows(Exception) {
+    MatrixParquetWriter.write(invalid, file, [amount: [4, 2] as int[]])
+  }
+
+  def valid = Matrix.builder('validDecimal').data(amount: [12.30]).types([BigDecimal]).build()
+  MatrixParquetWriter.write(valid, file, [amount: [4, 2] as int[]])
+  Matrix matrix = MatrixParquetReader.read(file)
+  assertEquals(valid, matrix)
+}
+```
+
+- [ ] **Step 2: Add a regression test for failed in-memory writes**
+
+Add the same precision-overflow scenario through `writeBytes(...)`, then verify a subsequent valid `writeBytes(...)` succeeds:
+
+```groovy
+@Test
+void testWriterClosesMemoryOutputWhenRowWriteFails() {
+  def invalid = Matrix.builder('invalidBytes').data(amount: [623.30]).types([BigDecimal]).build()
+
+  assertThrows(Exception) {
+    MatrixParquetWriter.writeBytes(invalid, [amount: [4, 2] as int[]])
+  }
+
+  def valid = Matrix.builder('validBytes').data(amount: [12.30]).types([BigDecimal]).build()
+  byte[] bytes = MatrixParquetWriter.writeBytes(valid, [amount: [4, 2] as int[]])
+  Matrix matrix = MatrixParquetReader.read(bytes)
+  assertEquals(valid, matrix)
+}
+```
+
+**Note on test rigor:** unlike the other tasks in this plan, these two tests will most likely **pass even without the fix** on Linux/macOS — reopening a file path (or building a fresh in-memory buffer) after a previous writer leaked its handle doesn't fail on POSIX filesystems, since nothing locks the path or the heap buffer. Treat Steps 1-2 as characterization tests that pin "the API stays usable after a failed write," not as proof the leak is fixed. The `withCloseable` change in Step 3 is still the correct fix (it prevents file-descriptor/buffer leaks under sustained failures, e.g. a long-running process hitting many invalid writes), but don't expect a red→green signal from these two tests specifically.
+
+- [ ] **Step 3: Wrap both writers in `withCloseable`**
+
+In `writeInternal`, wrap the complete row loop in. Use a named closure parameter rather than implicit `it` — every other `withCloseable` call in this codebase already does this (e.g. `MatrixParquetReader.groovy:776`'s `.withCloseable { reader -> ... }`), so this keeps the new code consistent with established style regardless of how `@CompileStatic` would infer `it`'s type from the `def writer` declaration:
+```groovy
+    writer.withCloseable { parquetWriter ->
+      def factory = new SimpleGroupFactory(schema)
+      def rowCount = matrix.rowCount()
+      def colNames = matrix.columnNames()
+
+      (0..<rowCount).each { i ->
+        def group = factory.newGroup()
+        colNames.each { col ->
+          def value = matrix[i, col]
+          if (value != null) {
+            def fieldType = schema.getType(col)
+            writeValue(group, col, fieldType, value)
+          }
+        }
+        parquetWriter.write(group)
+      }
+    }
+```
+
+Do the same in `writeBytesInternal`, and call `outputFile.getBytes()` only after the `withCloseable` block has completed. Preserve the original exception if writing fails; do not catch and replace it.
+
+- [ ] **Step 4: Verify and commit**
+
+Run:
+```bash
+./gradlew :matrix-parquet:test --tests "MatrixParquetTest.testWriterClosesFileWhenRowWriteFails" --tests "MatrixParquetTest.testWriterClosesMemoryOutputWhenRowWriteFails"
+./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest :matrix-parquet:spotlessCheck :matrix-parquet:test
+```
+
+```bash
+git add matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy matrix-parquet/src/test/groovy/MatrixParquetTest.groovy
+git commit -m "matrix-parquet: close writers when row writing fails"
+```
+
+---
+
+### Task 7: Implement documented `java.util.Date` round-trip support
+
+**Bug being fixed:** The README documents `java.util.Date` as `INT64` epoch milliseconds, but the schema builder currently falls through to `BINARY` while `writePrimitiveValue` appends a long value. The reader also does not reconstruct `Date` from stored metadata.
+
+**Files:**
+- Modify: `matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy` (`buildPrimitiveType`)
+- Modify: `matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy` (`readPrimitive`)
+- Test: `matrix-parquet/src/test/groovy/MatrixParquetTest.groovy`
+
+**Interfaces:**
+- Consumes: existing `java.util.Date`.
+- Produces: `java.util.Date` Matrix columns round-trip as `INT64` epoch milliseconds when Matrix metadata is present.
+
+- [ ] **Step 1: Add the failing test**
+
+```groovy
+@Test
+void testJavaUtilDateRoundTrip() {
+  Date first = new Date(1_700_000_000_123L)
+  Date second = new Date(1_700_000_100_456L)
+  def data = Matrix.builder('dateTest').data(
+      id: [1, 2],
+      created: [first, second]
+  ).types([Integer, Date]).build()
+
+  File file = tempDir.resolve('java_util_date.parquet').toFile()
+  MatrixParquetWriter.write(data, file)
+  Matrix matrix = MatrixParquetReader.read(file)
+
+  assertEquals([Integer, Date], matrix.types())
+  assertEquals(first, matrix.created[0])
+  assertEquals(second, matrix.created[1])
+}
+```
+
+- [ ] **Step 2: Store `java.util.Date` as `INT64`**
+
+In `buildPrimitiveType`, add `Date` to the `INT64` case without disturbing `java.sql.Date`, which must keep using `INT32 (DATE)`:
+```groovy
+      case Long, long, BigInteger, Date -> primitive = PrimitiveTypeName.INT64
+```
+
+This change assumes Task 5 has already removed `BigInteger` from the `INT64` branch. If applying these tasks out of order (Task 7 before Task 5), remove `BigInteger` from this branch first; the final branch either way should be:
+```groovy
+      case Long, long, Date -> primitive = PrimitiveTypeName.INT64
+```
+
+- [ ] **Step 3: Reconstruct `Date` on read when metadata requests it**
+
+In the `INT64` branch of `MatrixParquetReader.readPrimitive`, after the timestamp and `BigInteger` handling, add:
+```groovy
+        if (expectedType == Date) {
+          return new Date(longValue)
+        }
+```
+
+Make sure `longValue` is assigned before the `BigInteger` and `Date` checks so both paths use the same field read.
+
+- [ ] **Step 4: Verify and commit**
+
+Run:
+```bash
+./gradlew :matrix-parquet:test --tests "MatrixParquetTest.testJavaUtilDateRoundTrip"
+./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest :matrix-parquet:spotlessCheck :matrix-parquet:test
+```
+
+```bash
+git add matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy matrix-parquet/src/test/groovy/MatrixParquetTest.groovy
+git commit -m "matrix-parquet: implement java.util.Date round-trip support"
+```
+
+---
+
+## Phase 5: Decimal metadata normalization (Task 8)
+
+**Branch:** `feature/parquet-0.6.0-decimal-meta`, cut from `main` after Phase 3 merges (does not need Phase 4). **Depends on:** Phase 3 (sequenced after to avoid two concurrent phases editing `buildSchema`/`decimalMeta` call sites at once; no hard ordering requirement).
+
+### Task 8: Normalize and validate decimal metadata consistently
+
+**Bug/usability issue being fixed:** `ParquetWriteOptions.fromMap([decimalMeta: [amount: [8, 2]]])` rejects the natural Groovy list shape even though the docs describe `[precision, scale]`. Direct overloads such as `write(matrix, file, decimalMeta)` and `writeBytes(matrix, decimalMeta)` also bypass `ParquetWriteOptions.validate()` and rely on `buildPrimitiveType` silently clamping invalid values.
+
+**Files:**
+- Modify: `matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetWriteOptions.groovy`
+- Modify: `matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy`
+- Test: `matrix-parquet/src/test/groovy/ParquetFormatProviderTest.groovy`
+- Test: `matrix-parquet/src/test/groovy/MatrixParquetTest.groovy`
+- Modify: `matrix-parquet/readme.md`
+
+**Interfaces:**
+- Consumes: `decimalMeta` values supplied as `int[]`, `Number[]`, or `List<Number>` with exactly two entries.
+- Produces: all public decimal metadata paths normalize to `Map<String, int[]>` and reject invalid precision/scale values before schema construction.
+
+- [ ] **Step 1: Add SPI/list-shape tests**
+
+`ParquetFormatProviderTest.groovy` currently has a test that asserts the *opposite* of the behavior this task introduces. Delete it — leaving it in place will make the suite self-contradictory once Step 3 lands:
+```groovy
+  @Test
+  void testWriteOptionsRejectInvalidDecimalMetaShape() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      ParquetWriteOptions.fromMap([decimalMeta: [amount: [8, 2]]])
+    }
+
+    assertTrue(exception.message.contains("decimalMeta['amount'] must be an int[] of length 2"))
+  }
+```
+(This is currently at `ParquetFormatProviderTest.groovy:59-66`. Do not touch `testTypedWriteOptionsRejectInvalidDecimalMetaShape` a few lines below it — that one passes `[8] as int[]` (length 1), which stays invalid under the new rules too.)
+
+Replace it with:
+```groovy
+@Test
+void testWriteOptionsAcceptDecimalMetaListShape() {
+  ParquetWriteOptions options = ParquetWriteOptions.fromMap([decimalMeta: [amount: [8, 2]]])
+  assertEquals(8, options.decimalMeta.amount[0])
+  assertEquals(2, options.decimalMeta.amount[1])
+}
+```
+
+Add a provider-level round-trip using the natural map shape:
+```groovy
+@Test
+void testSpiWriteAcceptsDecimalMetaListShape() {
+  Matrix source = Matrix.builder('payments')
+      .data(amount: [12.30, 45.67])
+      .types([BigDecimal])
+      .build()
+
+  File file = tempDir.resolve('decimal_meta_list.parquet').toFile()
+  source.write([decimalMeta: [amount: [8, 2]]], file)
+  Matrix matrix = Matrix.read(file)
+
+  assertEquals(source, matrix)
+  assertEquals(2, matrix.amount[0].scale())
+}
+```
+
+- [ ] **Step 2: Add direct-overload validation tests**
+
+```groovy
+@Test
+void testDirectDecimalMetaRejectsInvalidPrecisionAndScale() {
+  def data = Matrix.builder('badDecimalMeta').data(amount: [12.30]).types([BigDecimal]).build()
+  File file = tempDir.resolve('bad_decimal_meta.parquet').toFile()
+
+  assertThrows(IllegalArgumentException) {
+    MatrixParquetWriter.write(data, file, [amount: [0, 0] as int[]])
+  }
+  assertThrows(IllegalArgumentException) {
+    MatrixParquetWriter.writeBytes(data, [amount: [5, 6] as int[]])
+  }
+}
+```
+
+- [ ] **Step 3: Centralize decimal metadata normalization in `ParquetWriteOptions`**
+
+Replace the existing `private static Map<String, int[]> validateDecimalMeta(Map<?, ?> value)` (widen visibility so `MatrixParquetWriter` can call it, rename, and widen the accepted shapes). AGENTS.md requires GroovyDoc on public methods, so document it:
+```groovy
+  /**
+   * Normalizes and validates a raw {@code decimalMeta} map into {@code Map<String, int[]>}.
+   *
+   * <p>Accepts {@code int[]}, {@code Number[]}, or {@code List<Number>} values of length 2
+   * {@code [precision, scale]} per column, so both direct Groovy callers (who tend to pass
+   * {@code int[]}) and SPI/options-map callers (who tend to pass a {@code List} from
+   * deserialized option values) can use the same entry point.</p>
+   *
+   * @param value raw map of column name to a length-2 precision/scale value
+   * @return normalized map of column name to validated {@code int[2]} [precision, scale]
+   * @throws IllegalArgumentException if any entry has the wrong shape, type, or an
+   *         out-of-range precision/scale
+   */
+  static Map<String, int[]> normalizeDecimalMeta(Map<?, ?> value) {
+    Map<String, int[]> normalized = [:]
+    value.each { key, meta ->
+      String columnName = String.valueOf(key)
+      int[] ps
+      if (meta instanceof int[]) {
+        ps = meta as int[]
+      } else if (meta instanceof Number[]) {
+        ps = (meta as Number[]).collect { it.intValue() } as int[]
+      } else if (meta instanceof List) {
+        ps = (meta as List).collect { (it as Number).intValue() } as int[]
+      } else {
+        throw new IllegalArgumentException(
+            "decimalMeta['$columnName'] must be an int[], Number[], or List<Number> of length 2 [precision, scale] but was ${meta?.class}")
+      }
+      if (ps.length != 2) {
+        throw new IllegalArgumentException(
+            "decimalMeta['$columnName'] must be an int[] of length 2 [precision, scale] but was ${meta?.class}")
+      }
+      if (ps[0] <= 0) {
+        throw new IllegalArgumentException("decimalMeta['$columnName'] precision must be > 0 but was ${ps[0]}")
+      }
+      if (ps[1] < 0) {
+        throw new IllegalArgumentException("decimalMeta['$columnName'] scale must be >= 0 but was ${ps[1]}")
+      }
+      if (ps[1] > ps[0]) {
+        throw new IllegalArgumentException("decimalMeta['$columnName'] scale (${ps[1]}) must not exceed precision (${ps[0]})")
+      }
+      normalized[columnName] = ps
+    }
+    normalized
+  }
+```
+
+Update both call sites in the same file:
+```groovy
+  void validate() {
+    ...
+    decimalMeta = normalizeDecimalMeta(decimalMeta)
+  }
+```
+```groovy
+      if (value != null) {
+        if (!(value instanceof Map)) {
+          throw new IllegalArgumentException("decimalMeta must be a Map<String, int[]> but was ${value?.class}")
+        }
+        result.decimalMeta(normalizeDecimalMeta(value as Map))
+      }
+```
+(replaces the `validateDecimalMeta(value as Map)` call inside `fromMap`).
+
+- [ ] **Step 4: Route direct writer overloads through the same normalization**
+
+In `MatrixParquetWriter.groovy:414-419`, change:
+```groovy
+  static File write(Matrix matrix, File fileOrDir, Map<String, int[]> decimalMeta) {
+    validateInput(matrix, fileOrDir)
+    File file = determineTargetFile(matrix, fileOrDir)
+
+    def schema = buildSchema(matrix, decimalMeta)
+    return writeInternal(matrix, file, schema)
+```
+to:
+```groovy
+  static File write(Matrix matrix, File fileOrDir, Map<String, int[]> decimalMeta) {
+    validateInput(matrix, fileOrDir)
+    File file = determineTargetFile(matrix, fileOrDir)
+
+    def schema = buildSchema(matrix, ParquetWriteOptions.normalizeDecimalMeta(decimalMeta ?: [:]))
+    return writeInternal(matrix, file, schema)
+```
+
+In `MatrixParquetWriter.groovy:497-505`, change:
+```groovy
+  static byte[] writeBytes(Matrix matrix, Map<String, int[]> decimalMeta) {
+    if (matrix == null) {
+      throw new IllegalArgumentException("Matrix cannot be null")
+    }
+    if (matrix.columnCount() == 0) {
+      throw new IllegalArgumentException("Matrix must have at least one column")
+    }
+    MessageType schema = buildSchema(matrix, decimalMeta)
+    return writeBytesInternal(matrix, schema)
+  }
+```
+to:
+```groovy
+  static byte[] writeBytes(Matrix matrix, Map<String, int[]> decimalMeta) {
+    if (matrix == null) {
+      throw new IllegalArgumentException("Matrix cannot be null")
+    }
+    if (matrix.columnCount() == 0) {
+      throw new IllegalArgumentException("Matrix must have at least one column")
+    }
+    MessageType schema = buildSchema(matrix, ParquetWriteOptions.normalizeDecimalMeta(decimalMeta ?: [:]))
+    return writeBytesInternal(matrix, schema)
+  }
+```
+
+- [ ] **Step 5: Remove silent clamping in `buildPrimitiveType`**
+
+In `MatrixParquetWriter.groovy`, the `BigDecimal` branch of `buildPrimitiveType` (after Task 2 has already removed the two dead commented-out lines) looks like:
+```groovy
+    if (clazz == BigDecimal) {
+      if (decimalMeta != null && decimalMeta.length == 2) {
+        int precision = decimalMeta[0]
+        int scale = decimalMeta[1]
+
+        // Add safeguards for invalid (0 or less) precision, which can be passed manually
+        // The inference method already ensures precision is at least 1.
+        if (precision <= 0) {
+          precision = 10 // Fallback to a default precision
+        }
+        // Add safeguards for invalid scale: must be non-negative and not greater than precision
+        if (scale < 0) {
+          scale = 0 // Fallback to a default scale
+        }
+        if (scale > precision) {
+          scale = precision // Clamp scale to precision
+        }
+
+        def builder = required
+```
+Remove the clamping block so it becomes:
+```groovy
+    if (clazz == BigDecimal) {
+      if (decimalMeta != null && decimalMeta.length == 2) {
+        int precision = decimalMeta[0]
+        int scale = decimalMeta[1]
+
+        def builder = required
+```
+After this task, every public entry point normalizes `decimalMeta` before it reaches `buildPrimitiveType`, so invalid precision/scale can no longer reach this point silently.
+
+- [ ] **Step 6: Update README examples**
+
+Clarify that SPI maps can use natural Groovy list syntax:
+```markdown
+data.write([decimalMeta: [amount: [8, 2]]], new File('money.parquet'))
+```
+
+Keep direct typed-builder examples using `int[]` where the method signature still requires it, unless the builder signature is widened in the implementation.
+
+- [ ] **Step 7: Verify and commit**
+
+Run:
+```bash
+./gradlew :matrix-parquet:test --tests "ParquetFormatProviderTest.testWriteOptionsAcceptDecimalMetaListShape" --tests "ParquetFormatProviderTest.testSpiWriteAcceptsDecimalMetaListShape" --tests "MatrixParquetTest.testDirectDecimalMetaRejectsInvalidPrecisionAndScale"
+./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest :matrix-parquet:spotlessCheck :matrix-parquet:test
+```
+
+```bash
+git add matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetWriteOptions.groovy matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy matrix-parquet/src/test/groovy/ParquetFormatProviderTest.groovy matrix-parquet/src/test/groovy/MatrixParquetTest.groovy matrix-parquet/readme.md
+git commit -m "matrix-parquet: normalize decimal metadata across write APIs"
+```
+
+---
+
+## Phase 6: Reader metadata handling (Tasks 9-10)
+
+**Branch:** `feature/parquet-0.6.0-reader-metadata`, cut from `main` after Phase 1 merges (does not need Phases 2-5). **Depends on:** Phase 1.
+
+### Task 9: Preserve matrix names for stream, byte-array, and URL reads
+
+**Usability issue being fixed:** `readFromInputStream` copies the content to a temporary file and calls `read(tempFile)`. If the caller does not provide `matrixName`, the result gets a temp-derived name such as `matrix-parquet-1234`, even when the Parquet schema has a meaningful message type name from the original matrix.
+
+**Files:**
+- Modify: `matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy`
+- Test: `matrix-parquet/src/test/groovy/MatrixParquetTest.groovy`
+- Modify: `matrix-parquet/readme.md`
+
+**Interfaces:**
+- Consumes: existing Parquet message type name from file metadata.
+- Produces: stream/byte-array reads use explicit `matrixName` when provided; otherwise they use the Parquet schema message name when it is not blank; file reads continue to use the file basename for backward compatibility.
+
+- [ ] **Step 1: Add failing tests**
+
+```groovy
+@Test
+void testByteArrayReadUsesSchemaNameWhenNoMatrixNameProvided() {
+  def data = Matrix.builder('schemaNamedMatrix').data(id: [1, 2]).types([Integer]).build()
+
+  byte[] bytes = MatrixParquetWriter.writeBytes(data)
+  Matrix matrix = MatrixParquetReader.read(bytes)
+
+  assertEquals('schemaNamedMatrix', matrix.matrixName)
+}
+
+@Test
+void testInputStreamReadUsesExplicitMatrixNameWhenProvided() {
+  def data = Matrix.builder('schemaName').data(id: [1]).types([Integer]).build()
+  byte[] bytes = MatrixParquetWriter.writeBytes(data)
+
+  Matrix matrix = MatrixParquetReader.read(new ByteArrayInputStream(bytes), 'explicitName')
+
+  assertEquals('explicitName', matrix.matrixName)
+}
+```
+
+- [ ] **Step 2: Add an internal read helper that accepts a fallback matrix name**
+
+`read(File file)` (`MatrixParquetReader.groovy:760-816`) currently derives `matrixName` from `file.name` before it has looked at the schema, and `read(File file, ZoneId zoneId)` (line 551) just sets a thread-local and delegates to `read(file)`. Refactor into three layers: a 3-arg private worker, a 4-arg zoneId-aware wrapper around it, and thin public methods.
+
+Replace the current `read(File file)` body (lines 760-816) with:
+```groovy
+  static Matrix read(File file) {
+    read(file, file == null ? null : defaultMatrixName(file), false, null)
+  }
+
+  private static String defaultMatrixName(File file) {
+    if (file.name.contains(DOT)) {
+      return file.name.substring(0, file.name.lastIndexOf(DOT))
+    }
+    file.name
+  }
+
+  private static Matrix read(File file, String fallbackMatrixName, boolean preferSchemaName, ZoneId zoneId) {
+    if (zoneId == null) {
+      return read(file, fallbackMatrixName, preferSchemaName)
+    }
+    try {
+      ZONE_ID_HOLDER.set(zoneId)
+      return read(file, fallbackMatrixName, preferSchemaName)
+    } finally {
+      ZONE_ID_HOLDER.remove()
+    }
+  }
+
+  private static Matrix read(File file, String fallbackMatrixName, boolean preferSchemaName) {
+    validateFile(file)
+    log.debug("Reading Parquet file: ${file.absolutePath}")
+    def path = new Path(file.toURI())
+    def conf = new Configuration()
+    // Open Parquet file metadata
+    def footer = ParquetFileReader.readFooter(conf, path)
+    def keyValueMetaData = footer.getFileMetaData().getKeyValueMetaData()
+    def typeString = keyValueMetaData.get(METADATA_COLUMN_TYPES)
+    def indexString = keyValueMetaData.get(METADATA_INDEX_COLUMNS)
+
+    List<Class> fieldTypes
+    if (typeString != null) {
+      fieldTypes = parseTypeString(typeString)
+    }
+
+    ParquetReader.builder(new GroupReadSupport(), path).build().withCloseable { reader ->
+      String schemaName = footer.getFileMetaData().getSchema().name
+      String matrixName = fallbackMatrixName
+      if (preferSchemaName && schemaName != null && !schemaName.trim().isEmpty()) {
+        matrixName = schemaName
+      }
+
+      Group row = reader.read()
+      GroupType schema = row != null ? row.getType() : footer.getFileMetaData().getSchema()
+      List<String> fieldNames = schema.fields*.name
+      if (fieldTypes == null) {
+        fieldTypes = extractFieldTypes(schema)
+      }
+      if (row == null) {
+        Matrix m = Matrix.builder(matrixName)
+            .columnNames(fieldNames)
+            .types(fieldTypes)
+            .build()
+        return restoreIndex(m, indexString)
+      }
+
+      def builder = Matrix.builder(matrixName)
+      .columnNames(fieldNames)
+      .types(fieldTypes)
+
+      while (row != null) {
+        def rowData = []
+        fieldNames.eachWithIndex { name, i ->
+          def type = fieldTypes[i]
+          def field = schema.getType(name)
+          def value = readValue(row, name, field, type)
+          rowData << value
+        }
+        builder.addRow(rowData as Object[])
+        row = reader.read()
+      }
+      Matrix m = builder.build()
+      restoreIndex(m, indexString)
+    }
+  }
+```
+
+Update `read(File file, ZoneId zoneId)` (line 551-561) to:
+```groovy
+  static Matrix read(File file, ZoneId zoneId) {
+    if (zoneId == null) {
+      throw new IllegalArgumentException(ERR_ZONE_ID_NULL)
+    }
+    read(file, file == null ? null : defaultMatrixName(file), false, zoneId)
+  }
+```
+
+Update `readFromInputStream` (line 833-856) to use the 4-arg helper directly instead of `read(tempFile.toFile())` / `read(tempFile.toFile(), zoneId)`:
+```groovy
+  private static Matrix readFromInputStream(InputStream is, String matrixName, ZoneId zoneId) {
+    if (is == null) {
+      throw new IllegalArgumentException('InputStream cannot be null')
+    }
+    java.nio.file.Path tempFile = Files.createTempFile('matrix-parquet-', '.parquet')
+    try {
+      Files.copy(is, tempFile, StandardCopyOption.REPLACE_EXISTING)
+      File file = tempFile.toFile()
+      Matrix result = read(file, defaultMatrixName(file), true, zoneId)
+      if (matrixName != null && !matrixName.trim().isEmpty()) {
+        result = result.withMatrixName(matrixName)
+      }
+      result
+    } finally {
+      try {
+        Files.deleteIfExists(tempFile)
+      } catch (IOException ignored) {
+      }
+    }
+  }
+```
+`defaultMatrixName(file)` here strips the temp file's `.parquet` extension (e.g. `matrix-parquet-1234.parquet` -> `matrix-parquet-1234`) and is only used as the fallback when `preferSchemaName` finds no usable schema name. Passing raw `file.name` instead (an earlier draft of this task did) would keep the `.parquet` extension in the fallback name, which does *not* match the pre-existing fallback behavior — the current `read(File file)` (lines 760-816) always strips the extension before using the basename as `matrixName`.
+
+**Note on `validateFile`:** the public `read(File file)` and `read(File file, ZoneId zoneId)` wrappers above deliberately do *not* call `validateFile(file)` themselves — only the private 3-arg worker does, once. Calling it in both places (as an earlier draft of this task did) is redundant on every successful read. The `file == null ? null : defaultMatrixName(file)` guard exists only to avoid an `NullPointerException` from `file.name` *before* `validateFile` gets a chance to throw its clearer `IllegalArgumentException('File cannot be null')` — the existing `testReaderValidation` test (`MatrixParquetTest.groovy:289-295`) already asserts this exact exception/message for `MatrixParquetReader.read((File) null)` and must still pass unchanged.
+
+- [ ] **Step 3: Keep explicit matrix name precedence**
+
+`readFromInputStream(is, matrixName, zoneId)` must still apply a non-blank explicit `matrixName` after reading:
+```groovy
+      if (matrixName != null && !matrixName.trim().isEmpty()) {
+        result = result.withMatrixName(matrixName)
+      }
+```
+
+- [ ] **Step 4: Document the behavior**
+
+Update README Default Behavior:
+```markdown
+- Matrix name for file reads: `matrixName` option wins; otherwise the file basename without extension
+- Matrix name for stream/byte-array/URL reads: `matrixName` option wins; otherwise the Parquet schema/message name when available
+```
+
+- [ ] **Step 5: Verify and commit**
+
+Run:
+```bash
+./gradlew :matrix-parquet:test --tests "MatrixParquetTest.testByteArrayReadUsesSchemaNameWhenNoMatrixNameProvided" --tests "MatrixParquetTest.testInputStreamReadUsesExplicitMatrixNameWhenProvided" --tests "MatrixParquetTest.testReaderValidation"
+./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest :matrix-parquet:spotlessCheck :matrix-parquet:test
+```
+Expected: `BUILD SUCCESSFUL`, including `testReaderValidation` confirming `read((File) null)` still throws `IllegalArgumentException('File cannot be null')` via the single `validateFile` call left in the private 3-arg worker.
+
+```bash
+git add matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy matrix-parquet/src/test/groovy/MatrixParquetTest.groovy matrix-parquet/readme.md
+git commit -m "matrix-parquet: preserve matrix names for stream reads"
+```
+
+---
+
+### Task 10: Store index metadata as structured JSON instead of comma-delimited text
+
+**Bug being fixed:** Index column metadata is currently stored as `matrix.indexedColumns().join(',')` and restored via `split(',')`. An index column whose name contains a comma cannot round-trip.
+
+**Files:**
+- Modify: `matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy`
+- Modify: `matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy`
+- Test: `matrix-parquet/src/test/groovy/MatrixParquetTest.groovy`
+
+**Interfaces:**
+- Consumes: existing metadata key `matrix.indexColumns`.
+- Produces: new writes store `matrix.indexColumns` as JSON string array; reads support both the new JSON form and the legacy comma-delimited form for backward compatibility.
+
+- [ ] **Step 1: Add the failing test**
+
+```groovy
+@Test
+void testIndexColumnNameWithCommaRoundTrip() {
+  def data = Matrix.builder('commaIndex').data(
+      'country,region': ['US,West', 'SE,Stockholm'],
+      quarter: ['Q1', 'Q2'],
+      sales: [100, 200]
+  ).types([String, String, Integer]).build()
+
+  data.createIndex('country,region')
+  byte[] bytes = MatrixParquetWriter.writeBytes(data)
+  Matrix matrix = MatrixParquetReader.read(bytes)
+
+  assertTrue(matrix.hasIndex())
+  assertEquals(['country,region'], matrix.indexedColumns())
+  assertEquals(1, matrix.lookup('US,West').rowCount())
+}
+```
+
+- [ ] **Step 2: Write JSON array metadata**
+
+Use `groovy.json.JsonOutput` in `MatrixParquetWriter`:
+```groovy
+extraMeta.put(METADATA_INDEX_COLUMNS, JsonOutput.toJson(matrix.indexedColumns()))
+```
+
+Apply this in both `writeInternal` and `writeBytesInternal`.
+
+- [ ] **Step 3: Read both JSON and legacy comma-delimited metadata**
+
+Add `import groovy.json.JsonSlurper` to `MatrixParquetReader.groovy`. Replace `restoreIndex` (`MatrixParquetReader.groovy:825-831`):
+```groovy
+  private static Matrix restoreIndex(Matrix matrix, String indexString) {
+    if (indexString != null && !indexString.trim().isEmpty()) {
+      String[] indexColumns = indexString.split(COMMA)*.trim() as String[]
+      matrix.createIndex(indexColumns)
+    }
+    matrix
+  }
+```
+with:
+```groovy
+  private static Matrix restoreIndex(Matrix matrix, String indexString) {
+    if (indexString != null && !indexString.trim().isEmpty()) {
+      String[] indexColumns
+      if (indexString.trim().startsWith('[')) {
+        indexColumns = (new JsonSlurper().parseText(indexString) as List)*.toString() as String[]
+      } else {
+        indexColumns = indexString.split(COMMA)*.trim() as String[]
+      }
+      matrix.createIndex(indexColumns)
+    }
+    matrix
+  }
+```
+Also add `import groovy.json.JsonOutput` to `MatrixParquetWriter.groovy` for Step 2.
+
+- [ ] **Step 4: Verify legacy metadata still reads**
+
+Create a Parquet file with `METADATA_INDEX_COLUMNS` set to the legacy value `'country,quarter'` and verify both columns are restored as before:
+
+```groovy
+@Test
+void testLegacyCommaDelimitedIndexMetadataStillReads() {
+  MessageType schema = Types.buildMessage()
+      .optional(PrimitiveType.PrimitiveTypeName.BINARY).named('country')
+      .optional(PrimitiveType.PrimitiveTypeName.BINARY).named('quarter')
+      .optional(PrimitiveType.PrimitiveTypeName.INT32).named('sales')
+      .named('LegacyIndex')
+
+  File file = tempDir.resolve('legacy_index_metadata.parquet').toFile()
+  Map<String, String> extraMeta = [
+      (MatrixParquetReader.METADATA_COLUMN_TYPES): 'java.lang.String,java.lang.String,java.lang.Integer',
+      (MatrixParquetReader.METADATA_INDEX_COLUMNS): 'country,quarter'
+  ]
+
+  def writer = ExampleParquetWriter.builder(new Path(file.toURI()))
+      .withConf(new Configuration())
+      .withType(schema)
+      .withExtraMetaData(extraMeta)
+      .build()
+  def group = new SimpleGroupFactory(schema).newGroup()
+  group.append('country', 'SE')
+  group.append('quarter', 'Q1')
+  group.append('sales', 100)
+  writer.write(group)
+  writer.close()
+
+  Matrix matrix = MatrixParquetReader.read(file)
+  assertTrue(matrix.hasIndex())
+  assertEquals(['country', 'quarter'], matrix.indexedColumns())
+}
+```
+
+- [ ] **Step 5: Verify and commit**
+
+Run:
+```bash
+./gradlew :matrix-parquet:test --tests "MatrixParquetTest.testIndexColumnNameWithCommaRoundTrip" --tests "MatrixParquetTest.testLegacyCommaDelimitedIndexMetadataStillReads"
+./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest :matrix-parquet:spotlessCheck :matrix-parquet:test
+```
+
+```bash
+git add matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy matrix-parquet/src/test/groovy/MatrixParquetTest.groovy
+git commit -m "matrix-parquet: store index metadata as JSON"
+```
+
+---
+
+## Phase 7: Final consolidation and verification (Task 11)
+
+**Branch:** `feature/parquet-0.6.0-final-verification`, cut from `main` after Phases 1-6 have all merged. **Depends on:** Phases 1-6.
+
+### Task 11: Final consolidation and verification
+
+**Files:**
+- Modify: `matrix-parquet/release.md` (final review pass)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: nothing new — this task is a verification/documentation gate, not a code change.
+
+- [ ] **Step 1: Append the remaining cleanup bullets to release notes**
+
+In `matrix-parquet/release.md`, ensure the `## v0.6.0, 2026-06-19` section (after Tasks 1, 4, 5, 6, 7, 8, 9, and 10's edits) also documents every remaining cleanup/fix. Add these bullets (order within the section doesn't matter, but keep dependency upgrades first per existing convention):
+```markdown
+- Fix bug: reading a `BigDecimal`-typed column stored as plain `BINARY` with no `DECIMAL` annotation (e.g. an externally-written file) incorrectly called `getDouble` on binary data; now parses the UTF-8 string as a `BigDecimal`
+- Fix bug: Parquet writers are now closed if row writing fails, preventing leaked file handles on exceptions
+- Fix bug: documented `java.util.Date` support now stores epoch milliseconds as `INT64` and restores `Date` values when Matrix metadata is present
+- Improve usability: `decimalMeta` options now accept natural Groovy list syntax (`[precision, scale]`) and all write paths validate precision/scale consistently
+- Improve usability: stream, byte-array, and URL reads now derive the matrix name from the Parquet schema/message name when no explicit `matrixName` is supplied
+- Fix bug: index column metadata is now stored as JSON, so index column names containing commas round-trip correctly while legacy comma-delimited metadata remains readable
+- Remove dead/redundant code: unreachable commented-out lines in `MatrixParquetWriter.buildPrimitiveType`; redundant empty-collection special case in `writeList`
+```
+
+The complete `## v0.6.0, 2026-06-19` section should now read:
+```markdown
+## v0.6.0, 2026-06-19
+- Upgrade dependencies
+  - org.apache.parquet:parquet-column 1.17.0 -> 1.17.1
+  - org.apache.parquet:parquet-hadoop 1.17.0 -> 1.17.1 
+- Add compression codec support: `ParquetWriteOptions.compressionCodec` / `WriterBuilder.compressionCodec(...)` / SPI `compressionCodec` option; default changed from `UNCOMPRESSED` to `SNAPPY`
+- Fix bug: `BigInteger` columns silently truncated when their value exceeded `Long` range (mapped to `INT64` via `.longValue()`); now mapped to `BINARY` with a `DECIMAL(precision, 0)` logical annotation, with precision auto-inferred from the data
+- Fix bug: reading a `BigDecimal`-typed column stored as plain `BINARY` with no `DECIMAL` annotation (e.g. an externally-written file) incorrectly called `getDouble` on binary data; now parses the UTF-8 string as a `BigDecimal`
+- Fix bug: Parquet writers are now closed if row writing fails, preventing leaked file handles on exceptions
+- Fix bug: documented `java.util.Date` support now stores epoch milliseconds as `INT64` and restores `Date` values when Matrix metadata is present
+- Improve usability: `decimalMeta` options now accept natural Groovy list syntax (`[precision, scale]`) and all write paths validate precision/scale consistently
+- Improve usability: stream, byte-array, and URL reads now derive the matrix name from the Parquet schema/message name when no explicit `matrixName` is supplied
+- Fix bug: index column metadata is now stored as JSON, so index column names containing commas round-trip correctly while legacy comma-delimited metadata remains readable
+- Remove dead/redundant code: unreachable commented-out lines in `MatrixParquetWriter.buildPrimitiveType`; redundant empty-collection special case in `writeList`
+```
+
+- [ ] **Step 2: Run the full module verification suite**
+
+Run: `./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest :matrix-parquet:spotlessCheck :matrix-parquet:test`
+Expected: `BUILD SUCCESSFUL`, all tasks pass with zero CodeNarc violations, zero Spotless formatting diffs, and all tests (existing + new) green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add matrix-parquet/release.md
+git commit -m "matrix-parquet: consolidate 0.6.0 release notes"
+```
+
+- [ ] **Step 4: Hand back to the user**
+
+Do not push. Per `AGENTS.md`, confirm with the user which branch to push to before any `git push`, and let them decide when to cut the actual `0.6.0` release (bumping `build.gradle` off `-SNAPSHOT` and finalizing the `release.md` date) — that is a separate, explicit release step outside this plan's scope.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Version bump to 0.6.0(-SNAPSHOT) instead of 0.5.1 → Task 1.
+- Compression support → Task 4.
+- `BigInteger` `INT64` → `BINARY`+`DECIMAL(p,0)` → Task 5.
+- Dead commented-out code in `buildPrimitiveType` → Task 2, Step 3.
+- Redundant empty-collection branch in `writeList` → Task 2, Step 4.
+- Redundant `@CompileStatic` annotations across all 7 production files → Task 2, Step 5.
+- Unused `nexusUrl` and redundant `compileGroovy` `configurationScript` in `matrix-parquet/build.gradle` → Task 2, Step 6.
+- Broken `BigDecimal`-from-`getDouble` read fallback → Task 3.
+- `BigInteger` overflow (the other usability/bug finding) → resolved by Task 5 (no longer possible once `BINARY`+`DECIMAL` is used; precision is always inferred).
+- Writer resource cleanup on row-write exceptions → Task 6.
+- Documented `java.util.Date` support actually round-trips → Task 7.
+- Direct and SPI `decimalMeta` validation/coercion, including natural Groovy list syntax → Task 8.
+- Stream/byte-array/URL read matrix names no longer default to temp-file names → Task 9.
+- Index column names containing commas round-trip through JSON metadata, with legacy metadata still readable → Task 10.
+- README updates for new user-facing behaviors → Task 4 Step 7, Task 5 Step 9, Task 8 Step 6, Task 9 Step 4.
+- Release notes for every change → Tasks 1, 4, 5, and consolidated in Task 11.
+
+**Placeholder scan:** No "TBD"/"similar to Task N"/vague error-handling language anywhere above — steps include concrete target files, method names, tests, and exact verification commands.
+
+**Type consistency:** `withBigIntegerPrecision(Matrix, Map<String, int[]>)` and `inferBigIntegerPrecision(Matrix, String)` (Task 5, Step 3) are used consistently by name in Steps 3-4. `compressionCodec` is spelled identically across `ParquetWriteOptions`, `WriterBuilder`, the SPI map key, and the README (Task 4). `expectedType == BigInteger` (Task 5, Step 6) matches the existing `expectedType` parameter name already used throughout `MatrixParquetReader.readPrimitive`. `decimalMeta` remains normalized to `Map<String, int[]>` internally after accepting `int[]`, `Number[]`, or `List<Number>` at option boundaries (Task 8).

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/InMemoryOutputFile.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/InMemoryOutputFile.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.parquet
 
-import groovy.transform.CompileStatic
-
 import org.apache.parquet.io.OutputFile
 import org.apache.parquet.io.PositionOutputStream
 
@@ -46,7 +44,6 @@ import org.apache.parquet.io.PositionOutputStream
  * @see MatrixParquetWriter
  * @see org.apache.parquet.io.OutputFile
  */
-@CompileStatic
 class InMemoryOutputFile implements OutputFile {
 
   private InMemoryPositionOutputStream stream

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/InMemoryPositionOutputStream.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/InMemoryPositionOutputStream.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.parquet
 
-import groovy.transform.CompileStatic
-
 import org.apache.parquet.io.PositionOutputStream
 
 /**
@@ -28,7 +26,6 @@ import org.apache.parquet.io.PositionOutputStream
  * @see InMemoryOutputFile
  * @see org.apache.parquet.io.PositionOutputStream
  */
-@CompileStatic
 class InMemoryPositionOutputStream extends PositionOutputStream {
 
   private final ByteArrayOutputStream contents

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.parquet
 
-import groovy.transform.CompileStatic
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.example.data.Group
@@ -86,7 +84,6 @@ import java.util.concurrent.ConcurrentHashMap
  * @see MatrixParquetWriter
  * @see Matrix
  */
-@CompileStatic
 class MatrixParquetReader {
 
   private static final Logger log = Logger.getLogger(MatrixParquetReader)
@@ -151,7 +148,6 @@ class MatrixParquetReader {
    *
    * <p>Obtain an instance via {@link MatrixParquetReader#builder()}.</p>
    */
-  @CompileStatic
   static class ReaderBuilder {
 
     private final ParquetReadOptions options = new ParquetReadOptions()

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.parquet
 
-import groovy.transform.CompileStatic
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.example.data.Group
@@ -86,7 +84,6 @@ import java.util.concurrent.ConcurrentHashMap
  * @see MatrixParquetReader
  * @see Matrix
  */
-@CompileStatic
 class MatrixParquetWriter {
 
   private static final Logger log = Logger.getLogger(MatrixParquetWriter)
@@ -180,7 +177,6 @@ class MatrixParquetWriter {
    *
    * <p>Obtain an instance via {@link MatrixParquetWriter#builder(Matrix)}.</p>
    */
-  @CompileStatic
   static class WriterBuilder {
 
     private final Matrix matrix
@@ -732,9 +728,6 @@ class MatrixParquetWriter {
   private static PrimitiveType buildPrimitiveType(String name, Class clazz, int[] decimalMeta = null, boolean required = false) {
     if (clazz == BigDecimal) {
       if (decimalMeta != null && decimalMeta.length == 2) {
-        // int precision = decimalMeta[0] ?: 10 // BUGGY: what if 0 is passed? (though inference prevents this)
-        // int scale = decimalMeta[1] ?: 2     // BUGGY: 0 ?: 2 becomes 2
-
         int precision = decimalMeta[0]
         int scale = decimalMeta[1]
 
@@ -1052,10 +1045,6 @@ class MatrixParquetWriter {
           "but got ${value.class.simpleName}. Value: ${truncateForError(value)}")
     }
     Collection<?> collection = (Collection<?>) value
-    if (collection.isEmpty()) {
-      group.addGroup(fieldName)
-      return
-    }
     Group listGroup = group.addGroup(fieldName)
     GroupType repeatedType = groupType.getType(0).asGroupType()
     Type elementType = repeatedType.getType(0)

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetFormatProvider.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetFormatProvider.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.parquet
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.spi.AbstractFormatProvider
 import se.alipsa.matrix.core.spi.OptionDescriptor
@@ -9,7 +7,6 @@ import se.alipsa.matrix.core.spi.OptionDescriptor
 /**
  * SPI format provider for Parquet files.
  */
-@CompileStatic
 class ParquetFormatProvider extends AbstractFormatProvider {
 
   private static final Set<String> EXTENSIONS = ['parquet'] as Set<String>

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetReadOptions.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetReadOptions.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.parquet
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.spi.OptionDescriptor
 import se.alipsa.matrix.core.spi.OptionMaps
 
@@ -10,7 +8,6 @@ import java.time.ZoneId
 /**
  * Typed options for Parquet read operations via the SPI.
  */
-@CompileStatic
 class ParquetReadOptions {
 
   String matrixName = null

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetWriteOptions.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetWriteOptions.groovy
@@ -1,7 +1,5 @@
 package se.alipsa.matrix.parquet
 
-import groovy.transform.CompileStatic
-
 import se.alipsa.matrix.core.spi.OptionDescriptor
 import se.alipsa.matrix.core.spi.OptionMaps
 
@@ -10,7 +8,6 @@ import java.time.ZoneId
 /**
  * Typed options for Parquet write operations via the SPI.
  */
-@CompileStatic
 class ParquetWriteOptions {
 
   private static final String KEY_PRECISION = 'precision'

--- a/matrix-parquet/src/test/groovy/MatrixParquetTest.groovy
+++ b/matrix-parquet/src/test/groovy/MatrixParquetTest.groovy
@@ -191,6 +191,21 @@ class MatrixParquetTest {
   }
 
   @Test
+  void testEmptyListValueRoundTrip() {
+    def data = Matrix.builder('emptyListTest').data(
+        id: [1, 2],
+        tags: [['a', 'b'], []]
+    ).types([Integer, List]).build()
+
+    File file = tempDir.resolve('empty_list_value.parquet').toFile()
+    MatrixParquetWriter.write(data, file)
+    Matrix matrix = MatrixParquetReader.read(file)
+
+    assertEquals(['a', 'b'], matrix.tags[0])
+    assertEquals([], matrix.tags[1])
+  }
+
+  @Test
   void testTimePrecisionRoundTrip() {
     // Test LocalDateTime with microsecond precision (schema uses MICROS)
     def dateTime1 = LocalDateTime.of(2024, 6, 15, 10, 30, 45, 123_456_000) // 123.456 ms


### PR DESCRIPTION
## Summary
- Bump `matrix-parquet` to `0.6.0-SNAPSHOT` and retitle the top release notes entry to v0.6.0.
- Remove redundant `@CompileStatic` annotations/imports now covered by root Gradle configuration.
- Remove duplicate module-local Groovy static compilation wiring, unused Nexus URL config, dead BigDecimal comments, and redundant empty-list write branch.
- Add an empty-list round-trip characterization test.
- Add the v0.6.0 implementation plan under `matrix-parquet/req/`.

## Modules touched
- `matrix-parquet`

## Tests
- `./gradlew :matrix-parquet:test --tests "MatrixParquetTest.testEmptyListValueRoundTrip"`
- `./gradlew :matrix-parquet:compileGroovy`
- `./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest`
- `./gradlew :matrix-parquet:spotlessCheck`
- `./gradlew :matrix-parquet:test`