### PR TITLE
matrix-pict Task 11: update docs

### DIFF
--- a/docs/cookbook/matrix-charts.md
+++ b/docs/cookbook/matrix-charts.md
@@ -240,6 +240,7 @@ You can also assign `yLabels` directly on `chart.style` after building:
 
 ```groovy
 import se.alipsa.matrix.pict.Style
+import se.alipsa.matrix.pict.Plot
 
 def style = new Style()
 style.yLabels = ['0': 'Low', '50': 'Target', '100': 'High']
@@ -252,6 +253,8 @@ def chart = LineChart.builder(data)
     .yAxisScale(0, 100, 50)
     .style(style)
     .build()
+
+Plot.png(chart, new File('capacity.png'))
 ```
 
 ### Recipe: Export a Plot Grid with Dimensions

--- a/docs/cookbook/matrix-charts.md
+++ b/docs/cookbook/matrix-charts.md
@@ -222,12 +222,29 @@ where arrowheads are rendered. Length and width are SVG user-unit pixels.
 
 ```groovy
 import se.alipsa.matrix.pict.LineChart
-import se.alipsa.matrix.pict.Style
 import se.alipsa.matrix.pict.Plot
+
+// Custom y-axis labels via builder (preferred)
+def chart = LineChart.builder(data)
+    .title('Capacity')
+    .x('month')
+    .y('capacity')
+    .yAxisScale(0, 100, 50)
+    .yLabels(['0': 'Low', '50': 'Target', '100': 'High'])
+    .build()
+
+Plot.png(chart, new File('capacity.png'))
+```
+
+You can also assign `yLabels` directly on `chart.style` after building:
+
+```groovy
+import se.alipsa.matrix.pict.Style
 
 def style = new Style()
 style.yLabels = ['0': 'Low', '50': 'Target', '100': 'High']
 
+// ... then pass the style to the builder:
 def chart = LineChart.builder(data)
     .title('Capacity')
     .x('month')
@@ -235,8 +252,6 @@ def chart = LineChart.builder(data)
     .yAxisScale(0, 100, 50)
     .style(style)
     .build()
-
-Plot.png(chart, new File('capacity.png'))
 ```
 
 ### Recipe: Export a Plot Grid with Dimensions

--- a/docs/tutorial/13-matrix-charts.md
+++ b/docs/tutorial/13-matrix-charts.md
@@ -99,7 +99,7 @@ def empData = Matrix.builder().data(
 
 // Create different types of charts
 def areaChart = AreaChart.create("Salaries", empData, "emp_name", "salary")
-def barChart = BarChart.createVertical("Salaries", empData, "emp_name", ChartType.NONE, "salary")
+def barChart = BarChart.createVertical("Salaries", empData, "emp_name", ChartType.BASIC, "salary")
 def pieChart = PieChart.create("Salaries", empData, "emp_name", "salary")
 ```
 
@@ -166,7 +166,7 @@ Plot.png(horizontalBarChart, new File("horizontal_bar_chart.png"))
 ```
 
 The `ChartType` enum provides different styles for bar charts:
-- `ChartType.NONE`: Standard bars
+- `ChartType.BASIC`: Standard bars
 - `ChartType.GROUPED`: Groups bars for multiple series
 - `ChartType.STACKED`: Stacks bars for multiple series
 
@@ -328,30 +328,22 @@ You can customize chart titles and axis labels:
 // Create a chart with custom title and axis labels
 def barChart = BarChart.createVertical(
     "Product Sales 2023",  // Chart title
-    productData, 
-    "product", 
-    ChartType.NONE, 
+    productData,
+    "product",
+    ChartType.BASIC,
     "sales"
 )
-.setXAxisLabel("Products")  // X-axis label
-.setYAxisLabel("Sales (in thousands)")  // Y-axis label
+.setXAxisTitle("Products")  // X-axis label
+.setYAxisTitle("Sales (in thousands)")  // Y-axis label
 ```
 
 ### Customizing Colors
 
-You can customize the colors used in charts:
+Color customization in matrix-pict is done via `Style.css`, which injects raw CSS into
+the Charm-rendered SVG. Use the Charm DSL directly for full color control.
 
 ```groovy
-import javafx.scene.paint.Color
-
-// Create a pie chart with custom colors
-def pieChart = PieChart.create("Market Share", marketData, "company", "market_share")
-    .setColors([
-        Color.BLUE,
-        Color.GREEN,
-        Color.RED,
-        Color.ORANGE
-    ])
+chart.style.css = 'rect.bar { fill: steelblue; }'
 ```
 
 ### Adding Legends
@@ -359,10 +351,12 @@ def pieChart = PieChart.create("Market Share", marketData, "company", "market_sh
 You can control the display of legends:
 
 ```groovy
+import se.alipsa.matrix.pict.Legend
+import se.alipsa.matrix.pict.Style
+
 // Create a chart with a legend
 def lineChart = LineChart.create("Temperature Trends", temperatureData, "date", "city_a", "city_b")
-    .setLegendVisible(true)
-    .setLegendSide(javafx.geometry.Side.RIGHT)
+lineChart.legend = new Legend(visible: true, position: Style.Position.RIGHT)
 ```
 
 ## Complete Example
@@ -371,7 +365,6 @@ Here's a complete example that demonstrates creating and exporting multiple char
 
 ```groovy
 import java.time.LocalDate
-import javafx.scene.paint.Color
 import se.alipsa.matrix.core.*
 import se.alipsa.matrix.pict.*
 

--- a/matrix-pict/README.md
+++ b/matrix-pict/README.md
@@ -70,6 +70,19 @@ def chart = BarChart.builder(data)
 Plot.png(chart, new File('fruit_sales.png'))
 ```
 
+### Custom Y-Axis Labels
+
+```groovy
+def chart = LineChart.builder(data)
+    .title('Revenue by Month')
+    .x('month')
+    .y('revenue')
+    .yLabels(['10000': '10K', '50000': '50K', '100000': '100K'])
+    .build()
+
+Plot.png(chart, new File('revenue.png'))
+```
+
 ## Chart Types
 
 - **AreaChart** — filled area charts for trends and cumulative values


### PR DESCRIPTION
Updates documentation for Task 11 of the matrix-pict 0.5.0 plan to reflect the API changes from Tasks 3–10.

Changes:
- `matrix-pict/README.md`: added a `yLabels` builder quick example.
- `matrix-pict/docs/pict.md`: verified it already documents `yLabels(Map)`, `getValueSeries(int)`, and the builder-based custom y-labels section (no changes needed).
- `docs/tutorial/13-matrix-charts.md`:
  - `ChartType.NONE` → `ChartType.BASIC`
  - `setXAxisLabel` / `setYAxisLabel` → `setXAxisTitle` / `setYAxisTitle`
  - Replaced the obsolete `setColors()` JavaFX Color example with a `Style.css`-based example.
  - Replaced `setLegendVisible` / `setLegendSide(javafx.geometry.Side)` with `legend = new Legend(...)` using `Style.Position`.
  - Removed the JavaFX `Color` import from the complete example.
- `docs/cookbook/matrix-charts.md`: added a `yLabels` builder example and kept the style-based approach as an alternative.

Verification:
- `./gradlew :matrix-pict:test` — 103 tests passed
- `./gradlew test` — full suite passed, no regressions

Touchess only documentation files.