### PR TITLE
matrix-parquet: implement v0.6.0 phase 3 BigInteger decimal mapping

### DIFF
--- a/matrix-parquet/readme.md
+++ b/matrix-parquet/readme.md
@@ -153,7 +153,7 @@ Matrix data = MatrixParquetReader.builder()
 |--------------------|--------------------------------|---------------------------------------------------|
 | Integer            | INT32                          |                                                   |
 | Long               | INT64                          |                                                   |
-| BigInteger         | INT64                          |                                                   |
+| BigInteger         | BINARY (DECIMAL, scale=0)      | Precision auto-inferred from data; no `Long` range limit |
 | Float              | FLOAT                          |                                                   |
 | Double             | DOUBLE                         |                                                   |
 | BigDecimal         | FIXED_LEN_BYTE_ARRAY (DECIMAL) | See [BigDecimal Precision](#bigdecimal-precision) |
@@ -286,6 +286,8 @@ This module requires **JDK 21** and is limited to JDK 21 maximum due to Hadoop 3
 Column type information is stored in Parquet file metadata. When reading files not created by `MatrixParquetWriter`:
 - Types are inferred from Parquet schema logical type annotations
 - Some type information may be lost (e.g., `java.sql.Timestamp` vs `LocalDateTime`)
+- `BigInteger` columns read without Matrix metadata (e.g. external files) are inferred as `BigDecimal` with scale 0, since both the Parquet schema and the inference logic only see a generic `DECIMAL` logical annotation
+- `BigInteger` values nested inside `List`/`Map` columns always get a declared precision of 38 regardless of their actual digit count (top-level column precision inference does not extend into nested structures), and round-trip back as numerically-equal `BigDecimal` values rather than `BigInteger` (nested elements carry no expected-type metadata, unlike top-level columns). This does not cause data loss or truncation, but external Parquet readers that validate `DECIMAL` precision against declared metadata rather than actual byte length may reject or misinterpret values with more than 38 digits
 
 ## Technical Notes
 

--- a/matrix-parquet/release.md
+++ b/matrix-parquet/release.md
@@ -5,6 +5,7 @@
   - org.apache.parquet:parquet-column 1.17.0 -> 1.17.1
   - org.apache.parquet:parquet-hadoop 1.17.0 -> 1.17.1 
 - Add compression codec support: `ParquetWriteOptions.compressionCodec` / `WriterBuilder.compressionCodec(...)` / SPI `compressionCodec` option; default changed from `UNCOMPRESSED` to `SNAPPY`
+- Fix bug: `BigInteger` columns silently truncated when their value exceeded `Long` range (mapped to `INT64` via `.longValue()`); now mapped to `BINARY` with a `DECIMAL(precision, 0)` logical annotation, with precision auto-inferred from the data
 
 ## v0.5.0, 2026-04-29
 - Add SPI integration: `MatrixParquetFormatProvider` registers `.parquet` extension with Matrix SPI so `Matrix.read(file)` and `matrix.write(file)` work without explicit imports

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
@@ -960,6 +960,9 @@ class MatrixParquetReader {
           def scale = logical.scale
           def binary = group.getBinary(fieldName, 0)
           def unscaled = new BigInteger(binary.getBytes())
+          if (expectedType == BigInteger) {
+            return unscaled
+          }
           return new BigDecimal(unscaled, scale)
         }
         if (expectedType == BigDecimal) {

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
@@ -690,14 +690,61 @@ class MatrixParquetWriter {
    * @return the Parquet MessageType schema.
    */
   private static MessageType buildSchema(Matrix matrix, Map<String, int[]> explicitDecimalMeta) {
+    Map<String, int[]> decimalMeta = withBigIntegerPrecision(matrix, explicitDecimalMeta)
     def builder = Types.buildMessage()
     matrix.columnNames().each { col ->
       def type = matrix.type(col)
-      def meta = explicitDecimalMeta?.get(col)
+      def meta = decimalMeta?.get(col)
       log.debug("Building schema for column '$col' of type $type with decimal meta: $meta")
       builder.addField(buildParquetType(col, matrix.column(col), type, meta))
     }
     return builder.named(matrix.matrixName ?: "MatrixSchema" )
+  }
+
+  /**
+   * Ensures every BigInteger column has decimal metadata {@code [precision, 0]}.
+   * Explicit caller-supplied metadata wins after validating its scale is 0
+   * and that its precision is large enough to hold every value in the column.
+   */
+  private static Map<String, int[]> withBigIntegerPrecision(Matrix matrix, Map<String, int[]> explicitDecimalMeta) {
+    Map<String, int[]> merged = explicitDecimalMeta != null ? new LinkedHashMap<>(explicitDecimalMeta) : new LinkedHashMap<>()
+    matrix.columnNames().each { col ->
+      if (matrix.type(col) != BigInteger) {
+        return
+      }
+      int[] existing = merged[col]
+      if (existing != null) {
+        if (existing[1] != 0) {
+          throw new IllegalArgumentException(
+              "decimalMeta['$col'] scale must be 0 for BigInteger columns but was ${existing[1]}")
+        }
+        int requiredPrecision = inferBigIntegerPrecision(matrix, col)
+        if (existing[0] < requiredPrecision) {
+          throw new IllegalArgumentException(
+              "decimalMeta['$col'] precision (${existing[0]}) is too small to hold the data in this " +
+              "column (requires at least $requiredPrecision digits)")
+        }
+      } else {
+        merged[col] = [inferBigIntegerPrecision(matrix, col), 0] as int[]
+      }
+    }
+    merged
+  }
+
+  /**
+   * Infers the minimum decimal precision needed to represent every BigInteger
+   * value in the given column as Parquet DECIMAL(precision, 0).
+   */
+  private static int inferBigIntegerPrecision(Matrix matrix, String col) {
+    int maxDigits = 1
+    (0..<matrix.rowCount()).each { i ->
+      def value = matrix[i, col]
+      if (value instanceof BigInteger) {
+        int digits = value.abs().toString().length()
+        maxDigits = Math.max(maxDigits, digits)
+      }
+    }
+    maxDigits
   }
 
   /**
@@ -751,6 +798,12 @@ class MatrixParquetWriter {
   }
 
   private static PrimitiveType buildPrimitiveType(String name, Class clazz, int[] decimalMeta = null, boolean required = false) {
+    if (clazz == BigInteger) {
+      int precision = (decimalMeta != null && decimalMeta.length == 2 && decimalMeta[0] > 0) ? decimalMeta[0] : 38
+      def builder = required ? Types.required(PrimitiveTypeName.BINARY) : Types.optional(PrimitiveTypeName.BINARY)
+      return builder.as(LogicalTypeAnnotation.decimalType(0, precision)).named(name)
+    }
+
     if (clazz == BigDecimal) {
       if (decimalMeta != null && decimalMeta.length == 2) {
         int precision = decimalMeta[0]
@@ -788,7 +841,7 @@ class MatrixParquetWriter {
 
     switch (clazz) {
       case Integer, int -> primitive = PrimitiveTypeName.INT32
-      case Long, long, BigInteger -> primitive = PrimitiveTypeName.INT64
+      case Long, long -> primitive = PrimitiveTypeName.INT64
       case Float, float -> primitive = PrimitiveTypeName.FLOAT
       case Double, double -> primitive = PrimitiveTypeName.DOUBLE
       case Boolean, boolean -> primitive = PrimitiveTypeName.BOOLEAN
@@ -1010,7 +1063,8 @@ class MatrixParquetWriter {
   private static void writePrimitiveValue(Group group, String fieldName, PrimitiveType field, Object value) {
     switch (value.class) {
       case Integer, int -> group.append(fieldName, (int) value)
-      case Long, long, BigInteger -> group.append(fieldName, ((Number) value).longValue())
+      case Long, long -> group.append(fieldName, ((Number) value).longValue())
+      case BigInteger -> group.add(fieldName, Binary.fromConstantByteArray(((BigInteger) value).toByteArray()))
       case Float, float -> group.append(fieldName, ((Number) value).floatValue())
       case Double, double -> group.append(fieldName, ((Number) value).doubleValue())
       case BigDecimal -> {

--- a/matrix-parquet/src/test/groovy/MatrixParquetBigIntegerTest.groovy
+++ b/matrix-parquet/src/test/groovy/MatrixParquetBigIntegerTest.groovy
@@ -1,0 +1,117 @@
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.parquet.MatrixParquetReader
+import se.alipsa.matrix.parquet.MatrixParquetWriter
+
+import java.nio.file.Path
+
+class MatrixParquetBigIntegerTest {
+
+  @TempDir
+  Path tempDir
+
+  @Test
+  void testBigIntegerRoundTrip() {
+    def data = Matrix.builder('bigIntTest').data(
+        id: [1, 2, 3],
+        big: [BigInteger.TEN, BigInteger.valueOf(-12345), BigInteger.ZERO]
+    ).types([Integer, BigInteger]).build()
+
+    File file = tempDir.resolve('bigint.parquet').toFile()
+    MatrixParquetWriter.write(data, file)
+    Matrix matrix = MatrixParquetReader.read(file)
+
+    assertEquals(BigInteger.TEN, matrix.big[0])
+    assertEquals(BigInteger.valueOf(-12345), matrix.big[1])
+    assertEquals(BigInteger.ZERO, matrix.big[2])
+    assertEquals(BigInteger, matrix.types()[1])
+  }
+
+  @Test
+  void testBigIntegerBeyondLongRangeRoundTrip() {
+    BigInteger huge = BigInteger.TEN.pow(30)
+    BigInteger hugeNegative = huge.negate().subtract(BigInteger.ONE)
+
+    def data = Matrix.builder('hugeBigInt').data(
+        id: [1, 2],
+        big: [huge, hugeNegative]
+    ).types([Integer, BigInteger]).build()
+
+    File file = tempDir.resolve('huge_bigint.parquet').toFile()
+    MatrixParquetWriter.write(data, file)
+    Matrix matrix = MatrixParquetReader.read(file)
+
+    assertEquals(huge, matrix.big[0])
+    assertEquals(hugeNegative, matrix.big[1])
+  }
+
+  @Test
+  void testBigIntegerExplicitDecimalMetaWrongScaleThrows() {
+    def data = Matrix.builder('badMeta').data(big: [BigInteger.ONE]).types([BigInteger]).build()
+    File file = tempDir.resolve('bad_bigint_meta.parquet').toFile()
+
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException) {
+      MatrixParquetWriter.write(data, file, [big: [10, 2] as int[]])
+    }
+    assertTrue(ex.message.contains('scale must be 0'))
+  }
+
+  @Test
+  void testBigIntegerExplicitDecimalMetaPrecisionHonored() {
+    def data = Matrix.builder('explicitMeta').data(big: [BigInteger.valueOf(42)]).types([BigInteger]).build()
+    File file = tempDir.resolve('explicit_bigint_meta.parquet').toFile()
+
+    MatrixParquetWriter.write(data, file, [big: [5, 0] as int[]])
+    Matrix matrix = MatrixParquetReader.read(file)
+    assertEquals(BigInteger.valueOf(42), matrix.big[0])
+  }
+
+  @Test
+  void testBigIntegerWithNullsRoundTrip() {
+    def data = Matrix.builder('bigIntNulls').data(
+        id: [1, 2, 3],
+        big: [BigInteger.valueOf(7), null, BigInteger.valueOf(-9)]
+    ).types([Integer, BigInteger]).build()
+
+    File file = tempDir.resolve('bigint_nulls.parquet').toFile()
+    MatrixParquetWriter.write(data, file)
+    Matrix matrix = MatrixParquetReader.read(file)
+
+    assertEquals(BigInteger.valueOf(7), matrix.big[0])
+    assertNull(matrix.big[1])
+    assertEquals(BigInteger.valueOf(-9), matrix.big[2])
+  }
+
+  @Test
+  void testBigIntegerExplicitPrecisionTooSmallThrows() {
+    def data = Matrix.builder('smallPrecision').data(big: [BigInteger.valueOf(9999)]).types([BigInteger]).build()
+    File file = tempDir.resolve('small_precision.parquet').toFile()
+
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException) {
+      MatrixParquetWriter.write(data, file, [big: [3, 0] as int[]])
+    }
+    assertTrue(ex.message.contains('too small'))
+  }
+
+  @Test
+  void testNestedBigIntegerListPrecisionFallsBackTo38() {
+    BigInteger huge = BigInteger.TEN.pow(30)
+    def data = Matrix.builder('nestedBigInt').data(
+        id: [1],
+        bigs: [[huge, BigInteger.ONE]]
+    ).types([Integer, List]).build()
+
+    File file = tempDir.resolve('nested_bigint.parquet').toFile()
+    MatrixParquetWriter.write(data, file)
+    Matrix matrix = MatrixParquetReader.read(file)
+
+    assertEquals([huge as BigDecimal, BigInteger.ONE as BigDecimal], matrix.bigs[0])
+  }
+}


### PR DESCRIPTION
## Summary
- Map top-level `BigInteger` columns to Parquet `BINARY` with `DECIMAL(precision, 0)` instead of `INT64`.
- Infer BigInteger decimal precision from column values and validate explicit metadata for scale `0` and sufficient precision.
- Write BigInteger values as binary two's-complement bytes and read them back as `BigInteger` when Matrix metadata expects that type.
- Add focused BigInteger regression tests, including values beyond `Long` range, nulls, explicit metadata validation, and nested list behavior.
- Update README and v0.6.0 release notes for the BigInteger encoding change.

## Modules touched
- `matrix-parquet`

## Tests
- `./gradlew :matrix-parquet:test --tests "MatrixParquetBigIntegerTest.testBigIntegerRoundTrip" --tests "MatrixParquetBigIntegerTest.testBigIntegerBeyondLongRangeRoundTrip" --tests "MatrixParquetBigIntegerTest.testBigIntegerExplicitDecimalMetaWrongScaleThrows" --tests "MatrixParquetBigIntegerTest.testBigIntegerExplicitDecimalMetaPrecisionHonored" --tests "MatrixParquetBigIntegerTest.testBigIntegerWithNullsRoundTrip" --tests "MatrixParquetBigIntegerTest.testBigIntegerExplicitPrecisionTooSmallThrows" --tests "MatrixParquetBigIntegerTest.testNestedBigIntegerListPrecisionFallsBackTo38"`
- `./gradlew :matrix-parquet:test`
- `./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest :matrix-parquet:spotlessCheck :matrix-parquet:test`