### PR TITLE
matrix-parquet: normalize decimal metadata across write APIs

### DIFF
--- a/matrix-parquet/readme.md
+++ b/matrix-parquet/readme.md
@@ -63,6 +63,7 @@ Matrix stockholm = Matrix.read([matrixName: 'events', zoneId: 'Europe/Stockholm'
 
 data.write([inferPrecisionAndScale: true], new File('copy.parquet'))
 data.write([precision: 38, scale: 18, zoneId: 'Europe/Stockholm'], new File('money.parquet'))
+data.write([decimalMeta: [amount: [8, 2]]], new File('money.parquet'))
 
 println Matrix.listReadOptions('parquet')
 println Matrix.listWriteOptions('parquet')

--- a/matrix-parquet/readme.md
+++ b/matrix-parquet/readme.md
@@ -63,7 +63,7 @@ Matrix stockholm = Matrix.read([matrixName: 'events', zoneId: 'Europe/Stockholm'
 
 data.write([inferPrecisionAndScale: true], new File('copy.parquet'))
 data.write([precision: 38, scale: 18, zoneId: 'Europe/Stockholm'], new File('money.parquet'))
-data.write([decimalMeta: [amount: [8, 2]]], new File('money.parquet'))
+data.write([decimalMeta: [amount: [8, 2]]], new File('money-meta.parquet'))
 
 println Matrix.listReadOptions('parquet')
 println Matrix.listWriteOptions('parquet')

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
@@ -863,12 +863,12 @@ class MatrixParquetReader {
 
   private static Class getJavaType(PrimitiveType.PrimitiveTypeName typeName) {
     switch (typeName) {
-      case PrimitiveTypeName.INT32: return Integer
-      case PrimitiveTypeName.INT64: return Long
-      case PrimitiveTypeName.FLOAT: return Float
-      case PrimitiveTypeName.DOUBLE: return Double
-      case PrimitiveTypeName.BOOLEAN: return Boolean
-      default: return String
+      case PrimitiveTypeName.INT32 -> Integer
+      case PrimitiveTypeName.INT64 -> Long
+      case PrimitiveTypeName.FLOAT -> Float
+      case PrimitiveTypeName.DOUBLE -> Double
+      case PrimitiveTypeName.BOOLEAN -> Boolean
+      default -> String
     }
   }
 
@@ -924,60 +924,59 @@ class MatrixParquetReader {
   private static Object readPrimitive(Group group, String fieldName, PrimitiveType fieldType, Class expectedType) {
     def logical = fieldType.logicalTypeAnnotation
     switch (fieldType.primitiveTypeName) {
-      case PrimitiveTypeName.INT32:
+      case PrimitiveTypeName.INT32 -> {
         if (logical == LogicalTypeAnnotation.dateType()) {
-          return LocalDate.ofEpochDay(group.getInteger(fieldName, 0))
-        }
-        if (logical instanceof LogicalTypeAnnotation.TimeLogicalTypeAnnotation) {
+          LocalDate.ofEpochDay(group.getInteger(fieldName, 0))
+        } else if (logical instanceof LogicalTypeAnnotation.TimeLogicalTypeAnnotation) {
           int millis = group.getInteger(fieldName, 0)
-          return Time.valueOf(LocalTime.ofNanoOfDay(millis * MICROS_PER_SECOND))
+          Time.valueOf(LocalTime.ofNanoOfDay(millis * MICROS_PER_SECOND))
+        } else if (expectedType == java.sql.Date) {
+          java.sql.Date.valueOf(LocalDate.ofEpochDay(group.getInteger(fieldName, 0)))
+        } else {
+          group.getInteger(fieldName, 0)
         }
-        if (expectedType == java.sql.Date) {
-          return java.sql.Date.valueOf(LocalDate.ofEpochDay(group.getInteger(fieldName, 0)))
-        }
-        return group.getInteger(fieldName, 0)
-      case PrimitiveTypeName.INT64:
+      }
+      case PrimitiveTypeName.INT64 -> {
         if (logical instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation) {
           Instant instant = timestampInstant(group.getLong(fieldName, 0), logical.unit)
           if (expectedType == java.sql.Timestamp) {
-            return java.sql.Timestamp.from(instant)
+            java.sql.Timestamp.from(instant)
+          } else if (expectedType == Date) {
+            Date.from(instant)
+          } else {
+            LocalDateTime.ofInstant(instant, getZoneId())
           }
-          if (expectedType == Date) {
-            return Date.from(instant)
+        } else {
+          def longValue = group.getLong(fieldName, 0)
+          if (expectedType == BigInteger) {
+            BigInteger.valueOf(longValue)
+          } else if (expectedType == Date) {
+            new Date(longValue)
+          } else {
+            longValue
           }
-          return LocalDateTime.ofInstant(instant, getZoneId())
         }
-        def longValue = group.getLong(fieldName, 0)
-        if (expectedType == BigInteger) {
-          return BigInteger.valueOf(longValue)
-        }
-        if (expectedType == Date) {
-          return new Date(longValue)
-        }
-        return longValue
-      case PrimitiveTypeName.FLOAT:
-        return group.getFloat(fieldName, 0)
-      case PrimitiveTypeName.DOUBLE:
-        return group.getDouble(fieldName, 0)
-      case PrimitiveTypeName.BOOLEAN:
-        return group.getBoolean(fieldName, 0)
-      case PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY:
-      case PrimitiveTypeName.BINARY:
+      }
+      case PrimitiveTypeName.FLOAT -> group.getFloat(fieldName, 0)
+      case PrimitiveTypeName.DOUBLE -> group.getDouble(fieldName, 0)
+      case PrimitiveTypeName.BOOLEAN -> group.getBoolean(fieldName, 0)
+      case PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, PrimitiveTypeName.BINARY -> {
         if (logical instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
           def scale = logical.scale
           def binary = group.getBinary(fieldName, 0)
           def unscaled = new BigInteger(binary.getBytes())
           if (expectedType == BigInteger) {
-            return unscaled
+            unscaled
+          } else {
+            new BigDecimal(unscaled, scale)
           }
-          return new BigDecimal(unscaled, scale)
+        } else if (expectedType == BigDecimal) {
+          new BigDecimal(group.getBinary(fieldName, 0).toStringUsingUTF8())
+        } else {
+          group.getBinary(fieldName, 0).toStringUsingUTF8()
         }
-        if (expectedType == BigDecimal) {
-          return new BigDecimal(group.getBinary(fieldName, 0).toStringUsingUTF8())
-        }
-        return group.getBinary(fieldName, 0).toStringUsingUTF8()
-      default:
-        return group.getString(fieldName, 0)
+      }
+      default -> group.getString(fieldName, 0)
     }
   }
 

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
@@ -114,7 +114,11 @@ class MatrixParquetReader {
   private static final String ERR_ZONE_ID_NULL = 'ZoneId cannot be null'
   private static final String DOT = '.'
   private static final String COMMA = ','
+  private static final long MILLIS_PER_SECOND = 1_000L
   private static final long MICROS_PER_SECOND = 1_000_000L
+  private static final long NANOS_PER_SECOND = 1_000_000_000L
+  private static final long NANOS_PER_MILLI = 1_000_000L
+  private static final long NANOS_PER_MICRO = 1_000L
 
   /**
    * Creates a new builder for reading Parquet data into a Matrix.
@@ -934,12 +938,12 @@ class MatrixParquetReader {
         return group.getInteger(fieldName, 0)
       case PrimitiveTypeName.INT64:
         if (logical instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation) {
-          long micros = group.getLong(fieldName, 0)
-          long epochSecond = Math.floorDiv(micros, MICROS_PER_SECOND)
-          int microOfSecond = (int) Math.floorMod(micros, MICROS_PER_SECOND)
-          Instant instant = Instant.ofEpochSecond(epochSecond, microOfSecond * 1_000L)
+          Instant instant = timestampInstant(group.getLong(fieldName, 0), logical.unit)
           if (expectedType == java.sql.Timestamp) {
             return java.sql.Timestamp.from(instant)
+          }
+          if (expectedType == Date) {
+            return Date.from(instant)
           }
           return LocalDateTime.ofInstant(instant, getZoneId())
         }
@@ -975,6 +979,22 @@ class MatrixParquetReader {
       default:
         return group.getString(fieldName, 0)
     }
+  }
+
+  private static Instant timestampInstant(long value, LogicalTypeAnnotation.TimeUnit unit) {
+    if (unit == LogicalTypeAnnotation.TimeUnit.MILLIS) {
+      return Instant.ofEpochSecond(
+          Math.floorDiv(value, MILLIS_PER_SECOND),
+          Math.floorMod(value, MILLIS_PER_SECOND) * NANOS_PER_MILLI)
+    }
+    if (unit == LogicalTypeAnnotation.TimeUnit.NANOS) {
+      return Instant.ofEpochSecond(
+          Math.floorDiv(value, NANOS_PER_SECOND),
+          Math.floorMod(value, NANOS_PER_SECOND))
+    }
+    Instant.ofEpochSecond(
+        Math.floorDiv(value, MICROS_PER_SECOND),
+        Math.floorMod(value, MICROS_PER_SECOND) * NANOS_PER_MICRO)
   }
 
   private static List readList(Group group, String fieldName, GroupType groupType) {

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
@@ -880,9 +880,11 @@ class MatrixParquetWriter {
     def mapBuilder = Types.optionalMap()
     List<Map> maps = values.findAll { it instanceof Map } as List<Map>
 
-    Object keySample = findFirstNonNull(maps.collectMany { it?.keySet() ?: [] } as List)
-    Class<?> keyClass = inferClass([keySample], keySample?.class ?: String)
-    PrimitiveType keyType = buildPrimitiveType(FIELD_KEY, keyClass ?: String, null, true)
+    List<Object> keySamples = maps.collectMany { it?.keySet() ?: [] } as List<Object>
+    Object keySample = findFirstNonNull(keySamples)
+    Class<?> keyClass = inferClass(keySamples, keySample?.class ?: String)
+    int[] keyDecimalMeta = keyClass == BigInteger ? [inferBigIntegerPrecision(keySamples), 0] as int[] : null
+    PrimitiveType keyType = buildPrimitiveType(FIELD_KEY, keyClass ?: String, keyDecimalMeta, true)
     mapBuilder.key(keyType)
 
     List<Object> valueSamples = maps.collectMany { it?.values() ?: [] } as List<Object>

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
@@ -844,7 +844,10 @@ class MatrixParquetWriter {
         primitive = PrimitiveTypeName.INT32
         logical = LogicalTypeAnnotation.timeType(true, LogicalTypeAnnotation.TimeUnit.MILLIS)
       }
-      case Date -> primitive = PrimitiveTypeName.INT64
+      case Date -> {
+        primitive = PrimitiveTypeName.INT64
+        logical = LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS)
+      }
       default -> primitive = PrimitiveTypeName.BINARY
     }
 

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
@@ -434,7 +434,7 @@ class MatrixParquetWriter {
     validateInput(matrix, fileOrDir)
     File file = determineTargetFile(matrix, fileOrDir)
 
-    def schema = buildSchema(matrix, decimalMeta)
+    def schema = buildSchema(matrix, ParquetWriteOptions.normalizeDecimalMeta(decimalMeta ?: [:]))
     return writeInternal(matrix, file, schema)
   }
 
@@ -520,7 +520,7 @@ class MatrixParquetWriter {
     if (matrix.columnCount() == 0) {
       throw new IllegalArgumentException("Matrix must have at least one column")
     }
-    MessageType schema = buildSchema(matrix, decimalMeta)
+    MessageType schema = buildSchema(matrix, ParquetWriteOptions.normalizeDecimalMeta(decimalMeta ?: [:]))
     return writeBytesInternal(matrix, schema)
   }
 
@@ -808,19 +808,6 @@ class MatrixParquetWriter {
       if (decimalMeta != null && decimalMeta.length == 2) {
         int precision = decimalMeta[0]
         int scale = decimalMeta[1]
-
-        // Add safeguards for invalid (0 or less) precision, which can be passed manually
-        // The inference method already ensures precision is at least 1.
-        if (precision <= 0) {
-          precision = 10 // Fallback to a default precision
-        }
-        // Add safeguards for invalid scale: must be non-negative and not greater than precision
-        if (scale < 0) {
-          scale = 0 // Fallback to a default scale
-        }
-        if (scale > precision) {
-          scale = precision // Clamp scale to precision
-        }
 
         def builder = required
             ? Types.required(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
@@ -747,6 +747,17 @@ class MatrixParquetWriter {
     maxDigits
   }
 
+  private static int inferBigIntegerPrecision(List<?> values) {
+    int maxDigits = 1
+    values.each { value ->
+      if (value instanceof BigInteger) {
+        int digits = value.abs().toString().length()
+        maxDigits = Math.max(maxDigits, digits)
+      }
+    }
+    maxDigits
+  }
+
   /**
    * Builds the Parquet schema based on the matrix, inferring decimal precision/scale if requested.
    * This is for backward compatibility and delegates to the explicit map builder.
@@ -794,12 +805,19 @@ class MatrixParquetWriter {
     }
 
     Class<?> effectiveClass = inferClass(values, clazz)
-    return buildPrimitiveType(name, effectiveClass, decimalMeta, false)
+    int[] effectiveDecimalMeta = decimalMeta
+    if (effectiveClass == BigInteger && effectiveDecimalMeta == null) {
+      effectiveDecimalMeta = [inferBigIntegerPrecision(values), 0] as int[]
+    }
+    return buildPrimitiveType(name, effectiveClass, effectiveDecimalMeta, false)
   }
 
   private static PrimitiveType buildPrimitiveType(String name, Class clazz, int[] decimalMeta = null, boolean required = false) {
     if (clazz == BigInteger) {
-      int precision = (decimalMeta != null && decimalMeta.length == 2 && decimalMeta[0] > 0) ? decimalMeta[0] : 38
+      if (decimalMeta == null || decimalMeta.length != 2 || decimalMeta[0] <= 0 || decimalMeta[1] != 0) {
+        throw new IllegalArgumentException("BigInteger field '$name' requires decimal metadata [precision, 0]")
+      }
+      int precision = decimalMeta[0]
       def builder = required ? Types.required(PrimitiveTypeName.BINARY) : Types.optional(PrimitiveTypeName.BINARY)
       return builder.as(LogicalTypeAnnotation.decimalType(0, precision)).named(name)
     }

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetWriteOptions.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetWriteOptions.groovy
@@ -190,9 +190,9 @@ class ParquetWriteOptions {
         ps = meta as int[]
       } else if (meta instanceof Number[]) {
         Number[] numbers = meta as Number[]
-        ps = numbers*.intValue() as int[]
+        ps = decimalMetaNumbers(columnName, numbers.toList())
       } else if (meta instanceof List) {
-        ps = (meta as List).collect { (it as Number).intValue() } as int[]
+        ps = decimalMetaNumbers(columnName, meta as List<?>)
       } else {
         throw new IllegalArgumentException(
             "decimalMeta['$columnName'] must be an int[], Number[], or List<Number> of length 2 [precision, scale] but was ${meta?.class}")
@@ -213,6 +213,17 @@ class ParquetWriteOptions {
       normalized[columnName] = ps
     }
     normalized
+  }
+
+  private static int[] decimalMetaNumbers(String columnName, Iterable<?> values) {
+    List<Integer> result = []
+    values.eachWithIndex { value, int index ->
+      if (!(value instanceof Number)) {
+        throw new IllegalArgumentException("decimalMeta['$columnName'][$index] must be a Number but was ${value?.class}")
+      }
+      result << value.intValue()
+    }
+    result as int[]
   }
 
   static String describe() {

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetWriteOptions.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/ParquetWriteOptions.groovy
@@ -98,7 +98,7 @@ class ParquetWriteOptions {
         throw new IllegalArgumentException("scale ($scale) must not exceed precision ($precision)")
       }
     }
-    validateDecimalMeta(decimalMeta)
+    decimalMeta = normalizeDecimalMeta(decimalMeta)
     if (compressionCodec == null) {
       throw new IllegalArgumentException('compressionCodec cannot be null')
     }
@@ -147,7 +147,7 @@ class ParquetWriteOptions {
         if (!(value instanceof Map)) {
           throw new IllegalArgumentException("decimalMeta must be a Map<String, int[]> but was ${value?.class}")
         }
-        result.decimalMeta(validateDecimalMeta(value as Map))
+        result.decimalMeta(normalizeDecimalMeta(value as Map))
       }
     }
     if (normalized.containsKey('zoneid')) {
@@ -170,15 +170,37 @@ class ParquetWriteOptions {
     result
   }
 
-  private static Map<String, int[]> validateDecimalMeta(Map<?, ?> value) {
-    Map<String, int[]> validated = [:]
+  /**
+   * Normalizes and validates a raw {@code decimalMeta} map into {@code Map<String, int[]>}.
+   *
+   * <p>Accepts {@code int[]}, {@code Number[]}, or {@code List<Number>} values of length 2
+   * {@code [precision, scale]} per column, so both direct Groovy callers and SPI/options-map
+   * callers can use the same entry point.</p>
+   *
+   * @param value raw map of column name to a length-2 precision/scale value
+   * @return normalized map of column name to validated {@code int[2]} [precision, scale]
+   * @throws IllegalArgumentException if any entry has the wrong shape, type, or an out-of-range precision/scale
+   */
+  static Map<String, int[]> normalizeDecimalMeta(Map<?, ?> value) {
+    Map<String, int[]> normalized = [:]
     value.each { key, meta ->
       String columnName = String.valueOf(key)
-      if (!(meta instanceof int[]) || (meta as int[]).length != 2) {
+      int[] ps
+      if (meta instanceof int[]) {
+        ps = meta as int[]
+      } else if (meta instanceof Number[]) {
+        Number[] numbers = meta as Number[]
+        ps = numbers*.intValue() as int[]
+      } else if (meta instanceof List) {
+        ps = (meta as List).collect { (it as Number).intValue() } as int[]
+      } else {
+        throw new IllegalArgumentException(
+            "decimalMeta['$columnName'] must be an int[], Number[], or List<Number> of length 2 [precision, scale] but was ${meta?.class}")
+      }
+      if (ps.length != 2) {
         throw new IllegalArgumentException(
             "decimalMeta['$columnName'] must be an int[] of length 2 [precision, scale] but was ${meta?.class}")
       }
-      int[] ps = meta as int[]
       if (ps[0] <= 0) {
         throw new IllegalArgumentException("decimalMeta['$columnName'] precision must be > 0 but was ${ps[0]}")
       }
@@ -188,9 +210,9 @@ class ParquetWriteOptions {
       if (ps[1] > ps[0]) {
         throw new IllegalArgumentException("decimalMeta['$columnName'] scale (${ps[1]}) must not exceed precision (${ps[0]})")
       }
-      validated[columnName] = ps
+      normalized[columnName] = ps
     }
-    validated
+    normalized
   }
 
   static String describe() {

--- a/matrix-parquet/src/test/groovy/MatrixParquetBigIntegerTest.groovy
+++ b/matrix-parquet/src/test/groovy/MatrixParquetBigIntegerTest.groovy
@@ -3,6 +3,9 @@ import static org.junit.jupiter.api.Assertions.assertNull
 import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.junit.jupiter.api.Assertions.assertTrue
 
+import org.apache.hadoop.conf.Configuration
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.schema.LogicalTypeAnnotation
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
@@ -101,7 +104,7 @@ class MatrixParquetBigIntegerTest {
   }
 
   @Test
-  void testNestedBigIntegerListPrecisionFallsBackTo38() {
+  void testNestedBigIntegerListPrecisionIsInferred() {
     BigInteger huge = BigInteger.TEN.pow(30)
     def data = Matrix.builder('nestedBigInt').data(
         id: [1],
@@ -110,6 +113,20 @@ class MatrixParquetBigIntegerTest {
 
     File file = tempDir.resolve('nested_bigint.parquet').toFile()
     MatrixParquetWriter.write(data, file)
+    def schema = ParquetFileReader
+        .readFooter(new Configuration(), new org.apache.hadoop.fs.Path(file.toURI()))
+        .fileMetaData.schema
+    def elementField = schema.getType('bigs')
+        .asGroupType()
+        .getType('list')
+        .asGroupType()
+        .getType('element')
+        .asPrimitiveType()
+    def logical = elementField.logicalTypeAnnotation as LogicalTypeAnnotation.DecimalLogicalTypeAnnotation
+
+    assertEquals(huge.toString().length(), logical.precision)
+    assertEquals(0, logical.scale)
+
     Matrix matrix = MatrixParquetReader.read(file)
 
     assertEquals([huge as BigDecimal, BigInteger.ONE as BigDecimal], matrix.bigs[0])

--- a/matrix-parquet/src/test/groovy/MatrixParquetBigIntegerTest.groovy
+++ b/matrix-parquet/src/test/groovy/MatrixParquetBigIntegerTest.groovy
@@ -131,4 +131,32 @@ class MatrixParquetBigIntegerTest {
 
     assertEquals([huge as BigDecimal, BigInteger.ONE as BigDecimal], matrix.bigs[0])
   }
+
+  @Test
+  void testMapBigIntegerKeyPrecisionIsInferred() {
+    BigInteger key = BigInteger.TEN.pow(30)
+    def data = Matrix.builder('mapBigIntKey').data(
+        m: [[(key): 'a']]
+    ).types([Map]).build()
+
+    File file = tempDir.resolve('map_bigint_key.parquet').toFile()
+    MatrixParquetWriter.write(data, file)
+    def schema = ParquetFileReader
+        .readFooter(new Configuration(), new org.apache.hadoop.fs.Path(file.toURI()))
+        .fileMetaData.schema
+    def keyField = schema.getType('m')
+        .asGroupType()
+        .getType('key_value')
+        .asGroupType()
+        .getType('key')
+        .asPrimitiveType()
+    def logical = keyField.logicalTypeAnnotation as LogicalTypeAnnotation.DecimalLogicalTypeAnnotation
+
+    assertEquals(key.toString().length(), logical.precision)
+    assertEquals(0, logical.scale)
+
+    Matrix matrix = MatrixParquetReader.read(file)
+
+    assertEquals([(key as BigDecimal): 'a'], matrix.m[0])
+  }
 }

--- a/matrix-parquet/src/test/groovy/MatrixParquetDecimalMetaTest.groovy
+++ b/matrix-parquet/src/test/groovy/MatrixParquetDecimalMetaTest.groovy
@@ -1,0 +1,28 @@
+import static org.junit.jupiter.api.Assertions.assertThrows
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.parquet.MatrixParquetWriter
+
+import java.nio.file.Path
+
+class MatrixParquetDecimalMetaTest {
+
+  @TempDir
+  Path tempDir
+
+  @Test
+  void testDirectDecimalMetaRejectsInvalidPrecisionAndScale() {
+    def data = Matrix.builder('badDecimalMeta').data(amount: [12.30]).types([BigDecimal]).build()
+    File file = tempDir.resolve('bad_decimal_meta.parquet').toFile()
+
+    assertThrows(IllegalArgumentException) {
+      MatrixParquetWriter.write(data, file, [amount: [0, 0] as int[]])
+    }
+    assertThrows(IllegalArgumentException) {
+      MatrixParquetWriter.writeBytes(data, [amount: [5, 6] as int[]])
+    }
+  }
+}

--- a/matrix-parquet/src/test/groovy/MatrixParquetWriterLifecycleTest.groovy
+++ b/matrix-parquet/src/test/groovy/MatrixParquetWriterLifecycleTest.groovy
@@ -1,6 +1,10 @@
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertThrows
 
+import org.apache.hadoop.conf.Configuration
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.schema.LogicalTypeAnnotation
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
@@ -55,6 +59,16 @@ class MatrixParquetWriterLifecycleTest {
 
     File file = tempDir.resolve('java_util_date.parquet').toFile()
     MatrixParquetWriter.write(data, file)
+    def schema = ParquetFileReader
+        .readFooter(new Configuration(), new org.apache.hadoop.fs.Path(file.toURI()))
+        .fileMetaData.schema
+    def createdField = schema.getType('created').asPrimitiveType()
+
+    assertEquals(PrimitiveTypeName.INT64, createdField.primitiveTypeName)
+    assertEquals(
+        LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS),
+        createdField.logicalTypeAnnotation)
+
     Matrix matrix = MatrixParquetReader.read(file)
 
     assertEquals([Integer, Date], matrix.types())

--- a/matrix-parquet/src/test/groovy/ParquetFormatProviderTest.groovy
+++ b/matrix-parquet/src/test/groovy/ParquetFormatProviderTest.groovy
@@ -86,6 +86,15 @@ class ParquetFormatProviderTest {
   }
 
   @Test
+  void testWriteOptionsRejectDecimalMetaListNonNumber() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      ParquetWriteOptions.fromMap([decimalMeta: [amount: [8, '2']]])
+    }
+
+    assertTrue(exception.message.contains("decimalMeta['amount'][1] must be a Number"))
+  }
+
+  @Test
   void testSpiWriteAcceptsDecimalMetaListShape() {
     Matrix source = Matrix.builder('payments')
         .data(amount: [12.30, 45.67])

--- a/matrix-parquet/src/test/groovy/ParquetFormatProviderTest.groovy
+++ b/matrix-parquet/src/test/groovy/ParquetFormatProviderTest.groovy
@@ -79,12 +79,25 @@ class ParquetFormatProviderTest {
   }
 
   @Test
-  void testWriteOptionsRejectInvalidDecimalMetaShape() {
-    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
-      ParquetWriteOptions.fromMap([decimalMeta: [amount: [8, 2]]])
-    }
+  void testWriteOptionsAcceptDecimalMetaListShape() {
+    ParquetWriteOptions options = ParquetWriteOptions.fromMap([decimalMeta: [amount: [8, 2]]])
+    assertEquals(8, options.decimalMeta.amount[0])
+    assertEquals(2, options.decimalMeta.amount[1])
+  }
 
-    assertTrue(exception.message.contains("decimalMeta['amount'] must be an int[] of length 2"))
+  @Test
+  void testSpiWriteAcceptsDecimalMetaListShape() {
+    Matrix source = Matrix.builder('payments')
+        .data(amount: [12.30, 45.67])
+        .types([BigDecimal])
+        .build()
+
+    File file = tempDir.resolve('decimal_meta_list.parquet').toFile()
+    source.write([decimalMeta: [amount: [8, 2]]], file)
+    Matrix matrix = Matrix.read(file)
+
+    assertEquals(source, matrix)
+    assertEquals(2, matrix.amount[0].scale())
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Normalize `decimalMeta` values through `ParquetWriteOptions` for SPI and direct writer APIs.
- Accept natural Groovy list metadata like `[amount: [8, 2]]` alongside `int[]` and `Number[]` values.
- Reject invalid decimal precision/scale and non-numeric decimal metadata elements before schema construction.
- Remove the remaining BigInteger precision fallback by inferring top-level, nested-list, and map-key BigInteger precision before primitive schema construction.
- Annotate `java.util.Date` columns as Parquet `TIMESTAMP(MILLIS)` and read timestamp units correctly.
- Migrate `MatrixParquetReader` primitive type switches to arrow switch syntax.
- Document the SPI `decimalMeta` list-shape example with a distinct output file in the matrix-parquet README.

## Modules touched
- `matrix-parquet`

## Tests
- `./gradlew :matrix-parquet:test --tests "MatrixParquetWriterLifecycleTest.testJavaUtilDateRoundTrip"`
- `./gradlew :matrix-parquet:test --tests "ParquetFormatProviderTest.testWriteOptionsRejectDecimalMetaListNonNumber" --tests "MatrixParquetBigIntegerTest.testNestedBigIntegerListPrecisionIsInferred"`
- `./gradlew :matrix-parquet:test --tests "MatrixParquetBigIntegerTest.testMapBigIntegerKeyPrecisionIsInferred"`
- `./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest :matrix-parquet:spotlessCheck :matrix-parquet:test`