### PR TITLE
Changed:

### DIFF
--- a/matrix-bom/bom.xml
+++ b/matrix-bom/bom.xml
@@ -40,7 +40,7 @@
     <matrixCsvVersion>2.4.0</matrixCsvVersion>
     <matrixDatasetsVersion>2.2.0</matrixDatasetsVersion>
     <matrixGgplotVersion>0.5.0-SNAPSHOT</matrixGgplotVersion>
-    <matrixGroovyExtVersion>0.2.0</matrixGroovyExtVersion>
+    <matrixGroovyExtVersion>0.3.0-SNAPSHOT</matrixGroovyExtVersion>
     <matrixGsheetsVersion>0.2.0</matrixGsheetsVersion>
     <matrixJsonVersion>2.3.0</matrixJsonVersion>
     <matrixLoggingVersion>0.1.0-SNAPSHOT</matrixLoggingVersion>

--- a/matrix-ggplot/req/0.5.0-plan.md
+++ b/matrix-ggplot/req/0.5.0-plan.md
@@ -1,0 +1,596 @@
+# matrix-ggplot 0.5.0 Plan
+
+## Scope
+
+Fix correctness, usability, and convention issues surfaced by the 0.5.0 module review. Each phase
+is a separate PR. A task is only done when its checkbox is `[x]` and the exact verification
+command used is recorded in the PR description or under the task.
+
+---
+
+## Phase 1 — Positional aesthetics in Aes and AesDsl
+
+**Problem:** `xend`, `yend`, `xmin`, `xmax`, `ymin`, `ymax` are missing as declared fields in both
+`Aes` and `AesDsl`. The `Aes(Map)` constructor silently ignores these keys; `getAestheticValue`
+returns null for them; the closure DSL (`aes { xend = col2 }`) can resolve the right-hand side
+but has nowhere to store it. Users porting R code that uses `aes(xend=col)` get a blank or
+wrong chart with no error.
+
+These aesthetics are required by `geom_segment`, `geom_curve`, `geom_errorbar`, `geom_ribbon`,
+`geom_rect`, and `geom_errorbarh`.
+
+The bridge (`GgCharmCompiler.applyParamColumnAesthetics`) already reads `xend`/`yend`/`xmin`/
+`xmax`/`ymin`/`ymax` from geom params, so passing them directly on the geom (`geom_segment(xend: 'col')`)
+works today. The goal of this phase is to also make the idiomatic ggplot2 form
+`geom_segment(mapping: aes(xend: 'col'))` work correctly.
+
+1.1 [x] Add `xend`, `yend`, `xmin`, `xmax`, `ymin`, `ymax` as declared `def` fields to
+`matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/aes/Aes.groovy`, alongside the existing
+position fields (`x`, `y`). Follow the same typed-setter pattern already used for `x` and `y`:
+add `setXend(String)`, `setXend(Identity)`, `setXend(Factor)`, `setXend(Expression)`,
+`setXend(AfterStat)`, `setXend(AfterScale)`, `setXend(CutWidth)`, `setXend(Closure)` and the
+same set for `yend`, `xmin`, `xmax`, `ymin`, `ymax`. Add GroovyDoc comments on the fields and
+setters matching the style used for `x` and `y` (describe the aesthetic's role and which geoms
+use it).
+
+1.2 [x] Add these six aesthetics to `getAestheticValue(String aesthetic)` in `Aes.groovy`
+(the switch expression that maps aesthetic name to field value).
+
+1.3 [x] Add these six aesthetics to the `assignAesthetic` switch fallback in `Aes.groovy`.
+This fallback handles value types that don't have a typed setter (e.g. a future wrapper class);
+the typed setters added in 1.1 are the primary dispatch path. Note: any future wrapper type will
+need both a typed setter in step 1.1 style and a case in this fallback.
+
+1.4 [x] Update `Aes.merge(Aes base)` (lines 578–646) to include `xend`, `yend`, `xmin`, `xmax`,
+`ymin`, `ymax`, following the same pattern used for `x` and `y`. The method's semantics are:
+start from `base`'s fields, then override with non-null fields from `this`. For the new fields,
+if `this.xend != null`, the merged result uses `this.xend`; otherwise it falls back to
+`base.xend`. Without this update, a layer whose own `mapping` specifies `xend` will silently
+lose that value when merged against a base mapping that does not set it.
+
+1.5 [x] Update `Aes.toString()` (lines 648–679) to include `xend`, `yend`, `xmin`, `xmax`,
+`ymin`, `ymax` in its output, following the same conditional-append pattern used for the other
+fields. Without this, logging and debugging `aes()` objects will silently omit these aesthetics.
+
+1.6 [x] Add `xend`, `yend`, `xmin`, `xmax`, `ymin`, `ymax` as declared `def` fields to
+`matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/aes/AesDsl.groovy`. Add them to the
+`getProperty` and `hasMappings` methods and to `toAes()` so they are transferred to the
+resulting `Aes` instance.
+
+1.7 [x] Add `xend`, `yend`, `xmin`, `xmax`, `ymin`, `ymax` to the `Aes(Map params)` constructor
+block in `Aes.groovy` (parallel to how `linewidth` / `lineWidth` are handled).
+
+1.8 [x] Add tests to `matrix-ggplot/src/test/groovy/gg/AesTypedSetterTest.groovy` (or a new
+`AesPositionalAestheticsTest.groovy`) verifying:
+- `aes(xend: 'x2', yend: 'y2')` stores and retrieves both values via `getAestheticValue`.
+- The closure form `aes { xend = x2; yend = y2 }` stores and retrieves correctly.
+- `merge()`: `layer.merge(base)` where `layer.xend = 'b'` and `base.xend = 'a'` yields `'b'`
+  (`this` wins over `base`); `layer.merge(base)` where `layer.xend = null` and
+  `base.xend = 'a'` yields `'a'` (falls back to base when `this` is null).
+- `toString()`: an `Aes` with `xend = 'col'` set includes `xend` in its string representation.
+- A round-trip `geom_segment(mapping: aes(x:'x1', y:'y1', xend:'x2', yend:'y2'))` on a simple
+  Matrix renders without error; assert using `svg.descendants()` to find at least one `Line`
+  element (per AGENTS.md: prefer direct SVG object access for structural assertions).
+
+1.9 [x] Verify Phase 1 with:
+```
+./gradlew :matrix-ggplot:codenarcMain :matrix-ggplot:codenarcTest :matrix-ggplot:spotlessCheck :matrix-ggplot:test -Pheadless=true
+```
+
+Result: SUCCESS (1754 tests, 1754 passed, 0 failed, 0 skipped).
+
+---
+
+## Phase 2 — geomFromName completeness and shared geom registry
+
+**Problem:** `GgChart.geomFromName(String name, Map)` handles only 6 geom types: point, smooth,
+bar, col, errorbar, segment. When a `stat_*` call specifies `geom: 'line'` (or any of the
+remaining 25+ geom names), the method returns `null`. The resulting `Layer` has a null geom; the
+compiler silently omits it and the chart renders blank with no warning.
+
+`GgPlot.GEOM_FACTORIES` (line 224) is `private` and only covers the 27 geoms that `qplot`
+supports. Several public `geom_*` factory methods have no entry in it: `geom_abline`,
+`geom_count`, `geom_curve`, `geom_errorbarh`, `geom_function`, `geom_hline`, `geom_quantile`,
+`geom_spoke`, `geom_vline`, `geom_raster`, `geom_linerange`, `geom_pointrange`, `geom_crossbar`.
+Using `GEOM_FACTORIES` as the authority for `geomFromName` would silently miss all of these.
+
+2.1 [ ] Extract a **shared `GEOM_REGISTRY`** from `GgPlot.GEOM_FACTORIES` and expand it to
+cover every `geom_*` factory method that is usable as a named geom in `stat_*` calls. Define it
+as a package-accessible constant in `GgChart.groovy` (or a dedicated `GeomRegistry.groovy` in
+the same package) so both `qplot` and `geomFromName` delegate to a single source of truth.
+The full set of public `geom_*` factory methods as of 0.5.0 is:
+`abline`, `area`, `bar`, `bin2d` / `bin_2d`, `blank`, `boxplot`, `col`, `contour`,
+`contour_filled` / `contourf`, `count`, `crossbar`, `curve`, `density`, `density_2d` /
+`density2d`, `density_2d_filled` / `density2d_filled`, `dotplot`, `errorbar`, `errorbarh`,
+`freqpoly`, `function`, `hex`, `histogram`, `hline`, `jitter`, `label`, `line`, `linerange`,
+`lm`, `mag`, `map`, `parallel`, `path`, `point`, `point_sampled`, `pointrange`, `polygon`,
+`qq`, `qq_line`, `quantile`, `raster`, `rect`, `ribbon`, `rug`, `segment`, `sf`, `sf_label`,
+`sf_text`, `smooth`, `spoke`, `step`, `text`, `tile`, `violin`, `vline`.
+The PR must decide explicitly which of these are **stat-compatible** (sensible as the `geom:`
+argument to `stat_summary`, `stat_smooth`, etc.) vs. **dedicated-factory-only**. The registry
+must:
+- Store **all keys in lowercase** (e.g. `'bin2d'`, not `'Bin2d'`). Because `geomFromName`
+  normalises the input with `.toLowerCase(Locale.ROOT)` before lookup, any mixed-case key in
+  the registry would never match. Build the map with lowercase key literals and add a comment
+  stating this requirement so future additions do not introduce silent mismatches. When `qplot`
+  switches to `GEOM_REGISTRY`, confirm it preserves its existing `.toLowerCase(Locale.ROOT)`
+  normalization at line 448 of `GgPlot.groovy` — that normalization must not be removed.
+- Include both alias spellings for every stat-compatible geom as separate lowercase entries
+  pointing to the same factory closure: `'bin2d'` and `'bin_2d'` → `GeomBin2d`;
+  `'contour_filled'` and `'contourf'` → `GeomContourFilled`; `'density_2d'` and `'density2d'`
+  → `GeomDensity2d`; `'density_2d_filled'` and `'density2d_filled'` → `GeomDensity2dFilled`.
+  Both spellings of a stat-compatible geom are registered; both spellings of an excluded geom
+  are absent.
+- Be wrapped with `Collections.unmodifiableMap(...)` to prevent accidental mutation at runtime.
+- Document the excluded set **and** the included set as comments immediately above the
+  constant. Both lists must be recorded verbatim in the PR description: Phase 7 release notes
+  need the positive included list; Phase 6 docs need to know which geoms to showcase.
+  Suggested starting point for the **excluded** set (with rationale):
+  - Reference-line annotation geoms (no stat equivalent): `abline`, `hline`, `vline`.
+  - Curved-segment geom requiring paired endpoints (`xend`/`yend`) that stat output cannot
+    provide: `curve`. (Note: `curve` is not a reference-line geom — it draws curved arcs
+    between two data points and is segment-like, not an annotation. Exclude it unless a
+    concrete stat use case is identified; revisit in a future release.)
+  - GIS / map geoms (require spatial data, not general stat output): `sf`, `sf_text`,
+    `sf_label`, `map`, `mag`.
+  - Plot-layout geom (not a data geom): `parallel`.
+  - Convenience wrapper (delegates to `GeomSmooth` with `method='lm'`, not a distinct class):
+    `lm`.
+  - Utility geoms (no rendering output or too specialized): `blank`, `point_sampled`.
+  Aliases of excluded geoms are also absent; aliases of included geoms must all be present.
+  The excluded set must be closed: if any spelling of a geom is excluded, all spellings are
+  excluded, and vice versa.
+
+2.2 [ ] Replace `GgChart.geomFromName` switch with a lookup into the shared registry.
+`qplot` already normalises geom names with `.toLowerCase(Locale.ROOT)` before lookup (line 448
+of `GgPlot.groovy`); `geomFromName` must apply the same normalisation so `geom: 'Line'` and
+`geom: 'line'` resolve identically:
+```groovy
+private static Geom geomFromName(String name, Map params = [:]) {
+    String key = name?.trim()?.toLowerCase(Locale.ROOT)
+    Closure<Geom> factory = GEOM_REGISTRY[key]
+    if (factory == null) {
+        throw new IllegalArgumentException(
+            "Unknown geom name: '${name}'. Known names: ${GEOM_REGISTRY.keySet().sort()}")
+    }
+    factory(params ?: [:])
+}
+```
+Add a test verifying that `geom: 'Line'` (mixed case) resolves the same as `geom: 'line'`.
+
+2.3 [ ] Update `qplot` in `GgPlot.groovy` to look up from the same shared registry instead of
+the private `GEOM_FACTORIES` map. Rename or remove `GEOM_FACTORIES` once all call sites have
+been migrated.
+
+2.4 [ ] Add tests in `matrix-ggplot/src/test/groovy/gg/GgPlotTest.groovy` (or a new
+`StatGeomNameTest.groovy`) verifying:
+- `stat_summary(geom: 'line', fun: { values -> values.average() })` renders without error;
+  assert using `svg.descendants()` to find at least one `Path` element (AGENTS.md: direct
+  object access preferred for structural assertions).
+- `geom: 'Line'` (mixed case) resolves the same as `geom: 'line'` (normalization).
+- An unknown geom name throws `IllegalArgumentException` whose message contains the unknown
+  name and the string `Known names:` (so the message format is verified, not just the type).
+
+2.5 [ ] Verify Phase 2 with:
+```
+./gradlew :matrix-ggplot:codenarcMain :matrix-ggplot:codenarcTest :matrix-ggplot:spotlessCheck :matrix-ggplot:test -Pheadless=true
+```
+
+---
+
+## Phase 3 — Per-aesthetic legend titles in labs()
+
+**Problem:** `Label.groovy` stores a single `legendTitle` field. When `labs(color: 'Speed',
+fill: 'Count')` is called, the `fill` assignment unconditionally overwrites the `color` title
+(`GgPlot.labs()` lines 863–867). Only the last assigned title survives; all others are silently
+lost. In R's ggplot2, each aesthetic has its own independent legend title.
+
+3.1 [ ] Replace `String legendTitle` in
+`matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/Label.groovy` with
+`Map<String, String> legendTitles = [:]` (a per-aesthetic title map). Replace the existing
+`/** called colour in ggplot2 */` comment with a description that reflects the map's purpose:
+`/** Per-aesthetic legend titles keyed by normalized aesthetic name (e.g. 'color', 'fill', 'size'). colour is stored as 'color'. */`
+
+3.2 [ ] Update `GgPlot.labs(Map params)` in
+`matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgPlot.groovy` to write each aesthetic
+title into the map:
+- `params.colour` or `params.color` → `label.legendTitles['color'] = value?.toString()`
+- `params.fill` → `label.legendTitles['fill'] = value?.toString()`
+- Any other key that is **not** a label-level key (`title`, `subtitle`, `caption`, `tag`, `x`,
+  `y`) and has a non-null value → store it under the normalized aesthetic name via
+  `GgCharmMappingRegistry.normalizeAesthetic(key)`. Coerce with `?.toString()` before storing
+  so GStrings and other `CharSequence` values do not cause `@CompileStatic` type errors.
+  Explicitly skip keys already handled by their own `label.title`, `label.subTitle`,
+  `label.caption`, `label.x`, and `label.y` assignments to prevent those from also appearing
+  as spurious legend titles.
+
+3.3 [ ] Update `GgChart.plus(Label)` in `GgChart.groovy` to merge `legendTitles` maps (union,
+with the incoming label winning on collision) instead of copying the single `legendTitle` string.
+Guard against a null `legendTitles` map on both the existing and incoming `Label`. The field in
+`GgChart` is `labels` (plural), not `label`:
+```groovy
+if (labels.legendTitles) {
+    this.labels.legendTitles = (this.labels.legendTitles ?: [:]) + labels.legendTitles
+}
+```
+
+3.4 [ ] Update `GgCharmCompiler.mapLabels` in
+`matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/bridge/GgCharmCompiler.groovy` to populate
+`labels.guides` from `source.legendTitles` rather than the single `source.legendTitle` string.
+**Preserve the existing precedence order**: `legendTitles` from `labs()` seeds the map first;
+`extractGuideTitles(guides)` (explicit `guides(...)` call) then overwrites matching keys;
+`extractGuideTitlesFromScales(scales)` (explicit `scale_*(name:)`) overwrites last. This means
+an explicit `guides(color: guide_legend(title: 'X'))` still wins over `labs(color: 'Y')`,
+matching ggplot2's own precedence. Replace only the `if (source?.legendTitle)` block:
+```groovy
+Map<String, String> guideTitles = [:]
+source?.legendTitles?.each { String aesthetic, String title ->
+    if (title != null && !title.isBlank()) {
+        guideTitles[GgCharmMappingRegistry.normalizeAesthetic(aesthetic)] = title
+    }
+}
+guideTitles.putAll(extractGuideTitles(guides))
+guideTitles.putAll(extractGuideTitlesFromScales(scales))
+labels.guides = guideTitles
+```
+
+3.5 [ ] Search for any other reference to `label.legendTitle` or `source.legendTitle` in the
+codebase — including `GgChart.groovy`, `GgCharmCompiler.groovy`, any test files that construct
+`Label` directly, and any groovy scripts under `src/` — and update them to use the new map.
+
+3.6 [ ] Add tests in `matrix-ggplot/src/test/groovy/gg/GgChartLabelTest.groovy` verifying:
+- `labs(color: 'Speed', fill: 'Count')` preserves both titles independently.
+- `labs(color: 'Speed') + labs(fill: 'Count')` also preserves both.
+- The single-aesthetic case `labs(color: 'X')` still works.
+- `labs(x: 'X Axis', color: 'Speed')` sets the axis label (`label.x == 'X Axis'`) and the
+  color legend title (`label.legendTitles['color'] == 'Speed'`) independently; neither bleeds
+  into the other.
+- `labs(title: 'T', subtitle: 'S', caption: 'C', x: 'X', y: 'Y', color: 'Hue')` stores none
+  of `title`, `subtitle`, `caption`, `x`, `y` in `legendTitles`.
+- Precedence: `labs(color: 'A') + guides(color: guide_legend(title: 'B'))` → rendered title is 'B' (guide wins).
+- Precedence: `labs(color: 'A') + scale_color_manual(name: 'C', values: ...)` → rendered title is 'C' (scale wins).
+
+3.7 [ ] Verify Phase 3 with:
+```
+./gradlew :matrix-ggplot:codenarcMain :matrix-ggplot:codenarcTest :matrix-ggplot:spotlessCheck :matrix-ggplot:test -Pheadless=true
+```
+
+---
+
+## Phase 4 — Remove render() coord side-effect
+
+**Problem:** `GgChart.render()` (line 539) mutates `this.coord = new CoordCartesian()` when no
+coord has been set. A pure "read" operation permanently changes the chart's observable state.
+Inspecting `chart.coord` after calling `render()` returns a non-null value the user never set.
+
+4.1 [ ] Before removing the mutation, grep the test sources and any example scripts for
+`chart.coord`, `\.coord\s*!=\s*null`, or assertions on `coord` after `render()`. Update or
+remove any test or example that relies on `chart.coord` being non-null post-render; document
+each such change in the PR description.
+
+4.2 [ ] Remove the `if (coord == null) { coord = new CoordCartesian() }` block from
+`GgChart.render()` in `matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgChart.groovy`.
+
+4.3 [ ] Ensure `GgCharmCompiler.adapt()` (or `mapCoord()`) handles a null `coord` gracefully by
+defaulting to `CharmCoordType.CARTESIAN` internally. Verify that
+`GgCharmMappingRegistry.mapCoordType(null)` returns `CharmCoordType.CARTESIAN`, or add that
+null-to-Cartesian default in `mapCoord` in `GgCharmCompiler.groovy`.
+
+4.4 [ ] Add a test verifying that `chart.coord` remains `null` after `chart.render()` when no
+coord was explicitly added, in `matrix-ggplot/src/test/groovy/gg/GgPlotTest.groovy`.
+
+4.5 [ ] Verify Phase 4 with:
+```
+./gradlew :matrix-ggplot:codenarcMain :matrix-ggplot:codenarcTest :matrix-ggplot:spotlessCheck :matrix-ggplot:test -Pheadless=true
+```
+
+---
+
+---
+
+## Phase 5 — Convention fixes
+
+**Problem (5a):** `GgPlot.guide_axis_stack(Object first, ...)` uses `Object` as a parameter type
+where only `Guide` and `String` are valid inputs (AGENTS.md: "Never use Object as a method
+parameter when specific types are known").
+
+**Problem (5b):** `ScaleColorFermenter.resolvePaletteName()` uses an old-style switch for a
+simple string→string value mapping. AGENTS.md anti-pattern: "Don't use switch statements for
+simple value mappings."
+
+**Problem (5c):** `Rconverter.MATH_FUNCTIONS` maps R math names to `Math.log`, `Math.sqrt`, etc.
+The generated Groovy code is non-idiomatic. AGENTS.md: "Always prefer BigDecimal extension
+methods over Math methods." The generated prefix form (`Math.log(x)`) should become the GDK
+suffix form (`x.log()`).
+
+### 5a — guide_axis_stack typed overloads
+
+5.1 [ ] Add typed overloads for `guide_axis_stack` in `GgPlot.groovy`. The additional
+arguments are also only valid as `Guide` or `String`, so use typed varargs — not `Object...`.
+Also add the `Map params` variant that currently only exists in the `Object` signature, so
+static callers with named parameters resolve without falling through to the dynamic fallback:
+```groovy
+static Guide guide_axis_stack(Guide first, Map params = [:]) { ... }
+static Guide guide_axis_stack(String first, Map params = [:]) { ... }
+static Guide guide_axis_stack(Guide first, Guide... additional) { ... }
+static Guide guide_axis_stack(Guide first, String... additional) { ... }
+static Guide guide_axis_stack(String first, Guide... additional) { ... }
+static Guide guide_axis_stack(String first, String... additional) { ... }
+```
+There are currently two `Object`-parameter signatures. After adding the typed overloads, retain
+only `guide_axis_stack(Object first, Object... additional)` as the `@CompileDynamic` fallback.
+The `guide_axis_stack(Object first, Map params = [:])` variant becomes redundant once the typed
+`Guide first, Map params = [:]` and `String first, Map params = [:]` overloads exist, so remove
+it rather than keeping two `Object`-based signatures. `Object...` must not appear in any
+non-fallback public signature.
+
+Note: `guide_axis_stack(Guide first, Map params = [:])` and `guide_axis_stack(Guide first,
+Guide... additional)` can both match a single-argument call `guide_axis_stack(myGuide)`.
+Groovy favors fixed-arity over varargs, so this resolves to the `Map params` overload with
+`params = [:]`. Verify this is the intended behavior and add a test calling
+`guide_axis_stack(myGuide)` with no second argument to confirm it compiles and runs without
+ambiguity error under `@CompileStatic`.
+
+### 5b — ScaleColorFermenter Map lookup
+
+5.2 [ ] Replace the switch in `ScaleColorFermenter.resolvePaletteName()` in
+`matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/scale/ScaleColorFermenter.groovy` with
+a static Map lookup:
+```groovy
+private static final Map<String, String> PALETTE_DEFAULTS = [
+    div        : 'Spectral',
+    diverging  : 'Spectral',
+    qual       : 'Set1',
+    qualitative: 'Set1',
+    seq        : 'Blues',
+    sequential : 'Blues'
+]
+
+private String resolvePaletteName() {
+    if (palette != null && BrewerPalettes.getPalette(palette) != null) {
+        return palette
+    }
+    PALETTE_DEFAULTS[type?.toLowerCase()] ?: 'Blues'
+}
+```
+
+### 5c — Add acos to matrix-groovy-ext
+
+`matrix-groovy-ext/src/main/groovy/se/alipsa/matrix/ext/NumberExtension.groovy` defines
+`asin` (line 901) and `atan` (line 826) but **not** `acos`. Including `acos` in `SUFFIX_METHODS`
+without first adding the extension method would generate `(it.x).acos()` calls that fail at
+runtime with `MissingMethodException`. This prerequisite step must be merged before the
+Rconverter changes in 5d.
+
+5.3 [ ] Add `acos(Number self)` and `acos(BigDecimal self)` to
+`matrix-groovy-ext/src/main/groovy/se/alipsa/matrix/ext/NumberExtension.groovy` following the
+same structure as `asin`. Guard against out-of-range input with
+`ArithmeticException("acos undefined for value outside [-1, 1]: ...")` (same pattern as `asin`
+line 926). Apply special cases before the general identity to avoid accumulated rounding error:
+- `x == 1`  → return `0G`
+- `x == -1` → return `PI32` (exact)
+- `x == 0`  → return `PI32 / 2` (exact)
+
+For all other values in `(-1, 1)`, use the identity `acos(x) = PI32/2 - asin(x)`. Without the
+special cases, `asin(1)` returns an approximation of `PI/2` and `PI32/2 - PI/2 ≠ 0`; similarly
+`asin(-1)` returns `-PI/2` and `PI32/2 - (-PI/2) ≠ PI32`. Add GroovyDoc with a usage example
+matching the style of surrounding methods. Also update `AGENTS.md` to document `acos()` in the
+extension method list, per project convention for new NumberExtension additions.
+
+5.4 [ ] Add tests in `matrix-groovy-ext/src/test/groovy/se/alipsa/matrix/ext/NumberExtensionTest.groovy`
+verifying:
+- `(0G).acos()` → exactly `PI32 / 2`.
+- `(1G).acos()` → exactly `0G` (special case, not computed via identity).
+- `(-1G).acos()` → exactly `PI32` (special case, not computed via identity).
+- `(0.5G).acos()` → approximately `PI32 / 3` (within a small tolerance).
+- `(2G).acos()` throws `ArithmeticException`.
+
+5.5 [ ] Verify the matrix-groovy-ext change with:
+```
+./gradlew :matrix-groovy-ext:codenarcMain :matrix-groovy-ext:codenarcTest :matrix-groovy-ext:spotlessCheck :matrix-groovy-ext:test
+```
+
+### 5d — Rconverter extension methods
+
+**Context:** At line 386–389 of `Rconverter.groovy`, when a math function token is detected,
+the converter appends only the mapped function name (e.g. `Math.log`) and then the main loop
+continues — the `(` and argument are emitted verbatim on subsequent iterations. Simply changing
+`MATH_FUNCTIONS` values from `'Math.log'` to `'.log'` cannot produce `(arg).log()` because the
+argument is not yet known at the token-replacement point. Producing suffix form requires parsing
+the function call as a unit: consume the function name, parse and recursively convert its
+argument expression (including its parentheses), then emit `(convertedArg).log()`.
+
+5.6 [ ] Refactor the function-call branch in `convertExpression` (around line 386) in
+`Rconverter.groovy`. When a suffix-eligible function token is detected:
+1. Use the existing `findMatchingParen(expr, j)` (line 710) to locate the closing `)`:
+   ```groovy
+   int matchingParenIndex = findMatchingParen(expr, j)
+   String inner = expr.substring(j + 1, matchingParenIndex)
+   List<String> args = splitTopLevel(inner, ',' as char)
+   ```
+   `j` is the index of the opening `(` found after skipping whitespace past the function
+   token (the existing loop already computes this). Using `i` instead would fail for calls
+   with whitespace before the paren such as `log (x)`. Do not reimplement parenthesis
+   scanning or comma splitting inline.
+2. Dispatch on argument count and emit the converted form:
+   - **Single argument** (`args.size() == 1`): recursively convert `args[0]`, emit
+     `(convertedArg).suffixMethod()`.
+   - **Two-argument `log`** (`args.size() == 2` and `token == 'log'`): recursively convert
+     both arguments, emit `(convertedX).log(convertedBase)`.
+     `NumberExtension.log(Number self, Number base)` exists at line 265 of
+     `NumberExtension.groovy`. This is the only multi-argument case with a valid extension
+     method overload in this project.
+   - **All other multi-argument calls**: throw `UnsupportedOperationException` with a
+     descriptive message (e.g. `"Multi-argument ${token}() is not supported in R→Groovy
+     conversion"`). A bare comment is not a valid Groovy expression inside `expr { ... }`
+     closures and would cause a compile error in the generated code.
+3. After emitting any of the above forms, advance the main-loop index past the consumed call:
+   ```groovy
+   i = matchingParenIndex + 1
+   continue
+   ```
+   Without this, the main loop will re-enter at `(` and emit the raw parentheses and argument
+   characters a second time.
+
+The refactor replaces `MATH_FUNCTIONS` entirely with a single **`SUFFIX_METHODS`** map.
+All R math functions — including `abs` and `round` — have idiomatic Groovy GDK equivalents
+used throughout this codebase (see `ScaleColorViridisC.groovy:213`, `SecondaryAxis.groovy:155`
+etc.) and must not emit `Math.*` calls. Delete `MATH_FUNCTIONS`:
+
+```groovy
+private static final Map<String, String> SUFFIX_METHODS = [
+    log      : 'log',
+    log10    : 'log10',
+    sqrt     : 'sqrt',
+    exp      : 'exp',
+    abs      : 'abs',      // GDK: Number.abs()
+    sin      : 'sin',
+    cos      : 'cos',
+    tan      : 'tan',
+    asin     : 'asin',
+    acos     : 'acos',
+    atan     : 'atan',
+    floor    : 'floor',
+    ceil     : 'ceil',
+    ceiling  : 'ceil',     // R spelling → GDK method name
+    round    : 'round',    // GDK: BigDecimal.round() — no-arg rounds to integer
+]
+```
+
+In `convertExpression`, when a function token is detected, check `SUFFIX_METHODS`; if found,
+apply the suffix-form dispatch (step 2 above). If not found in `SUFFIX_METHODS`, emit the
+token unchanged (existing behavior for unknown function names). There is no separate prefix
+path.
+
+5.7 [ ] For the `pi` token (line 377), emit the fully-qualified
+`se.alipsa.matrix.ext.NumberExtension.PI` instead of `Math.PI`. This gives a `BigDecimal`
+constant (16-digit precision, line 74 of `NumberExtension.groovy`) consistent with the
+project's BigDecimal-first numeric policy. If a generated expression requires higher precision,
+emit `se.alipsa.matrix.ext.NumberExtension.PI32` (30-digit, line 76) instead — the converter
+may expose a `highPrecision` flag or derive the choice from context. Using the fully-qualified
+name avoids injecting a static import into the generated snippet.
+
+5.8 [ ] Add or update tests in `matrix-ggplot/src/test/groovy/gg/RconverterTest.groovy`
+covering all fourteen suffix-eligible methods (fifteen R names including the `ceiling` alias)
+and the edge cases:
+- `log`, `log10`, `sqrt`, `exp`, `abs`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `floor`,
+  `ceil`, `round` each produce suffix form with a simple column argument.
+- R's `ceiling(x)` maps to `(it.x).ceil()` (fifteenth name, alias for `ceil`).
+- `abs(x)` → `(it.x).abs()`; `round(x)` → `(it.x).round()` (no `Math.*` calls).
+- `pi` → `se.alipsa.matrix.ext.NumberExtension.PI` (BigDecimal, not `Math.PI`).
+- Deeply nested: `log((x + 1) * 2)` → `((it.x + 1) * 2).log()`.
+- Nested: `sqrt(abs(x))` → `((it.x).abs()).sqrt()`.
+- Two-argument log with literal base: `log(x, 10)` → `(it.x).log(10)`.
+- Two-argument log with column base: `log(x, base_col)` → `(it.x).log(it.base_col)` — verifies
+  that both arguments are recursively converted, not just the first.
+- Multi-argument call with no supported overload: `round(x, 2)` throws
+  `UnsupportedOperationException` with a message containing `"round"` and `"not supported"` —
+  verifies the exception path fires (`.round()` is no-arg; a two-arg form has no equivalent).
+
+5.9 [ ] Verify Phase 5 with:
+```
+./gradlew :matrix-ggplot:codenarcMain :matrix-ggplot:codenarcTest :matrix-ggplot:spotlessCheck :matrix-ggplot:test -Pheadless=true
+```
+
+---
+
+## Phase 6 — Documentation updates
+
+Update all user-facing documentation to reflect the new capabilities added in Phases 1–5.
+
+6.1 [ ] Update `matrix-ggplot/README.md`:
+- Bump dependency version references to `0.5.0` (once release is confirmed).
+- Add a section **"Positional aesthetics in aes()"** showing `xend`, `yend`, `xmin`, `xmax`,
+  `ymin`, `ymax` usage with `geom_segment`, `geom_errorbar`, and `geom_ribbon` examples.
+- Update the `labs()` example to show independent `color` and `fill` legend titles:
+  `labs(title: 'My Chart', color: 'Speed', fill: 'Count')`.
+- Update the `guide_axis_stack()` example to use a typed `Guide` argument.
+
+6.2 [ ] Update `docs/cookbook/matrix-ggplot.md`:
+- Add **Recipe: Segment chart with aes(xend, yend)** showing a complete `geom_segment` example.
+- Add **Recipe: Error bars with aes(ymin, ymax)** showing `geom_errorbar`.
+- Add **Recipe: Separate legend titles per aesthetic** showing `labs(color: ..., fill: ...)`.
+- Add **Recipe: stat_summary with named geom** showing `stat_summary(geom: 'line', ...)`.
+
+6.3 [ ] Update `docs/tutorial/13b-matrix-ggplot.md`:
+- Add a subsection under the aesthetics chapter for positional range aesthetics
+  (`xend`, `yend`, `xmin`, `xmax`, `ymin`, `ymax`) with a worked example.
+- Update the `labs()` section to show multi-aesthetic legend title assignment.
+
+6.4 [ ] Create `matrix-ggplot/src/test/groovy/gg/DocExamplesTest.groovy` containing one test
+method per new doc snippet (each recipe from 6.2 and the worked examples from 6.3). Each test
+must: build the chart, call `render()`, and assert structural correctness following AGENTS.md
+testing guidance:
+- **Prefer direct SVG object access** for structural assertions: use `svg.descendants()` to find
+  typed SVG element instances (e.g. `Line`, `Path`, `Rect`) and assert on their count or
+  attribute values. This is more robust and does not depend on serialization format.
+- Use `SvgWriter.toXml(svg)` only when the test specifically needs to assert on serialized
+  content such as CSS class names, exact label text, or stroke attributes that are not exposed
+  on the element objects.
+- Never use `svg.toString()` — it returns the Java object representation, not XML.
+This ensures that docs stay in sync with the implementation and are not silently broken by
+future changes.
+
+6.5 [ ] Verify Phase 6 with:
+```
+./gradlew :matrix-ggplot:codenarcTest :matrix-ggplot:spotlessCheck :matrix-ggplot:test --tests 'gg.DocExamplesTest' -Pheadless=true
+```
+
+---
+
+## Phase 7 — Release notes
+
+7.1 [ ] Create `matrix-ggplot/release.md` with the following structure:
+
+```markdown
+# matrix-ggplot Release Notes
+
+## 0.5.0
+
+### New features
+- `aes()` now supports positional range aesthetics: `xend`, `yend`, `xmin`, `xmax`, `ymin`,
+  `ymax`. Both the map form (`aes(xend: 'col')`) and the closure form
+  (`aes { xend = col }`) work correctly and are passed through to the renderer.
+- `labs()` now accepts independent legend titles per aesthetic:
+  `labs(color: 'Speed', fill: 'Count')` sets separate titles for each guide.
+- `stat_summary(geom: 'line')` and all other stat-compatible named geoms in `GEOM_REGISTRY`
+  now work as the `geom:` argument to `stat_*` functions (previously only 6 types were
+  handled). **Before merging Phase 7, replace this placeholder with the exact list of
+  stat-compatible geoms recorded in the Phase 2 PR description.**
+- `guide_axis_stack()` now has typed overloads for `Guide` and `String` first arguments.
+
+### Bug fixes
+- `labs(color: ..., fill: ...)` — fill no longer silently overwrites the color legend title.
+- `stat_*` calls with `geom: '<name>'` for unsupported names now throw
+  `IllegalArgumentException` immediately instead of silently rendering a blank chart.
+- `GgChart.render()` no longer mutates the chart's `coord` field as a side effect. Charts
+  with no explicit coordinate system are still rendered as Cartesian; the default is now
+  applied inside the compiler instead of on the chart object.
+
+### Improvements
+- `ScaleColorFermenter` palette type lookup uses a Map instead of a switch statement for
+  cleaner extensibility.
+- `Rconverter` now generates idiomatic Groovy GDK extension method calls (e.g. `x.log()`)
+  instead of Java-style `Math.log(x)` calls.
+```
+
+7.2 [ ] Verify the release notes accurately reflect all changes merged in Phases 1–5 and
+that no referenced feature is missing or mis-described.
+
+---
+
+## Cross-cutting — Final verification
+
+After all phase PRs have been merged to the SNAPSHOT branch:
+
+X.1 [ ] Run the full test suite for all modules touched by this release (Phase 5c modifies
+`matrix-groovy-ext` in addition to `matrix-ggplot`):
+```
+./gradlew :matrix-groovy-ext:codenarcMain :matrix-groovy-ext:codenarcTest :matrix-groovy-ext:spotlessCheck :matrix-groovy-ext:test :matrix-ggplot:codenarcMain :matrix-ggplot:codenarcTest :matrix-ggplot:spotlessCheck :matrix-ggplot:test -Pheadless=true
+```
+
+X.2 [ ] Confirm `build/reports/codenarc/main.html` and `build/reports/codenarc/test.html`
+report zero violations for **both** `matrix-groovy-ext` and `matrix-ggplot`.
+
+X.3 [ ] Record all final verification commands and outcomes in the release PR description
+before tagging `0.5.0`.

--- a/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/aes/Aes.groovy
+++ b/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/aes/Aes.groovy
@@ -17,6 +17,18 @@ class Aes {
   def x
   /** Y position - column name or I(value) */
   def y
+  /** X end position for segment and curve geoms - column name or I(value) */
+  def xend
+  /** Y end position for segment and curve geoms - column name or I(value) */
+  def yend
+  /** Minimum X boundary for rectangle and range geoms - column name or I(value) */
+  def xmin
+  /** Maximum X boundary for rectangle and range geoms - column name or I(value) */
+  def xmax
+  /** Minimum Y boundary for ribbon, errorbar, and rectangle geoms - column name or I(value) */
+  def ymin
+  /** Maximum Y boundary for ribbon, errorbar, and rectangle geoms - column name or I(value) */
+  def ymax
 
   // Color aesthetics
   /** Outline color - column name or I(value) */
@@ -78,6 +90,108 @@ class Aes {
   void setY(AfterScale scale) { this.@y = scale }
   void setY(CutWidth cut) { this.@y = cut }
   void setY(Closure expression) { this.@y = expression }
+
+  /** Set the x-end aesthetic used by segment and curve geoms. */
+  void setXend(String columnName) { this.@xend = columnName }
+  /** Set the x-end aesthetic to a constant identity value. */
+  void setXend(Identity constant) { this.@xend = constant }
+  /** Set the x-end aesthetic to a factor mapping. */
+  void setXend(Factor factor) { this.@xend = factor }
+  /** Set the x-end aesthetic to an expression mapping. */
+  void setXend(Expression expr) { this.@xend = expr }
+  /** Set the x-end aesthetic to an after-stat mapping. */
+  void setXend(AfterStat stat) { this.@xend = stat }
+  /** Set the x-end aesthetic to an after-scale mapping. */
+  void setXend(AfterScale scale) { this.@xend = scale }
+  /** Set the x-end aesthetic to a cut-width mapping. */
+  void setXend(CutWidth cut) { this.@xend = cut }
+  /** Set the x-end aesthetic to a closure expression. */
+  void setXend(Closure expression) { this.@xend = expression }
+
+  /** Set the y-end aesthetic used by segment and curve geoms. */
+  void setYend(String columnName) { this.@yend = columnName }
+  /** Set the y-end aesthetic to a constant identity value. */
+  void setYend(Identity constant) { this.@yend = constant }
+  /** Set the y-end aesthetic to a factor mapping. */
+  void setYend(Factor factor) { this.@yend = factor }
+  /** Set the y-end aesthetic to an expression mapping. */
+  void setYend(Expression expr) { this.@yend = expr }
+  /** Set the y-end aesthetic to an after-stat mapping. */
+  void setYend(AfterStat stat) { this.@yend = stat }
+  /** Set the y-end aesthetic to an after-scale mapping. */
+  void setYend(AfterScale scale) { this.@yend = scale }
+  /** Set the y-end aesthetic to a cut-width mapping. */
+  void setYend(CutWidth cut) { this.@yend = cut }
+  /** Set the y-end aesthetic to a closure expression. */
+  void setYend(Closure expression) { this.@yend = expression }
+
+  /** Set the minimum x-bound aesthetic used by rect and errorbarh geoms. */
+  void setXmin(String columnName) { this.@xmin = columnName }
+  /** Set the minimum x-bound aesthetic to a constant identity value. */
+  void setXmin(Identity constant) { this.@xmin = constant }
+  /** Set the minimum x-bound aesthetic to a factor mapping. */
+  void setXmin(Factor factor) { this.@xmin = factor }
+  /** Set the minimum x-bound aesthetic to an expression mapping. */
+  void setXmin(Expression expr) { this.@xmin = expr }
+  /** Set the minimum x-bound aesthetic to an after-stat mapping. */
+  void setXmin(AfterStat stat) { this.@xmin = stat }
+  /** Set the minimum x-bound aesthetic to an after-scale mapping. */
+  void setXmin(AfterScale scale) { this.@xmin = scale }
+  /** Set the minimum x-bound aesthetic to a cut-width mapping. */
+  void setXmin(CutWidth cut) { this.@xmin = cut }
+  /** Set the minimum x-bound aesthetic to a closure expression. */
+  void setXmin(Closure expression) { this.@xmin = expression }
+
+  /** Set the maximum x-bound aesthetic used by rect and errorbarh geoms. */
+  void setXmax(String columnName) { this.@xmax = columnName }
+  /** Set the maximum x-bound aesthetic to a constant identity value. */
+  void setXmax(Identity constant) { this.@xmax = constant }
+  /** Set the maximum x-bound aesthetic to a factor mapping. */
+  void setXmax(Factor factor) { this.@xmax = factor }
+  /** Set the maximum x-bound aesthetic to an expression mapping. */
+  void setXmax(Expression expr) { this.@xmax = expr }
+  /** Set the maximum x-bound aesthetic to an after-stat mapping. */
+  void setXmax(AfterStat stat) { this.@xmax = stat }
+  /** Set the maximum x-bound aesthetic to an after-scale mapping. */
+  void setXmax(AfterScale scale) { this.@xmax = scale }
+  /** Set the maximum x-bound aesthetic to a cut-width mapping. */
+  void setXmax(CutWidth cut) { this.@xmax = cut }
+  /** Set the maximum x-bound aesthetic to a closure expression. */
+  void setXmax(Closure expression) { this.@xmax = expression }
+
+  /** Set the minimum y-bound aesthetic used by ribbon, rect, and errorbar geoms. */
+  void setYmin(String columnName) { this.@ymin = columnName }
+  /** Set the minimum y-bound aesthetic to a constant identity value. */
+  void setYmin(Identity constant) { this.@ymin = constant }
+  /** Set the minimum y-bound aesthetic to a factor mapping. */
+  void setYmin(Factor factor) { this.@ymin = factor }
+  /** Set the minimum y-bound aesthetic to an expression mapping. */
+  void setYmin(Expression expr) { this.@ymin = expr }
+  /** Set the minimum y-bound aesthetic to an after-stat mapping. */
+  void setYmin(AfterStat stat) { this.@ymin = stat }
+  /** Set the minimum y-bound aesthetic to an after-scale mapping. */
+  void setYmin(AfterScale scale) { this.@ymin = scale }
+  /** Set the minimum y-bound aesthetic to a cut-width mapping. */
+  void setYmin(CutWidth cut) { this.@ymin = cut }
+  /** Set the minimum y-bound aesthetic to a closure expression. */
+  void setYmin(Closure expression) { this.@ymin = expression }
+
+  /** Set the maximum y-bound aesthetic used by ribbon, rect, and errorbar geoms. */
+  void setYmax(String columnName) { this.@ymax = columnName }
+  /** Set the maximum y-bound aesthetic to a constant identity value. */
+  void setYmax(Identity constant) { this.@ymax = constant }
+  /** Set the maximum y-bound aesthetic to a factor mapping. */
+  void setYmax(Factor factor) { this.@ymax = factor }
+  /** Set the maximum y-bound aesthetic to an expression mapping. */
+  void setYmax(Expression expr) { this.@ymax = expr }
+  /** Set the maximum y-bound aesthetic to an after-stat mapping. */
+  void setYmax(AfterStat stat) { this.@ymax = stat }
+  /** Set the maximum y-bound aesthetic to an after-scale mapping. */
+  void setYmax(AfterScale scale) { this.@ymax = scale }
+  /** Set the maximum y-bound aesthetic to a cut-width mapping. */
+  void setYmax(CutWidth cut) { this.@ymax = cut }
+  /** Set the maximum y-bound aesthetic to a closure expression. */
+  void setYmax(Closure expression) { this.@ymax = expression }
 
   void setColor(String columnName) { this.@color = columnName }
   void setColor(Identity constant) { this.@color = constant }
@@ -282,6 +396,25 @@ class Aes {
       assignAesthetic('y', yValue)
     }
 
+    if (params.xend != null) {
+      assignAesthetic('xend', params.xend)
+    }
+    if (params.yend != null) {
+      assignAesthetic('yend', params.yend)
+    }
+    if (params.xmin != null) {
+      assignAesthetic('xmin', params.xmin)
+    }
+    if (params.xmax != null) {
+      assignAesthetic('xmax', params.xmax)
+    }
+    if (params.ymin != null) {
+      assignAesthetic('ymin', params.ymin)
+    }
+    if (params.ymax != null) {
+      assignAesthetic('ymax', params.ymax)
+    }
+
     def colorValue = firstNonNull([params.color, params.col, params.colour, params.colorCol])
     if (colorValue != null) {
       assignAesthetic('color', colorValue)
@@ -352,6 +485,12 @@ class Aes {
       switch (name) {
         case 'x' -> this.@x = value
         case 'y' -> this.@y = value
+        case 'xend' -> this.@xend = value
+        case 'yend' -> this.@yend = value
+        case 'xmin' -> this.@xmin = value
+        case 'xmax' -> this.@xmax = value
+        case 'ymin' -> this.@ymin = value
+        case 'ymax' -> this.@ymax = value
         case 'color' -> this.@color = value
         case 'fill' -> this.@fill = value
         case 'size' -> this.@size = value
@@ -393,7 +532,8 @@ class Aes {
    * This method provides type-safe access to aesthetic values without dynamic property access.
    * <p>
    * Supported aesthetic names: x, y, color, colour, fill, size, shape, alpha,
-   * linetype, linewidth, group, label, tooltip, weight, geometry, map_id
+   * xend, yend, xmin, xmax, ymin, ymax, linetype, linewidth, group, label,
+   * tooltip, weight, geometry, map_id
    *
    * @param aesthetic the aesthetic name (e.g., 'x', 'y', 'color', 'fill', etc.)
    * @return the value of the aesthetic, or null if not found or unknown aesthetic name
@@ -402,6 +542,12 @@ class Aes {
     switch (aesthetic) {
       case 'x' -> x
       case 'y' -> y
+      case 'xend' -> xend
+      case 'yend' -> yend
+      case 'xmin' -> xmin
+      case 'xmax' -> xmax
+      case 'ymin' -> ymin
+      case 'ymax' -> ymax
       case 'color', 'colour' -> color
       case 'fill' -> fill
       case 'size' -> size
@@ -583,6 +729,12 @@ class Aes {
     // Start with base values
     result.@x = base.x
     result.@y = base.y
+    result.@xend = base.xend
+    result.@yend = base.yend
+    result.@xmin = base.xmin
+    result.@xmax = base.xmax
+    result.@ymin = base.ymin
+    result.@ymax = base.ymax
     result.@color = base.color
     result.@fill = base.fill
     result.@size = base.size
@@ -602,6 +754,24 @@ class Aes {
     }
     if (this.y != null) {
       result.@y = this.y
+    }
+    if (this.xend != null) {
+      result.@xend = this.xend
+    }
+    if (this.yend != null) {
+      result.@yend = this.yend
+    }
+    if (this.xmin != null) {
+      result.@xmin = this.xmin
+    }
+    if (this.xmax != null) {
+      result.@xmax = this.xmax
+    }
+    if (this.ymin != null) {
+      result.@ymin = this.ymin
+    }
+    if (this.ymax != null) {
+      result.@ymax = this.ymax
     }
     if (this.color != null) {
       result.@color = this.color
@@ -653,6 +823,24 @@ class Aes {
     }
     if (y != null) {
       parts << "yCol=$y"
+    }
+    if (xend != null) {
+      parts << "xend=$xend"
+    }
+    if (yend != null) {
+      parts << "yend=$yend"
+    }
+    if (xmin != null) {
+      parts << "xmin=$xmin"
+    }
+    if (xmax != null) {
+      parts << "xmax=$xmax"
+    }
+    if (ymin != null) {
+      parts << "ymin=$ymin"
+    }
+    if (ymax != null) {
+      parts << "ymax=$ymax"
     }
     if (color != null) {
       parts << "colorCol=$color"

--- a/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/aes/AesDsl.groovy
+++ b/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/aes/AesDsl.groovy
@@ -19,9 +19,47 @@ import groovy.transform.CompileStatic
 @SuppressWarnings(['CyclomaticComplexity', 'PropertyName'])
 class AesDsl {
 
+  private static final String COLOR_FIELD = 'color'
+  private static final String LINEWIDTH_FIELD = 'linewidth'
+  private static final String MAP_ID_FIELD = 'map_id'
+
+  private static final Map<String, String> PROPERTY_FIELDS = [
+      x        : 'x',
+      y        : 'y',
+      xend     : 'xend',
+      yend     : 'yend',
+      xmin     : 'xmin',
+      xmax     : 'xmax',
+      ymin     : 'ymin',
+      ymax     : 'ymax',
+      color    : COLOR_FIELD,
+      colour   : COLOR_FIELD,
+      col      : COLOR_FIELD,
+      fill     : 'fill',
+      size     : 'size',
+      shape    : 'shape',
+      alpha    : 'alpha',
+      linetype : 'linetype',
+      linewidth: LINEWIDTH_FIELD,
+      lineWidth: LINEWIDTH_FIELD,
+      group    : 'group',
+      label    : 'label',
+      tooltip  : 'tooltip',
+      weight   : 'weight',
+      geometry : 'geometry',
+      map_id   : MAP_ID_FIELD,
+      mapId    : MAP_ID_FIELD
+  ]
+
   // Known aesthetics kept as explicit fields for IDE completion.
   def x
   def y
+  def xend
+  def yend
+  def xmin
+  def xmax
+  def ymin
+  def ymax
   def color
   def fill
   def size
@@ -79,48 +117,12 @@ class AesDsl {
    */
   @CompileDynamic
   def getProperty(String name) {
-    switch (name) {
-      case 'x':
-        return this.@x != null ? this.@x : 'x'
-      case 'y':
-        return this.@y != null ? this.@y : 'y'
-      case 'color':
-        return this.@color != null ? this.@color : 'color'
-      case 'colour':
-        return this.@color != null ? this.@color : 'colour'
-      case 'col':
-        return this.@color != null ? this.@color : 'col'
-      case 'fill':
-        return this.@fill != null ? this.@fill : 'fill'
-      case 'size':
-        return this.@size != null ? this.@size : 'size'
-      case 'shape':
-        return this.@shape != null ? this.@shape : 'shape'
-      case 'alpha':
-        return this.@alpha != null ? this.@alpha : 'alpha'
-      case 'linetype':
-        return this.@linetype != null ? this.@linetype : 'linetype'
-      case 'linewidth':
-        return this.@linewidth != null ? this.@linewidth : 'linewidth'
-      case 'lineWidth':
-        return this.@linewidth != null ? this.@linewidth : 'lineWidth'
-      case 'group':
-        return this.@group != null ? this.@group : 'group'
-      case 'label':
-        return this.@label != null ? this.@label : 'label'
-      case 'tooltip':
-        return this.@tooltip != null ? this.@tooltip : 'tooltip'
-      case 'weight':
-        return this.@weight != null ? this.@weight : 'weight'
-      case 'geometry':
-        return this.@geometry != null ? this.@geometry : 'geometry'
-      case 'map_id':
-        return this.@map_id != null ? this.@map_id : 'map_id'
-      case 'mapId':
-        return this.@map_id != null ? this.@map_id : 'mapId'
-      default:
-        return propertyMissing(name)
+    String fieldName = PROPERTY_FIELDS[name]
+    if (fieldName == null) {
+      return propertyMissing(name)
     }
+    def value = this.@"$fieldName"
+    value != null ? value : name
   }
 
   /**
@@ -148,6 +150,24 @@ class AesDsl {
     }
     if (this.@y != null) {
       aes.y = this.@y
+    }
+    if (this.@xend != null) {
+      aes.xend = this.@xend
+    }
+    if (this.@yend != null) {
+      aes.yend = this.@yend
+    }
+    if (this.@xmin != null) {
+      aes.xmin = this.@xmin
+    }
+    if (this.@xmax != null) {
+      aes.xmax = this.@xmax
+    }
+    if (this.@ymin != null) {
+      aes.ymin = this.@ymin
+    }
+    if (this.@ymax != null) {
+      aes.ymax = this.@ymax
     }
     if (this.@color != null) {
       aes.color = this.@color
@@ -197,6 +217,12 @@ class AesDsl {
   boolean hasMappings() {
     this.@x != null ||
         this.@y != null ||
+        this.@xend != null ||
+        this.@yend != null ||
+        this.@xmin != null ||
+        this.@xmax != null ||
+        this.@ymin != null ||
+        this.@ymax != null ||
         this.@color != null ||
         this.@fill != null ||
         this.@size != null ||

--- a/matrix-ggplot/src/test/groovy/gg/AesTypedSetterTest.groovy
+++ b/matrix-ggplot/src/test/groovy/gg/AesTypedSetterTest.groovy
@@ -5,13 +5,18 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static se.alipsa.matrix.gg.GgPlot.I
+import static se.alipsa.matrix.gg.GgPlot.aes
 import static se.alipsa.matrix.gg.GgPlot.after_scale
 import static se.alipsa.matrix.gg.GgPlot.after_stat
 import static se.alipsa.matrix.gg.GgPlot.cut_width
 import static se.alipsa.matrix.gg.GgPlot.factor
+import static se.alipsa.matrix.gg.GgPlot.geom_segment
+import static se.alipsa.matrix.gg.GgPlot.ggplot
 
 import org.junit.jupiter.api.Test
 
+import se.alipsa.groovy.svg.Line
+import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.gg.aes.Aes
 import se.alipsa.matrix.gg.aes.Factor
 import se.alipsa.matrix.gg.aes.Identity
@@ -106,5 +111,72 @@ class AesTypedSetterTest {
     assertEquals('widthCol', aes.linewidth)
     assertEquals('idCol', aes.map_id)
     assertEquals('species', colourAlias.color)
+  }
+
+  @Test
+  void testMapConstructorSupportsRangePositionAesthetics() {
+    Aes aes = aes(xend: 'x2', yend: 'y2', xmin: 'x0', xmax: 'x3', ymin: 'y0', ymax: 'y3')
+
+    assertEquals('x2', aes.getAestheticValue('xend'))
+    assertEquals('y2', aes.getAestheticValue('yend'))
+    assertEquals('x0', aes.getAestheticValue('xmin'))
+    assertEquals('x3', aes.getAestheticValue('xmax'))
+    assertEquals('y0', aes.getAestheticValue('ymin'))
+    assertEquals('y3', aes.getAestheticValue('ymax'))
+  }
+
+  @Test
+  void testClosureDslSupportsRangePositionAesthetics() {
+    Aes aes = aes {
+      xend = x2
+      yend = y2
+      xmin = x0
+      xmax = x3
+      ymin = y0
+      ymax = y3
+    }
+
+    assertEquals('x2', aes.getAestheticValue('xend'))
+    assertEquals('y2', aes.getAestheticValue('yend'))
+    assertEquals('x0', aes.getAestheticValue('xmin'))
+    assertEquals('x3', aes.getAestheticValue('xmax'))
+    assertEquals('y0', aes.getAestheticValue('ymin'))
+    assertEquals('y3', aes.getAestheticValue('ymax'))
+  }
+
+  @Test
+  void testMergeSupportsRangePositionAesthetics() {
+    Aes base = new Aes(xend: 'a', yend: 'baseY')
+    Aes layer = new Aes(xend: 'b')
+    Aes merged = layer.merge(base)
+    Aes fallback = new Aes().merge(base)
+
+    assertEquals('b', merged.xend)
+    assertEquals('baseY', merged.yend)
+    assertEquals('a', fallback.xend)
+  }
+
+  @Test
+  void testToStringIncludesRangePositionAesthetics() {
+    Aes aes = new Aes(xend: 'col')
+
+    assertTrue(aes.toString().contains('xend=col'))
+  }
+
+  @Test
+  void testSegmentMappingUsesRangePositionAesthetics() {
+    Matrix data = Matrix.builder()
+        .columnNames(['x1', 'y1', 'x2', 'y2'])
+        .rows([
+            [1, 1, 2, 2],
+            [2, 1, 3, 2]
+        ])
+        .build()
+
+    def svg = (ggplot(data, aes(x: 'x1', y: 'y1')) +
+        geom_segment(mapping: aes(x: 'x1', y: 'y1', xend: 'x2', yend: 'y2'))).render()
+
+    def lines = svg.descendants().findAll { it instanceof Line }
+    assertTrue(lines.size() > 0, 'Segment mapping should render line elements')
   }
 }

--- a/matrix-groovy-ext/build.gradle
+++ b/matrix-groovy-ext/build.gradle
@@ -9,7 +9,7 @@ plugins {
   alias(libs.plugins.alipsaNexusRelease)
 }
 group = 'se.alipsa.matrix'
-version = '0.2.0' // remember to change Extension module info if changing version
+version = '0.3.0-SNAPSHOT' // remember to change Extension module info if changing version
 description = "Groovy extensions for the matrix library"
 
 JavaCompile javaCompile = compileJava {

--- a/matrix-groovy-ext/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
+++ b/matrix-groovy-ext/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
@@ -1,3 +1,3 @@
 moduleName=matrix-groovy-ext
-moduleVersion=0.3.0
+moduleVersion=0.3.0-SNAPSHOT
 extensionClasses=se.alipsa.matrix.ext.NumberExtension

--- a/matrix-groovy-ext/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
+++ b/matrix-groovy-ext/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
@@ -1,3 +1,3 @@
 moduleName=matrix-groovy-ext
-moduleVersion=0.2.0
+moduleVersion=0.3.0
 extensionClasses=se.alipsa.matrix.ext.NumberExtension


### PR DESCRIPTION
  - matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/aes/Aes.groovy: added xend, yend, xmin, xmax, ymin, ymax fields, typed setters, map constructor handling, fallback assignment, getAestheticValue, merge, and toString.

  - matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/aes/AesDsl.groovy: added the six positional aesthetics to DSL storage, property resolution, toAes, and hasMappings.
  - matrix-ggplot/src/test/groovy/gg/AesTypedSetterTest.groovy: added coverage for map form, closure DSL, merge override/fallback, toString, and geom_segment(mapping: aes(... xend/yend ...)) rendering.

  - matrix-ggplot/req/0.5.0-plan.md: marked Phase 1 complete and recorded verification result.

  Verification passed:

  ./gradlew :matrix-ggplot:codenarcMain :matrix-ggplot:codenarcTest :matrix-ggplot:spotlessCheck :matrix-ggplot:test -Pheadless=true

  Result: SUCCESS (1754 tests, 1754 passed, 0 failed, 0 skipped).