### PR TITLE
Remove ggplot render coord side effect

### DIFF
--- a/matrix-ggplot/req/0.5.0-plan.md
+++ b/matrix-ggplot/req/0.5.0-plan.md
@@ -268,26 +268,32 @@ Result: SUCCESS (1764 tests, 1764 passed, 0 failed, 0 skipped).
 coord has been set. A pure "read" operation permanently changes the chart's observable state.
 Inspecting `chart.coord` after calling `render()` returns a non-null value the user never set.
 
-4.1 [ ] Before removing the mutation, grep the test sources and any example scripts for
+4.1 [x] Before removing the mutation, grep the test sources and any example scripts for
 `chart.coord`, `\.coord\s*!=\s*null`, or assertions on `coord` after `render()`. Update or
 remove any test or example that relies on `chart.coord` being non-null post-render; document
 each such change in the PR description.
 
-4.2 [ ] Remove the `if (coord == null) { coord = new CoordCartesian() }` block from
+Result: Checked with `rg -n "chart\\.coord|\\.coord\\s*!=\\s*null|assert.*coord|coord.*assert|render\\(\\).*coord|coord.*render\\(\\)" matrix-ggplot/src/test matrix-ggplot/src/main matrix-examples`. No tests or examples relied on `render()` setting a default coord.
+
+4.2 [x] Remove the `if (coord == null) { coord = new CoordCartesian() }` block from
 `GgChart.render()` in `matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgChart.groovy`.
 
-4.3 [ ] Ensure `GgCharmCompiler.adapt()` (or `mapCoord()`) handles a null `coord` gracefully by
+4.3 [x] Ensure `GgCharmCompiler.adapt()` (or `mapCoord()`) handles a null `coord` gracefully by
 defaulting to `CharmCoordType.CARTESIAN` internally. Verify that
 `GgCharmMappingRegistry.mapCoordType(null)` returns `CharmCoordType.CARTESIAN`, or add that
 null-to-Cartesian default in `mapCoord` in `GgCharmCompiler.groovy`.
 
-4.4 [ ] Add a test verifying that `chart.coord` remains `null` after `chart.render()` when no
+Result: Verified existing `GgCharmMappingRegistry.mapCoordType(null)` returns `CharmCoordType.CARTESIAN`.
+
+4.4 [x] Add a test verifying that `chart.coord` remains `null` after `chart.render()` when no
 coord was explicitly added, in `matrix-ggplot/src/test/groovy/gg/GgPlotTest.groovy`.
 
-4.5 [ ] Verify Phase 4 with:
+4.5 [x] Verify Phase 4 with:
 ```
 ./gradlew :matrix-ggplot:codenarcMain :matrix-ggplot:codenarcTest :matrix-ggplot:spotlessCheck :matrix-ggplot:test -Pheadless=true
 ```
+
+Result: SUCCESS (1773 tests, 1773 passed, 0 failed, 0 skipped).
 
 ---
 

--- a/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgChart.groovy
+++ b/matrix-ggplot/src/main/groovy/se/alipsa/matrix/gg/GgChart.groovy
@@ -7,7 +7,6 @@ import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.gg.aes.Aes
 import se.alipsa.matrix.gg.bridge.GgCharmCompiler
 import se.alipsa.matrix.gg.coord.Coord
-import se.alipsa.matrix.gg.coord.CoordCartesian
 import se.alipsa.matrix.gg.facet.Facet
 import se.alipsa.matrix.gg.geom.Geom
 import se.alipsa.matrix.gg.layer.Layer
@@ -518,10 +517,6 @@ class GgChart {
    * @return The rendered SVG object
    */
   Svg render() {
-    // Use default coordinate system if not set
-    if (coord == null) {
-      coord = new CoordCartesian()
-    }
     new GgCharmCompiler().render(this)
   }
 }

--- a/matrix-ggplot/src/test/groovy/gg/GgPlotTest.groovy
+++ b/matrix-ggplot/src/test/groovy/gg/GgPlotTest.groovy
@@ -50,6 +50,17 @@ class GgPlotTest {
   }
 
   @Test
+  void testRenderDoesNotSetDefaultCoordOnChart() {
+    def chart = ggplot(iris, aes(x: 'Sepal Length', y: 'Petal Length')) + geom_point()
+    assertNull(chart.coord)
+
+    Svg svg = chart.render()
+
+    assertNotNull(svg)
+    assertNull(chart.coord)
+  }
+
+  @Test
   void testPoint() {
     ggplot(iris, aes(x: 'Sepal Length', y: 'Petal Length', col: 'Species')) + geom_point()
 


### PR DESCRIPTION
## Summary

Implements Phase 4 of `matrix-ggplot/req/0.5.0-plan.md`.

- Removes the `GgChart.render()` side effect that assigned a default `CoordCartesian` to `chart.coord`.
- Keeps default Cartesian behavior inside the compiler path via the existing `GgCharmMappingRegistry.mapCoordType(null)` default.
- Adds a regression test proving `chart.coord` remains `null` after rendering when no coord was explicitly added.
- Marks Phase 4 tasks complete in the 0.5.0 plan with the verification result.

## Notes

Phase 4.1 grep found no tests or examples that relied on `render()` setting a default coord. Existing `chart.coord` assertions were for charts with explicit coord settings.

## Modules touched

- `matrix-ggplot`

## Verification

- `./gradlew :matrix-ggplot:codenarcMain :matrix-ggplot:codenarcTest :matrix-ggplot:spotlessCheck :matrix-ggplot:test -Pheadless=true`
  - SUCCESS (1773 tests, 1773 passed, 0 failed, 0 skipped)
- `./gradlew test`
  - SUCCESS
