### PR TITLE
matrix-parquet: implement v0.6.0 phase 2 compression and binary read fix

### DIFF
--- a/matrix-parquet/readme.md
+++ b/matrix-parquet/readme.md
@@ -17,11 +17,11 @@ This module enables import and export of [Apache Parquet](https://parquet.apache
 
 **Direct API (recommended)**
 - `MatrixParquetReader.builder()` — fluent reader with `.matrixName()`, `.zoneId()`, `.read(File/Path/URL/InputStream/byte[])` 
-- `MatrixParquetWriter.builder(matrix)` — fluent writer with `.precision()`, `.scale()`, `.decimalMeta()`, `.zoneId()`, `.inferPrecisionAndScale()`, `.write(File/Path/OutputStream)`, `.writeBytes()`
+- `MatrixParquetWriter.builder(matrix)` — fluent writer with `.precision()`, `.scale()`, `.decimalMeta()`, `.compressionCodec()`, `.zoneId()`, `.inferPrecisionAndScale()`, `.write(File/Path/OutputStream)`, `.writeBytes()`
 
 **SPI (generic Matrix API)**
 - `Matrix.read(options, file)` — options map with keys `matrixName`, `zoneId`
-- `matrix.write(options, file)` — options map with keys `inferPrecisionAndScale`, `precision`, `scale`, `decimalMeta`, `zoneId`
+- `matrix.write(options, file)` — options map with keys `inferPrecisionAndScale`, `precision`, `scale`, `decimalMeta`, `compressionCodec`, `zoneId`
 
 **Typed options classes**
 - `ParquetReadOptions` — typed options for reading; use `ParquetReadOptions.describe()` for runtime discovery
@@ -36,6 +36,7 @@ This module enables import and export of [Apache Parquet](https://parquet.apache
 **Writing**
 - Parquet message type name: `matrix.matrixName` when present, otherwise `MatrixSchema`
 - BigDecimal: precision and scale are inferred from the data by default (`inferPrecisionAndScale = true`)
+- Compression: `SNAPPY` by default; override with the `compressionCodec` option (e.g. `GZIP`, `ZSTD`, `UNCOMPRESSED`)
 - Timezone: system default; override with `zoneId` option
 - Nested Map columns: stored as MAP when value types are homogeneous, as STRUCT when heterogeneous
 
@@ -236,6 +237,29 @@ Matrix matrix = MatrixParquetReader.read(file, "myData", ZoneId.of("Europe/Londo
 ```
 
 **Important:** For consistent round-trip behavior, use the same timezone for writing and reading. If files are shared across systems with different default timezones, explicitly specify the timezone.
+
+## Compression
+
+Parquet files are compressed with `SNAPPY` by default. Override per write:
+
+```groovy
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
+
+// Builder API
+MatrixParquetWriter.builder(data)
+    .compressionCodec(CompressionCodecName.GZIP)
+    .write(file)
+
+// String form (also accepted)
+MatrixParquetWriter.builder(data)
+    .compressionCodec('ZSTD')
+    .write(file)
+
+// SPI options map
+data.write([compressionCodec: 'UNCOMPRESSED'], file)
+```
+
+Supported codec names: `UNCOMPRESSED`, `SNAPPY`, `GZIP`, `ZSTD`, `LZ4_RAW` (any value of `org.apache.parquet.hadoop.metadata.CompressionCodecName`). Compression is transparent on read — `MatrixParquetReader` auto-detects the codec from the file footer, no reader-side configuration is needed.
 
 ## Known Limitations
 

--- a/matrix-parquet/release.md
+++ b/matrix-parquet/release.md
@@ -4,6 +4,7 @@
 - Upgrade dependencies
   - org.apache.parquet:parquet-column 1.17.0 -> 1.17.1
   - org.apache.parquet:parquet-hadoop 1.17.0 -> 1.17.1 
+- Add compression codec support: `ParquetWriteOptions.compressionCodec` / `WriterBuilder.compressionCodec(...)` / SPI `compressionCodec` option; default changed from `UNCOMPRESSED` to `SNAPPY`
 
 ## v0.5.0, 2026-04-29
 - Add SPI integration: `MatrixParquetFormatProvider` registers `.parquet` extension with Matrix SPI so `Matrix.read(file)` and `matrix.write(file)` work without explicit imports

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
@@ -963,7 +963,7 @@ class MatrixParquetReader {
           return new BigDecimal(unscaled, scale)
         }
         if (expectedType == BigDecimal) {
-          return BigDecimal.valueOf(group.getDouble(fieldName, 0))
+          return new BigDecimal(group.getBinary(fieldName, 0).toStringUsingUTF8())
         }
         return group.getBinary(fieldName, 0).toStringUsingUTF8()
       default:

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
@@ -6,6 +6,7 @@ import org.apache.parquet.example.data.Group
 import org.apache.parquet.example.data.simple.SimpleGroupFactory
 import org.apache.parquet.hadoop.ParquetFileWriter
 import org.apache.parquet.hadoop.example.ExampleParquetWriter
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.apache.parquet.io.api.Binary
 import org.apache.parquet.schema.GroupType
 import org.apache.parquet.schema.LogicalTypeAnnotation
@@ -255,6 +256,28 @@ class MatrixParquetWriter {
     }
 
     /**
+     * Sets the compression codec for the Parquet file (default: {@code SNAPPY}).
+     *
+     * @param value the compression codec
+     * @return this builder
+     */
+    WriterBuilder compressionCodec(CompressionCodecName value) {
+      options.compressionCodec(value)
+      this
+    }
+
+    /**
+     * Sets the compression codec for the Parquet file (default: {@code SNAPPY}).
+     *
+     * @param value the compression codec name, e.g. "GZIP", "SNAPPY", "ZSTD", "UNCOMPRESSED"
+     * @return this builder
+     */
+    WriterBuilder compressionCodec(String value) {
+      options.compressionCodec(value)
+      this
+    }
+
+    /**
      * Writes the matrix to the specified file or directory.
      *
      * @param fileOrDir the target file or directory; if a directory, the filename is derived from the matrix name
@@ -434,12 +457,12 @@ class MatrixParquetWriter {
     if (options.zoneId != null) {
       try {
         ZONE_ID_HOLDER.set(options.zoneId)
-        return writeInternal(matrix, file, schema)
+        return writeInternal(matrix, file, schema, options.compressionCodec)
       } finally {
         ZONE_ID_HOLDER.remove()
       }
     }
-    return writeInternal(matrix, file, schema)
+    return writeInternal(matrix, file, schema, options.compressionCodec)
   }
 
   /**
@@ -523,12 +546,12 @@ class MatrixParquetWriter {
     if (options.zoneId != null) {
       try {
         ZONE_ID_HOLDER.set(options.zoneId)
-        return writeBytesInternal(matrix, schema)
+        return writeBytesInternal(matrix, schema, options.compressionCodec)
       } finally {
         ZONE_ID_HOLDER.remove()
       }
     }
-    return writeBytesInternal(matrix, schema)
+    return writeBytesInternal(matrix, schema, options.compressionCodec)
   }
 
   private static File determineTargetFile(Matrix matrix, File fileOrDir) {
@@ -567,7 +590,7 @@ class MatrixParquetWriter {
    * @param schema the Parquet MessageType schema
    * @return the target file
    */
-  private static File writeInternal(Matrix matrix, File file, MessageType schema) {
+  private static File writeInternal(Matrix matrix, File file, MessageType schema, CompressionCodecName compressionCodec = CompressionCodecName.SNAPPY) {
     def conf = new Configuration()
     def extraMeta = new HashMap<String, String>()
     extraMeta.put(METADATA_COLUMN_TYPES, matrix.types().collect { it.name }.join(','))
@@ -579,6 +602,7 @@ class MatrixParquetWriter {
         .withConf(conf)
         .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
         .withType(schema)
+        .withCompressionCodec(compressionCodec)
         .withExtraMetaData(extraMeta)
         .build()
 
@@ -620,7 +644,7 @@ class MatrixParquetWriter {
    * @param schema the Parquet MessageType schema
    * @return byte array containing Parquet data
    */
-  private static byte[] writeBytesInternal(Matrix matrix, MessageType schema) {
+  private static byte[] writeBytesInternal(Matrix matrix, MessageType schema, CompressionCodecName compressionCodec = CompressionCodecName.SNAPPY) {
     def conf = new Configuration()
     def extraMeta = new HashMap<String, String>()
     extraMeta.put(METADATA_COLUMN_TYPES, matrix.types().collect { it.name }.join(','))
@@ -633,6 +657,7 @@ class MatrixParquetWriter {
     def writer = ExampleParquetWriter.builder(outputFile)
         .withConf(conf)
         .withType(schema)
+        .withCompressionCodec(compressionCodec)
         .withExtraMetaData(extraMeta)
         .build()
 

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetWriteOptions.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetWriteOptions.groovy
@@ -1,5 +1,7 @@
 package se.alipsa.matrix.parquet
 
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
+
 import se.alipsa.matrix.core.spi.OptionDescriptor
 import se.alipsa.matrix.core.spi.OptionMaps
 
@@ -18,6 +20,7 @@ class ParquetWriteOptions {
   Integer scale = null
   Map<String, int[]> decimalMeta = [:]
   ZoneId zoneId = null
+  CompressionCodecName compressionCodec = CompressionCodecName.SNAPPY
 
   ParquetWriteOptions inferPrecisionAndScale(boolean value) {
     this.inferPrecisionAndScale = value
@@ -49,6 +52,29 @@ class ParquetWriteOptions {
     this
   }
 
+  /**
+   * Sets the compression codec for the Parquet file (default: {@code SNAPPY}).
+   *
+   * @param value the compression codec
+   * @return this options instance
+   */
+  ParquetWriteOptions compressionCodec(CompressionCodecName value) {
+    this.compressionCodec = value
+    this
+  }
+
+  /**
+   * Sets the compression codec from its name (default: {@code "SNAPPY"}).
+   *
+   * @param value the codec name, e.g. "GZIP", "ZSTD", "UNCOMPRESSED"
+   * @return this options instance
+   * @throws IllegalArgumentException if value is not a recognized codec name
+   */
+  ParquetWriteOptions compressionCodec(String value) {
+    this.compressionCodec = CompressionCodecName.valueOf(value.toUpperCase())
+    this
+  }
+
   boolean hasUniformPrecisionAndScale() {
     precision != null && scale != null
   }
@@ -73,10 +99,13 @@ class ParquetWriteOptions {
       }
     }
     validateDecimalMeta(decimalMeta)
+    if (compressionCodec == null) {
+      throw new IllegalArgumentException('compressionCodec cannot be null')
+    }
   }
 
   Map<String, ?> toMap() {
-    Map<String, Object> result = [inferPrecisionAndScale: inferPrecisionAndScale]
+    Map<String, Object> result = [inferPrecisionAndScale: inferPrecisionAndScale, compressionCodec: compressionCodec.name()]
     if (precision != null) {
       result.precision = precision
       result.scale = scale
@@ -129,6 +158,14 @@ class ParquetWriteOptions {
         result.zoneId(String.valueOf(value))
       }
     }
+    if (normalized.containsKey('compressioncodec')) {
+      def value = normalized.compressioncodec
+      if (value instanceof CompressionCodecName) {
+        result.compressionCodec(value as CompressionCodecName)
+      } else if (value != null) {
+        result.compressionCodec(String.valueOf(value))
+      }
+    }
     result.validate()
     result
   }
@@ -166,7 +203,8 @@ class ParquetWriteOptions {
         new OptionDescriptor(KEY_PRECISION, Integer, null, 'Uniform precision for all BigDecimal columns'),
         new OptionDescriptor(KEY_SCALE, Integer, null, 'Uniform scale for all BigDecimal columns'),
         new OptionDescriptor('decimalMeta', Map, null, 'Map of column names to [precision, scale] arrays'),
-        new OptionDescriptor('zoneId', ZoneId, null, 'Time zone to use when writing timestamp values')
+        new OptionDescriptor('zoneId', ZoneId, null, 'Time zone to use when writing timestamp values'),
+        new OptionDescriptor('compressionCodec', CompressionCodecName, CompressionCodecName.SNAPPY.name(), 'Compression codec for the Parquet file (e.g. SNAPPY, GZIP, ZSTD, UNCOMPRESSED)')
     ]
   }
 }

--- a/matrix-parquet/src/test/groovy/MatrixParquetTest.groovy
+++ b/matrix-parquet/src/test/groovy/MatrixParquetTest.groovy
@@ -9,7 +9,9 @@ import static se.alipsa.matrix.core.ListConverter.toLocalDates
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path as HadoopPath
 import org.apache.parquet.example.data.simple.SimpleGroupFactory
+import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.parquet.hadoop.example.ExampleParquetWriter
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.apache.parquet.schema.MessageType
 import org.apache.parquet.schema.PrimitiveType
 import org.apache.parquet.schema.Types
@@ -177,7 +179,7 @@ class MatrixParquetTest {
     writer.close()
 
     Matrix matrix = MatrixParquetReader.read(file)
-    assertEquals(new BigDecimal('123.45'), matrix.amount[0])
+    assertEquals(123.45G, matrix.amount[0])
   }
 
   @Test
@@ -233,6 +235,67 @@ class MatrixParquetTest {
 
     assertEquals(['a', 'b'], matrix.tags[0])
     assertEquals([], matrix.tags[1])
+  }
+
+  @Test
+  void testCompressionDefaultIsSnappy() {
+    def data = Matrix.builder('compressedDefault').data(
+        id: 1..50,
+        name: (1..50).collect { "name$it".toString() }
+    ).types([Integer, String]).build()
+
+    File file = tempDir.resolve('compressed_default.parquet').toFile()
+    MatrixParquetWriter.write(data, file)
+
+    def footer = ParquetFileReader.readFooter(new Configuration(), new HadoopPath(file.toURI()))
+    def codec = footer.blocks[0].columns[0].codec
+    assertEquals(CompressionCodecName.SNAPPY, codec)
+
+    Matrix matrix = MatrixParquetReader.read(file)
+    assertEquals(data.rowCount(), matrix.rowCount())
+    assertIterableEquals(data.id, matrix.id)
+    assertIterableEquals(data.name, matrix.name)
+  }
+
+  @Test
+  void testCompressionCodecOverrideViaBuilder() {
+    def data = Matrix.builder('gzipTest').data(
+        id: [1, 2, 3],
+        value: ['a', 'b', 'c']
+    ).types([Integer, String]).build()
+
+    File file = tempDir.resolve('gzip.parquet').toFile()
+    MatrixParquetWriter.builder(data)
+        .compressionCodec(CompressionCodecName.GZIP)
+        .write(file)
+
+    def footer = ParquetFileReader.readFooter(new Configuration(), new HadoopPath(file.toURI()))
+    assertEquals(CompressionCodecName.GZIP, footer.blocks[0].columns[0].codec)
+
+    Matrix matrix = MatrixParquetReader.read(file)
+    assertIterableEquals(data.id, matrix.id)
+    assertIterableEquals(data.value, matrix.value)
+  }
+
+  @Test
+  void testCompressionCodecUncompressedViaStringAndBytes() {
+    def data = Matrix.builder('uncompressedTest').data(id: [1, 2]).types([Integer]).build()
+
+    byte[] bytes = MatrixParquetWriter.builder(data)
+        .compressionCodec('UNCOMPRESSED')
+        .writeBytes()
+
+    Matrix matrix = MatrixParquetReader.read(bytes)
+    assertIterableEquals(data.id, matrix.id)
+  }
+
+  @Test
+  void testCompressionCodecRejectsInvalidName() {
+    def data = Matrix.builder('badCodec').data(id: [1]).types([Integer]).build()
+
+    assertThrows(IllegalArgumentException) {
+      MatrixParquetWriter.builder(data).compressionCodec('NOT_A_CODEC').writeBytes()
+    }
   }
 
   @Test

--- a/matrix-parquet/src/test/groovy/MatrixParquetTest.groovy
+++ b/matrix-parquet/src/test/groovy/MatrixParquetTest.groovy
@@ -6,6 +6,13 @@ import static se.alipsa.matrix.core.ListConverter.toBigDecimals
 import static se.alipsa.matrix.core.ListConverter.toDoubles
 import static se.alipsa.matrix.core.ListConverter.toLocalDates
 
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path as HadoopPath
+import org.apache.parquet.example.data.simple.SimpleGroupFactory
+import org.apache.parquet.hadoop.example.ExampleParquetWriter
+import org.apache.parquet.schema.MessageType
+import org.apache.parquet.schema.PrimitiveType
+import org.apache.parquet.schema.Types
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
@@ -148,6 +155,29 @@ class MatrixParquetTest {
     String message = exception.getMessage() ?: ''
     assertTrue(message.contains('exceeds the configured precision'),
         "Expected an exception indicating a precision overflow, but got: ${message}")
+  }
+
+  @Test
+  void testBigDecimalFallbackFromPlainBinaryColumn() {
+    MessageType schema = Types.buildMessage()
+        .optional(PrimitiveType.PrimitiveTypeName.BINARY).named('amount')
+        .named('ExternalSchema')
+
+    File file = tempDir.resolve('external_plain_binary.parquet').toFile()
+    Map<String, String> extraMeta = [(MatrixParquetReader.METADATA_COLUMN_TYPES): 'java.math.BigDecimal']
+
+    def writer = ExampleParquetWriter.builder(new HadoopPath(file.toURI()))
+        .withConf(new Configuration())
+        .withType(schema)
+        .withExtraMetaData(extraMeta)
+        .build()
+    def group = new SimpleGroupFactory(schema).newGroup()
+    group.append('amount', '123.45')
+    writer.write(group)
+    writer.close()
+
+    Matrix matrix = MatrixParquetReader.read(file)
+    assertEquals(new BigDecimal('123.45'), matrix.amount[0])
   }
 
   @Test

--- a/matrix-parquet/src/test/groovy/ParquetFormatProviderTest.groovy
+++ b/matrix-parquet/src/test/groovy/ParquetFormatProviderTest.groovy
@@ -1,7 +1,12 @@
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertIterableEquals
 import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.junit.jupiter.api.Assertions.assertTrue
 
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path as HadoopPath
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
@@ -47,6 +52,23 @@ class ParquetFormatProviderTest {
     assertEquals(source.columnNames(), matrix.columnNames())
     assertEquals(12.30, matrix[0, 'amount'])
     assertEquals(source[0, 'createdAt'], matrix[0, 'createdAt'])
+  }
+
+  @Test
+  void testCompressionCodecViaOptionsMap() {
+    Matrix source = Matrix.builder('compressedSpi')
+        .columns(id: [1, 2, 3], name: ['a', 'b', 'c'])
+        .types([Integer, String])
+        .build()
+
+    File file = tempDir.resolve('spi_compressed.parquet').toFile()
+    source.write([compressionCodec: 'GZIP'], file)
+
+    def footer = ParquetFileReader.readFooter(new Configuration(), new HadoopPath(file.toURI()))
+    assertEquals(CompressionCodecName.GZIP, footer.blocks[0].columns[0].codec)
+
+    Matrix matrix = Matrix.read(file)
+    assertIterableEquals(source.id, matrix.id)
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Fix BigDecimal fallback reads for external plain `BINARY` Parquet columns by parsing UTF-8 binary content instead of calling `getDouble`.
- Add Parquet compression codec support to `ParquetWriteOptions`, `MatrixParquetWriter.WriterBuilder`, byte-array writes, file writes, and SPI options maps.
- Default Parquet writes to `SNAPPY` compression while allowing overrides such as `GZIP`, `ZSTD`, and `UNCOMPRESSED`.
- Document compression behavior in the README and v0.6.0 release notes.

## Modules touched
- `matrix-parquet`

## Tests
- `./gradlew :matrix-parquet:test --tests "MatrixParquetTest.testBigDecimalFallbackFromPlainBinaryColumn"`
- `./gradlew :matrix-parquet:test --tests "MatrixParquetTest.testCompressionDefaultIsSnappy" --tests "MatrixParquetTest.testCompressionCodecOverrideViaBuilder" --tests "MatrixParquetTest.testCompressionCodecUncompressedViaStringAndBytes"`
- `./gradlew :matrix-parquet:test --tests "ParquetFormatProviderTest.testCompressionCodecViaOptionsMap"`
- `./gradlew :matrix-parquet:test --tests "MatrixParquetTest.testCompressionCodecRejectsInvalidName"`
- `./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest :matrix-parquet:spotlessCheck :matrix-parquet:test`