### PR TITLE
[codex] Fix stats ellipse t scale

### DIFF
--- a/matrix-stats/req/2.5.1-plan.md
+++ b/matrix-stats/req/2.5.1-plan.md
@@ -70,13 +70,13 @@ This matches the behaviour already enforced by `NumberExtension.log()` and the d
 
 **File:** `matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Ellipse.groovy`
 
-3.1 [ ] Add tests in `matrix-stats/src/test/groovy/EllipseTest.groovy` that:
+3.1 [x] Add tests in `matrix-stats/src/test/groovy/EllipseTest.groovy` that:
 - For `type = 't'` with a small sample (e.g., n = 5, level = 0.95), assert that the resulting ellipse axes are strictly larger than those produced by `type = 'norm'` on the same data, matching the F-distribution formula.
 - For a very large sample (e.g., n = 1000), assert that the `'t'` and `'norm'` ellipses converge to within a small tolerance, since `F(0.95, 2, 999) ≈ χ²(0.95, 2) / 2`.
 
 Remove or update the existing comment at `EllipseTest.groovy:114` that states "'t' and 'norm' should produce same results for this implementation", as that documents the incorrect behaviour.
 
-3.2 [ ] Replace the chi-squared quantile used for type `'t'` with the F-distribution scale. In the `calculate()` method, the `'t'` branch (currently using `chiSq.inverseCumulativeProbability(level)`) should become:
+3.2 [x] Replace the chi-squared quantile used for type `'t'` with the F-distribution scale. In the `calculate()` method, the `'t'` branch (currently using `chiSq.inverseCumulativeProbability(level)`) should become:
 
 ```groovy
 case 't':
@@ -87,13 +87,14 @@ case 't':
 
 The existing `FDistribution` class in `se.alipsa.matrix.stats.distribution` is already available as a project dependency. The `'norm'` branch is correct as-is (`scale = Math.sqrt(chiSq.inverseCumulativeProbability(level))`).
 
-3.3 [ ] Update the GroovyDoc for `Ellipse.calculate()` to document the distinction: `'t'` uses an F-distribution scale suitable for finite samples (equivalent to ggplot2's `stat_ellipse` `type = "t"`); `'norm'` uses a chi-squared(2) scale assuming asymptotic normality.
+3.3 [x] Update the GroovyDoc for `Ellipse.calculate()` to document the distinction: `'t'` uses an F-distribution scale suitable for finite samples (equivalent to ggplot2's `stat_ellipse` `type = "t"`); `'norm'` uses a chi-squared(2) scale assuming asymptotic normality.
 
-3.4 [ ] Run and record verification:
-- [ ] `./gradlew :matrix-stats:codenarcMain`
-- [ ] `./gradlew :matrix-stats:spotlessCheck`
-- [ ] `./gradlew :matrix-stats:test --tests 'EllipseTest'`
-- [ ] `./gradlew :matrix-stats:test`
+3.4 [x] Run and record verification:
+- [x] `./gradlew :matrix-stats:codenarcMain` — passed
+- [x] `./gradlew :matrix-stats:spotlessCheck` — passed
+- [x] `./gradlew :matrix-stats:test --tests 'EllipseTest'` — passed (16 tests)
+- [x] `./gradlew :matrix-stats:test` — passed (1008 tests)
+- [x] `./gradlew test` — passed
 
 ---
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Ellipse.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Ellipse.groovy
@@ -1,6 +1,7 @@
 package se.alipsa.matrix.stats
 
 import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
+import se.alipsa.matrix.stats.distribution.FDistribution
 
 /**
  * Confidence ellipse calculations for bivariate normal data.
@@ -27,7 +28,9 @@ class Ellipse {
    * @param xValues X coordinates
    * @param yValues Y coordinates
    * @param level Confidence level (default 0.95)
-   * @param type Ellipse type: 't', 'norm', or 'euclid' (default 't')
+   * @param type Ellipse type: 't', 'norm', or 'euclid' (default 't'). The 't' type uses an
+   * F-distribution scale for finite samples, equivalent to ggplot2's {@code stat_ellipse(type = "t")}.
+   * The 'norm' type uses a chi-squared(2) scale for asymptotic normality.
    * @param segments Number of points to generate (default 51)
    * @return EllipseData containing x,y coordinates of the ellipse
    * @throws IllegalArgumentException if either input has fewer than 3 points or the input sizes differ
@@ -93,17 +96,7 @@ class Ellipse {
       theta = Math.atan2(lambda1 - varX, covXY)
     }
 
-    // Scale factor based on confidence level
-    double scale
-    if (type == 't' || type == 'norm') {
-      // Use chi-square quantile for multivariate normal (2 degrees of freedom)
-      // For bivariate normal, confidence ellipse is based on chi-square(2)
-      ChiSquaredDistribution chiSq = new ChiSquaredDistribution(2)
-      double quantile = chiSq.inverseCumulativeProbability(level)
-      scale = Math.sqrt(quantile)
-    } else {
-      scale = 1.0
-    }
+    double scale = scaleFor(type, level, n)
 
     // Generate ellipse points
     List<BigDecimal> ellipseX = []
@@ -130,5 +123,17 @@ class Ellipse {
     }
 
     new EllipseData(ellipseX, ellipseY)
+  }
+
+  private static double scaleFor(String type, double level, int n) {
+    if (type == 't') {
+      FDistribution fDist = new FDistribution(2, n - 1)
+      return Math.sqrt(2.0d * (fDist.inverseCumulativeProbability(level) as double))
+    }
+    if (type == 'norm') {
+      ChiSquaredDistribution chiSq = new ChiSquaredDistribution(2)
+      return Math.sqrt(chiSq.inverseCumulativeProbability(level) as double)
+    }
+    1.0d
   }
 }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Ellipse.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Ellipse.groovy
@@ -125,7 +125,7 @@ class Ellipse {
     new EllipseData(ellipseX, ellipseY)
   }
 
-  private static double scaleFor(String type, double level, int n) {
+  private static double scaleFor(String type, Number level, int n) {
     if (type == 't') {
       FDistribution fDist = new FDistribution(2, n - 1)
       return Math.sqrt(2.0d * (fDist.inverseCumulativeProbability(level) as double))

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/FDistribution.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/distribution/FDistribution.groovy
@@ -10,6 +10,7 @@ import se.alipsa.matrix.stats.util.NumericConversion
  */
 @SuppressWarnings('DuplicateNumberLiteral')
 class FDistribution implements ContinuousDistribution {
+  private static final int MAX_INVERSE_ITERATIONS = 100
   private static final String GROUP_LABEL = 'group'
 
   private final BigDecimal dfNumerator
@@ -86,6 +87,65 @@ class FDistribution implements ContinuousDistribution {
   @Deprecated
   double cumulativeProbability(double f) {
     cdfValue(f)
+  }
+
+  /**
+   * Computes the inverse cumulative distribution function for the F-distribution.
+   *
+   * @param p probability in [0, 1]
+   * @return the F-value where {@code P(F <= f) = p}
+   */
+  BigDecimal inverseCumulativeProbability(Number p) {
+    BigDecimal.valueOf(inverseCumulativeProbabilityValue(NumericConversion.toFiniteDouble(p, 'p')))
+  }
+
+  /**
+   * Primitive compatibility bridge retained during the idiomatic API transition.
+   *
+   * @param p probability in [0, 1]
+   * @return the F-value where {@code P(F <= f) = p}
+   * @deprecated Prefer {@link #inverseCumulativeProbability(Number)}
+   */
+  @Deprecated
+  double inverseCumulativeProbability(double p) {
+    inverseCumulativeProbabilityValue(p)
+  }
+
+  private double inverseCumulativeProbabilityValue(double p) {
+    if (p < 0.0d || p > 1.0d) {
+      throw new IllegalArgumentException("p must be between 0 and 1, got: $p")
+    }
+    if (p == 0.0d) {
+      return 0.0d
+    }
+    if (p == 1.0d) {
+      return Double.POSITIVE_INFINITY
+    }
+
+    double low = 0.0d
+    double high = 1.0d
+    while (cdfValue(high) < p) {
+      low = high
+      high *= 2.0d
+      if (high > Double.MAX_VALUE / 4.0d) {
+        break
+      }
+    }
+
+    for (int i = 0; i < MAX_INVERSE_ITERATIONS; i++) {
+      double mid = 0.5d * (low + high)
+      double cdf = cdfValue(mid)
+      if (Math.abs(cdf - p) < 1e-12d || high - low < 1e-12d * Math.max(1.0d, mid)) {
+        return mid
+      }
+      if (cdf < p) {
+        low = mid
+      } else {
+        high = mid
+      }
+    }
+
+    0.5d * (low + high)
   }
 
   /**

--- a/matrix-stats/src/test/groovy/EllipseTest.groovy
+++ b/matrix-stats/src/test/groovy/EllipseTest.groovy
@@ -3,6 +3,8 @@ import static org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
 import se.alipsa.matrix.stats.Ellipse
+import se.alipsa.matrix.stats.distribution.ChiSquaredDistribution
+import se.alipsa.matrix.stats.distribution.FDistribution
 
 /**
  * Unit tests for the Ellipse class, covering mathematical correctness,
@@ -111,7 +113,6 @@ class EllipseTest {
     assertEquals(51, resultNorm.x.size())
     assertAllFinite(resultNorm.x, resultNorm.y)
 
-    // 't' and 'norm' should produce same results for this implementation
     assertEquals(resultT.x.size(), resultNorm.x.size())
 
     // Test 'euclid' type (scale = 1.0, smaller ellipse)
@@ -123,6 +124,39 @@ class EllipseTest {
     def maxRadiusT = calculateMaxRadius(resultT.x, resultT.y)
     def maxRadiusEuclid = calculateMaxRadius(resultEuclid.x, resultEuclid.y)
     assertTrue(maxRadiusEuclid < maxRadiusT, 'Euclid ellipse should be smaller than t-type')
+  }
+
+  @Test
+  void testTTypeUsesFiniteSampleFDistributionScale() {
+    def xVals = [1G, 2G, 3G, 4G, 5G]
+    def yVals = [2G, 4G, 3G, 5G, 6G]
+    double level = 0.95
+
+    def resultT = Ellipse.calculate(xVals, yVals, level, 't', 101)
+    def resultNorm = Ellipse.calculate(xVals, yVals, level, 'norm', 101)
+
+    double radiusT = calculateMaxRadiusFromMean(resultT.x, resultT.y, xVals, yVals)
+    double radiusNorm = calculateMaxRadiusFromMean(resultNorm.x, resultNorm.y, xVals, yVals)
+    double expectedRatio = Math.sqrt(
+        2.0d * (new FDistribution(2, xVals.size() - 1).inverseCumulativeProbability(level) as double)
+    ) / Math.sqrt(new ChiSquaredDistribution(2).inverseCumulativeProbability(level) as double)
+
+    assertTrue(radiusT > radiusNorm, 'Finite-sample t ellipse should be wider than norm ellipse')
+    assertEquals(expectedRatio, radiusT / radiusNorm, 1e-9d)
+  }
+
+  @Test
+  void testTTypeConvergesToNormTypeForLargeSamples() {
+    def xVals = (1..1000).collect { int i -> i as BigDecimal }
+    def yVals = xVals.collect { BigDecimal x -> (x * 0.75G + ((x as int) % 7)) as BigDecimal }
+
+    def resultT = Ellipse.calculate(xVals, yVals, 0.95, 't', 101)
+    def resultNorm = Ellipse.calculate(xVals, yVals, 0.95, 'norm', 101)
+
+    double radiusT = calculateMaxRadiusFromMean(resultT.x, resultT.y, xVals, yVals)
+    double radiusNorm = calculateMaxRadiusFromMean(resultNorm.x, resultNorm.y, xVals, yVals)
+
+    assertEquals(1.0d, radiusT / radiusNorm, 0.01d)
   }
 
   @Test
@@ -186,9 +220,11 @@ class EllipseTest {
     BigDecimal meanX = xVals.sum() / xVals.size()
     BigDecimal meanY = yVals.sum() / yVals.size()
 
-    // Calculate centroid of ellipse
-    BigDecimal ellipseCenterX = result.x.sum() / result.x.size()
-    BigDecimal ellipseCenterY = result.y.sum() / result.y.size()
+    // Calculate centroid of ellipse, excluding the duplicated closing point
+    List<BigDecimal> uniqueX = result.x[0..-2]
+    List<BigDecimal> uniqueY = result.y[0..-2]
+    BigDecimal ellipseCenterX = uniqueX.sum() / uniqueX.size()
+    BigDecimal ellipseCenterY = uniqueY.sum() / uniqueY.size()
 
     // Ellipse center should be very close to data mean
     assertTrue(Math.abs((ellipseCenterX - meanX) as double) < 0.1,
@@ -261,6 +297,23 @@ class EllipseTest {
     for (int i = 0; i < xVals.size(); i++) {
       double dx = (xVals[i] as double) - centerX
       double dy = (yVals[i] as double) - centerY
+      double dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist > maxDist) {
+        maxDist = dist
+      }
+    }
+    maxDist
+  }
+
+  private double calculateMaxRadiusFromMean(List<BigDecimal> ellipseX, List<BigDecimal> ellipseY,
+                                            List<BigDecimal> dataX, List<BigDecimal> dataY) {
+    double centerX = (dataX.sum() / dataX.size()) as double
+    double centerY = (dataY.sum() / dataY.size()) as double
+
+    double maxDist = 0
+    for (int i = 0; i < ellipseX.size(); i++) {
+      double dx = (ellipseX[i] as double) - centerX
+      double dy = (ellipseY[i] as double) - centerY
       double dist = Math.sqrt(dx * dx + dy * dy)
       if (dist > maxDist) {
         maxDist = dist

--- a/matrix-stats/src/test/groovy/EllipseTest.groovy
+++ b/matrix-stats/src/test/groovy/EllipseTest.groovy
@@ -130,7 +130,7 @@ class EllipseTest {
   void testTTypeUsesFiniteSampleFDistributionScale() {
     def xVals = [1G, 2G, 3G, 4G, 5G]
     def yVals = [2G, 4G, 3G, 5G, 6G]
-    double level = 0.95
+    Number level = 0.95
 
     def resultT = Ellipse.calculate(xVals, yVals, level, 't', 101)
     def resultNorm = Ellipse.calculate(xVals, yVals, level, 'norm', 101)


### PR DESCRIPTION
## Summary
- Change `Ellipse.calculate(..., type: 't')` to use the finite-sample F-distribution scale instead of the chi-squared scale used by `norm`.
- Add `FDistribution.inverseCumulativeProbability(...)` so the native distribution can provide the needed quantile.
- Add regression coverage for small-sample widening and large-sample convergence, and record task 3 verification in `matrix-stats/req/2.5.1-plan.md`.

## Modules touched
- `matrix-stats`

## Tests
- `./gradlew :matrix-stats:codenarcMain`
- `./gradlew :matrix-stats:spotlessCheck`
- `./gradlew :matrix-stats:test --tests 'EllipseTest'`
- `./gradlew :matrix-stats:test`
- `./gradlew test`