### PR TITLE
Avoid deprecated factory calls in pict builders

### DIFF
--- a/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/BoxChart.groovy
+++ b/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/BoxChart.groovy
@@ -7,6 +7,29 @@ import se.alipsa.matrix.core.Matrix
 @SuppressWarnings('UnnecessaryObjectReferences')
 class BoxChart extends Chart<BoxChart> {
 
+  private static BoxChart fromCategoryValue(String title, Matrix data, String categoryCol, String valueCol) {
+    Map<String, Matrix> groups = data.split(categoryCol).sort() as Map<String, Matrix>
+    BoxChart chart = new BoxChart()
+    chart.title = title
+    chart.categorySeries = ListConverter.toStrings(groups.keySet()) as List<?>
+    chart.valueSeries = groups.values().collect { Matrix m -> m[valueCol].removeNulls() as List<?> }
+    chart.valueSeriesNames = chart.categorySeries as List<String>
+    chart.xAxisTitle = categoryCol
+    chart.yAxisTitle = valueCol
+    chart
+  }
+
+  private static BoxChart fromColumns(String title, Matrix data, List<String> columnNames) {
+    BoxChart chart = new BoxChart()
+    chart.title = title
+    chart.categorySeries = columnNames as List<?>
+    chart.valueSeries = columnNames.collect { String col -> data[col] as List<?> }
+    chart.valueSeriesNames = columnNames
+    chart.xAxisTitle = 'X'
+    chart.yAxisTitle = 'Y'
+    chart
+  }
+
   /**
    * Creates a box chart from category and value columns.
    *
@@ -19,15 +42,7 @@ class BoxChart extends Chart<BoxChart> {
    */
   @Deprecated
   static BoxChart create(String title, Matrix data, String categoryColumnName, String valueColumn) {
-    Map<String, Matrix> groups = data.split(categoryColumnName).sort() as Map<String, Matrix>
-    BoxChart chart = new BoxChart()
-    chart.title = title
-    chart.categorySeries = ListConverter.toStrings(groups.keySet()) as List<?>
-    chart.valueSeries = groups.values().collect { Matrix m -> m[valueColumn].removeNulls() as List<?> }
-    chart.valueSeriesNames = chart.categorySeries as List<String>
-    chart.xAxisTitle = categoryColumnName
-    chart.yAxisTitle = valueColumn
-    return chart
+    fromCategoryValue(title, data, categoryColumnName, valueColumn)
   }
 
   /**
@@ -41,18 +56,7 @@ class BoxChart extends Chart<BoxChart> {
    */
   @Deprecated
   static BoxChart create(String title, Matrix data, List<String> columnNames) {
-    BoxChart chart = new BoxChart()
-    chart.title = title
-    chart.categorySeries = columnNames as List<?>
-    List<List<?>> valueColumns = []
-    columnNames.each { String col ->
-      valueColumns.add(data[col] as List<?>)
-    }
-    chart.valueSeries = valueColumns
-    chart.valueSeriesNames = columnNames
-    chart.xAxisTitle = 'X'
-    chart.yAxisTitle = 'Y'
-    return chart
+    fromColumns(title, data, columnNames)
   }
 
   /**
@@ -115,12 +119,9 @@ class BoxChart extends Chart<BoxChart> {
         }
       }
       String chartTitle = this.@title
-      BoxChart chart
-      if (columnNames) {
-        chart = BoxChart.create(chartTitle, data, columnNames)
-      } else {
-        chart = BoxChart.create(chartTitle, data, xCol, yCols[0])
-      }
+      BoxChart chart = columnNames
+          ? BoxChart.fromColumns(chartTitle, data, columnNames)
+          : BoxChart.fromCategoryValue(chartTitle, data, xCol, yCols[0])
       applyTo(chart)
       chart
     }

--- a/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/BubbleChart.groovy
+++ b/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/BubbleChart.groovy
@@ -37,6 +37,32 @@ class BubbleChart extends Chart<BubbleChart> {
   /** Optional grouping column name. */
   String groupColumn
 
+  private static BubbleChart fromMatrix(String title, Matrix data, String xCol, String yCol, String sizeCol) {
+    BubbleChart chart = new BubbleChart()
+    chart.title = title
+    chart.categorySeries = data.column(xCol) as List<?>
+    chart.valueSeries = [data.column(yCol) as List<?>]
+    chart.sizeSeries = data.column(sizeCol) as List<? extends Number>
+    chart.xAxisTitle = xCol
+    chart.yAxisTitle = yCol
+    chart.valueSeriesNames = [yCol]
+    chart
+  }
+
+  private static BubbleChart fromMatrixGrouped(
+      String title,
+      Matrix data,
+      String xCol,
+      String yCol,
+      String sizeCol,
+      String groupCol
+  ) {
+    BubbleChart chart = fromMatrix(title, data, xCol, yCol, sizeCol)
+    chart.groupColumn = groupCol
+    chart.groupSeries = data.column(groupCol) as List<?>
+    chart
+  }
+
   /**
    * Creates a bubble chart from a Matrix.
    *
@@ -50,15 +76,7 @@ class BubbleChart extends Chart<BubbleChart> {
    */
   @Deprecated
   static BubbleChart create(String title, Matrix data, String xCol, String yCol, String sizeCol) {
-    BubbleChart chart = new BubbleChart()
-    chart.title = title
-    chart.categorySeries = data.column(xCol) as List<?>
-    chart.valueSeries = [data.column(yCol) as List<?>]
-    chart.sizeSeries = data.column(sizeCol) as List<? extends Number>
-    chart.xAxisTitle = xCol
-    chart.yAxisTitle = yCol
-    chart.valueSeriesNames = [yCol]
-    chart
+    fromMatrix(title, data, xCol, yCol, sizeCol)
   }
 
   /**
@@ -75,10 +93,7 @@ class BubbleChart extends Chart<BubbleChart> {
    */
   @Deprecated
   static BubbleChart create(String title, Matrix data, String xCol, String yCol, String sizeCol, String groupCol) {
-    BubbleChart chart = create(title, data, xCol, yCol, sizeCol)
-    chart.groupColumn = groupCol
-    chart.groupSeries = data.column(groupCol) as List<?>
-    chart
+    fromMatrixGrouped(title, data, xCol, yCol, sizeCol, groupCol)
   }
 
   /**
@@ -136,8 +151,8 @@ class BubbleChart extends Chart<BubbleChart> {
       }
       String yCol = yCols[0]
       BubbleChart chart = groupCol
-          ? BubbleChart.create(this.@title, data, xCol, yCol, sizeCol, groupCol)
-          : BubbleChart.create(this.@title, data, xCol, yCol, sizeCol)
+          ? BubbleChart.fromMatrixGrouped(this.@title, data, xCol, yCol, sizeCol, groupCol)
+          : BubbleChart.fromMatrix(this.@title, data, xCol, yCol, sizeCol)
       applyTo(chart)
       chart
     }

--- a/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
+++ b/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
@@ -42,7 +42,7 @@ class Histogram extends Chart<Histogram> {
     String columnName = params.columnName as String
     Integer bins = params.getOrDefault('bins', 9) as Integer
     int binDecimals = params.getOrDefault('binDecimals', 1) as int
-    return create(title, data, columnName, bins, binDecimals)
+    return fromData(title, data, columnName, bins, binDecimals)
   }
 
   /**

--- a/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
+++ b/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
@@ -14,6 +14,19 @@ class Histogram extends Chart<Histogram> {
   Map<MinMax, Integer> ranges
   Integer numberOfBins = 9
 
+  private static Histogram fromData(String title, Matrix data, String columnName, Integer bins, int binDecimals) {
+    Histogram chart = new Histogram()
+    chart.title = title
+    chart.numberOfBins = bins
+    if (Number.isAssignableFrom(data.type(columnName))) {
+      chart.originalData = data.column(columnName) as List<? extends Number>
+      chart.ranges = createRanges(chart.originalData, bins, binDecimals)
+    } else {
+      throw new IllegalArgumentException('Column must be numeric in a histogram (hint: you can Barplot a Frequency)')
+    }
+    chart
+  }
+
   /**
    * Creates a histogram from named parameters.
    *
@@ -45,16 +58,7 @@ class Histogram extends Chart<Histogram> {
    */
   @Deprecated
   static Histogram create(String title, Matrix data, String columnName, Integer bins = 9, int binDecimals = 1) {
-    Histogram chart = new Histogram()
-    chart.title = title
-    chart.numberOfBins = bins
-    if (Number.isAssignableFrom(data.type(columnName))) {
-      chart.originalData = data.column(columnName) as List<? extends Number>
-      chart.ranges = createRanges(chart.originalData, bins, binDecimals)
-    } else {
-      throw new IllegalArgumentException('Column must be numeric in a histogram (hint: you can Barplot a Frequency)')
-    }
-    return chart
+    fromData(title, data, columnName, bins, binDecimals)
   }
 
   /**
@@ -167,7 +171,7 @@ class Histogram extends Chart<Histogram> {
       if (xCol == null) {
         throw new IllegalStateException('x(...) must be called before build()')
       }
-      Histogram chart = Histogram.create(this.@title, data, xCol, bins, binDecimals)
+      Histogram chart = Histogram.fromData(this.@title, data, xCol, bins, binDecimals)
       applyTo(chart)
       chart
     }

--- a/matrix-pict/src/test/groovy/chart/ChartBuilderTest.groovy
+++ b/matrix-pict/src/test/groovy/chart/ChartBuilderTest.groovy
@@ -246,6 +246,8 @@ class ChartBuilderTest {
     assertEquals(factory.title, builder.title)
     assertEquals(factory.categorySeries, builder.categorySeries)
     assertEquals(factory.valueSeries.size(), builder.valueSeries.size())
+    assertEquals('X', builder.xAxisTitle)
+    assertEquals('Y', builder.yAxisTitle)
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Extract private creation helpers for `BoxChart`, `Histogram`, and `BubbleChart`.
- Route deprecated factory methods and builders through the shared helpers.
- Update builders so they no longer call their own deprecated `create(...)` methods internally.
- Add BoxChart column-mode assertions for preserved default axis titles.

## Modules touched
- `matrix-pict`

## Root cause
Several builders delegated to deprecated factory methods in the same class. That preserved behavior but caused internal deprecation warnings during builder usage.

## Tests
- `./gradlew :matrix-pict:test --tests "chart.ChartBuilderTest.testBoxChartBuilderWithColumns"`
- `./gradlew :matrix-pict:test --tests "chart.ChartBuilderTest.testBoxChartBuilderWithColumns" --tests "chart.ChartBuilderTest.testHistogramBuilder" --tests "chart.ChartFactoryBaselineTest.testBubbleChartFactory" --tests "chart.ChartFactoryBaselineTest.testBubbleChartGroupedFactory"`
- `./gradlew :matrix-pict:codenarcMain`
- `./gradlew :matrix-pict:spotlessCheck`
- `./gradlew :matrix-pict:test`
- `git diff --check`