### PR TITLE
[codex] Fix undefined Pearson correlation

### DIFF
--- a/matrix-examples/whiskey/src/main/gmd/WhiskeyAnalysis.gmd
+++ b/matrix-examples/whiskey/src/main/gmd/WhiskeyAnalysis.gmd
@@ -116,7 +116,8 @@ import se.alipsa.matrix.stats.*
 import se.alipsa.matrix.xchart.*
 
 def corr = [(size - 1)..0, 0..<size].combinations().collect { i, j ->
-  Correlation.cor(data*.getAt(j), data*.getAt(i)) * 100 as int
+  def correlation = Correlation.cor(data*.getAt(j), data*.getAt(i))
+  correlation == null ? 0 : correlation * 100 as int
 }
 
 def corrMatrix = Matrix.builder().data(X: 0..<corr.size(), Heat: corr)

--- a/matrix-examples/whiskey/src/main/groovy/WhiskeyAnalysis.groovy
+++ b/matrix-examples/whiskey/src/main/groovy/WhiskeyAnalysis.groovy
@@ -91,7 +91,8 @@ CorrelationHeatmapChart.create(m)
   .display()
 
 corr = [(size - 1)..0, 0..<size].combinations().collect { int i, int j ->
-  Correlation.cor(data[j] as List<? extends Number>, data[i] as List<? extends Number>) * 100 as int
+  def correlation = Correlation.cor(data[j] as List<? extends Number>, data[i] as List<? extends Number>)
+  correlation == null ? 0 : correlation * 100 as int
 }
 
 corrMatrix = Matrix.builder().data(X: 0..<corr.size(), Heat: corr)

--- a/matrix-stats/req/2.5.1-plan.md
+++ b/matrix-stats/req/2.5.1-plan.md
@@ -102,12 +102,12 @@ The existing `FDistribution` class in `se.alipsa.matrix.stats.distribution` is a
 
 **File:** `matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Correlation.groovy`
 
-4.1 [ ] Add tests in `matrix-stats/src/test/groovy/CorrelationTest.groovy` for:
+4.1 [x] Add tests in `matrix-stats/src/test/groovy/CorrelationTest.groovy` for:
 - `corPearson([1,1,1], [2,4,6])` — x is constant, result should be `null` (or `Double.NaN` per chosen convention; see 4.2).
 - `corPearson([1,2,3], [5,5,5])` — y is constant, same expected result.
 - `corPearson([3,3,3], [7,7,7])` — both constant.
 
-4.2 [ ] Change the `if (bottomSquared == 0) { return 0 }` guard at line 113 to return `null` instead of `0`, consistent with how other undefined statistical results are signalled in this module:
+4.2 [x] Change the `if (bottomSquared == 0) { return 0 }` guard at line 113 to return `null` instead of `0`, consistent with how other undefined statistical results are signalled in this module:
 
 ```groovy
 if (bottomSquared == 0) { return null }
@@ -115,13 +115,14 @@ if (bottomSquared == 0) { return null }
 
 If the existing Spearman and Kendall overloads have callers that assume a numeric return, add a GroovyDoc note that `null` is returned when one or both inputs have zero variance.
 
-4.3 [ ] Verify that `corSpearman()` and `corKendall()` are not affected (they delegate to their own denominators and are not expected to call `corPearson()` directly with constant-rank inputs).
+4.3 [x] Verify that existing `corSpearman()` and `corKendall()` behavior is preserved for covered non-constant inputs. `corSpearman()` delegates to `corPearson()` on ranks, so constant-rank inputs now follow the same undefined/null behavior; the GroovyDoc documents that case.
 
-4.4 [ ] Run and record verification:
-- [ ] `./gradlew :matrix-stats:codenarcMain`
-- [ ] `./gradlew :matrix-stats:spotlessCheck`
-- [ ] `./gradlew :matrix-stats:test --tests 'CorrelationTest'`
-- [ ] `./gradlew :matrix-stats:test`
+4.4 [x] Run and record verification:
+- [x] `./gradlew :matrix-stats:codenarcMain` — passed
+- [x] `./gradlew :matrix-stats:spotlessCheck` — passed
+- [x] `./gradlew :matrix-stats:test --tests 'CorrelationTest'` — passed (9 tests)
+- [x] `./gradlew :matrix-stats:test` — passed (1011 tests)
+- [x] `./gradlew test` — passed
 
 ---
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Correlation.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Correlation.groovy
@@ -51,6 +51,7 @@ package se.alipsa.matrix.stats
  *   <li><b>+1</b>: Perfect positive correlation</li>
  *   <li><b>0</b>: No correlation</li>
  *   <li><b>-1</b>: Perfect negative correlation</li>
+ *   <li><b>null</b>: Undefined correlation, for example when an input has zero variance</li>
  * </ul>
  *
  * @see <a href="https://en.wikipedia.org/wiki/Pearson_correlation_coefficient">Pearson Correlation</a>
@@ -83,7 +84,7 @@ class Correlation {
    * @param numbersX the first list of Numbers
    * @param numbersY the second list of Numbers
    * @return a value between -1 to +1 where -1 represents X and Y are negatively correlated
-   * and +1 represents X and Y are positively correlated
+   * and +1 represents X and Y are positively correlated, or null if either input has zero variance
    * @throws IllegalArgumentException if inputs are null, empty, of different sizes, or have insufficient observations
    */
   static BigDecimal corPearson(List<? extends Number> numbersX, List<? extends Number> numbersY) {
@@ -111,7 +112,7 @@ class Correlation {
 
     BigDecimal bottomSquared = (size * sumX2 - sumX * sumX) * (size * sumY2 - sumY * sumY)
     if (bottomSquared == 0) {
-      return 0
+      return null
     }
     BigDecimal bottom = bottomSquared.sqrt()
     BigDecimal top = size * sumXY - sumX * sumY
@@ -124,7 +125,7 @@ class Correlation {
    * @param numbersX the first list of Numbers
    * @param numbersY the second list of Numbers
    * @return a value between -1 to +1 where -1 represents X and Y are negatively correlated
-   * and +1 represents X and Y are positively correlated
+   * and +1 represents X and Y are positively correlated, or null if either ranked input has zero variance
    * @throws IllegalArgumentException if inputs are null, empty, of different sizes, or have insufficient observations
    */
   static BigDecimal corSpearman(List<? extends Number> numbersX, List<? extends Number> numbersY) {

--- a/matrix-stats/src/test/groovy/CorrelationTest.groovy
+++ b/matrix-stats/src/test/groovy/CorrelationTest.groovy
@@ -1,4 +1,5 @@
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNull
 import static se.alipsa.matrix.stats.Correlation.*
 
 import org.apache.commons.math3.stat.correlation.KendallsCorrelation
@@ -19,6 +20,21 @@ class CorrelationTest {
     assertEquals(
         0.95346258924560,
         cor([15, 18, 21, 24, 27], [25, 25, 27, 31, 32]).setScale(14, RoundingMode.HALF_EVEN))
+  }
+
+  @Test
+  void testPearsonCorrelationReturnsNullWhenXIsConstant() {
+    assertNull(corPearson([1, 1, 1], [2, 4, 6]))
+  }
+
+  @Test
+  void testPearsonCorrelationReturnsNullWhenYIsConstant() {
+    assertNull(corPearson([1, 2, 3], [5, 5, 5]))
+  }
+
+  @Test
+  void testPearsonCorrelationReturnsNullWhenBothInputsAreConstant() {
+    assertNull(corPearson([3, 3, 3], [7, 7, 7]))
   }
 
   /**

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
@@ -70,7 +70,8 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
 
   /**
    * Add a correlation heatmap series computed from the specified numeric columns.
-   * The correlation matrix is calculated using Pearson correlation coefficients.
+   * The correlation matrix is calculated using Pearson correlation coefficients. Undefined correlations
+   * from zero-variance columns are rendered as 0-valued heatmap cells.
    *
    * @param title the name for this series (displayed in legend)
    * @param columnNames the names of the numeric columns to compute correlations for
@@ -88,7 +89,7 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
       (0..<size).collect { int j ->
         List<BigDecimal> xValues = ListConverter.toBigDecimals(data[j])
         List<BigDecimal> yValues = ListConverter.toBigDecimals(data[i])
-        Correlation.cor(xValues, yValues).round(CORRELATION_SCALE)
+        roundCorrelation(Correlation.cor(xValues, yValues))
       }
     }
     def corrMatrix = Matrix.builder().data(X: 0..<corr.size(), Heat: corr)
@@ -128,6 +129,10 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
     }
     xchart.addSeries(seriesName, rowLabels, columnLabels, heatData)
     this
+  }
+
+  private static BigDecimal roundCorrelation(BigDecimal correlation) {
+    correlation == null ? 0G : correlation.round(CORRELATION_SCALE)
   }
 
   private void validateColumns(List<String> columnNames) {

--- a/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/CorrelationHeatmapChartTest.groovy
+++ b/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/CorrelationHeatmapChartTest.groovy
@@ -76,4 +76,16 @@ class CorrelationHeatmapChartTest {
     assertNotNull(chart.getSeries('Correlation'))
   }
 
+  @Test
+  void testCorrelationHeatmapAcceptsConstantNumericColumn() {
+    Matrix matrix = Matrix.builder()
+        .data(x: [1, 2, 3], constant: [5, 5, 5])
+        .types([Number, Number])
+        .build()
+
+    def chart = CorrelationHeatmapChart.create(matrix).addSeries('Correlation', ['x', 'constant'])
+
+    assertNotNull(chart.getSeries('Correlation'))
+  }
+
 }


### PR DESCRIPTION
## Summary
- Return `null` from `Correlation.corPearson()` when one or both inputs have zero variance instead of reporting `0`.
- Document undefined/null correlation results for Pearson and rank-based Spearman behavior.
- Add Pearson regression tests for constant x, constant y, and both inputs constant.
- Guard `CorrelationHeatmapChart` and the whiskey example against undefined correlations by rendering them with a `0` sentinel instead of crashing.
- Record task 4 verification in `matrix-stats/req/2.5.1-plan.md`.

## Modules touched
- `matrix-stats`
- `matrix-xchart`
- `matrix-examples:whiskey`

## Tests
- `./gradlew :matrix-stats:codenarcMain`
- `./gradlew :matrix-stats:spotlessCheck`
- `./gradlew :matrix-stats:test --tests 'CorrelationTest'`
- `./gradlew :matrix-stats:test`
- `./gradlew :matrix-xchart:codenarcMain :matrix-xchart:codenarcTest`
- `./gradlew :matrix-xchart:spotlessCheck`
- `./gradlew :matrix-xchart:test --tests 'test.alipsa.matrix.xchart.CorrelationHeatmapChartTest' -Pheadless=true`
- `./gradlew :matrix-xchart:test -Pheadless=true`
- `./gradlew :matrix-examples:whiskey:compileGroovy`
- `./gradlew test`