### PR TITLE
Add JavaBean axis getter aliases

### DIFF
--- a/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Chart.groovy
+++ b/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Chart.groovy
@@ -78,12 +78,42 @@ abstract class Chart<T extends Chart> {
     return xAxisTitle
   }
 
+  /**
+   * Returns the x-axis title label.
+   * JavaBean-convention alias for {@link #getxAxisTitle()}.
+   *
+   * @return the x-axis title label
+   */
+  String getXAxisTitle() {
+    xAxisTitle
+  }
+
   String getyAxisTitle() {
     return yAxisTitle
   }
 
+  /**
+   * Returns the y-axis title label.
+   * JavaBean-convention alias for {@link #getyAxisTitle()}.
+   *
+   * @return the y-axis title label
+   */
+  String getYAxisTitle() {
+    yAxisTitle
+  }
+
   AxisScale getxAxisScale() {
     return xAxisScale
+  }
+
+  /**
+   * Returns the custom x-axis scale, or {@code null} if not set.
+   * JavaBean-convention alias for {@link #getxAxisScale()}.
+   *
+   * @return the custom x-axis scale, or {@code null} if not set
+   */
+  AxisScale getXAxisScale() {
+    xAxisScale
   }
 
   T setXAxisScale(AxisScale xAxisScale) {
@@ -98,6 +128,16 @@ abstract class Chart<T extends Chart> {
 
   AxisScale getyAxisScale() {
     return yAxisScale
+  }
+
+  /**
+   * Returns the custom y-axis scale, or {@code null} if not set.
+   * JavaBean-convention alias for {@link #getyAxisScale()}.
+   *
+   * @return the custom y-axis scale, or {@code null} if not set
+   */
+  AxisScale getYAxisScale() {
+    yAxisScale
   }
 
   T setYAxisScale(AxisScale yAxisScale) {

--- a/matrix-pict/src/test/groovy/chart/ChartFactoryBaselineTest.groovy
+++ b/matrix-pict/src/test/groovy/chart/ChartFactoryBaselineTest.groovy
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.function.Executable
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.pict.AreaChart
+import se.alipsa.matrix.pict.AxisScale
 import se.alipsa.matrix.pict.BarChart
 import se.alipsa.matrix.pict.BubbleChart
 import se.alipsa.matrix.pict.Chart
@@ -212,10 +213,19 @@ class ChartFactoryBaselineTest {
         .title('T').x('x').y('y')
         .xAxisTitle('X Title').yAxisTitle('Y Title')
         .build()
+    AxisScale xScale = new AxisScale(1.0G, 10.0G, 1.0G)
+    AxisScale yScale = new AxisScale(2.0G, 20.0G, 2.0G)
+    chart.setXAxisScale(xScale)
+    chart.setYAxisScale(yScale)
+
     assertEquals('X Title', chart.getXAxisTitle())
     assertEquals('Y Title', chart.getYAxisTitle())
     assertEquals('X Title', chart.xAxisTitle)
     assertEquals('Y Title', chart.yAxisTitle)
+    assertSame(xScale, chart.getXAxisScale())
+    assertSame(yScale, chart.getYAxisScale())
+    assertSame(xScale, chart.xAxisScale)
+    assertSame(yScale, chart.yAxisScale)
   }
 
   @Test

--- a/matrix-pict/src/test/groovy/chart/ChartFactoryBaselineTest.groovy
+++ b/matrix-pict/src/test/groovy/chart/ChartFactoryBaselineTest.groovy
@@ -189,6 +189,36 @@ class ChartFactoryBaselineTest {
   }
 
   @Test
+  void testChartJavaBeanGetterAliasesAdded() {
+    List<String> methods = Chart.methods*.name
+    assertTrue(methods.contains('getXAxisTitle'), 'getXAxisTitle alias must exist')
+    assertTrue(methods.contains('getYAxisTitle'), 'getYAxisTitle alias must exist')
+    assertTrue(methods.contains('getXAxisScale'), 'getXAxisScale alias must exist')
+    assertTrue(methods.contains('getYAxisScale'), 'getYAxisScale alias must exist')
+    assertTrue(methods.contains('getxAxisTitle'), 'getxAxisTitle must remain for chart.xAxisTitle property access')
+    assertTrue(methods.contains('getyAxisTitle'), 'getyAxisTitle must remain for chart.yAxisTitle property access')
+    assertTrue(methods.contains('getxAxisScale'), 'getxAxisScale must remain for chart.xAxisScale property access')
+    assertTrue(methods.contains('getyAxisScale'), 'getyAxisScale must remain for chart.yAxisScale property access')
+  }
+
+  @Test
+  void testChartJavaBeanAliasesReturnSameValueAsPropertyAccess() {
+    Matrix data = Matrix.builder()
+        .columnNames(['x', 'y'])
+        .rows([[1, 2]])
+        .types([int, int])
+        .build()
+    AreaChart chart = AreaChart.builder(data)
+        .title('T').x('x').y('y')
+        .xAxisTitle('X Title').yAxisTitle('Y Title')
+        .build()
+    assertEquals('X Title', chart.getXAxisTitle())
+    assertEquals('Y Title', chart.getYAxisTitle())
+    assertEquals('X Title', chart.xAxisTitle)
+    assertEquals('Y Title', chart.yAxisTitle)
+  }
+
+  @Test
   void testChartToStringWithNullSeriesDoesNotThrow() {
     LineChart chart = new LineChart()
     chart.title = 'Partial'


### PR DESCRIPTION
## Summary
- Add JavaBean-style axis getter aliases to `Chart`: `getXAxisTitle`, `getYAxisTitle`, `getXAxisScale`, and `getYAxisScale`.
- Keep the existing lowercase getters so Groovy property access such as `chart.xAxisTitle` and `chart.xAxisScale` remains compatible.
- Add baseline tests proving both getter naming styles coexist and title aliases return the same values as property access.

## Modules touched
- `matrix-pict`

## Root cause
The existing lowercase getters support Groovy property access but do not follow JavaBean naming conventions. Adding aliases gives JavaBean callers the expected method names without breaking existing Groovy callers.

## Tests
- `./gradlew :matrix-pict:test --tests "chart.ChartFactoryBaselineTest.testChartJavaBeanGetterAliasesAdded" --tests "chart.ChartFactoryBaselineTest.testChartJavaBeanAliasesReturnSameValueAsPropertyAccess"`
- `./gradlew :matrix-pict:codenarcMain`
- `./gradlew :matrix-pict:spotlessCheck`
- `./gradlew :matrix-pict:test`