### PR TITLE
Add validateSeries first-series regression

### DIFF
--- a/matrix-pict/src/test/groovy/chart/ChartFactoryBaselineTest.groovy
+++ b/matrix-pict/src/test/groovy/chart/ChartFactoryBaselineTest.groovy
@@ -262,6 +262,11 @@ class ChartFactoryBaselineTest {
         .columns([x: ['a', 'b'], y: [1, 2], z: [3, 4]])
         .types([String, int, int])
         .build()
+    Matrix invalidFirstColumnCount = Matrix.builder()
+        .matrixName('invalidFirst')
+        .columns([x: ['a', 'b']])
+        .types([String])
+        .build()
     Matrix invalidType = Matrix.builder()
         .matrixName('invalidType')
         .columns([x: [1, 2], y: [1, 2]])
@@ -272,6 +277,11 @@ class ChartFactoryBaselineTest {
       Chart.validateSeries([] as Matrix[])
     }
     assertEquals('The series contains no data', noData.message)
+
+    IllegalArgumentException badFirstCols = assertThrows(IllegalArgumentException) {
+      Chart.validateSeries([invalidFirstColumnCount] as Matrix[])
+    }
+    assertTrue(badFirstCols.message.contains('does not contain 2 columns.'))
 
     IllegalArgumentException badCols = assertThrows(IllegalArgumentException) {
       Chart.validateSeries([valid, invalidColumnCount] as Matrix[])


### PR DESCRIPTION
## Summary
- Add a regression test for `Chart.validateSeries` when `series[0]` has the wrong column count.
- Covers the previous failure mode where a one-column first series could hit `type(1)` before the documented `IllegalArgumentException` path.

## Modules touched
- `matrix-pict`

## Tests
- `./gradlew :matrix-pict:codenarcMain`
- `./gradlew :matrix-pict:spotlessCheck`
- `./gradlew :matrix-pict:test`