### PR TITLE
matrix-parquet: implement v0.6.0 phase 4 writer fixes

### DIFF
--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
@@ -947,6 +947,9 @@ class MatrixParquetReader {
         if (expectedType == BigInteger) {
           return BigInteger.valueOf(longValue)
         }
+        if (expectedType == Date) {
+          return new Date(longValue)
+        }
         return longValue
       case PrimitiveTypeName.FLOAT:
         return group.getFloat(fieldName, 0)

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
@@ -606,23 +606,23 @@ class MatrixParquetWriter {
         .withExtraMetaData(extraMeta)
         .build()
 
-    def factory = new SimpleGroupFactory(schema)
-    def rowCount = matrix.rowCount()
-    def colNames = matrix.columnNames()
+    writer.withCloseable { parquetWriter ->
+      def factory = new SimpleGroupFactory(schema)
+      def rowCount = matrix.rowCount()
+      def colNames = matrix.columnNames()
 
-    (0..<rowCount).each { i ->
-      def group = factory.newGroup()
-      colNames.each { col ->
-        def value = matrix[i, col]
-        if (value != null) {
-          def fieldType = schema.getType(col)
-          writeValue(group, col, fieldType, value)
+      (0..<rowCount).each { i ->
+        def group = factory.newGroup()
+        colNames.each { col ->
+          def value = matrix[i, col]
+          if (value != null) {
+            def fieldType = schema.getType(col)
+            writeValue(group, col, fieldType, value)
+          }
         }
+        parquetWriter.write(group)
       }
-      writer.write(group)
     }
-
-    writer.close()
     return file
   }
 
@@ -661,23 +661,23 @@ class MatrixParquetWriter {
         .withExtraMetaData(extraMeta)
         .build()
 
-    def factory = new SimpleGroupFactory(schema)
-    def rowCount = matrix.rowCount()
-    def colNames = matrix.columnNames()
+    writer.withCloseable { parquetWriter ->
+      def factory = new SimpleGroupFactory(schema)
+      def rowCount = matrix.rowCount()
+      def colNames = matrix.columnNames()
 
-    (0..<rowCount).each { i ->
-      def group = factory.newGroup()
-      colNames.each { col ->
-        def value = matrix[i, col]
-        if (value != null) {
-          def fieldType = schema.getType(col)
-          writeValue(group, col, fieldType, value)
+      (0..<rowCount).each { i ->
+        def group = factory.newGroup()
+        colNames.each { col ->
+          def value = matrix[i, col]
+          if (value != null) {
+            def fieldType = schema.getType(col)
+            writeValue(group, col, fieldType, value)
+          }
         }
+        parquetWriter.write(group)
       }
-      writer.write(group)
     }
-
-    writer.close()
     return outputFile.getBytes()
   }
 

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
@@ -857,6 +857,7 @@ class MatrixParquetWriter {
         primitive = PrimitiveTypeName.INT32
         logical = LogicalTypeAnnotation.timeType(true, LogicalTypeAnnotation.TimeUnit.MILLIS)
       }
+      case Date -> primitive = PrimitiveTypeName.INT64
       default -> primitive = PrimitiveTypeName.BINARY
     }
 

--- a/matrix-parquet/src/test/groovy/MatrixParquetWriterLifecycleTest.groovy
+++ b/matrix-parquet/src/test/groovy/MatrixParquetWriterLifecycleTest.groovy
@@ -43,4 +43,22 @@ class MatrixParquetWriterLifecycleTest {
     Matrix matrix = MatrixParquetReader.read(bytes)
     assertEquals(valid, matrix)
   }
+
+  @Test
+  void testJavaUtilDateRoundTrip() {
+    Date first = new Date(1_700_000_000_123L)
+    Date second = new Date(1_700_000_100_456L)
+    def data = Matrix.builder('dateTest').data(
+        id: [1, 2],
+        created: [first, second]
+    ).types([Integer, Date]).build()
+
+    File file = tempDir.resolve('java_util_date.parquet').toFile()
+    MatrixParquetWriter.write(data, file)
+    Matrix matrix = MatrixParquetReader.read(file)
+
+    assertEquals([Integer, Date], matrix.types())
+    assertEquals(first, matrix.created[0])
+    assertEquals(second, matrix.created[1])
+  }
 }

--- a/matrix-parquet/src/test/groovy/MatrixParquetWriterLifecycleTest.groovy
+++ b/matrix-parquet/src/test/groovy/MatrixParquetWriterLifecycleTest.groovy
@@ -1,0 +1,46 @@
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertThrows
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.parquet.MatrixParquetReader
+import se.alipsa.matrix.parquet.MatrixParquetWriter
+
+import java.nio.file.Path
+
+class MatrixParquetWriterLifecycleTest {
+
+  @TempDir
+  Path tempDir
+
+  @Test
+  void testWriterClosesFileWhenRowWriteFails() {
+    def invalid = Matrix.builder('invalidDecimal').data(amount: [623.30]).types([BigDecimal]).build()
+    File file = tempDir.resolve('failed_write_reuse.parquet').toFile()
+
+    assertThrows(Exception) {
+      MatrixParquetWriter.write(invalid, file, [amount: [4, 2] as int[]])
+    }
+
+    def valid = Matrix.builder('validDecimal').data(amount: [12.30]).types([BigDecimal]).build()
+    MatrixParquetWriter.write(valid, file, [amount: [4, 2] as int[]])
+    Matrix matrix = MatrixParquetReader.read(file)
+    assertEquals(valid, matrix)
+  }
+
+  @Test
+  void testWriterClosesMemoryOutputWhenRowWriteFails() {
+    def invalid = Matrix.builder('invalidBytes').data(amount: [623.30]).types([BigDecimal]).build()
+
+    assertThrows(Exception) {
+      MatrixParquetWriter.writeBytes(invalid, [amount: [4, 2] as int[]])
+    }
+
+    def valid = Matrix.builder('validBytes').data(amount: [12.30]).types([BigDecimal]).build()
+    byte[] bytes = MatrixParquetWriter.writeBytes(valid, [amount: [4, 2] as int[]])
+    Matrix matrix = MatrixParquetReader.read(bytes)
+    assertEquals(valid, matrix)
+  }
+}


### PR DESCRIPTION
## Summary
- Wrap file and in-memory Parquet writers in `withCloseable` so writer resources close even when row writing fails.
- Add writer failure characterization tests for file and byte-array write paths.
- Implement documented `java.util.Date` round-trip support as `INT64` epoch milliseconds.
- Preserve existing `java.sql.Date` and `java.sql.Timestamp` mappings while adding plain `java.util.Date` handling.

## Modules touched
- `matrix-parquet`

## Tests
- `./gradlew :matrix-parquet:test --tests "MatrixParquetWriterLifecycleTest.testWriterClosesFileWhenRowWriteFails" --tests "MatrixParquetWriterLifecycleTest.testWriterClosesMemoryOutputWhenRowWriteFails"`
- `./gradlew :matrix-parquet:test --tests "MatrixParquetWriterLifecycleTest.testJavaUtilDateRoundTrip"`
- `./gradlew :matrix-parquet:test --tests "MatrixParquetWriterLifecycleTest.testJavaUtilDateRoundTrip" --tests "MatrixParquetTest.testTimePrecisionRoundTrip"`
- `./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest :matrix-parquet:spotlessCheck :matrix-parquet:test`