### PR TITLE
Use int dimensions for pict PNG export

### DIFF
--- a/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Plot.groovy
+++ b/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Plot.groovy
@@ -45,7 +45,7 @@ class Plot {
    * @throws IllegalArgumentException if chart or file is null
    * @throws IOException if file writing fails
    */
-  static void png(Chart chart, File file, double width = 800, double height = 600) throws IOException {
+  static void png(Chart chart, File file, int width = 800, int height = 600) throws IOException {
     requireChart(chart)
     try (OutputStream os = Files.newOutputStream(requireFile(file).toPath())) {
       png(chart, os, width, height)
@@ -61,11 +61,23 @@ class Plot {
    * @param height image height in pixels
    * @throws IllegalArgumentException if chart or output stream is null
    */
-  static void png(Chart chart, OutputStream os, double width = 800, double height = 600) {
+  static void png(Chart chart, OutputStream os, int width = 800, int height = 600) {
     requireChart(chart)
     requireOutputStream(os)
-    Svg svg = CharmBridge.renderSvg(chart, width as int, height as int)
+    Svg svg = CharmBridge.renderSvg(chart, width, height)
     ChartToPng.export(svg, os)
+  }
+
+  /** @deprecated Use {@link #png(Chart, File, int, int)}. Pixel dimensions must be integers. */
+  @Deprecated
+  static void png(Chart chart, File file, double width, double height) throws IOException {
+    png(chart, file, (int) width, (int) height)
+  }
+
+  /** @deprecated Use {@link #png(Chart, OutputStream, int, int)}. Pixel dimensions must be integers. */
+  @Deprecated
+  static void png(Chart chart, OutputStream os, double width, double height) {
+    png(chart, os, (int) width, (int) height)
   }
 
   /**

--- a/matrix-pict/src/test/groovy/chart/ChartBuilderTest.groovy
+++ b/matrix-pict/src/test/groovy/chart/ChartBuilderTest.groovy
@@ -579,4 +579,26 @@ class ChartBuilderTest {
     assertEquals(['10': 'Low', '20': 'Medium', '30': 'High'], chart.style.yLabels)
   }
 
+  @Test
+  void testPlotPngMethodSignaturesUseInt() {
+    def pngMethods = Plot.methods.findAll { it.name == 'png' }
+    def hasFileIntOverload = pngMethods.any { method ->
+      method.parameterTypes.toList() == [se.alipsa.matrix.pict.Chart, File, int, int]
+    }
+    def hasStreamIntOverload = pngMethods.any { method ->
+      method.parameterTypes.toList() == [se.alipsa.matrix.pict.Chart, OutputStream, int, int]
+    }
+    def hasFileDoubleOverload = pngMethods.any { method ->
+      method.parameterTypes.toList() == [se.alipsa.matrix.pict.Chart, File, double, double]
+    }
+    def hasStreamDoubleOverload = pngMethods.any { method ->
+      method.parameterTypes.toList() == [se.alipsa.matrix.pict.Chart, OutputStream, double, double]
+    }
+
+    assertTrue(hasFileIntOverload, 'Plot.png(Chart, File, int, int) must exist')
+    assertTrue(hasStreamIntOverload, 'Plot.png(Chart, OutputStream, int, int) must exist')
+    assertTrue(hasFileDoubleOverload, 'Plot.png(Chart, File, double, double) must remain (deprecated)')
+    assertTrue(hasStreamDoubleOverload, 'Plot.png(Chart, OutputStream, double, double) must remain (deprecated)')
+  }
+
 }


### PR DESCRIPTION
## Summary
- Add preferred `Plot.png(Chart, File, int, int)` and `Plot.png(Chart, OutputStream, int, int)` overloads.
- Keep explicit `double` width/height overloads as deprecated compatibility wrappers.
- Add reflection coverage to ensure both the new `int` signatures and deprecated `double` signatures remain available.

## Modules touched
- `matrix-pict`

## Root cause
`Plot.png` accepted `double` dimensions and immediately cast them to `int` before rendering, while the SVG export API already uses integer pixel dimensions.

## Tests
- Confirmed `./gradlew :matrix-pict:test --tests "chart.ChartBuilderTest.testPlotPngMethodSignaturesUseInt"` failed before the production change.
- `./gradlew :matrix-pict:test --tests "chart.ChartBuilderTest.testPlotPngMethodSignaturesUseInt"`
- `./gradlew :matrix-pict:test --tests "PngTest" --tests "chart.PlotCompatibilityTest.testLegacyPngFileExport" --tests "chart.PlotCompatibilityTest.testLegacyPngOutputStreamExport" --tests "chart.PlotCompatibilityTest.testLegacyPngNullTargets"`
- `./gradlew :matrix-pict:codenarcMain`
- `./gradlew :matrix-pict:spotlessCheck`
- `./gradlew :matrix-pict:test`
- `git diff --check`