### PR TITLE
Fix Normalize.logNorm negative inputs

### DIFF
--- a/matrix-stats/req/2.5.1-plan.md
+++ b/matrix-stats/req/2.5.1-plan.md
@@ -47,9 +47,9 @@ This task is already completed
 
 **File:** `matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy`
 
-2.1 [ ] Add a test in `matrix-stats/src/test/groovy/NormalizeTest.groovy` asserting that `Normalize.logNorm(-5.0)` returns `null`, `Normalize.logNorm(-1G)` returns `null`, and `Normalize.logNorm(0)` still returns `null`. Also add a list-level test that `Normalize.logNorm([-1.0, 2.0, null])` returns `[null, <value>, null]` without throwing.
+2.1 [x] Add a test in `matrix-stats/src/test/groovy/NormalizeTest.groovy` asserting that `Normalize.logNorm(-5.0)` returns `null`, `Normalize.logNorm(-1G)` returns `null`, and `Normalize.logNorm(0)` still returns `null`. Also add a list-level test that `Normalize.logNorm([-1.0, 2.0, null])` returns `[null, <value>, null]` without throwing.
 
-2.2 [ ] Extend the guard at line 34 to include negative values:
+2.2 [x] Extend the guard at line 34 to include negative values:
 
 ```groovy
 if (x == null || x <= 0) return null
@@ -57,11 +57,12 @@ if (x == null || x <= 0) return null
 
 This matches the behaviour already enforced by `NumberExtension.log()` and the documented contract ("null/NaN for invalid input"). The single-element `logNorm(T x)` method and both list overloads share this path, so no additional change is needed for list normalisation.
 
-2.3 [ ] Run and record verification:
-- [ ] `./gradlew :matrix-stats:codenarcMain`
-- [ ] `./gradlew :matrix-stats:spotlessCheck`
-- [ ] `./gradlew :matrix-stats:test --tests 'NormalizeTest'`
-- [ ] `./gradlew :matrix-stats:test`
+2.3 [x] Run and record verification:
+- [x] `./gradlew :matrix-stats:codenarcMain` — passed
+- [x] `./gradlew :matrix-stats:spotlessCheck` — passed
+- [x] `./gradlew :matrix-stats:test --tests 'NormalizeTest'` — passed (25 tests)
+- [x] `./gradlew :matrix-stats:test` — passed (1006 tests)
+- [x] `./gradlew test` — passed
 
 ---
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
@@ -31,8 +31,8 @@ class Normalize {
    * @return the natural logarithm (base e) of the x value, or null/NaN for invalid input
    */
   static <T extends Number> T logNorm(T x, int... decimals) {
-    if (x == null || x == 0) {
-      return null  // logNorm always returns null for zero/invalid
+    if (x == null || x <= 0) {
+      return null  // logNorm always returns null for zero/negative/invalid
     }
 
     if (x instanceof Float && (x as Float).isInfinite()) {

--- a/matrix-stats/src/test/groovy/NormalizeTest.groovy
+++ b/matrix-stats/src/test/groovy/NormalizeTest.groovy
@@ -76,6 +76,29 @@ class NormalizeTest {
     assertIterableEquals([null]*3, Normalize.logNorm([0.0g, 0.0g, 0.0g]), 'BigDecimal should be null')
   }
 
+  /**
+   * Verifies logarithmic normalization returns null for non-positive scalar values.
+   */
+  @Test
+  void testLogNormNonPositiveScalarsReturnNull() {
+    assertNull(Normalize.logNorm(-5.0))
+    assertNull(Normalize.logNorm(-1G))
+    assertNull(Normalize.logNorm(0))
+  }
+
+  /**
+   * Verifies logarithmic normalization preserves list shape when non-positive values are present.
+   */
+  @Test
+  void testLogNormListWithNegativeValueReturnsNullSlot() {
+    List result = Normalize.logNorm([-1.0, 2.0, null])
+
+    assertEquals(3, result.size())
+    assertNull(result[0])
+    assertEquals(Math.log(2.0d), (result[1] as Number).doubleValue(), 1e-6d)
+    assertNull(result[2])
+  }
+
   @Test
   void testMinMaxNormDouble() {
 


### PR DESCRIPTION
## Summary
- Return `null` for negative `Normalize.logNorm` scalar inputs instead of letting negative values reach logarithm evaluation.
- Add scalar and list regression tests covering negative, zero, positive, and null log-normalization inputs.
- Mark task 2 complete in `matrix-stats/req/2.5.1-plan.md` with verification results.

## Modules touched
- `matrix-stats`

## Verification
- `./gradlew :matrix-stats:codenarcMain` — passed
- `./gradlew :matrix-stats:spotlessCheck` — passed
- `./gradlew :matrix-stats:test --tests 'NormalizeTest'` — passed (25 tests)
- `./gradlew :matrix-stats:test` — passed (1006 tests)
- `./gradlew test` — passed