### PR TITLE
Add yLabels builder method

### DIFF
--- a/matrix-pict/docs/pict.md
+++ b/matrix-pict/docs/pict.md
@@ -134,6 +134,7 @@ All builders inherit these methods from `Chart.ChartBuilder`:
 | `xAxisVisible(boolean)`                                         | Whether the x-axis is visible                      |
 | `yAxisVisible(boolean)`                                         | Whether the y-axis is visible                      |
 | `css(String)`                                                   | Custom CSS string injected into Charm-rendered SVG |
+| `yLabels(Map<String, String>)`                                  | Custom y-axis labels: map of break values as strings to display labels |
 | `build()`                                                       | Build the chart                                    |
 
 ### Chart-Specific Builder Methods
@@ -694,7 +695,16 @@ chart.style.css = 'stroke-width: 2; font-family: Arial;'
 ### Custom Y Labels
 
 ```groovy
-chart.style.yLabels = ['0': 'Low', '50': 'Target', '100': 'High']
+// Via builder (preferred)
+def chart = LineChart.builder(data)
+    .title('Graded')
+    .x('month')
+    .y('revenue')
+    .yLabels(['10000': '10K', '20000': '20K', '30000': '30K'])
+    .build()
+
+// Or directly on the style after build
+chart.style.yLabels = ['10000': '10K', '20000': '20K', '30000': '30K']
 ```
 
 Custom y labels are applied by the Charm bridge. Map keys are parsed as numeric axis

--- a/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Chart.groovy
+++ b/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Chart.groovy
@@ -335,6 +335,15 @@ abstract class Chart<T extends Chart> {
      */
     B css(String css) { ensureStyle(); style.css = css; this as B }
 
+    /**
+     * Sets custom y-axis break labels applied by the Charm bridge.
+     * Keys are numeric break values as strings; values are the display labels.
+     *
+     * @param labels map of axis value strings to display labels
+     * @return this builder
+     */
+    B yLabels(Map<String, String> labels) { ensureStyle(); style.yLabels = labels; this as B }
+
     private void ensureStyle() {
       if (style == null) {
         style = new Style()

--- a/matrix-pict/src/test/groovy/chart/ChartBuilderTest.groovy
+++ b/matrix-pict/src/test/groovy/chart/ChartBuilderTest.groovy
@@ -560,4 +560,21 @@ class ChartBuilderTest {
     assertEquals('stroke-width: 2;', chart.style.css)
   }
 
+  @Test
+  void testBuilderYLabelsMethod() {
+    def data = Matrix.builder()
+        .columnNames(['x', 'y'])
+        .rows([[1, 10], [2, 20], [3, 30]])
+        .types([int, int])
+        .build()
+    LineChart chart = LineChart.builder(data)
+        .title('Y Labels')
+        .x('x')
+        .y('y')
+        .yLabels(['10': 'Low', '20': 'Medium', '30': 'High'])
+        .build()
+    assertNotNull(chart.style)
+    assertEquals(['10': 'Low', '20': 'Medium', '30': 'High'], chart.style.yLabels)
+  }
+
 }


### PR DESCRIPTION
## Summary
- Add `ChartBuilder.yLabels(Map<String, String>)` for fluent custom y-axis label configuration.
- Keep direct `chart.style.yLabels` assignment documented as an alternative.
- Add builder test coverage for the new fluent method.

## Modules touched
- `matrix-pict`

## Root cause
`Style.yLabels` was supported by the Charm bridge but lacked a corresponding fluent builder method, unlike the other style options.

## Tests
- `./gradlew :matrix-pict:test --tests "chart.ChartBuilderTest.testBuilderYLabelsMethod"`
- `./gradlew :matrix-pict:codenarcMain`
- `./gradlew :matrix-pict:spotlessCheck`
- `./gradlew :matrix-pict:test`