### PR TITLE
Support per-aesthetic legend titles

### DIFF
--- a/matrix-ggplot/req/0.5.0-plan.md
+++ b/matrix-ggplot/req/0.5.0-plan.md
@@ -188,13 +188,13 @@ fill: 'Count')` is called, the `fill` assignment unconditionally overwrites the 
 (`GgPlot.labs()` lines 863–867). Only the last assigned title survives; all others are silently
 lost. In R's ggplot2, each aesthetic has its own independent legend title.
 
-3.1 [ ] Replace `String legendTitle` in
+3.1 [x] Replace `String legendTitle` in
 `matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/Label.groovy` with
 `Map<String, String> legendTitles = [:]` (a per-aesthetic title map). Replace the existing
 `/** called colour in ggplot2 */` comment with a description that reflects the map's purpose:
 `/** Per-aesthetic legend titles keyed by normalized aesthetic name (e.g. 'color', 'fill', 'size'). colour is stored as 'color'. */`
 
-3.2 [ ] Update `GgPlot.labs(Map params)` in
+3.2 [x] Update `GgPlot.labs(Map params)` in
 `matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgPlot.groovy` to write each aesthetic
 title into the map:
 - `params.colour` or `params.color` → `label.legendTitles['color'] = value?.toString()`
@@ -207,7 +207,7 @@ title into the map:
   `label.caption`, `label.x`, and `label.y` assignments to prevent those from also appearing
   as spurious legend titles.
 
-3.3 [ ] Update `GgChart.plus(Label)` in `GgChart.groovy` to merge `legendTitles` maps (union,
+3.3 [x] Update `GgChart.plus(Label)` in `GgChart.groovy` to merge `legendTitles` maps (union,
 with the incoming label winning on collision) instead of copying the single `legendTitle` string.
 Guard against a null `legendTitles` map on both the existing and incoming `Label`. The field in
 `GgChart` is `labels` (plural), not `label`:
@@ -217,7 +217,7 @@ if (labels.legendTitles) {
 }
 ```
 
-3.4 [ ] Update `GgCharmCompiler.mapLabels` in
+3.4 [x] Update `GgCharmCompiler.mapLabels` in
 `matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/bridge/GgCharmCompiler.groovy` to populate
 `labels.guides` from `source.legendTitles` rather than the single `source.legendTitle` string.
 **Preserve the existing precedence order**: `legendTitles` from `labs()` seeds the map first;
@@ -237,11 +237,11 @@ guideTitles.putAll(extractGuideTitlesFromScales(scales))
 labels.guides = guideTitles
 ```
 
-3.5 [ ] Search for any other reference to `label.legendTitle` or `source.legendTitle` in the
+3.5 [x] Search for any other reference to `label.legendTitle` or `source.legendTitle` in the
 codebase — including `GgChart.groovy`, `GgCharmCompiler.groovy`, any test files that construct
 `Label` directly, and any groovy scripts under `src/` — and update them to use the new map.
 
-3.6 [ ] Add tests in `matrix-ggplot/src/test/groovy/gg/GgChartLabelTest.groovy` verifying:
+3.6 [x] Add tests in `matrix-ggplot/src/test/groovy/gg/GgChartLabelTest.groovy` verifying:
 - `labs(color: 'Speed', fill: 'Count')` preserves both titles independently.
 - `labs(color: 'Speed') + labs(fill: 'Count')` also preserves both.
 - The single-aesthetic case `labs(color: 'X')` still works.
@@ -253,10 +253,12 @@ codebase — including `GgChart.groovy`, `GgCharmCompiler.groovy`, any test file
 - Precedence: `labs(color: 'A') + guides(color: guide_legend(title: 'B'))` → rendered title is 'B' (guide wins).
 - Precedence: `labs(color: 'A') + scale_color_manual(name: 'C', values: ...)` → rendered title is 'C' (scale wins).
 
-3.7 [ ] Verify Phase 3 with:
+3.7 [x] Verify Phase 3 with:
 ```
 ./gradlew :matrix-ggplot:codenarcMain :matrix-ggplot:codenarcTest :matrix-ggplot:spotlessCheck :matrix-ggplot:test -Pheadless=true
 ```
+
+Result: SUCCESS (1764 tests, 1764 passed, 0 failed, 0 skipped).
 
 ---
 

--- a/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgChart.groovy
+++ b/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgChart.groovy
@@ -421,7 +421,7 @@ class GgChart {
       this.labels.caption = labels.caption
     }
     if (labels.legendTitles) {
-      this.labels.legendTitles = (this.labels.legendTitles ?: [:]) + labels.legendTitles
+      this.labels.legendTitles = this.labels.legendTitles + labels.legendTitles
     }
     if (labels.xSet) {
       this.labels.x = labels.x

--- a/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgChart.groovy
+++ b/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgChart.groovy
@@ -420,8 +420,8 @@ class GgChart {
     if (labels.caption) {
       this.labels.caption = labels.caption
     }
-    if (labels.legendTitle) {
-      this.labels.legendTitle = labels.legendTitle
+    if (labels.legendTitles) {
+      this.labels.legendTitles = (this.labels.legendTitles ?: [:]) + labels.legendTitles
     }
     if (labels.xSet) {
       this.labels.x = labels.x

--- a/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgPlot.groovy
+++ b/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgPlot.groovy
@@ -19,6 +19,7 @@ import se.alipsa.matrix.gg.aes.CutWidth
 import se.alipsa.matrix.gg.aes.Expression
 import se.alipsa.matrix.gg.aes.Factor
 import se.alipsa.matrix.gg.aes.Identity
+import se.alipsa.matrix.gg.bridge.GgCharmMappingRegistry
 import se.alipsa.matrix.gg.coord.CoordCartesian
 import se.alipsa.matrix.gg.coord.CoordFixed
 import se.alipsa.matrix.gg.coord.CoordFlip
@@ -190,6 +191,10 @@ class GgPlot {
   /** Global default theme (thread-local for thread safety) */
   private static final ThreadLocal<Theme> GLOBAL_THEME =
       ThreadLocal.withInitial { Themes.gray() }
+
+  private static final Set<String> LABEL_KEYS = [
+      'title', 'subtitle', 'caption', 'tag', 'x', 'y'
+  ] as Set<String>
 
   // ============ Core functions ============
 
@@ -828,11 +833,21 @@ class GgPlot {
       label.y = params.y?.toString()
       label.ySet = true
     }
-    if (params.colour || params.color) {
-      label.legendTitle = params.colour ?: params.color
+    def colorTitle = params.colour ?: params.color
+    if (colorTitle != null) {
+      label.legendTitles['color'] = colorTitle?.toString()
     }
-    if (params.fill) {
-      label.legendTitle = params.fill
+    if (params.fill != null) {
+      label.legendTitles['fill'] = params.fill?.toString()
+    }
+    params.each { key, value ->
+      String name = key
+      if (value != null && !LABEL_KEYS.contains(name) && name !in ['color', 'colour', 'fill']) {
+        String aesthetic = GgCharmMappingRegistry.normalizeAesthetic(name)
+        if (aesthetic != null && !aesthetic.isBlank()) {
+          label.legendTitles[aesthetic] = value?.toString()
+        }
+      }
     }
     return label
   }

--- a/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgPlot.groovy
+++ b/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgPlot.groovy
@@ -19,7 +19,6 @@ import se.alipsa.matrix.gg.aes.CutWidth
 import se.alipsa.matrix.gg.aes.Expression
 import se.alipsa.matrix.gg.aes.Factor
 import se.alipsa.matrix.gg.aes.Identity
-import se.alipsa.matrix.gg.bridge.GgCharmMappingRegistry
 import se.alipsa.matrix.gg.coord.CoordCartesian
 import se.alipsa.matrix.gg.coord.CoordFixed
 import se.alipsa.matrix.gg.coord.CoordFlip
@@ -835,21 +834,29 @@ class GgPlot {
     }
     def colorTitle = params.colour ?: params.color
     if (colorTitle != null) {
-      label.legendTitles['color'] = colorTitle?.toString()
+      label.legendTitles['color'] = colorTitle.toString()
     }
     if (params.fill != null) {
-      label.legendTitles['fill'] = params.fill?.toString()
+      label.legendTitles['fill'] = params.fill.toString()
     }
     params.each { key, value ->
       String name = key
       if (value != null && !LABEL_KEYS.contains(name) && name !in ['color', 'colour', 'fill']) {
-        String aesthetic = GgCharmMappingRegistry.normalizeAesthetic(name)
+        String aesthetic = normalizeAesthetic(name)
         if (aesthetic != null && !aesthetic.isBlank()) {
           label.legendTitles[aesthetic] = value?.toString()
         }
       }
     }
     return label
+  }
+
+  private static String normalizeAesthetic(String aesthetic) {
+    if (aesthetic == null) {
+      return null
+    }
+    String normalized = aesthetic.trim().toLowerCase(Locale.ROOT)
+    normalized == 'colour' ? 'color' : normalized
   }
 
   /**

--- a/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgPlot.groovy
+++ b/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgPlot.groovy
@@ -19,6 +19,7 @@ import se.alipsa.matrix.gg.aes.CutWidth
 import se.alipsa.matrix.gg.aes.Expression
 import se.alipsa.matrix.gg.aes.Factor
 import se.alipsa.matrix.gg.aes.Identity
+import se.alipsa.matrix.gg.bridge.GgCharmMappingRegistry
 import se.alipsa.matrix.gg.coord.CoordCartesian
 import se.alipsa.matrix.gg.coord.CoordFixed
 import se.alipsa.matrix.gg.coord.CoordFlip
@@ -192,7 +193,11 @@ class GgPlot {
       ThreadLocal.withInitial { Themes.gray() }
 
   private static final Set<String> LABEL_KEYS = [
-      'title', 'subtitle', 'caption', 'tag', 'x', 'y'
+      'title', 'subtitle', 'caption', 'x', 'y'
+  ] as Set<String>
+
+  private static final Set<String> LEGEND_LABEL_AESTHETICS = [
+      'color', 'fill', 'size', 'shape', 'alpha', 'linetype', 'linewidth', 'group'
   ] as Set<String>
 
   // ============ Core functions ============
@@ -832,31 +837,26 @@ class GgPlot {
       label.y = params.y?.toString()
       label.ySet = true
     }
-    def colorTitle = params.colour ?: params.color
-    if (colorTitle != null) {
-      label.legendTitles['color'] = colorTitle.toString()
-    }
-    if (params.fill != null) {
-      label.legendTitles['fill'] = params.fill.toString()
-    }
+    setLegendTitle(label, 'color', params.colour ?: params.color)
+    setLegendTitle(label, 'fill', params.fill)
     params.each { key, value ->
       String name = key
-      if (value != null && !LABEL_KEYS.contains(name) && name !in ['color', 'colour', 'fill']) {
-        String aesthetic = normalizeAesthetic(name)
-        if (aesthetic != null && !aesthetic.isBlank()) {
-          label.legendTitles[aesthetic] = value.toString()
+      if (!LABEL_KEYS.contains(name) && name !in ['color', 'colour', 'fill']) {
+        String aesthetic = GgCharmMappingRegistry.normalizeAesthetic(name)
+        if (!LEGEND_LABEL_AESTHETICS.contains(aesthetic)) {
+          throw new IllegalArgumentException("Unsupported labs() key: '${name}'")
         }
+        setLegendTitle(label, aesthetic, value)
       }
     }
     return label
   }
 
-  private static String normalizeAesthetic(String aesthetic) {
-    if (aesthetic == null) {
-      return null
+  private static void setLegendTitle(Label label, String aesthetic, Object title) {
+    String legendTitle = title
+    if (legendTitle) {
+      label.legendTitles[aesthetic] = legendTitle
     }
-    String normalized = aesthetic.trim().toLowerCase(Locale.ROOT)
-    normalized == 'colour' ? 'color' : normalized
   }
 
   /**

--- a/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgPlot.groovy
+++ b/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgPlot.groovy
@@ -197,7 +197,7 @@ class GgPlot {
   ] as Set<String>
 
   private static final Set<String> LEGEND_LABEL_AESTHETICS = [
-      'color', 'fill', 'size', 'shape', 'alpha', 'linetype', 'linewidth', 'group'
+      'color', 'fill', 'size', 'shape', 'alpha', 'linetype', 'linewidth'
   ] as Set<String>
 
   // ============ Core functions ============
@@ -854,7 +854,7 @@ class GgPlot {
 
   private static void setLegendTitle(Label label, String aesthetic, Object title) {
     String legendTitle = title
-    if (legendTitle) {
+    if (legendTitle?.trim()) {
       label.legendTitles[aesthetic] = legendTitle
     }
   }

--- a/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgPlot.groovy
+++ b/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgPlot.groovy
@@ -844,7 +844,7 @@ class GgPlot {
       if (value != null && !LABEL_KEYS.contains(name) && name !in ['color', 'colour', 'fill']) {
         String aesthetic = normalizeAesthetic(name)
         if (aesthetic != null && !aesthetic.isBlank()) {
-          label.legendTitles[aesthetic] = value?.toString()
+          label.legendTitles[aesthetic] = value.toString()
         }
       }
     }

--- a/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/Label.groovy
+++ b/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/Label.groovy
@@ -14,7 +14,8 @@ class Label {
   String caption
   String x
   String y
-  String legendTitle // called colour in ggplot2
+  /** Per-aesthetic legend titles keyed by normalized aesthetic name (e.g. 'color', 'fill', 'size'). colour is stored as 'color'. */
+  Map<String, String> legendTitles = [:]
 
   /** True when the x label was explicitly set via labs/xlab. */
   boolean xSet = false

--- a/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/bridge/GgCharmCompiler.groovy
+++ b/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/bridge/GgCharmCompiler.groovy
@@ -1294,8 +1294,10 @@ class GgCharmCompiler {
     }
 
     Map<String, String> guideTitles = [:]
-    if (source?.legendTitle) {
-      guideTitles['color'] = source.legendTitle
+    source?.legendTitles?.each { String aesthetic, String title ->
+      if (title != null && !title.isBlank()) {
+        guideTitles[GgCharmMappingRegistry.normalizeAesthetic(aesthetic)] = title
+      }
     }
     guideTitles.putAll(extractGuideTitles(guides))
     guideTitles.putAll(extractGuideTitlesFromScales(scales))

--- a/matrix-ggplot/src/test/groovy/gg/GgChartLabelTest.groovy
+++ b/matrix-ggplot/src/test/groovy/gg/GgChartLabelTest.groovy
@@ -97,10 +97,54 @@ class GgChartLabelTest {
   }
 
   @Test
+  void testBlankLegendTitleDoesNotClobberExistingColorTitle() {
+    GgChart chart = GgPlot.ggplot(legendData, GgPlot.aes(x: 'x', y: 'y', color: 'group')) +
+        GgPlot.labs(color: 'Category') +
+        GgPlot.labs(color: '')
+
+    assertEquals('Category', chart.labels.legendTitles['color'])
+  }
+
+  @Test
+  void testBlankLegendTitleDoesNotClobberExistingFillTitle() {
+    GgChart chart = GgPlot.ggplot(legendData, GgPlot.aes(x: 'x', y: 'y', fill: 'kind')) +
+        GgPlot.labs(fill: 'Kind') +
+        GgPlot.labs(fill: '')
+
+    assertEquals('Kind', chart.labels.legendTitles['fill'])
+  }
+
+  @Test
   void testSingleAestheticLegendTitleStillWorks() {
     Label label = GgPlot.labs(color: 'Hue')
 
     assertEquals('Hue', label.legendTitles['color'])
+  }
+
+  @Test
+  void testAdditionalKnownAestheticLegendTitlesAreAccepted() {
+    Label label = GgPlot.labs(size: 'Area', linetype: 'Trend')
+
+    assertEquals('Area', label.legendTitles['size'])
+    assertEquals('Trend', label.legendTitles['linetype'])
+  }
+
+  @Test
+  void testUnknownLabsKeyIsRejected() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      GgPlot.labs(badParam: 'oops')
+    }
+
+    assertEquals("Unsupported labs() key: 'badParam'", exception.message)
+  }
+
+  @Test
+  void testUnsupportedTagLabsKeyIsRejected() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      GgPlot.labs(tag: 'Fig. 1')
+    }
+
+    assertEquals("Unsupported labs() key: 'tag'", exception.message)
   }
 
   @Test

--- a/matrix-ggplot/src/test/groovy/gg/GgChartLabelTest.groovy
+++ b/matrix-ggplot/src/test/groovy/gg/GgChartLabelTest.groovy
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.*
 
 import org.junit.jupiter.api.Test
 
+import se.alipsa.groovy.svg.Svg
+import se.alipsa.groovy.svg.Text
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.gg.GgChart
 import se.alipsa.matrix.gg.GgPlot
@@ -11,6 +13,17 @@ import se.alipsa.matrix.gg.Label
 
 @SuppressWarnings('ExplicitCallToPlusMethod')
 class GgChartLabelTest {
+
+  private final Matrix legendData = Matrix.builder()
+      .columnNames(['x', 'y', 'group', 'kind'])
+      .rows([
+          [1, 2, 'one', 'alpha'],
+          [2, 4, 'two', 'beta'],
+          [3, 6, 'one', 'alpha'],
+          [4, 8, 'two', 'beta'],
+      ])
+      .types([int, int, String, String])
+      .build()
 
   @Test
   void testLabelSettersToggleFlags() {
@@ -63,5 +76,82 @@ class GgChartLabelTest {
     assertEquals('X', chart.labels.x)
     assertEquals('Y', chart.labels.y)
     assertEquals('Title', chart.labels.title)
+  }
+
+  @Test
+  void testLabsPreservesColorAndFillLegendTitles() {
+    Label label = GgPlot.labs(color: 'Speed', fill: 'Count')
+
+    assertEquals('Speed', label.legendTitles['color'])
+    assertEquals('Count', label.legendTitles['fill'])
+  }
+
+  @Test
+  void testSeparateLabsCallsPreserveLegendTitles() {
+    GgChart chart = GgPlot.ggplot(legendData, GgPlot.aes(x: 'x', y: 'y', color: 'group', fill: 'kind')) +
+        GgPlot.labs(color: 'Speed') +
+        GgPlot.labs(fill: 'Count')
+
+    assertEquals('Speed', chart.labels.legendTitles['color'])
+    assertEquals('Count', chart.labels.legendTitles['fill'])
+  }
+
+  @Test
+  void testSingleAestheticLegendTitleStillWorks() {
+    Label label = GgPlot.labs(color: 'Hue')
+
+    assertEquals('Hue', label.legendTitles['color'])
+  }
+
+  @Test
+  void testAxisLabelAndLegendTitleAreIndependent() {
+    Label label = GgPlot.labs(x: 'X Axis', color: 'Speed')
+
+    assertEquals('X Axis', label.x)
+    assertEquals('Speed', label.legendTitles['color'])
+    assertFalse(label.legendTitles.containsKey('x'))
+  }
+
+  @Test
+  void testLabelLevelKeysAreNotStoredAsLegendTitles() {
+    Label label = GgPlot.labs(title: 'T', subtitle: 'S', caption: 'C', x: 'X', y: 'Y', color: 'Hue')
+
+    assertEquals('Hue', label.legendTitles['color'])
+    assertFalse(label.legendTitles.containsKey('title'))
+    assertFalse(label.legendTitles.containsKey('subtitle'))
+    assertFalse(label.legendTitles.containsKey('caption'))
+    assertFalse(label.legendTitles.containsKey('x'))
+    assertFalse(label.legendTitles.containsKey('y'))
+  }
+
+  @Test
+  void testGuideLegendTitleWinsOverLabsTitle() {
+    Svg svg = (GgPlot.ggplot(legendData, GgPlot.aes(x: 'x', y: 'y', color: 'group')) +
+        GgPlot.geom_point() +
+        GgPlot.labs(color: 'Labs Legend') +
+        GgPlot.guides(color: GgPlot.guide_legend(title: 'Guide Legend'))).render()
+
+    String text = svgText(svg)
+    assertTrue(text.contains('Guide Legend'), text)
+    assertFalse(text.contains('Labs Legend'), text)
+  }
+
+  @Test
+  void testScaleLegendTitleWinsOverLabsTitle() {
+    Svg svg = (GgPlot.ggplot(legendData, GgPlot.aes(x: 'x', y: 'y', color: 'group')) +
+        GgPlot.geom_point() +
+        GgPlot.labs(color: 'Labs Legend') +
+        GgPlot.scale_color_manual(name: 'Scale Legend', values: [one: '#336699', two: '#CC6633'])).render()
+
+    String text = svgText(svg)
+    assertTrue(text.contains('Scale Legend'), text)
+    assertFalse(text.contains('Labs Legend'), text)
+  }
+
+  private static String svgText(Svg svg) {
+    svg.descendants()
+        .findAll { it instanceof Text }
+        .collect { (it as Text).content }
+        .join(' ')
   }
 }

--- a/matrix-ggplot/src/test/groovy/gg/GgChartLabelTest.groovy
+++ b/matrix-ggplot/src/test/groovy/gg/GgChartLabelTest.groovy
@@ -106,6 +106,15 @@ class GgChartLabelTest {
   }
 
   @Test
+  void testWhitespaceLegendTitleDoesNotClobberExistingColorTitle() {
+    GgChart chart = GgPlot.ggplot(legendData, GgPlot.aes(x: 'x', y: 'y', color: 'group')) +
+        GgPlot.labs(color: 'Category') +
+        GgPlot.labs(color: '   ')
+
+    assertEquals('Category', chart.labels.legendTitles['color'])
+  }
+
+  @Test
   void testBlankLegendTitleDoesNotClobberExistingFillTitle() {
     GgChart chart = GgPlot.ggplot(legendData, GgPlot.aes(x: 'x', y: 'y', fill: 'kind')) +
         GgPlot.labs(fill: 'Kind') +
@@ -119,6 +128,14 @@ class GgChartLabelTest {
     Label label = GgPlot.labs(color: 'Hue')
 
     assertEquals('Hue', label.legendTitles['color'])
+  }
+
+  @Test
+  void testBritishSpellingColourLegendTitleNormalizesToColor() {
+    Label label = GgPlot.labs(colour: 'Hue')
+
+    assertEquals('Hue', label.legendTitles['color'])
+    assertFalse(label.legendTitles.containsKey('colour'))
   }
 
   @Test
@@ -145,6 +162,15 @@ class GgChartLabelTest {
     }
 
     assertEquals("Unsupported labs() key: 'tag'", exception.message)
+  }
+
+  @Test
+  void testGroupLabsKeyIsRejected() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      GgPlot.labs(group: 'Grouping')
+    }
+
+    assertEquals("Unsupported labs() key: 'group'", exception.message)
   }
 
   @Test


### PR DESCRIPTION
## Summary

Implements Phase 3 of `matrix-ggplot/req/0.5.0-plan.md`.

- Replaces the single `Label.legendTitle` with per-aesthetic `legendTitles`.
- Updates `labs()` so `color`, `fill`, and other non-axis/non-title aesthetics can each store independent legend titles.
- Merges label maps across separate `labs()` calls while preserving axis label intent.
- Maps per-aesthetic lab titles into Charm guide titles while preserving precedence: `labs()` < `guides()` < explicit scale names.
- Adds tests for multi-aesthetic labels, separate `labs()` calls, axis/legend independence, label-key exclusion, and rendered precedence.

## Validation

- `./gradlew :matrix-ggplot:test --tests "gg.GgChartLabelTest" -Pheadless=true`
- `./gradlew :matrix-ggplot:codenarcMain :matrix-ggplot:codenarcTest :matrix-ggplot:spotlessCheck :matrix-ggplot:test -Pheadless=true`

Full suite result: `SUCCESS (1764 tests, 1764 passed, 0 failed, 0 skipped)`.
