### PR TITLE
Add matrix-ggplot 0.5.0 release notes

### DIFF
--- a/matrix-ggplot/release.md
+++ b/matrix-ggplot/release.md
@@ -1,0 +1,53 @@
+# matrix-ggplot Release Notes
+
+## 0.5.0
+
+### New features
+
+- `aes()` now supports positional range aesthetics: `xend`, `yend`, `xmin`, `xmax`, `ymin`,
+  `ymax`. Both the map form (`aes(xend: 'col')`) and the closure form
+  (`aes { xend = col }`) work correctly and are passed through to the renderer.
+- `labs()` now accepts independent legend titles per aesthetic:
+  `labs(color: 'Speed', fill: 'Count')` sets separate titles for each guide.
+- `stat_summary(geom: 'line')` and all other stat-compatible named geoms in `GEOM_REGISTRY`
+  now work as the `geom:` argument to `stat_*` functions. The stat-compatible names are:
+  `area`, `bar`, `bin2d`, `bin_2d`, `boxplot`, `col`, `contour`, `contour_filled`,
+  `contourf`, `count`, `crossbar`, `density`, `density_2d`, `density2d`,
+  `density_2d_filled`, `density2d_filled`, `dotplot`, `errorbar`, `errorbarh`,
+  `freqpoly`, `function`, `hex`, `histogram`, `jitter`, `label`, `line`, `linerange`,
+  `path`, `point`, `pointrange`, `polygon`, `qq`, `qq_line`, `quantile`, `raster`,
+  `rect`, `ribbon`, `rug`, `segment`, `smooth`, `spoke`, `step`, `text`, `tile`,
+  and `violin`.
+- `guide_axis_stack()` now has typed overloads for `Guide` and `String` first arguments,
+  plus typed vararg overloads for additional guides.
+- R-to-Groovy conversion now emits BigDecimal-friendly extension-method calls for math
+  functions, including nested calls and two-argument `log(x, base)`.
+- `acos()` is available as a `Number` and `BigDecimal` extension method through
+  `matrix-groovy-ext`, enabling generated `acos()` expressions to run without a missing
+  method error.
+
+### Bug fixes
+
+- `labs(color: ..., fill: ...)` no longer silently lets the fill title overwrite the color
+  legend title.
+- `stat_*` calls with `geom: '<name>'` for unsupported names now throw
+  `IllegalArgumentException` immediately instead of silently rendering a blank chart.
+- `GgChart.render()` no longer mutates the chart's `coord` field as a side effect. Charts
+  with no explicit coordinate system are still rendered as Cartesian; the default is now
+  applied inside the compiler instead of on the chart object.
+- R-to-Groovy conversion now emits `se.alipsa.matrix.ext.NumberExtension.PI` for `pi` instead
+  of `Math.PI`, preserving the project's BigDecimal-first numeric behavior.
+- Multi-argument R math calls without a supported extension-method equivalent now fail with
+  a descriptive `UnsupportedOperationException` instead of generating invalid Groovy code.
+
+### Improvements
+
+- `ScaleColorFermenter` palette type lookup uses a Map instead of a switch statement for
+  cleaner extensibility.
+- `Rconverter` now generates idiomatic Groovy GDK extension method calls, such as
+  `(it.x).log()`, instead of Java-style `Math.log(it.x)` calls.
+- `qplot` and `stat_*` named-geom resolution now share the same lowercase, immutable
+  `GEOM_REGISTRY`, keeping aliases and error messages consistent.
+- Unsupported dedicated-factory-only geoms remain intentionally outside `GEOM_REGISTRY`:
+  `abline`, `hline`, `vline`, `curve`, `sf`, `sf_text`, `sf_label`, `map`, `mag`,
+  `parallel`, `lm`, `blank`, and `point_sampled`.

--- a/matrix-ggplot/req/0.5.0-plan.md
+++ b/matrix-ggplot/req/0.5.0-plan.md
@@ -559,7 +559,7 @@ Result: SUCCESS (7 tests, 7 passed, 0 failed, 0 skipped).
 
 ## Phase 7 — Release notes
 
-7.1 [ ] Create `matrix-ggplot/release.md` with the following structure:
+7.1 [x] Create `matrix-ggplot/release.md` with the following structure:
 
 ```markdown
 # matrix-ggplot Release Notes
@@ -593,8 +593,16 @@ Result: SUCCESS (7 tests, 7 passed, 0 failed, 0 skipped).
   instead of Java-style `Math.log(x)` calls.
 ```
 
-7.2 [ ] Verify the release notes accurately reflect all changes merged in Phases 1–5 and
+7.2 [x] Verify the release notes accurately reflect all changes merged in Phases 1–5 and
 that no referenced feature is missing or mis-described.
+
+Result: Verified against the Phase 1–5 task list and the `GeomRegistry.GEOM_REGISTRY`
+included/excluded comments. Checked with:
+```
+test -f matrix-ggplot/release.md
+! rg -n "TODO|placeholder|Before merging|Phase 7" matrix-ggplot/release.md
+./gradlew :matrix-ggplot:spotlessCheck
+```
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `matrix-ggplot/release.md` for the 0.5.0 release notes and marks Phase 7 complete in `matrix-ggplot/req/0.5.0-plan.md`.

The release notes cover the Phase 1-5 changes: positional range aesthetics in `aes()`, independent per-aesthetic `labs()` legend titles, stat-compatible named geoms through `GEOM_REGISTRY`, typed `guide_axis_stack()` overloads, render coord side-effect removal, `ScaleColorFermenter` map lookup, and R-to-Groovy math conversion improvements.

## Modules touched

- `matrix-ggplot`

## GEOM_REGISTRY lists recorded

Stat-compatible names: `area`, `bar`, `bin2d`, `bin_2d`, `boxplot`, `col`, `contour`, `contour_filled`, `contourf`, `count`, `crossbar`, `density`, `density_2d`, `density2d`, `density_2d_filled`, `density2d_filled`, `dotplot`, `errorbar`, `errorbarh`, `freqpoly`, `function`, `hex`, `histogram`, `jitter`, `label`, `line`, `linerange`, `path`, `point`, `pointrange`, `polygon`, `qq`, `qq_line`, `quantile`, `raster`, `rect`, `ribbon`, `rug`, `segment`, `smooth`, `spoke`, `step`, `text`, `tile`, `violin`.

Dedicated-factory-only names intentionally outside the registry: `abline`, `hline`, `vline`, `curve`, `sf`, `sf_text`, `sf_label`, `map`, `mag`, `parallel`, `lm`, `blank`, `point_sampled`.

## Verification

- `test -f matrix-ggplot/release.md`
- `! rg -n "TODO|placeholder|Before merging|Phase 7" matrix-ggplot/release.md`
- `./gradlew :matrix-ggplot:spotlessCheck`
- `git diff --check`