### PR TITLE
Fix value series accessor typo

### DIFF
--- a/matrix-pict/docs/pict.md
+++ b/matrix-pict/docs/pict.md
@@ -785,7 +785,8 @@ chart.setValueSeriesNames(['CPU %', 'Memory %', 'Disk %'])
 ```groovy
 chart.categorySeries        // List -- category labels
 chart.valueSeries           // List<List> -- all value series
-chart.getValueSerie(0)      // List -- first value series
+chart.getValueSeries(0)     // List -- first value series (preferred)
+chart.getValueSerie(0)      // @Deprecated alias; use getValueSeries(int) instead
 chart.valueSeriesNames      // List<String> -- series names
 ```
 

--- a/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Chart.groovy
+++ b/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Chart.groovy
@@ -175,8 +175,15 @@ abstract class Chart<T extends Chart> {
     this as T
   }
 
-  List<?> getValueSerie(int index) {
+  /** Returns the value series at the given zero-based index. */
+  List<?> getValueSeries(int index) {
     valueSeries[index]
+  }
+
+  /** @deprecated Use {@link #getValueSeries(int)}. */
+  @Deprecated
+  List<?> getValueSerie(int index) {
+    getValueSeries(index)
   }
 
   List<String> getValueSeriesNames() {

--- a/matrix-pict/src/test/groovy/chart/ChartBuilderTest.groovy
+++ b/matrix-pict/src/test/groovy/chart/ChartBuilderTest.groovy
@@ -155,6 +155,24 @@ class ChartBuilderTest {
   }
 
   @Test
+  void testGetValueSeriesAtIndex() {
+    def data = Matrix.builder()
+        .columnNames(['x', 'y', 'z'])
+        .rows([[1, 10, 100], [2, 20, 200]])
+        .types([int, int, int])
+        .build()
+    LineChart chart = LineChart.builder(data)
+        .title('Test')
+        .x('x')
+        .y('y', 'z')
+        .build()
+    assertEquals([10, 20], chart.getValueSeries(0))
+    assertEquals([100, 200], chart.getValueSeries(1))
+    assertEquals([10, 20], chart.getValueSerie(0))
+    assertEquals([100, 200], chart.getValueSerie(1))
+  }
+
+  @Test
   void testScatterChartBuilder() {
     def mtcars = Dataset.mtcars()
 


### PR DESCRIPTION
## Summary
- Add the correctly named `Chart.getValueSeries(int)` accessor.
- Retain `Chart.getValueSerie(int)` as a deprecated delegating alias for compatibility.
- Update the matrix-pict docs to prefer the corrected method and note the deprecated alias.
- Add builder test coverage for both accessor names.

## Modules touched
- `matrix-pict`

## Root cause
The indexed value-series accessor was exposed as `getValueSerie(int)`, missing the trailing `s`. The compatibility alias keeps existing callers working while making the corrected method available.

## Tests
- `./gradlew :matrix-pict:test --tests "chart.ChartBuilderTest.testGetValueSeriesAtIndex"`
- `./gradlew :matrix-pict:codenarcMain`
- `./gradlew :matrix-pict:spotlessCheck`
- `./gradlew :matrix-pict:test`