### PR TITLE
matrix-pict: fix CodeNarc UnnecessaryPackageReference violations

### DIFF
--- a/matrix-pict/src/test/groovy/chart/ChartBuilderTest.groovy
+++ b/matrix-pict/src/test/groovy/chart/ChartBuilderTest.groovy
@@ -583,16 +583,16 @@ class ChartBuilderTest {
   void testPlotPngMethodSignaturesUseInt() {
     def pngMethods = Plot.methods.findAll { it.name == 'png' }
     def hasFileIntOverload = pngMethods.any { method ->
-      method.parameterTypes.toList() == [se.alipsa.matrix.pict.Chart, File, int, int]
+      method.parameterTypes.toList() == [Chart, File, int, int]
     }
     def hasStreamIntOverload = pngMethods.any { method ->
-      method.parameterTypes.toList() == [se.alipsa.matrix.pict.Chart, OutputStream, int, int]
+      method.parameterTypes.toList() == [Chart, OutputStream, int, int]
     }
     def hasFileDoubleOverload = pngMethods.any { method ->
-      method.parameterTypes.toList() == [se.alipsa.matrix.pict.Chart, File, double, double]
+      method.parameterTypes.toList() == [Chart, File, double, double]
     }
     def hasStreamDoubleOverload = pngMethods.any { method ->
-      method.parameterTypes.toList() == [se.alipsa.matrix.pict.Chart, OutputStream, double, double]
+      method.parameterTypes.toList() == [Chart, OutputStream, double, double]
     }
 
     assertTrue(hasFileIntOverload, 'Plot.png(Chart, File, int, int) must exist')


### PR DESCRIPTION
Fixes four UnnecessaryPackageReference violations in ChartBuilderTest.groovy introduced by the Task 9 Plot.png int-overload test. The test already imports se.alipsa.matrix.pict.*, so the fully-qualified se.alipsa.matrix.pict.Chart references were unnecessary. Replaced them with plain Chart.

Verification:
- ./gradlew :matrix-pict:codenarcTest -- passed
- ./gradlew :matrix-pict:test -- 103 tests passed