### PR TITLE
matrix-pict: document BigInteger -> NUMERIC fix in release notes

### DIFF
--- a/matrix-pict/release.md
+++ b/matrix-pict/release.md
@@ -9,6 +9,8 @@ to `matrix-pict`. The package name `se.alipsa.matrix.pict` is unchanged.
 **Bug Fixes**
 - `DataType.sqlType(BigDecimal)` now returns `'DECIMAL'` instead of falling through
   to the `'BLOB'` default.
+- `DataType.sqlType(BigInteger)` now returns `'NUMERIC'` instead of falling through
+  to the `'BLOB'` default.
 - `Chart.toString()` no longer throws `NullPointerException` on a chart where the
   series fields have not yet been populated.
 


### PR DESCRIPTION
The v0.5.0 release notes already documented the  ->  fix in , but the corresponding  ->  mapping (added in commit ) was missing. This adds it to the Bug Fixes section.