### PR TITLE
Fix LinearRegression.summary() matrix orientation

### DIFF
--- a/matrix-stats/build.gradle
+++ b/matrix-stats/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = 'se.alipsa.matrix'
-version = '2.5.0'
+version = '2.5.1'
 description = "Statistical hypothesis tests based on Matrix data."
 
 ext.nexusUrl = version.contains("SNAPSHOT")

--- a/matrix-stats/release.md
+++ b/matrix-stats/release.md
@@ -2,6 +2,7 @@
 
 ## v2.5.1, 2026-06-30
 - Add toString to GoalSeek.Result for easier debugging and logging.
+- Fix `LinearRegression.summary()` matrix orientation so coefficient labels, estimates, and standard errors align with their column names.
 
 ## v2.5.0, 2026-06-14
 - `GoalSeek.solve()` now returns a typed `GoalSeek.Result` with BigDecimal accessors for the computed value, result, and difference. Existing callers that need the previous map-shaped value can use `GoalSeek.solve(...) as Map`.

--- a/matrix-stats/release.md
+++ b/matrix-stats/release.md
@@ -1,5 +1,8 @@
 # Matrix stats release history
 
+## v2.5.1, 2026-06-30
+- Add toString to GoalSeek.Result for easier debugging and logging.
+
 ## v2.5.0, 2026-06-14
 - `GoalSeek.solve()` now returns a typed `GoalSeek.Result` with BigDecimal accessors for the computed value, result, and difference. Existing callers that need the previous map-shaped value can use `GoalSeek.solve(...) as Map`.
 - Add Groovy-friendly `Number` overloads for `GoalSeek` target, bracket, threshold, and max-iteration arguments.

--- a/matrix-stats/req/2.5.1-plan.md
+++ b/matrix-stats/req/2.5.1-plan.md
@@ -1,0 +1,166 @@
+# Matrix Stats v2.5.1 Bug Fix Plan
+
+## Scope
+
+This plan covers five correctness bugs found during a source-code review of the matrix-stats module at v2.5.1. Each numbered section is intended to be implementable and reviewable as a separate pull request.
+
+A task is only complete when its tests have passed and the exact test command has been recorded in this file or the PR description.
+
+## Summary of Findings
+
+- `LinearRegression.summary()` builds a Matrix using `.rows()` with three two-element inner lists, which `.rows()` transposes to two data columns, but three column names are declared. The resulting Matrix has a column-name/data mismatch that produces corrupt or garbled summary output.
+- `Normalize.logNorm()` guards against `null` and `0` but not negative values. Negative input reaches `NumberExtension.log()` which throws `IllegalArgumentException`; the GroovyDoc promises null/NaN for invalid input.
+- `Ellipse.calculate()` with type `'t'` uses the chi-squared(2) quantile for the confidence scale, the same formula as type `'norm'`. The correct formula for `'t'` uses the F-distribution: `scale = sqrt(2 * qf(level, 2, n-1))`, which gives a wider ellipse for small samples.
+- `Correlation.corPearson()` returns `0` when `bottomSquared == 0` (one or both variables are constant). The Pearson correlation is mathematically undefined in this case; returning `0` falsely signals "no correlation" to callers.
+- `Normalize.minMaxNormNullValue()` returns `Double.NaN` for `Integer`/`Long` null-sentinel values, while `meanNormNullValue()` returns `Float.NaN` for the same input types. Code that normalises an Integer column with both methods will see inconsistent null-sentinel types.
+
+---
+
+## 0. Add toString override to GoalSeek.Result
+This task is already completed
+
+## 1. LinearRegression.summary() Matrix Orientation Fix
+
+**File:** `matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy`
+
+1.1 [ ] Add a test in `matrix-stats/src/test/groovy/LinearRegressionTest.groovy` that calls `summary()` on a valid regression, parses the returned string (which contains `coefficients.content()`), and asserts that it contains both the intercept label, the slope label, and at least one formatted numeric value. This confirms the matrix is well-formed before and after the fix.
+
+1.2 [ ] Replace the `.rows([...])` call at lines 219-223 with `.columns([...])`. The current three inner lists are already column-oriented (labels, estimates, std-errors), so switching from `.rows()` to `.columns()` eliminates the unintended transpose and aligns the two data columns with the three declared column names:
+
+```groovy
+.columns([
+    [interceptLab, xLab],
+    [getIntercept(3), getSlope(3)],
+    [getInterceptStdErr(3), getSlopeStdErr(3)]
+])
+```
+
+1.3 [ ] Run and record verification:
+- [ ] `./gradlew :matrix-stats:codenarcMain`
+- [ ] `./gradlew :matrix-stats:spotlessCheck`
+- [ ] `./gradlew :matrix-stats:test --tests 'LinearRegressionTest'`
+- [ ] `./gradlew :matrix-stats:test`
+
+---
+
+## 2. Normalize.logNorm() Negative-Input Guard
+
+**File:** `matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy`
+
+2.1 [ ] Add a test in `matrix-stats/src/test/groovy/NormalizeTest.groovy` asserting that `Normalize.logNorm(-5.0)` returns `null`, `Normalize.logNorm(-1G)` returns `null`, and `Normalize.logNorm(0)` still returns `null`. Also add a list-level test that `Normalize.logNorm([-1.0, 2.0, null])` returns `[null, <value>, null]` without throwing.
+
+2.2 [ ] Extend the guard at line 34 to include negative values:
+
+```groovy
+if (x == null || x <= 0) return null
+```
+
+This matches the behaviour already enforced by `NumberExtension.log()` and the documented contract ("null/NaN for invalid input"). The single-element `logNorm(T x)` method and both list overloads share this path, so no additional change is needed for list normalisation.
+
+2.3 [ ] Run and record verification:
+- [ ] `./gradlew :matrix-stats:codenarcMain`
+- [ ] `./gradlew :matrix-stats:spotlessCheck`
+- [ ] `./gradlew :matrix-stats:test --tests 'NormalizeTest'`
+- [ ] `./gradlew :matrix-stats:test`
+
+---
+
+## 3. Ellipse 't' Type: F-Distribution Scale
+
+**File:** `matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Ellipse.groovy`
+
+3.1 [ ] Add tests in `matrix-stats/src/test/groovy/EllipseTest.groovy` that:
+- For `type = 't'` with a small sample (e.g., n = 5, level = 0.95), assert that the resulting ellipse axes are strictly larger than those produced by `type = 'norm'` on the same data, matching the F-distribution formula.
+- For a very large sample (e.g., n = 1000), assert that the `'t'` and `'norm'` ellipses converge to within a small tolerance, since `F(0.95, 2, 999) ≈ χ²(0.95, 2) / 2`.
+
+Remove or update the existing comment at `EllipseTest.groovy:114` that states "'t' and 'norm' should produce same results for this implementation", as that documents the incorrect behaviour.
+
+3.2 [ ] Replace the chi-squared quantile used for type `'t'` with the F-distribution scale. In the `calculate()` method, the `'t'` branch (currently using `chiSq.inverseCumulativeProbability(level)`) should become:
+
+```groovy
+case 't':
+    FDistribution fDist = new FDistribution(2, n - 1)
+    scale = Math.sqrt(2.0 * fDist.inverseCumulativeProbability(level))
+    break
+```
+
+The existing `FDistribution` class in `se.alipsa.matrix.stats.distribution` is already available as a project dependency. The `'norm'` branch is correct as-is (`scale = Math.sqrt(chiSq.inverseCumulativeProbability(level))`).
+
+3.3 [ ] Update the GroovyDoc for `Ellipse.calculate()` to document the distinction: `'t'` uses an F-distribution scale suitable for finite samples (equivalent to ggplot2's `stat_ellipse` `type = "t"`); `'norm'` uses a chi-squared(2) scale assuming asymptotic normality.
+
+3.4 [ ] Run and record verification:
+- [ ] `./gradlew :matrix-stats:codenarcMain`
+- [ ] `./gradlew :matrix-stats:spotlessCheck`
+- [ ] `./gradlew :matrix-stats:test --tests 'EllipseTest'`
+- [ ] `./gradlew :matrix-stats:test`
+
+---
+
+## 4. Correlation.corPearson() Undefined-Correlation Handling
+
+**File:** `matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Correlation.groovy`
+
+4.1 [ ] Add tests in `matrix-stats/src/test/groovy/CorrelationTest.groovy` for:
+- `corPearson([1,1,1], [2,4,6])` — x is constant, result should be `null` (or `Double.NaN` per chosen convention; see 4.2).
+- `corPearson([1,2,3], [5,5,5])` — y is constant, same expected result.
+- `corPearson([3,3,3], [7,7,7])` — both constant.
+
+4.2 [ ] Change the `if (bottomSquared == 0) { return 0 }` guard at line 113 to return `null` instead of `0`, consistent with how other undefined statistical results are signalled in this module:
+
+```groovy
+if (bottomSquared == 0) { return null }
+```
+
+If the existing Spearman and Kendall overloads have callers that assume a numeric return, add a GroovyDoc note that `null` is returned when one or both inputs have zero variance.
+
+4.3 [ ] Verify that `corSpearman()` and `corKendall()` are not affected (they delegate to their own denominators and are not expected to call `corPearson()` directly with constant-rank inputs).
+
+4.4 [ ] Run and record verification:
+- [ ] `./gradlew :matrix-stats:codenarcMain`
+- [ ] `./gradlew :matrix-stats:spotlessCheck`
+- [ ] `./gradlew :matrix-stats:test --tests 'CorrelationTest'`
+- [ ] `./gradlew :matrix-stats:test`
+
+---
+
+## 5. Normalize: Consistent Null-Sentinel Type for Integer/Long
+
+**File:** `matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy`
+
+5.1 [ ] Add tests in `matrix-stats/src/test/groovy/NormalizeTest.groovy` that normalise an `Integer` column (e.g., `[1, null, 3]`) with both `minMaxNorm` and `meanNorm` and assert that in both cases the null-sentinel position produces the same class (`Double.NaN` or `null`).
+
+5.2 [ ] Align `meanNormNullValue()` with `minMaxNormNullValue()` for `Integer` and `Long` inputs by returning `Double.NaN` (the same sentinel used by `minMaxNorm`). Change the `meanNormNullValue()` fallthrough case:
+
+```groovy
+// Byte, Short, Integer, Long, Float → use Double.NaN for Integer/Long, Float.NaN for Byte/Short/Float
+if (sample instanceof Integer || sample instanceof Long) {
+    return Double.NaN as T
+}
+Float.NaN as T
+```
+
+5.3 [ ] Update the GroovyDoc comment above `meanNormNullValue()` to reflect the corrected type mapping.
+
+5.4 [ ] Run and record verification:
+- [ ] `./gradlew :matrix-stats:codenarcMain`
+- [ ] `./gradlew :matrix-stats:spotlessCheck`
+- [ ] `./gradlew :matrix-stats:test --tests 'NormalizeTest'`
+- [ ] `./gradlew :matrix-stats:test`
+
+---
+
+## 6. Final Verification and Release Notes
+
+6.1 [ ] Run module verification in the repository-required order:
+- [ ] `./gradlew :matrix-stats:codenarcMain`
+- [ ] `./gradlew :matrix-stats:spotlessCheck`
+- [ ] `./gradlew :matrix-stats:test`
+
+6.2 [ ] Run full regression verification before release/merge:
+- [ ] `./gradlew test`
+
+6.3 [ ] Record all exact passing commands in this plan or in the PR description before marking any implementation section complete.
+
+6.4 [ ] Update `matrix-stats/release.md` with a v2.5.1 section documenting the five bug fixes.
+
+6.5 [ ] Confirm no unrelated generated artifacts or local build outputs are included in the PR.

--- a/matrix-stats/req/2.5.1-plan.md
+++ b/matrix-stats/req/2.5.1-plan.md
@@ -23,9 +23,9 @@ This task is already completed
 
 **File:** `matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy`
 
-1.1 [ ] Add a test in `matrix-stats/src/test/groovy/LinearRegressionTest.groovy` that calls `summary()` on a valid regression, parses the returned string (which contains `coefficients.content()`), and asserts that it contains both the intercept label, the slope label, and at least one formatted numeric value. This confirms the matrix is well-formed before and after the fix.
+1.1 [x] Add a test in `matrix-stats/src/test/groovy/LinearRegressionTest.groovy` that calls `summary()` on a valid regression, parses the returned string (which contains `coefficients.content()`), and asserts that it contains both the intercept label, the slope label, and at least one formatted numeric value. This confirms the matrix is well-formed before and after the fix.
 
-1.2 [ ] Replace the `.rows([...])` call at lines 219-223 with `.columns([...])`. The current three inner lists are already column-oriented (labels, estimates, std-errors), so switching from `.rows()` to `.columns()` eliminates the unintended transpose and aligns the two data columns with the three declared column names:
+1.2 [x] Replace the `.rows([...])` call at lines 219-223 with `.columns([...])`. The current three inner lists are already column-oriented (labels, estimates, std-errors), so switching from `.rows()` to `.columns()` eliminates the unintended transpose and aligns the two data columns with the three declared column names:
 
 ```groovy
 .columns([
@@ -35,11 +35,11 @@ This task is already completed
 ])
 ```
 
-1.3 [ ] Run and record verification:
-- [ ] `./gradlew :matrix-stats:codenarcMain`
-- [ ] `./gradlew :matrix-stats:spotlessCheck`
-- [ ] `./gradlew :matrix-stats:test --tests 'LinearRegressionTest'`
-- [ ] `./gradlew :matrix-stats:test`
+1.3 [x] Run and record verification:
+- [x] `./gradlew :matrix-stats:codenarcMain` — passed
+- [x] `./gradlew :matrix-stats:spotlessCheck` — passed
+- [x] `./gradlew :matrix-stats:test --tests 'LinearRegressionTest'` — passed (13 tests)
+- [x] `./gradlew :matrix-stats:test` — passed (1003 tests)
 
 ---
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy
@@ -216,7 +216,7 @@ class LinearRegression {
     Matrix coefficients = Matrix.builder()
     .matrixName('Coefficients')
     .columnNames(['           ','Estimate','Std. Error' /*, 't value', 'Pr(>|t|)'*/])
-    .rows([
+    .columns([
             [interceptLab, xLab],
             [getIntercept(3), getSlope(3)],
             [getInterceptStdErr(3), getSlopeStdErr(3)]

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/GoalSeek.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/solver/GoalSeek.groovy
@@ -250,5 +250,10 @@ class GoalSeek {
       }
       super.asType(targetType)
     }
+
+    @Override
+    String toString() {
+      "[value:$value, result:$result, diff:$diff, iterations:$iterations]"
+    }
   }
 }

--- a/matrix-stats/src/test/groovy/LinearRegressionTest.groovy
+++ b/matrix-stats/src/test/groovy/LinearRegressionTest.groovy
@@ -183,4 +183,19 @@ class LinearRegressionTest {
 
     assertEquals("Matrix value at row 0, column 'y' must be numeric", exception.message)
   }
+
+  @Test
+  void testSummaryContainsInterceptSlopeAndNumericValue() {
+    def table = Matrix.builder().data(
+      x: [2, 3, 5, 7, 9, 11, 14],
+      y: [4.02, 5.44, 7.12, 10.88, 15.10, 20.91, 26.02]
+    ).build()
+    def model = new LinearRegression(table, 'x', 'y')
+    def summary = model.summary()
+
+    assertTrue(summary.contains('(Intercept)'), 'Summary should contain intercept label')
+    assertTrue(summary.contains('x'), 'Summary should contain slope label')
+    assertTrue(summary.contains('Std. Error'), 'Summary should contain std error column')
+    assertNotNull(summary.find(/\d+\.\d+/), 'Summary should contain a formatted numeric value')
+  }
 }

--- a/matrix-stats/src/test/groovy/rootfinding/GoalSeekTest.groovy
+++ b/matrix-stats/src/test/groovy/rootfinding/GoalSeekTest.groovy
@@ -68,6 +68,12 @@ class GoalSeekTest {
   }
 
   @Test
+  void testResultToString() {
+    def result = GoalSeek.solve(27000, 0, 100) { it * 100_000 }
+    assertTrue(result.toString() ==~ /.*\[value:.*, result:.*, diff:.*, iterations:\d+\].*/)
+  }
+
+  @Test
   void testMatchesApacheBrentReference() {
     double target = 27000.0d
     double minValue = 0.0d


### PR DESCRIPTION
Fixes the matrix orientation bug in `LinearRegression.summary()` where `.rows()` was transposing the coefficient columns, causing a column-name/data mismatch.

## Changes
- `matrix-stats/src/main/groovy/se/alipsa/matrix/stats/regression/LinearRegression.groovy`: switched from `.rows()` to `.columns()` so the three declared column names align with the three data columns.
- `matrix-stats/src/test/groovy/LinearRegressionTest.groovy`: added `testSummaryContainsInterceptSlopeAndNumericValue` to verify `summary()` output contains the intercept label, slope label, `Std. Error` column, and a formatted numeric value.
- `matrix-stats/req/2.5.1-plan.md`: marked task 1 complete and recorded verification commands.

## Tests run
- `./gradlew :matrix-stats:codenarcMain` — passed
- `./gradlew :matrix-stats:spotlessCheck` — passed
- `./gradlew :matrix-stats:test --tests 'LinearRegressionTest'` — passed (13 tests)
- `./gradlew :matrix-stats:test` — passed (1003 tests)