### PR TITLE
matrix-pict Task 10: add missing GroovyDoc

### DIFF
--- a/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/AxisScale.groovy
+++ b/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/AxisScale.groovy
@@ -25,14 +25,17 @@ class AxisScale {
     this.step = step
   }
 
+  /** Returns the start (minimum) value of this scale. */
   BigDecimal getStart() {
     return start
   }
 
+  /** Returns the end (maximum) value of this scale. */
   BigDecimal getEnd() {
     return end
   }
 
+  /** Returns the step size between consecutive axis breaks. */
   BigDecimal getStep() {
     return step
   }

--- a/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
+++ b/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Histogram.groovy
@@ -180,6 +180,15 @@ class Histogram extends Chart<Histogram> {
 
 }
 
+/**
+ * Represents a bin range {@code [minValue, maxValue]} in a histogram.
+ *
+ * <p>The {@link #toString()} method formats the range as {@code "min-max"},
+ * with values rounded to the histogram's configured {@code binDecimals} decimal places.</p>
+ *
+ * <p>Instances are created by {@link Histogram} factory methods and builders;
+ * direct construction is not intended for regular use.</p>
+ */
 class MinMax {
 
   BigDecimal minValue

--- a/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Style.groovy
+++ b/matrix-pict/src/main/groovy/se/alipsa/matrix/pict/Style.groovy
@@ -63,7 +63,10 @@ class Style {
   /** whether to show the title or not */
   Boolean titleVisible
 
+  /** Whether to render the x-axis. When {@code false}, the axis line, ticks, labels, and title are all hidden. */
   Boolean xAxisVisible
+
+  /** Whether to render the y-axis. When {@code false}, the axis line, ticks, labels, and title are all hidden. */
   Boolean yAxisVisible
 
   /** Maps numeric y-axis break values to custom display labels. */


### PR DESCRIPTION
Adds missing GroovyDoc for Task 10 of the matrix-pict 0.5.0 plan:

- `Histogram.MinMax`: class-level documentation explaining its role as a histogram bin range and display formatting.
- `AxisScale`: one-line GroovyDoc for `getStart()`, `getEnd()`, and `getStep()`.
- `Style`: field-level GroovyDoc for `xAxisVisible` and `yAxisVisible`.

Verification run:
- `./gradlew :matrix-pict:codenarcMain` — no violations
- `./gradlew :matrix-pict:test` — 103 passed
- `./gradlew test` — full suite passed, no regressions

Touches only `matrix-pict` production sources.