### PR TITLE
Simplify yLabels bridge sorting

### DIFF
--- a/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
+++ b/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/CharmBridge.groovy
@@ -368,14 +368,9 @@ class CharmBridge {
   }
 
   private static void applyYLabels(Scale scale, Map<String, String> yLabels) {
-    List<AbstractMap.SimpleEntry<BigDecimal, String>> entries = yLabels.collect { String value, String label ->
-      new AbstractMap.SimpleEntry<BigDecimal, String>(new BigDecimal(value), label)
-    }
-    entries.sort { AbstractMap.SimpleEntry<BigDecimal, String> entry ->
-      entry.key
-    }
-    scale.breaks = entries*.key
-    scale.labels = entries*.value
+    List<String> sortedKeys = yLabels.keySet().sort { String key -> new BigDecimal(key) } as List<String>
+    scale.breaks = sortedKeys.collect { String key -> new BigDecimal(key) }
+    scale.labels = sortedKeys.collect { String key -> yLabels[key] }
   }
 
   /**


### PR DESCRIPTION
## Summary
- Replace `AbstractMap.SimpleEntry` usage in `CharmBridge.applyYLabels` with idiomatic Groovy key sorting and collection transforms.
- Preserve numeric sorting of y-label break keys and existing label order behavior.

## Modules touched
- `matrix-pict`

## Root cause
`applyYLabels` used Java `AbstractMap.SimpleEntry` just to pair parsed break values with labels before sorting. Sorting keys numerically and collecting breaks/labels directly is simpler and avoids the Java helper type.

## Tests
- `./gradlew :matrix-pict:test --tests "chart.PlotCompatibilityTest.testLegacyYLabelsApplyToCharmBridge"` before and after the change
- `./gradlew :matrix-pict:codenarcMain`
- `./gradlew :matrix-pict:spotlessCheck`
- `./gradlew :matrix-pict:test`