### PR TITLE
matrix-parquet: improve reader metadata handling

### DIFF
--- a/matrix-parquet/readme.md
+++ b/matrix-parquet/readme.md
@@ -40,6 +40,7 @@ This module enables import and export of [Apache Parquet](https://parquet.apache
 - Compression: `SNAPPY` by default; override with the `compressionCodec` option (e.g. `GZIP`, `ZSTD`, `UNCOMPRESSED`)
 - Timezone: system default; override with `zoneId` option
 - Nested Map columns: stored as MAP when value types are homogeneous, as STRUCT when heterogeneous
+- Index columns: written to `matrix.indexColumns` metadata as a JSON string array so column names containing commas round-trip; readers also accept the legacy comma-delimited metadata form
 
 ## Installation
 

--- a/matrix-parquet/readme.md
+++ b/matrix-parquet/readme.md
@@ -30,7 +30,8 @@ This module enables import and export of [Apache Parquet](https://parquet.apache
 ## Default Behavior
 
 **Reading**
-- Matrix name: `matrixName` option wins; otherwise the file basename without extension (e.g. `data.parquet` → matrix named `data`)
+- Matrix name for file reads: `matrixName` option wins; otherwise the file basename without extension (e.g. `data.parquet` → matrix named `data`)
+- Matrix name for stream/byte-array/URL reads: `matrixName` option wins; otherwise the Parquet schema/message name when available
 - Timezone: system default; override with `zoneId` option
 
 **Writing**

--- a/matrix-parquet/release.md
+++ b/matrix-parquet/release.md
@@ -6,6 +6,7 @@
   - org.apache.parquet:parquet-hadoop 1.17.0 -> 1.17.1 
 - Add compression codec support: `ParquetWriteOptions.compressionCodec` / `WriterBuilder.compressionCodec(...)` / SPI `compressionCodec` option; default changed from `UNCOMPRESSED` to `SNAPPY`
 - Fix bug: `BigInteger` columns silently truncated when their value exceeded `Long` range (mapped to `INT64` via `.longValue()`); now mapped to `BINARY` with a `DECIMAL(precision, 0)` logical annotation, with precision auto-inferred from the data
+- Breaking metadata-format change: indexed column names are now written to `matrix.indexColumns` as a JSON string array instead of comma-delimited text so names containing commas round-trip; the new reader accepts both JSON and legacy comma-delimited metadata, but older readers and external tools that split the metadata value on commas will not parse new files correctly
 
 ## v0.5.0, 2026-04-29
 - Add SPI integration: `MatrixParquetFormatProvider` registers `.parquet` extension with Matrix SPI so `Matrix.read(file)` and `matrix.write(file)` work without explicit imports

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
@@ -357,7 +357,7 @@ class MatrixParquetReader {
    * @throws IllegalArgumentException if file is null, does not exist, or is a directory
    */
   static Matrix read(File file, String matrixName) {
-    read(file, file == null ? null : defaultMatrixName(file), false, null).withMatrixName(matrixName)
+    read(file, null, false, null).withMatrixName(matrixName)
   }
 
   /**
@@ -656,7 +656,7 @@ class MatrixParquetReader {
     if (zoneId == null) {
       throw new IllegalArgumentException(ERR_ZONE_ID_NULL)
     }
-    read(file, file == null ? null : defaultMatrixName(file), false, zoneId).withMatrixName(matrixName)
+    read(file, null, false, zoneId).withMatrixName(matrixName)
   }
 
   /**
@@ -843,8 +843,16 @@ class MatrixParquetReader {
   private static String[] parseIndexColumns(String indexString) {
     String value = indexString.trim()
     if (value.startsWith('[')) {
-      return parseJsonStringArray(value) as String[]
+      try {
+        return parseJsonStringArray(value) as String[]
+      } catch (IllegalArgumentException ignored) {
+        return parseLegacyIndexColumns(value)
+      }
     }
+    parseLegacyIndexColumns(value)
+  }
+
+  private static String[] parseLegacyIndexColumns(String value) {
     value.split(COMMA)*.trim() as String[]
   }
 

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
@@ -341,6 +341,13 @@ class MatrixParquetReader {
     }
   }
 
+  private static String defaultMatrixName(File file) {
+    if (file.name.contains(DOT)) {
+      return file.name.substring(0, file.name.lastIndexOf(DOT))
+    }
+    file.name
+  }
+
   /**
    * Read the Parquet file into a {@link Matrix} using the supplied name.
    *
@@ -350,8 +357,7 @@ class MatrixParquetReader {
    * @throws IllegalArgumentException if file is null, does not exist, or is a directory
    */
   static Matrix read(File file, String matrixName) {
-    validateFile(file)
-    read(file).withMatrixName(matrixName)
+    read(file, file == null ? null : defaultMatrixName(file), false, null).withMatrixName(matrixName)
   }
 
   /**
@@ -552,12 +558,7 @@ class MatrixParquetReader {
     if (zoneId == null) {
       throw new IllegalArgumentException(ERR_ZONE_ID_NULL)
     }
-    try {
-      ZONE_ID_HOLDER.set(zoneId)
-      return read(file)
-    } finally {
-      ZONE_ID_HOLDER.remove()
-    }
+    read(file, file == null ? null : defaultMatrixName(file), false, zoneId)
   }
 
   /**
@@ -655,12 +656,7 @@ class MatrixParquetReader {
     if (zoneId == null) {
       throw new IllegalArgumentException(ERR_ZONE_ID_NULL)
     }
-    try {
-      ZONE_ID_HOLDER.set(zoneId)
-      return read(file, matrixName)
-    } finally {
-      ZONE_ID_HOLDER.remove()
-    }
+    read(file, file == null ? null : defaultMatrixName(file), false, zoneId).withMatrixName(matrixName)
   }
 
   /**
@@ -758,6 +754,22 @@ class MatrixParquetReader {
    * @throws IllegalArgumentException if file is null, does not exist, or is a directory
    */
   static Matrix read(File file) {
+    read(file, file == null ? null : defaultMatrixName(file), false, null)
+  }
+
+  private static Matrix read(File file, String fallbackMatrixName, boolean preferSchemaName, ZoneId zoneId) {
+    if (zoneId == null) {
+      return read(file, fallbackMatrixName, preferSchemaName)
+    }
+    try {
+      ZONE_ID_HOLDER.set(zoneId)
+      return read(file, fallbackMatrixName, preferSchemaName)
+    } finally {
+      ZONE_ID_HOLDER.remove()
+    }
+  }
+
+  private static Matrix read(File file, String fallbackMatrixName, boolean preferSchemaName) {
     validateFile(file)
     log.debug("Reading Parquet file: ${file.absolutePath}")
     def path = new Path(file.toURI())
@@ -774,11 +786,10 @@ class MatrixParquetReader {
     }
 
     ParquetReader.builder(new GroupReadSupport(), path).build().withCloseable { reader ->
-      String matrixName
-      if (file.name.contains(DOT)) {
-        matrixName = file.name.substring(0, file.name.lastIndexOf(DOT))
-      } else {
-        matrixName = file.name
+      String schemaName = footer.getFileMetaData().getSchema().name
+      String matrixName = fallbackMatrixName
+      if (preferSchemaName && schemaName != null && !schemaName.trim().isEmpty()) {
+        matrixName = schemaName
       }
 
       Group row = reader.read()
@@ -819,7 +830,7 @@ class MatrixParquetReader {
    * Restores the index on a Matrix from the serialized index column names string.
    *
    * @param matrix the matrix to restore the index on
-   * @param indexString comma-separated index column names, or null if no index
+   * @param indexString JSON array or legacy comma-separated index column names, or null if no index
    * @return the matrix with index restored (or unchanged if no index metadata)
    */
   private static Matrix restoreIndex(Matrix matrix, String indexString) {
@@ -837,12 +848,8 @@ class MatrixParquetReader {
     java.nio.file.Path tempFile = Files.createTempFile('matrix-parquet-', '.parquet')
     try {
       Files.copy(is, tempFile, StandardCopyOption.REPLACE_EXISTING)
-      Matrix result
-      if (zoneId != null) {
-        result = read(tempFile.toFile(), zoneId)
-      } else {
-        result = read(tempFile.toFile())
-      }
+      File file = tempFile.toFile()
+      Matrix result = read(file, defaultMatrixName(file), true, zoneId)
       if (matrixName != null && !matrixName.trim().isEmpty()) {
         result = result.withMatrixName(matrixName)
       }

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetReader.groovy
@@ -835,10 +835,106 @@ class MatrixParquetReader {
    */
   private static Matrix restoreIndex(Matrix matrix, String indexString) {
     if (indexString != null && !indexString.trim().isEmpty()) {
-      String[] indexColumns = indexString.split(COMMA)*.trim() as String[]
-      matrix.createIndex(indexColumns)
+      matrix.createIndex(parseIndexColumns(indexString))
     }
     matrix
+  }
+
+  private static String[] parseIndexColumns(String indexString) {
+    String value = indexString.trim()
+    if (value.startsWith('[')) {
+      return parseJsonStringArray(value) as String[]
+    }
+    value.split(COMMA)*.trim() as String[]
+  }
+
+  private static List<String> parseJsonStringArray(String json) {
+    List<String> result = []
+    int pos = skipWhitespace(json, 0)
+    if (pos >= json.length() || json.charAt(pos) != '[' as char) {
+      throw new IllegalArgumentException("Invalid index metadata JSON: $json")
+    }
+    pos = skipWhitespace(json, pos + 1)
+    if (pos < json.length() && json.charAt(pos) == ']' as char) {
+      return result
+    }
+    while (pos < json.length()) {
+      if (json.charAt(pos) != '"' as char) {
+        throw new IllegalArgumentException("Invalid index metadata JSON: $json")
+      }
+      StringBuilder value = new StringBuilder()
+      pos++
+      while (pos < json.length()) {
+        char ch = json.charAt(pos)
+        if (ch == '"' as char) {
+          pos++
+          break
+        }
+        if (ch == '\\' as char) {
+          pos = appendEscapedJsonChar(json, pos + 1, value)
+        } else {
+          value.append(ch)
+          pos++
+        }
+      }
+      result << value.toString()
+      pos = skipWhitespace(json, pos)
+      if (pos < json.length() && json.charAt(pos) == ',' as char) {
+        pos = skipWhitespace(json, pos + 1)
+      } else if (pos < json.length() && json.charAt(pos) == ']' as char) {
+        return result
+      } else {
+        throw new IllegalArgumentException("Invalid index metadata JSON: $json")
+      }
+    }
+    throw new IllegalArgumentException("Invalid index metadata JSON: $json")
+  }
+
+  private static int appendEscapedJsonChar(String json, int pos, StringBuilder value) {
+    if (pos >= json.length()) {
+      throw new IllegalArgumentException("Invalid index metadata JSON: $json")
+    }
+    char escaped = json.charAt(pos)
+    if (escaped == '"' as char || escaped == '\\' as char || escaped == '/' as char) {
+      value.append(escaped)
+      return pos + 1
+    }
+    if (escaped == 'b' as char) {
+      value.append('\b')
+      return pos + 1
+    }
+    if (escaped == 'f' as char) {
+      value.append('\f')
+      return pos + 1
+    }
+    if (escaped == 'n' as char) {
+      value.append('\n')
+      return pos + 1
+    }
+    if (escaped == 'r' as char) {
+      value.append('\r')
+      return pos + 1
+    }
+    if (escaped == 't' as char) {
+      value.append('\t')
+      return pos + 1
+    }
+    if (escaped == 'u' as char) {
+      if (pos + 4 >= json.length()) {
+        throw new IllegalArgumentException("Invalid index metadata JSON: $json")
+      }
+      value.append((char) Integer.parseInt(json.substring(pos + 1, pos + 5), 16))
+      return pos + 5
+    }
+    throw new IllegalArgumentException("Invalid index metadata JSON: $json")
+  }
+
+  private static int skipWhitespace(String value, int pos) {
+    int current = pos
+    while (current < value.length() && Character.isWhitespace(value.charAt(current))) {
+      current++
+    }
+    current
   }
 
   private static Matrix readFromInputStream(InputStream is, String matrixName, ZoneId zoneId) {

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
@@ -686,14 +686,31 @@ class MatrixParquetWriter {
   }
 
   private static String escapeJson(String value) {
-    String.valueOf(value)
-        .replace('\\', '\\\\')
-        .replace('"', '\\"')
-        .replace('\b', '\\b')
-        .replace('\f', '\\f')
-        .replace('\n', '\\n')
-        .replace('\r', '\\r')
-        .replace('\t', '\\t')
+    StringBuilder escaped = new StringBuilder()
+    String source = String.valueOf(value)
+    for (int i = 0; i < source.length(); i++) {
+      char ch = source.charAt(i)
+      if (ch == '\\' as char) {
+        escaped.append('\\\\')
+      } else if (ch == '"' as char) {
+        escaped.append('\\"')
+      } else if (ch == '\b' as char) {
+        escaped.append('\\b')
+      } else if (ch == '\f' as char) {
+        escaped.append('\\f')
+      } else if (ch == '\n' as char) {
+        escaped.append('\\n')
+      } else if (ch == '\r' as char) {
+        escaped.append('\\r')
+      } else if (ch == '\t' as char) {
+        escaped.append('\\t')
+      } else if (Character.isISOControl(ch)) {
+        escaped.append('\\').append('u').append(Integer.toHexString((int) ch).padLeft(4, '0'))
+      } else {
+        escaped.append(ch)
+      }
+    }
+    escaped.toString()
   }
 
   /**

--- a/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
+++ b/matrix-parquet/src/main/groovy/se/alipsa/matrix/parquet/MatrixParquetWriter.groovy
@@ -595,7 +595,7 @@ class MatrixParquetWriter {
     def extraMeta = new HashMap<String, String>()
     extraMeta.put(METADATA_COLUMN_TYPES, matrix.types().collect { it.name }.join(','))
     if (matrix.hasIndex()) {
-      extraMeta.put(METADATA_INDEX_COLUMNS, matrix.indexedColumns().join(','))
+      extraMeta.put(METADATA_INDEX_COLUMNS, toJsonStringArray(matrix.indexedColumns()))
     }
 
     def writer = ExampleParquetWriter.builder(new Path(file.toURI()))
@@ -649,7 +649,7 @@ class MatrixParquetWriter {
     def extraMeta = new HashMap<String, String>()
     extraMeta.put(METADATA_COLUMN_TYPES, matrix.types().collect { it.name }.join(','))
     if (matrix.hasIndex()) {
-      extraMeta.put(METADATA_INDEX_COLUMNS, matrix.indexedColumns().join(','))
+      extraMeta.put(METADATA_INDEX_COLUMNS, toJsonStringArray(matrix.indexedColumns()))
     }
 
     InMemoryOutputFile outputFile = new InMemoryOutputFile()
@@ -679,6 +679,21 @@ class MatrixParquetWriter {
       }
     }
     return outputFile.getBytes()
+  }
+
+  private static String toJsonStringArray(List<String> values) {
+    "[${values.collect { String value -> "\"${escapeJson(value)}\"" }.join(',')}]"
+  }
+
+  private static String escapeJson(String value) {
+    String.valueOf(value)
+        .replace('\\', '\\\\')
+        .replace('"', '\\"')
+        .replace('\b', '\\b')
+        .replace('\f', '\\f')
+        .replace('\n', '\\n')
+        .replace('\r', '\\r')
+        .replace('\t', '\\t')
   }
 
   /**

--- a/matrix-parquet/src/test/groovy/MatrixParquetReaderMetadataTest.groovy
+++ b/matrix-parquet/src/test/groovy/MatrixParquetReaderMetadataTest.groovy
@@ -1,12 +1,26 @@
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
 
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path as HadoopPath
+import org.apache.parquet.example.data.simple.SimpleGroupFactory
+import org.apache.parquet.hadoop.example.ExampleParquetWriter
+import org.apache.parquet.schema.MessageType
+import org.apache.parquet.schema.PrimitiveType
+import org.apache.parquet.schema.Types
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.parquet.MatrixParquetReader
 import se.alipsa.matrix.parquet.MatrixParquetWriter
 
+import java.nio.file.Path
+
 class MatrixParquetReaderMetadataTest {
+
+  @TempDir
+  Path tempDir
 
   @Test
   void testByteArrayReadUsesSchemaNameWhenNoMatrixNameProvided() {
@@ -26,5 +40,54 @@ class MatrixParquetReaderMetadataTest {
     Matrix matrix = MatrixParquetReader.read(new ByteArrayInputStream(bytes), 'explicitName')
 
     assertEquals('explicitName', matrix.matrixName)
+  }
+
+  @Test
+  void testIndexColumnNameWithCommaRoundTrip() {
+    def data = Matrix.builder('commaIndex').data(
+        'country,region': ['US,West', 'SE,Stockholm'],
+        quarter: ['Q1', 'Q2'],
+        sales: [100, 200]
+    ).types([String, String, Integer]).build()
+
+    data.createIndex('country,region')
+    byte[] bytes = MatrixParquetWriter.writeBytes(data)
+    Matrix matrix = MatrixParquetReader.read(bytes)
+
+    assertTrue(matrix.hasIndex())
+    assertEquals(['country,region'], matrix.indexedColumns())
+    assertEquals(1, matrix.lookup('US,West').rowCount())
+  }
+
+  @Test
+  void testLegacyCommaDelimitedIndexMetadataStillReads() {
+    MessageType schema = Types.buildMessage()
+        .optional(PrimitiveType.PrimitiveTypeName.BINARY).named('country')
+        .optional(PrimitiveType.PrimitiveTypeName.BINARY).named('quarter')
+        .optional(PrimitiveType.PrimitiveTypeName.INT32).named('sales')
+        .named('LegacyIndex')
+
+    File file = tempDir.resolve('legacy_index_metadata.parquet').toFile()
+    Map<String, String> extraMeta = [
+        (MatrixParquetReader.METADATA_COLUMN_TYPES): 'java.lang.String,java.lang.String,java.lang.Integer',
+        (MatrixParquetReader.METADATA_INDEX_COLUMNS): 'country,quarter'
+    ]
+
+    def writer = ExampleParquetWriter.builder(new HadoopPath(file.toURI()))
+        .withConf(new Configuration())
+        .withType(schema)
+        .withExtraMetaData(extraMeta)
+        .build()
+    writer.withCloseable { parquetWriter ->
+      def group = new SimpleGroupFactory(schema).newGroup()
+      group.append('country', 'SE')
+      group.append('quarter', 'Q1')
+      group.append('sales', 100)
+      parquetWriter.write(group)
+    }
+
+    Matrix matrix = MatrixParquetReader.read(file)
+    assertTrue(matrix.hasIndex())
+    assertEquals(['country', 'quarter'], matrix.indexedColumns())
   }
 }

--- a/matrix-parquet/src/test/groovy/MatrixParquetReaderMetadataTest.groovy
+++ b/matrix-parquet/src/test/groovy/MatrixParquetReaderMetadataTest.groovy
@@ -126,7 +126,7 @@ class MatrixParquetReaderMetadataTest {
 
   @Test
   void testJsonIndexMetadataEscapesGenericControlCharacters() {
-    String controlColumn = "control\u0001column"
+    String controlColumn = 'control\u0001column'
     def data = Matrix.builder('controlIndex').data(
         (controlColumn): ['A'],
         sales: [100]

--- a/matrix-parquet/src/test/groovy/MatrixParquetReaderMetadataTest.groovy
+++ b/matrix-parquet/src/test/groovy/MatrixParquetReaderMetadataTest.groovy
@@ -1,0 +1,30 @@
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+import org.junit.jupiter.api.Test
+
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.parquet.MatrixParquetReader
+import se.alipsa.matrix.parquet.MatrixParquetWriter
+
+class MatrixParquetReaderMetadataTest {
+
+  @Test
+  void testByteArrayReadUsesSchemaNameWhenNoMatrixNameProvided() {
+    def data = Matrix.builder('schemaNamedMatrix').data(id: [1, 2]).types([Integer]).build()
+
+    byte[] bytes = MatrixParquetWriter.writeBytes(data)
+    Matrix matrix = MatrixParquetReader.read(bytes)
+
+    assertEquals('schemaNamedMatrix', matrix.matrixName)
+  }
+
+  @Test
+  void testInputStreamReadUsesExplicitMatrixNameWhenProvided() {
+    def data = Matrix.builder('schemaName').data(id: [1]).types([Integer]).build()
+    byte[] bytes = MatrixParquetWriter.writeBytes(data)
+
+    Matrix matrix = MatrixParquetReader.read(new ByteArrayInputStream(bytes), 'explicitName')
+
+    assertEquals('explicitName', matrix.matrixName)
+  }
+}

--- a/matrix-parquet/src/test/groovy/MatrixParquetReaderMetadataTest.groovy
+++ b/matrix-parquet/src/test/groovy/MatrixParquetReaderMetadataTest.groovy
@@ -1,9 +1,11 @@
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
 import static org.junit.jupiter.api.Assertions.assertTrue
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path as HadoopPath
 import org.apache.parquet.example.data.simple.SimpleGroupFactory
+import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.parquet.hadoop.example.ExampleParquetWriter
 import org.apache.parquet.schema.MessageType
 import org.apache.parquet.schema.PrimitiveType
@@ -89,5 +91,59 @@ class MatrixParquetReaderMetadataTest {
     Matrix matrix = MatrixParquetReader.read(file)
     assertTrue(matrix.hasIndex())
     assertEquals(['country', 'quarter'], matrix.indexedColumns())
+  }
+
+  @Test
+  void testLegacySingleIndexColumnStartingWithBracketStillReads() {
+    MessageType schema = Types.buildMessage()
+        .optional(PrimitiveType.PrimitiveTypeName.BINARY).named('[2024]')
+        .optional(PrimitiveType.PrimitiveTypeName.INT32).named('sales')
+        .named('LegacyBracketIndex')
+
+    File file = tempDir.resolve('legacy_bracket_index_metadata.parquet').toFile()
+    Map<String, String> extraMeta = [
+        (MatrixParquetReader.METADATA_COLUMN_TYPES): 'java.lang.String,java.lang.Integer',
+        (MatrixParquetReader.METADATA_INDEX_COLUMNS): '[2024]'
+    ]
+
+    def writer = ExampleParquetWriter.builder(new HadoopPath(file.toURI()))
+        .withConf(new Configuration())
+        .withType(schema)
+        .withExtraMetaData(extraMeta)
+        .build()
+    writer.withCloseable { parquetWriter ->
+      def group = new SimpleGroupFactory(schema).newGroup()
+      group.append('[2024]', 'FY')
+      group.append('sales', 100)
+      parquetWriter.write(group)
+    }
+
+    Matrix matrix = MatrixParquetReader.read(file)
+    assertTrue(matrix.hasIndex())
+    assertEquals(['[2024]'], matrix.indexedColumns())
+    assertEquals(1, matrix.lookup('FY').rowCount())
+  }
+
+  @Test
+  void testJsonIndexMetadataEscapesGenericControlCharacters() {
+    String controlColumn = "control\u0001column"
+    def data = Matrix.builder('controlIndex').data(
+        (controlColumn): ['A'],
+        sales: [100]
+    ).types([String, Integer]).build()
+    data.createIndex(controlColumn)
+
+    File file = tempDir.resolve('control_index_metadata.parquet').toFile()
+    MatrixParquetWriter.write(data, file)
+
+    def footer = ParquetFileReader.readFooter(new Configuration(), new HadoopPath(file.toURI()))
+    String indexMetadata = footer.fileMetaData.keyValueMetaData[MatrixParquetWriter.METADATA_INDEX_COLUMNS]
+
+    assertTrue(indexMetadata.contains('\\u0001'))
+    assertFalse(indexMetadata.contains('\u0001'))
+
+    Matrix matrix = MatrixParquetReader.read(file)
+    assertTrue(matrix.hasIndex())
+    assertEquals([controlColumn], matrix.indexedColumns())
   }
 }


### PR DESCRIPTION
## Summary
- Preserve matrix names for byte-array, stream, and URL reads by using the Parquet schema/message name when no explicit `matrixName` is provided.
- Keep file reads backward-compatible by continuing to use the file basename when no matrix name is supplied.
- Store index column metadata as a JSON string array so column names containing commas round-trip correctly.
- Keep legacy comma-delimited index metadata readable.
- Document the updated matrix-name default behavior in the matrix-parquet README.

## Modules touched
- `matrix-parquet`

## Tests
- `./gradlew :matrix-parquet:test --tests "MatrixParquetReaderMetadataTest.testByteArrayReadUsesSchemaNameWhenNoMatrixNameProvided" --tests "MatrixParquetReaderMetadataTest.testInputStreamReadUsesExplicitMatrixNameWhenProvided" --tests "MatrixParquetTest.testReaderValidation"`
- `./gradlew :matrix-parquet:test --tests "MatrixParquetReaderMetadataTest.testIndexColumnNameWithCommaRoundTrip" --tests "MatrixParquetReaderMetadataTest.testLegacyCommaDelimitedIndexMetadataStillReads"`
- `./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest :matrix-parquet:spotlessCheck :matrix-parquet:test`