### PR TITLE
Map BigDecimal to DECIMAL in pict

### DIFF
--- a/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/DataType.groovy
+++ b/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/DataType.groovy
@@ -76,6 +76,7 @@ enum DataType {
       case Boolean -> 'BIT'
       case String -> "VARCHAR(${varcharSize.length > 0 ? varcharSize[0] : 8000})"
       case Double -> 'DOUBLE'
+      case BigDecimal -> 'DECIMAL'
       case LocalDate -> 'DATE'
       case LocalTime -> 'TIME'
       case LocalDateTime, Instant -> 'TIMESTAMP'

--- a/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/DataType.groovy
+++ b/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/DataType.groovy
@@ -77,6 +77,7 @@ enum DataType {
       case String -> "VARCHAR(${varcharSize.length > 0 ? varcharSize[0] : 8000})"
       case Double -> 'DOUBLE'
       case BigDecimal -> 'DECIMAL'
+      case BigInteger -> 'NUMERIC'
       case LocalDate -> 'DATE'
       case LocalTime -> 'TIME'
       case LocalDateTime, Instant -> 'TIMESTAMP'

--- a/matrix-pict/src/test/groovy/chart/ChartFactoryBaselineTest.groovy
+++ b/matrix-pict/src/test/groovy/chart/ChartFactoryBaselineTest.groovy
@@ -247,7 +247,7 @@ class ChartFactoryBaselineTest {
     assertEquals('TIME', DataType.sqlType(LocalTime))
     assertEquals('TIMESTAMP', DataType.sqlType(LocalDateTime))
     assertEquals('TIMESTAMP', DataType.sqlType(Instant))
-    assertEquals('BLOB', DataType.sqlType(BigDecimal))
+    assertEquals('DECIMAL', DataType.sqlType(BigDecimal))
   }
 
   @Test

--- a/matrix-pict/src/test/groovy/chart/ChartFactoryBaselineTest.groovy
+++ b/matrix-pict/src/test/groovy/chart/ChartFactoryBaselineTest.groovy
@@ -248,6 +248,7 @@ class ChartFactoryBaselineTest {
     assertEquals('TIMESTAMP', DataType.sqlType(LocalDateTime))
     assertEquals('TIMESTAMP', DataType.sqlType(Instant))
     assertEquals('DECIMAL', DataType.sqlType(BigDecimal))
+    assertEquals('NUMERIC', DataType.sqlType(BigInteger))
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Map `BigDecimal` columns to SQL `DECIMAL` in `DataType.sqlType`.
- Update the matrix-pict baseline test to expect `DECIMAL` instead of falling through to `BLOB`.

## Modules touched
- `matrix-pict`

## Root cause
`BigDecimal` is numeric but was not listed in the SQL type switch, so it fell through to the default `BLOB` mapping.

## Tests
- `./gradlew :matrix-pict:test --tests "chart.ChartFactoryBaselineTest.testDataTypeSqlTypeMappings"`
- `./gradlew :matrix-pict:codenarcMain`
- `./gradlew :matrix-pict:spotlessCheck`
- `./gradlew :matrix-pict:test`