### PR TITLE
matrix-parquet: consolidate 0.6.0 release notes

### DIFF
--- a/docs/cookbook/cookbook.md
+++ b/docs/cookbook/cookbook.md
@@ -12,6 +12,6 @@
 9. [Matrix Avro](matrix-avro.md)
    Decimal-safe writes, schema evolution, explicit nested schema control, and SPI recipes
 10. [Matrix BigQuery](matrix-bigquery.md)
-   Querying, dataset/table setup, overwrite vs append, and emulator-oriented recipes
+    Querying, dataset/table setup, overwrite vs append, and emulator-oriented recipes
 11. [Matrix Smile](matrix-smile.md)
     Smile ML integration: data conversion, feature engineering, statistical analysis, and machine learning

--- a/docs/cookbook/cookbook.md
+++ b/docs/cookbook/cookbook.md
@@ -7,9 +7,11 @@
 5. [Matrix Spreadsheet](matrix-spreadsheet.md)
 6. [Matrix Pict and Charts](matrix-charts.md)
 7. [Matrix GGPlot](matrix-ggplot.md)
-8. [Matrix Avro](matrix-avro.md)
+8. [Matrix Parquet](matrix-parquet.md)
+   Compression, decimal metadata, BigInteger safety, schema-derived names, and index metadata recipes
+9. [Matrix Avro](matrix-avro.md)
    Decimal-safe writes, schema evolution, explicit nested schema control, and SPI recipes
-9. [Matrix BigQuery](matrix-bigquery.md)
+10. [Matrix BigQuery](matrix-bigquery.md)
    Querying, dataset/table setup, overwrite vs append, and emulator-oriented recipes
-10. [Matrix Smile](matrix-smile.md)
+11. [Matrix Smile](matrix-smile.md)
     Smile ML integration: data conversion, feature engineering, statistical analysis, and machine learning

--- a/docs/cookbook/matrix-parquet.md
+++ b/docs/cookbook/matrix-parquet.md
@@ -1,0 +1,160 @@
+# Matrix Parquet
+
+Focused recipes for Parquet import/export, compression, numeric metadata, stream naming, and index metadata.
+
+## Inspect the available Parquet options at runtime
+
+```groovy
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.parquet.ParquetReadOptions
+import se.alipsa.matrix.parquet.ParquetWriteOptions
+
+println Matrix.listReadOptions('parquet')
+println Matrix.listWriteOptions('parquet')
+println ParquetReadOptions.describe()
+println ParquetWriteOptions.describe()
+```
+
+## Read and write with the generic Matrix API
+
+```groovy
+import se.alipsa.matrix.core.Matrix
+
+Matrix data = Matrix.read(new File('orders.parquet'))
+
+data.write([
+    compressionCodec: 'GZIP',
+    decimalMeta     : [amount: [12, 2]]
+], new File('orders-copy.parquet'))
+```
+
+`decimalMeta` accepts Groovy lists, `Number[]`, and `int[]` values shaped as `[precision, scale]`.
+
+## Write with explicit compression
+
+```groovy
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
+import se.alipsa.matrix.parquet.MatrixParquetWriter
+
+MatrixParquetWriter.builder(data)
+    .compressionCodec(CompressionCodecName.ZSTD)
+    .write(new File('orders-zstd.parquet'))
+
+MatrixParquetWriter.builder(data)
+    .compressionCodec('UNCOMPRESSED')
+    .write(new File('orders-plain.parquet'))
+```
+
+`SNAPPY` is the default. Reading compressed files is transparent.
+
+## Force decimal metadata for selected columns
+
+```groovy
+import se.alipsa.matrix.parquet.MatrixParquetWriter
+
+MatrixParquetWriter.write(data, new File('orders-decimal.parquet'), [
+    amount: [12, 2],
+    tax   : [8, 2]
+])
+```
+
+Validation is shared by direct, builder, and SPI writes: precision must be greater than 0, scale must be at least 0, and scale must not exceed precision.
+
+## Store very large integer identifiers safely
+
+```groovy
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.parquet.MatrixParquetReader
+import se.alipsa.matrix.parquet.MatrixParquetWriter
+
+Matrix ids = Matrix.builder('ids')
+    .columns(id: [new BigInteger('123456789012345678901234567890')])
+    .types(BigInteger)
+    .build()
+
+MatrixParquetWriter.write(ids, new File('ids.parquet'))
+Matrix restored = MatrixParquetReader.read(new File('ids.parquet'))
+
+assert restored[0, 'id'] == ids[0, 'id']
+```
+
+`BigInteger` is written as Parquet `DECIMAL(precision, 0)` rather than being narrowed to `Long`.
+
+## Preserve a matrix name through bytes or streams
+
+```groovy
+import se.alipsa.matrix.parquet.MatrixParquetReader
+import se.alipsa.matrix.parquet.MatrixParquetWriter
+
+byte[] bytes = MatrixParquetWriter.writeBytes(data.withMatrixName('Orders'))
+
+Matrix restored = MatrixParquetReader.read(bytes)
+assert restored.matrixName == 'Orders'
+
+Matrix explicit = MatrixParquetReader.read(bytes, 'OrdersFromApi')
+assert explicit.matrixName == 'OrdersFromApi'
+```
+
+When no explicit name is supplied for byte-array, stream, or URL reads, the reader uses the Parquet schema/message name.
+
+## Round-trip `java.util.Date`
+
+```groovy
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.parquet.MatrixParquetReader
+import se.alipsa.matrix.parquet.MatrixParquetWriter
+
+Matrix events = Matrix.builder('events')
+    .columns(event: ['created'], happenedAt: [new Date(1_735_689_600_000L)])
+    .types(String, Date)
+    .build()
+
+MatrixParquetWriter.write(events, new File('events.parquet'))
+Matrix restored = MatrixParquetReader.read(new File('events.parquet'))
+
+assert restored[0, 'happenedAt'] == events[0, 'happenedAt']
+```
+
+Matrix metadata lets the reader restore `java.util.Date` values from epoch milliseconds.
+
+## Preserve indexes whose column names contain commas
+
+```groovy
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.parquet.MatrixParquetReader
+import se.alipsa.matrix.parquet.MatrixParquetWriter
+
+Matrix sales = Matrix.builder('sales')
+    .columns(
+        'country,region': ['SE,Stockholm', 'US,West'],
+        quarter: ['Q1', 'Q2'],
+        revenue: [100, 200]
+    )
+    .types(String, String, Integer)
+    .build()
+
+sales.createIndex('country,region')
+MatrixParquetWriter.write(sales, new File('sales.parquet'))
+
+Matrix restored = MatrixParquetReader.read(new File('sales.parquet'))
+assert restored.indexedColumns() == ['country,region']
+assert restored.lookup('SE,Stockholm').rowCount() == 1
+```
+
+New writes store `matrix.indexColumns` as a JSON string array. The reader also accepts legacy comma-delimited metadata, but older readers and external tools that split this metadata value on commas will not parse newly-written index metadata correctly.
+
+## Read external string-encoded decimals
+
+When an external file stores a Matrix-declared `BigDecimal` column as plain UTF-8 `BINARY` without a Parquet `DECIMAL` annotation, the reader parses the text as `BigDecimal` instead of treating the field as a double value.
+
+For files with no Matrix metadata at all, Parquet `DECIMAL` columns are inferred as `BigDecimal`. Scale-0 decimals from external files cannot be distinguished from original `BigInteger` columns without Matrix metadata.
+
+## Common troubleshooting
+
+- Large file uses too much memory: Matrix reads the complete result into memory; reduce upstream or increase heap size.
+- `BigInteger` reads as `BigDecimal` from an external file: expected when Matrix metadata is absent.
+- An older consumer misreads `matrix.indexColumns`: 0.6.0 writes JSON metadata for indexed column names.
+- Compression setting appears ignored on read: expected; Parquet stores codec metadata in the file footer, and the reader auto-detects it.
+
+---
+[Back to index](cookbook.md)

--- a/docs/tutorial/1-introduction.md
+++ b/docs/tutorial/1-introduction.md
@@ -132,7 +132,7 @@ The Matrix project consists of multiple modules, each providing specific functio
 
 9. **matrix-bom**: Bill of Materials for simplified dependency management.
 
-10. **matrix-parquet**: Parquet file format support (experimental).
+10. **matrix-parquet**: Apache Parquet import/export with compression, decimal metadata, nested values, and Matrix index preservation.
 
 11. **matrix-bigquery**: Google BigQuery integration (experimental).
 

--- a/docs/tutorial/10-matrix-bom.md
+++ b/docs/tutorial/10-matrix-bom.md
@@ -186,7 +186,7 @@ The Matrix BOM includes version management for the following modules:
 - `matrix-json`: JSON serialization and deserialization
 - `matrix-xchart`: Chart creation using XChart
 - `matrix-sql`: Database interaction
-- `matrix-parquet`: Parquet file format support (experimental)
+- `matrix-parquet`: Apache Parquet import/export with compression, decimal metadata, nested values, and Matrix index preservation
 - `matrix-bigquery`: Google BigQuery integration (experimental)
 - `matrix-charts`: Charm rendering engine and export utilities (experimental)
 - `matrix-pict`: Chart-type-first API backed by the Charm engine (experimental)

--- a/docs/tutorial/11-matrix-parquet.md
+++ b/docs/tutorial/11-matrix-parquet.md
@@ -1,97 +1,54 @@
 # Matrix Parquet Module
 
-The Matrix Parquet module enables importing data from Apache Parquet files into Matrix objects and exporting Matrix objects to Parquet files. This module is particularly useful when working with big data ecosystems that commonly use the Parquet format.
-
-## What is Apache Parquet?
-
-Apache Parquet is a columnar storage file format designed for efficient data storage and retrieval. It offers efficient data compression and encoding schemes with enhanced performance to handle complex data in bulk. Parquet is commonly used in big data processing frameworks like Hadoop, Spark, and other data processing systems.
+The Matrix Parquet module reads and writes Apache Parquet files using the native `MatrixParquetReader` and `MatrixParquetWriter` APIs. Parquet is a columnar file format used heavily in Hadoop, Spark, lakehouse, and analytics pipelines.
 
 ## Installation
 
-To use the matrix-parquet module, add the following dependencies to your project:
-
-### Gradle Configuration
+When you use the Matrix BOM, add `matrix-parquet` alongside `matrix-core`:
 
 ```groovy
-implementation 'org.apache.groovy:groovy:5.0.5'
+implementation 'org.apache.groovy:groovy:5.0.6'
 implementation platform('se.alipsa.matrix:matrix-bom:2.5.0')
 implementation 'se.alipsa.matrix:matrix-core'
 implementation 'se.alipsa.matrix:matrix-parquet'
 ```
 
-### Maven Configuration
+With Maven:
 
 ```xml
 <project>
-   <dependencyManagement>
-      <dependencies>
-         <dependency>
-            <groupId>se.alipsa.matrix</groupId>
-            <artifactId>matrix-bom</artifactId>
-            <version>2.3.0</version>
-            <type>pom</type>
-            <scope>import</scope>
-         </dependency>
-      </dependencies>
-   </dependencyManagement>
-   <dependencies>
-     <dependency>
-       <groupId>org.apache.groovy</groupId>
-       <artifactId>groovy</artifactId>
-       <version>5.0.5</version>
-     </dependency>
-     <dependency>
-       <groupId>se.alipsa.matrix</groupId>
-       <artifactId>matrix-core</artifactId>
-     </dependency>
-     <dependency>
-       <groupId>se.alipsa.matrix</groupId>
-       <artifactId>matrix-parquet</artifactId>
-     </dependency>
-   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>se.alipsa.matrix</groupId>
+        <artifactId>matrix-bom</artifactId>
+        <version>2.5.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.groovy</groupId>
+      <artifactId>groovy</artifactId>
+      <version>5.0.6</version>
+    </dependency>
+    <dependency>
+      <groupId>se.alipsa.matrix</groupId>
+      <artifactId>matrix-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>se.alipsa.matrix</groupId>
+      <artifactId>matrix-parquet</artifactId>
+    </dependency>
+  </dependencies>
 </project>
 ```
 
-## Using the Matrix Parquet Module
+## Reading and Writing
 
-The matrix-parquet module provides a simple API through the `MatrixParquetIO` class, which has methods for reading from and writing to Parquet files.
-
-### Importing Data from a Parquet File
-
-To import data from a Parquet file into a Matrix object:
-
-```groovy
-import se.alipsa.matrix.core.Matrix
-import se.alipsa.matrix.parquet.MatrixParquetReader
-
-// Read a Parquet file into a Matrix
-File parquetFile = new File("path/to/data.parquet")
-Matrix data = MatrixParquetReader.read(parquetFile, 'myData')
-
-// You can also omit the name parameter, and it will use the file name as the Matrix name
-Matrix data2 = MatrixParquetReader.read(parquetFile)
-```
-
-### Exporting a Matrix to a Parquet File
-
-To export a Matrix object to a Parquet file:
-
-```groovy
-import se.alipsa.matrix.core.Matrix
-import se.alipsa.matrix.datasets.Dataset
-import se.alipsa.matrix.parquet.MatrixParquetWriter
-
-// Create or obtain a Matrix
-Matrix data = Dataset.cars()
-
-// Write the Matrix to a Parquet file
-File outputFile = new File("path/to/output.parquet")
-MatrixParquetWriter.write(data, outputFile)
-```
-
-## Complete Example
-
-Here's a complete example that demonstrates creating a Matrix, writing it to a Parquet file, and then reading it back:
+Use the direct APIs when you want the full Parquet-specific surface:
 
 ```groovy
 import se.alipsa.matrix.core.Matrix
@@ -99,82 +56,207 @@ import se.alipsa.matrix.datasets.Dataset
 import se.alipsa.matrix.parquet.MatrixParquetReader
 import se.alipsa.matrix.parquet.MatrixParquetWriter
 
-// Create a Matrix using a built-in dataset
-Matrix cars = Dataset.cars()
-println "Original Matrix:"
-println cars.head(5)  // Display the first 5 rows
+Matrix cars = Dataset.cars().withMatrixName('cars')
+File file = new File('cars.parquet')
 
-// Write the Matrix to a Parquet file
-File parquetFile = new File("cars.parquet")
-MatrixParquetWriter.write(cars, parquetFile)
-println "Matrix written to ${parquetFile.absolutePath}"
+MatrixParquetWriter.write(cars, file)
+Matrix restored = MatrixParquetReader.read(file)
 
-// Read the Parquet file back into a new Matrix
-Matrix carsFromParquet = MatrixParquetReader.read(parquetFile, 'cars')
-println "\nMatrix read from Parquet file:"
-println carsFromParquet.head(5)  // Display the first 5 rows
-
-// Verify that the original and imported Matrices are equal
-assert cars == carsFromParquet
-println "\nThe original Matrix and the Matrix read from Parquet are identical."
+assert restored.matrixName == 'cars'
+assert restored.rowCount() == cars.rowCount()
 ```
 
-## Working with Large Datasets
+For file reads, the default matrix name comes from the file name unless you pass an explicit name:
 
-When working with Parquet files, it's important to remember that Matrix objects are in-memory data structures. This means you need to have enough RAM available to fit the entire dataset when reading a Parquet file into a Matrix.
-
-If you're working with very large Parquet files, consider these approaches:
-
-1. **Filter the data**: If possible, filter the data before loading it into a Matrix.
-2. **Sample the data**: Load only a sample of the data for exploratory analysis.
-3. **Process in chunks**: Process the data in smaller chunks if your workflow allows it.
-
-## Technical Implementation Details
-
-The matrix-parquet module uses the [carpet-record](https://github.com/jerolba/carpet-record) library to handle Parquet file operations. 
-This implementation converts each row in the Matrix to a Record class that is created dynamically to match the structure of the Matrix.
-
-### Dependency Resolution
-
-The carpet-record library requires some dependencies that are fetched using Groovy's `@Grab` annotation. 
-If you encounter dependency resolution issues, you might need to manually resolve some dependencies using Maven:
-E.g:
-```bash
-mvn dependency:get -Dartifact='commons-pool:commons-pool:1.6'
-mvn dependency:get -Dartifact='com.google.guava:guava:27.0-jre'
+```groovy
+Matrix named = MatrixParquetReader.read(new File('sales.parquet'), 'quarterly_sales')
 ```
 
-### Limitations
+For stream, byte-array, and URL reads, the reader now uses the Parquet schema/message name when no explicit `matrixName` is supplied. This avoids temporary-file names leaking into matrices read from non-file sources.
 
-There are a few limitations to be aware of when using the matrix-parquet module:
+```groovy
+byte[] content = MatrixParquetWriter.writeBytes(cars)
 
-1. **In-memory processing**: As mentioned, Matrix objects are in-memory structures, so very large Parquet files might cause memory issues.
-2. **Classpath conflicts**: If you have carpet-record in your system classpath, the dynamic Record class creation might not work correctly.
-3. **Experimental status**: The matrix-parquet module is marked as experimental, which means its API might change in future releases.
+Matrix fromBytes = MatrixParquetReader.read(content)
+assert fromBytes.matrixName == 'cars'
+```
+
+## Generic Matrix API
+
+If `matrix-parquet` is on the classpath, `.parquet` files are also available through the generic Matrix SPI:
+
+```groovy
+import se.alipsa.matrix.core.Matrix
+
+Matrix data = Matrix.read(new File('cars.parquet'))
+Matrix events = Matrix.read([matrixName: 'events', zoneId: 'Europe/Stockholm'], new File('events.parquet'))
+
+data.write([compressionCodec: 'GZIP'], new File('cars-gzip.parquet'))
+data.write([decimalMeta: [amount: [12, 2]]], new File('money.parquet'))
+
+println Matrix.listReadOptions('parquet')
+println Matrix.listWriteOptions('parquet')
+```
+
+The `decimalMeta` option accepts natural Groovy list values such as `[12, 2]` as well as array values. All write paths validate that precision is positive, scale is non-negative, and scale does not exceed precision.
+
+## Builder API
+
+The builder API is useful when multiple options apply to one operation:
+
+```groovy
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
+import se.alipsa.matrix.parquet.MatrixParquetReader
+import se.alipsa.matrix.parquet.MatrixParquetWriter
+
+MatrixParquetWriter.builder(cars)
+    .compressionCodec(CompressionCodecName.ZSTD)
+    .decimalMeta([price: [12, 2]])
+    .zoneId('Europe/Stockholm')
+    .write(new File('cars-zstd.parquet'))
+
+Matrix restored = MatrixParquetReader.builder()
+    .zoneId('Europe/Stockholm')
+    .read(new File('cars-zstd.parquet'))
+```
+
+## Compression
+
+Parquet files are written with `SNAPPY` compression by default. You can override the codec with the builder, typed options, or SPI map:
+
+```groovy
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
+import se.alipsa.matrix.parquet.MatrixParquetWriter
+import se.alipsa.matrix.parquet.ParquetWriteOptions
+
+MatrixParquetWriter.builder(cars)
+    .compressionCodec('GZIP')
+    .write(new File('cars-gzip.parquet'))
+
+MatrixParquetWriter.write(cars, new File('cars-zstd.parquet'), new ParquetWriteOptions()
+    .compressionCodec(CompressionCodecName.ZSTD)
+)
+
+cars.write([compressionCodec: 'UNCOMPRESSED'], new File('cars-uncompressed.parquet'))
+```
+
+Supported codec names are the values from `org.apache.parquet.hadoop.metadata.CompressionCodecName`, including `UNCOMPRESSED`, `SNAPPY`, `GZIP`, `ZSTD`, and `LZ4_RAW`. Reading is automatic; no reader-side compression option is needed.
+
+## Numeric and Date Types
+
+`BigDecimal` columns are stored as Parquet `DECIMAL` values. By default, precision and scale are inferred from the data:
+
+```groovy
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.parquet.MatrixParquetWriter
+
+Matrix invoices = Matrix.builder('invoices')
+    .columns(id: [1, 2], amount: [123.45G, 98765.43G])
+    .types(Integer, BigDecimal)
+    .build()
+
+MatrixParquetWriter.write(invoices, new File('invoices.parquet'))
+```
+
+If you need fixed metadata, provide precision and scale:
+
+```groovy
+MatrixParquetWriter.write(invoices, new File('invoices-fixed.parquet'), [
+    amount: [10, 2]
+])
+```
+
+`BigInteger` columns are written as `BINARY` with a `DECIMAL(precision, 0)` annotation, with precision inferred from the actual values. This avoids the `Long` range limit that older versions hit when writing very large integers.
+
+```groovy
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.parquet.MatrixParquetWriter
+
+Matrix identifiers = Matrix.builder('identifiers')
+    .columns(id: [new BigInteger('123456789012345678901234567890')])
+    .types(BigInteger)
+    .build()
+
+MatrixParquetWriter.write(identifiers, new File('identifiers.parquet'))
+```
+
+`java.util.Date` values round-trip as epoch milliseconds when Matrix metadata is present. `LocalDateTime` and `Timestamp` values use microsecond timestamp precision, and `Time` values use millisecond precision.
+
+## Time Zones
+
+`LocalDateTime` values are converted through UTC using the system default time zone unless you specify one:
+
+```groovy
+import java.time.ZoneId
+import java.time.LocalDateTime
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.parquet.MatrixParquetReader
+import se.alipsa.matrix.parquet.MatrixParquetWriter
+
+Matrix events = Matrix.builder('events')
+    .columns(name: ['created'], occurredAt: [LocalDateTime.of(2026, 6, 20, 12, 0)])
+    .types(String, LocalDateTime)
+    .build()
+
+MatrixParquetWriter.write(events, new File('events.parquet'), ZoneId.of('Europe/Stockholm'))
+Matrix stockholm = MatrixParquetReader.read(new File('events.parquet'), ZoneId.of('Europe/Stockholm'))
+```
+
+The same option is available through the builder and SPI maps as `zoneId`.
+
+## Index Metadata
+
+Matrix indexes created with `createIndex(...)` are preserved in Parquet metadata:
+
+```groovy
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.parquet.MatrixParquetReader
+import se.alipsa.matrix.parquet.MatrixParquetWriter
+
+Matrix sales = Matrix.builder('sales')
+    .columns(
+        'country,region': ['SE,Stockholm', 'US,West'],
+        quarter: ['Q1', 'Q2'],
+        revenue: [100, 200]
+    )
+    .types(String, String, Integer)
+    .build()
+
+sales.createIndex('country,region')
+MatrixParquetWriter.write(sales, new File('sales.parquet'))
+
+Matrix restored = MatrixParquetReader.read(new File('sales.parquet'))
+assert restored.indexedColumns() == ['country,region']
+```
+
+In 0.6.0, index column names are stored under `matrix.indexColumns` as a JSON string array so names containing commas round-trip correctly. The reader still accepts the legacy comma-delimited metadata form. Older Matrix versions and external consumers that split `matrix.indexColumns` on commas will not parse newly-written index metadata correctly.
+
+## Reading External Parquet Files
+
+Files not written by Matrix are still readable. Without Matrix metadata, column types are inferred from the Parquet schema and logical annotations. A plain `BINARY` column that Matrix metadata declares as `BigDecimal` is parsed from its UTF-8 text content, which supports external files that encode decimals as strings.
+
+Some type information cannot be recovered from external files. For example, a generic Parquet `DECIMAL` logical type is read as `BigDecimal`; without Matrix metadata, the reader cannot distinguish an original `BigInteger` column from a scale-0 decimal column.
+
+## Memory Model
+
+Matrix is an in-memory data structure. Reading a Parquet file loads the full result into memory. For very large files, filter or prepare the data upstream, increase JVM heap size, or use big-data tooling for the initial reduction before importing into Matrix.
 
 ## Third-Party Libraries
 
-The matrix-parquet module relies on the following third-party libraries:
+The module uses Apache Parquet and Hadoop libraries directly:
 
-1. **com.jerolba:carpet-record**: Used to import and export Matrices to and from Parquet files.
-   - License: Apache License 2.0
-
-2. **org.apache.hadoop:hadoop-client**: Required for carpet-record to work.
-   - License: Apache License 2.0
+- `org.apache.parquet:parquet-column`
+- `org.apache.parquet:parquet-hadoop`
+- `org.apache.hadoop:hadoop-common`
+- `org.apache.hadoop:hadoop-mapreduce-client-core`
 
 ## Best Practices
 
-Here are some best practices for working with the matrix-parquet module:
-
-1. **Memory management**: Be mindful of memory usage when working with large Parquet files.
-2. **Error handling**: Implement proper error handling to catch and handle exceptions that might occur during file operations.
-3. **File paths**: Use absolute file paths to avoid issues with relative paths.
-4. **Testing**: Always test your Parquet file operations with small datasets before working with larger ones.
-5. **Version compatibility**: Keep track of the version compatibility between matrix-core and matrix-parquet modules.
-
-## Conclusion
-
-The matrix-parquet module provides a convenient way to work with Parquet files in the Matrix library. It allows you to easily import data from Parquet files into Matrix objects and export Matrix objects to Parquet files, enabling integration with big data ecosystems.
+1. Use the generic `Matrix.read(...)` / `matrix.write(...)` API for simple file workflows.
+2. Use `MatrixParquetWriter.builder(...)` when combining compression, decimal metadata, and time-zone options.
+3. Keep `inferPrecisionAndScale` enabled unless you need a fixed schema contract.
+4. Record the `matrix.indexColumns` JSON metadata change if older readers or external tools consume your Parquet metadata.
+5. Test representative data before writing very large files, especially nested maps/lists and high-precision numeric columns.
 
 In the next section, we'll explore the matrix-bigquery module, which provides functionality for interacting with Google BigQuery.
 

--- a/docs/tutorial/outline.md
+++ b/docs/tutorial/outline.md
@@ -85,9 +85,11 @@
 - Simplifying dependency configuration
 - Version management
 
-## 11. Experimental (early development) Modules
+## 11. Additional I/O and Integration Modules
 - [Matrix Parquet Module](11-matrix-parquet.md)
-  - Working with Parquet files
+  - Native Parquet read/write APIs and generic Matrix SPI
+  - Compression codecs, decimal metadata, BigInteger safety, and Date handling
+  - Schema-derived names for stream reads and JSON index metadata
 - [Matrix Avro Module](11b-matrix-avro.md)
   - Reading and writing Avro object container files
   - Options-first `AvroReadOptions` and `AvroWriteOptions` usage

--- a/matrix-parquet/release.md
+++ b/matrix-parquet/release.md
@@ -6,7 +6,14 @@
   - org.apache.parquet:parquet-hadoop 1.17.0 -> 1.17.1 
 - Add compression codec support: `ParquetWriteOptions.compressionCodec` / `WriterBuilder.compressionCodec(...)` / SPI `compressionCodec` option; default changed from `UNCOMPRESSED` to `SNAPPY`
 - Fix bug: `BigInteger` columns silently truncated when their value exceeded `Long` range (mapped to `INT64` via `.longValue()`); now mapped to `BINARY` with a `DECIMAL(precision, 0)` logical annotation, with precision auto-inferred from the data
-- Breaking metadata-format change: indexed column names are now written to `matrix.indexColumns` as a JSON string array instead of comma-delimited text so names containing commas round-trip; the new reader accepts both JSON and legacy comma-delimited metadata, but older readers and external tools that split the metadata value on commas will not parse new files correctly
+- Fix bug: reading a `BigDecimal`-typed column stored as plain `BINARY` with no `DECIMAL` annotation (e.g. an externally-written file) incorrectly called `getDouble` on binary data; now parses the UTF-8 string as a `BigDecimal`
+- Fix bug: Parquet writers are now closed if row writing fails, preventing leaked file handles on exceptions
+- Fix bug: documented `java.util.Date` support now stores epoch milliseconds as `INT64` and restores `Date` values when Matrix metadata is present
+- Improve usability: `decimalMeta` options now accept natural Groovy list syntax (`[precision, scale]`) and all write paths validate precision/scale consistently
+- Improve usability: stream, byte-array, and URL reads now derive the matrix name from the Parquet schema/message name when no explicit `matrixName` is supplied
+- Fix bug: index column metadata is now stored as JSON, so index column names containing commas round-trip correctly while legacy comma-delimited metadata remains readable
+- Breaking metadata-format change: indexed column names are now written to `matrix.indexColumns` as a JSON string array instead of comma-delimited text; older readers and external tools that split the metadata value on commas will not parse new files correctly
+- Remove dead/redundant code: unreachable commented-out lines in `MatrixParquetWriter.buildPrimitiveType`; redundant empty-collection special case in `writeList`
 
 ## v0.5.0, 2026-04-29
 - Add SPI integration: `MatrixParquetFormatProvider` registers `.parquet` extension with Matrix SPI so `Matrix.read(file)` and `matrix.write(file)` work without explicit imports

--- a/matrix-parquet/release.md
+++ b/matrix-parquet/release.md
@@ -3,7 +3,7 @@
 ## v0.6.0, 2026-06-19
 - Upgrade dependencies
   - org.apache.parquet:parquet-column 1.17.0 -> 1.17.1
-  - org.apache.parquet:parquet-hadoop 1.17.0 -> 1.17.1 
+  - org.apache.parquet:parquet-hadoop 1.17.0 -> 1.17.1
 - Add compression codec support: `ParquetWriteOptions.compressionCodec` / `WriterBuilder.compressionCodec(...)` / SPI `compressionCodec` option; default changed from `UNCOMPRESSED` to `SNAPPY`
 - Fix bug: `BigInteger` columns silently truncated when their value exceeded `Long` range (mapped to `INT64` via `.longValue()`); now mapped to `BINARY` with a `DECIMAL(precision, 0)` logical annotation, with precision auto-inferred from the data
 - Fix bug: reading a `BigDecimal`-typed column stored as plain `BINARY` with no `DECIMAL` annotation (e.g. an externally-written file) incorrectly called `getDouble` on binary data; now parses the UTF-8 string as a `BigDecimal`


### PR DESCRIPTION
## Summary
- Consolidate the `matrix-parquet` v0.6.0 release notes with the remaining Phase 7 cleanup and fix bullets.
- Keep the explicit `matrix.indexColumns` JSON metadata compatibility warning for older readers and external tools.
- Update the parquet tutorial for the intended 0.6.0 behavior: native reader/writer APIs, SPI usage, compression, decimal metadata, BigInteger safety, `Date` handling, schema-derived stream names, index metadata, and external decimal reads.
- Add a Matrix Parquet cookbook page and wire it into the cookbook index and tutorial navigation.

## Modules touched
- `matrix-parquet`
- `docs/tutorial`
- `docs/cookbook`

## Tests and checks
- `./gradlew :matrix-parquet:codenarcMain :matrix-parquet:codenarcTest :matrix-parquet:spotlessCheck :matrix-parquet:test`
  - Result: `BUILD SUCCESSFUL`, `77 tests, 77 passed`.
- `./gradlew :matrix-parquet:spotlessCheck :matrix-parquet:codenarcMain -g ./.gradle-user`
  - Result: `BUILD SUCCESSFUL`.
- `git diff --check`
  - Result: passed for the documentation updates.