### PR TITLE
[codex] Fix normalize null sentinel types

### DIFF
--- a/matrix-bom/bom.xml
+++ b/matrix-bom/bom.xml
@@ -51,7 +51,7 @@
     <matrixSqlVersion>2.4.0</matrixSqlVersion>
     <matrixStatsVersion>2.5.1</matrixStatsVersion>
     <matrixTablesawVersion>0.3.0</matrixTablesawVersion>
-    <matrixXChartVersion>0.3.0</matrixXChartVersion>
+    <matrixXChartVersion>0.3.1-SNAPSHOT</matrixXChartVersion>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/matrix-stats/req/2.5.1-plan.md
+++ b/matrix-stats/req/2.5.1-plan.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This plan covers five correctness bugs found during a source-code review of the matrix-stats module at v2.5.1. Each numbered section is intended to be implementable and reviewable as a separate pull request.
+This plan covers six correctness bugs found during a source-code review of the matrix-stats module at v2.5.1. Each numbered section is intended to be implementable and reviewable as a separate pull request.
 
 A task is only complete when its tests have passed and the exact test command has been recorded in this file or the PR description.
 
@@ -13,6 +13,7 @@ A task is only complete when its tests have passed and the exact test command ha
 - `Ellipse.calculate()` with type `'t'` uses the chi-squared(2) quantile for the confidence scale, the same formula as type `'norm'`. The correct formula for `'t'` uses the F-distribution: `scale = sqrt(2 * qf(level, 2, n-1))`, which gives a wider ellipse for small samples.
 - `Correlation.corPearson()` returns `0` when `bottomSquared == 0` (one or both variables are constant). The Pearson correlation is mathematically undefined in this case; returning `0` falsely signals "no correlation" to callers.
 - `Normalize.minMaxNormNullValue()` returns `Double.NaN` for `Integer`/`Long` null-sentinel values, while `meanNormNullValue()` returns `Float.NaN` for the same input types. Code that normalises an Integer column with both methods will see inconsistent null-sentinel types.
+- Follow-up from task 5's review: `minMaxNorm`/`meanNorm` are the only "undefined result" paths left in `Normalize.groovy` that return a type-dependent `NaN` sentinel instead of plain `null`. `stdScaleNorm`, `logNorm` (post-task 2), and `Correlation.corPearson()`/`corSpearman()` (post-task 4) all already return `null` unconditionally. Rather than hardcoding one convention, add an optional, explicit sentinel choice so any consumer (not just `matrix-tablesaw`) can opt into the representation it needs.
 
 ---
 
@@ -153,18 +154,50 @@ Float.NaN as T
 
 ---
 
-## 6. Final Verification and Release Notes
+## 6. Normalize: Explicit, Opt-In Missing-Value Sentinel
 
-6.1 [ ] Run module verification in the repository-required order:
+**File:** `matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy`, `matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/Normalizer.groovy`
+
+Task 5 made `minMaxNormNullValue()` and `meanNormNullValue()` agree with each other, but both still return type-dependent sentinels (`null` for BigDecimal/BigInteger, `Float.NaN` for Byte/Short/Float, `Double.NaN` for Double/Integer/Long). Every other undefined-result path in this module — `stdScaleNorm`, `logNorm` (task 2), `Correlation.corPearson()`/`corSpearman()` (task 4) — returns plain `null` regardless of `T`. Instead of hardcoding a single implicit convention, add an explicit, optional parameter so any caller can choose the sentinel it needs, defaulting to `null` everywhere for consistency with the rest of the module.
+
+6.1 [ ] Add a `MissingValueType` enum nested in `Normalize` with values `NULL`, `FLOAT_NAN`, `DOUBLE_NAN`. Thread an optional `MissingValueType missingValueType = MissingValueType.NULL` parameter through the `minMaxNorm` and `meanNorm` overloads (`T`, `T[]`, `List`, `Matrix` column, `Matrix`), inserted **before** the trailing `int... decimals` varargs, e.g.:
+
+```groovy
+static <T extends Number> T minMaxNorm(T x, Number min, Number max,
+                                        MissingValueType missingValueType = MissingValueType.NULL,
+                                        int... decimals)
+```
+
+Confirmed during review: this ordering is backward-compatible. An enum-typed parameter cannot bind to a bare `int` literal, so existing calls like `minMaxNorm(list, 2)` keep resolving `2` to `decimals`, not the new parameter — verified with a standalone `@CompileStatic` reproduction. **Do not** type the new parameter as a plain `Number` (or anything else `int`-assignable) — that overlaps with `decimals` and silently rebinds existing positional calls, e.g. `minMaxNorm(list, 2)` would reinterpret `2` as the sentinel instead of the decimals count.
+
+6.2 [ ] Replace the private `minMaxNormNullValue()`/`meanNormNullValue()` per-type branching with a single lookup keyed on `missingValueType`: `NULL` → `null`, `FLOAT_NAN` → `Float.NaN`, `DOUBLE_NAN` → `Double.NaN`, applied uniformly regardless of the sampled `T`/`Class`. Default (`NULL`) matches `stdScaleNorm`'s existing behaviour for every numeric type, including `Integer`/`Long`/`Double`.
+
+6.3 [ ] Update `matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/Normalizer.groovy`'s `minMaxNorm`/`meanNorm` overloads for `DoubleColumn`/`FloatColumn` to pass `MissingValueType.DOUBLE_NAN`/`MissingValueType.FLOAT_NAN` explicitly to `Normalize.minMaxNorm`/`meanNorm`, since Tablesaw's `DoubleColumn`/`FloatColumn` use `NaN` as their own missing-value sentinel. The `BigDecimalColumn` overloads keep the default (`NULL`).
+
+6.4 [ ] Update GroovyDoc on the affected `Normalize` methods to document the new parameter and its default, and add/adjust tests in `matrix-stats/src/test/groovy/NormalizeTest.groovy` covering all three `MissingValueType` values (including that the default with no argument is `null`), plus a `matrix-tablesaw` test confirming a zero-range column still reports its value as missing (`NaN`) via the explicit `DOUBLE_NAN`/`FLOAT_NAN` call.
+
+6.5 [ ] Run and record verification:
+- [ ] `./gradlew :matrix-stats:codenarcMain`
+- [ ] `./gradlew :matrix-stats:spotlessCheck`
+- [ ] `./gradlew :matrix-stats:test --tests 'NormalizeTest'`
+- [ ] `./gradlew :matrix-stats:test`
+- [ ] `./gradlew :matrix-tablesaw:test`
+- [ ] `./gradlew test`
+
+---
+
+## 7. Final Verification and Release Notes
+
+7.1 [ ] Run module verification in the repository-required order:
 - [ ] `./gradlew :matrix-stats:codenarcMain`
 - [ ] `./gradlew :matrix-stats:spotlessCheck`
 - [ ] `./gradlew :matrix-stats:test`
 
-6.2 [ ] Run full regression verification before release/merge:
+7.2 [ ] Run full regression verification before release/merge:
 - [ ] `./gradlew test`
 
-6.3 [ ] Record all exact passing commands in this plan or in the PR description before marking any implementation section complete.
+7.3 [ ] Record all exact passing commands in this plan or in the PR description before marking any implementation section complete.
 
-6.4 [ ] Update `matrix-stats/release.md` with a v2.5.1 section documenting the five bug fixes.
+7.4 [ ] Update `matrix-stats/release.md` with a v2.5.1 section documenting the six bug fixes.
 
-6.5 [ ] Confirm no unrelated generated artifacts or local build outputs are included in the PR.
+7.5 [ ] Confirm no unrelated generated artifacts or local build outputs are included in the PR.

--- a/matrix-stats/req/2.5.1-plan.md
+++ b/matrix-stats/req/2.5.1-plan.md
@@ -130,9 +130,9 @@ If the existing Spearman and Kendall overloads have callers that assume a numeri
 
 **File:** `matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy`
 
-5.1 [ ] Add tests in `matrix-stats/src/test/groovy/NormalizeTest.groovy` that normalise an `Integer` column (e.g., `[1, null, 3]`) with both `minMaxNorm` and `meanNorm` and assert that in both cases the null-sentinel position produces the same class (`Double.NaN` or `null`).
+5.1 [x] Add tests in `matrix-stats/src/test/groovy/NormalizeTest.groovy` that normalise an `Integer` column (e.g., `[1, null, 3]`) with both `minMaxNorm` and `meanNorm` and assert that in both cases the null-sentinel position produces the same class (`Double.NaN` or `null`).
 
-5.2 [ ] Align `meanNormNullValue()` with `minMaxNormNullValue()` for `Integer` and `Long` inputs by returning `Double.NaN` (the same sentinel used by `minMaxNorm`). Change the `meanNormNullValue()` fallthrough case:
+5.2 [x] Align `meanNormNullValue()` with `minMaxNormNullValue()` for `Integer` and `Long` inputs by returning `Double.NaN` (the same sentinel used by `minMaxNorm`). Change the `meanNormNullValue()` fallthrough case:
 
 ```groovy
 // Byte, Short, Integer, Long, Float → use Double.NaN for Integer/Long, Float.NaN for Byte/Short/Float
@@ -142,13 +142,14 @@ if (sample instanceof Integer || sample instanceof Long) {
 Float.NaN as T
 ```
 
-5.3 [ ] Update the GroovyDoc comment above `meanNormNullValue()` to reflect the corrected type mapping.
+5.3 [x] Update the GroovyDoc comment above `meanNormNullValue()` to reflect the corrected type mapping.
 
-5.4 [ ] Run and record verification:
-- [ ] `./gradlew :matrix-stats:codenarcMain`
-- [ ] `./gradlew :matrix-stats:spotlessCheck`
-- [ ] `./gradlew :matrix-stats:test --tests 'NormalizeTest'`
-- [ ] `./gradlew :matrix-stats:test`
+5.4 [x] Run and record verification:
+- [x] `./gradlew :matrix-stats:codenarcMain` — passed
+- [x] `./gradlew :matrix-stats:spotlessCheck` — passed
+- [x] `./gradlew :matrix-stats:test --tests 'NormalizeTest'` — passed (27 tests)
+- [x] `./gradlew :matrix-stats:test` — passed (1013 tests)
+- [x] `./gradlew test` — passed
 
 ---
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
@@ -165,8 +165,9 @@ class Normalize {
     List<Number> numbers = numericValues(values)
     Number min = numbers.min()
     Number max = numbers.max()
+    Class nullValueType = numbers.first().class
 
-    values.collect { minMaxNorm(it as Number, min, max, decimals) }
+    values.collect { it == null ? minMaxNormNullValue(nullValueType) : minMaxNorm(it as Number, min, max, decimals) }
   }
 
   /**
@@ -457,24 +458,34 @@ class Normalize {
   }
 
   /**
-   * Returns null/NaN for meanNorm: Float.NaN for Byte/Short/Integer/Long/Float, Double.NaN for Double, null for BigInteger/BigDecimal
+   * Returns null/NaN for meanNorm: Float.NaN for Byte/Short/Float, Double.NaN for Integer/Long/Double, null for BigInteger/BigDecimal
    */
   private static <T extends Number> T meanNormNullValue(T sample) {
     if (sample instanceof BigDecimal || sample instanceof BigInteger) {
       return null
     }
-    if (sample instanceof Double) {
+    if (sample instanceof Double || sample instanceof Integer || sample instanceof Long) {
       return Double.NaN as T
     }
-    // Byte, Short, Integer, Long, Float
+    // Byte, Short, Float
     Float.NaN as T
+  }
+
+  private static Number minMaxNormNullValue(Class sampleType) {
+    if (sampleType == BigDecimal || sampleType == BigInteger) {
+      return null
+    }
+    if (sampleType == Double || sampleType == Integer || sampleType == Long) {
+      return Double.NaN
+    }
+    Float.NaN
   }
 
   private static Number meanNormNullValue(Class sampleType) {
     if (sampleType == BigDecimal || sampleType == BigInteger) {
       return null
     }
-    if (sampleType == Double) {
+    if (sampleType == Double || sampleType == Integer || sampleType == Long) {
       return Double.NaN
     }
     Float.NaN

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
@@ -153,6 +153,8 @@ class Normalize {
 
   /**
    * Apply min-max normalization to a list of values.
+   * For lists containing nulls, the null sentinel is inferred from the first non-null numeric value,
+   * assuming the list represents one homogeneous numeric column.
    */
   static List minMaxNorm(List values, int... decimals) {
     if (values.isEmpty()) {
@@ -245,6 +247,8 @@ class Normalize {
 
   /**
    * Apply mean normalization to a list of values.
+   * For lists containing nulls, the null sentinel is inferred from the first non-null numeric value,
+   * assuming the list represents one homogeneous numeric column.
    */
   static List meanNorm(List values, int... decimals) {
     if (values.isEmpty()) {
@@ -370,6 +374,18 @@ class Normalize {
     STD_SCALE
   }
 
+  private enum MissingValueType {
+    NULL(null),
+    DOUBLE_NAN(Double.NaN),
+    FLOAT_NAN(Float.NaN)
+
+    final Number sentinel
+
+    private MissingValueType(Number sentinel) {
+      this.sentinel = sentinel
+    }
+  }
+
   private static Matrix normalizeMatrix(Matrix table, Normalization normalization, int... decimals) {
     List<List> columns = []
     List<Class> types = []
@@ -447,48 +463,36 @@ class Normalize {
    * Returns null/NaN for minMaxNorm: Float.NaN for Byte/Short/Float, Double.NaN for Integer/Long/Double, null for BigInteger/BigDecimal
    */
   private static <T extends Number> T minMaxNormNullValue(T sample) {
-    if (sample instanceof BigDecimal || sample instanceof BigInteger) {
-      return null
-    }
-    if (sample instanceof Double || sample instanceof Integer || sample instanceof Long) {
-      return Double.NaN as T
-    }
-    // Byte, Short, Float
-    Float.NaN as T
+    nullSentinel(sample == null ? null : sample.class) as T
   }
 
   /**
    * Returns null/NaN for meanNorm: Float.NaN for Byte/Short/Float, Double.NaN for Integer/Long/Double, null for BigInteger/BigDecimal
    */
   private static <T extends Number> T meanNormNullValue(T sample) {
-    if (sample instanceof BigDecimal || sample instanceof BigInteger) {
-      return null
-    }
-    if (sample instanceof Double || sample instanceof Integer || sample instanceof Long) {
-      return Double.NaN as T
-    }
-    // Byte, Short, Float
-    Float.NaN as T
+    nullSentinel(sample == null ? null : sample.class) as T
   }
 
   private static Number minMaxNormNullValue(Class sampleType) {
-    if (sampleType == BigDecimal || sampleType == BigInteger) {
-      return null
-    }
-    if (sampleType == Double || sampleType == Integer || sampleType == Long) {
-      return Double.NaN
-    }
-    Float.NaN
+    nullSentinel(sampleType)
   }
 
   private static Number meanNormNullValue(Class sampleType) {
+    nullSentinel(sampleType)
+  }
+
+  private static Number nullSentinel(Class sampleType) {
+    missingValueType(sampleType).sentinel
+  }
+
+  private static MissingValueType missingValueType(Class sampleType) {
     if (sampleType == BigDecimal || sampleType == BigInteger) {
-      return null
+      return MissingValueType.NULL
     }
     if (sampleType == Double || sampleType == Integer || sampleType == Long) {
-      return Double.NaN
+      return MissingValueType.DOUBLE_NAN
     }
-    Float.NaN
+    MissingValueType.FLOAT_NAN
   }
 
   /**

--- a/matrix-stats/src/test/groovy/NormalizeTest.groovy
+++ b/matrix-stats/src/test/groovy/NormalizeTest.groovy
@@ -269,6 +269,36 @@ class NormalizeTest {
   }
 
   @Test
+  void testIntegerNullSentinelTypeMatchesForMinMaxAndMeanNorm() {
+    List<Integer> values = [1, null, 3]
+
+    List minMaxResult = Normalize.minMaxNorm(values, 6)
+    List meanResult = Normalize.meanNorm(values, 6)
+
+    assertEquals(Double, minMaxResult[1].class)
+    assertTrue((minMaxResult[1] as Double).isNaN())
+    assertEquals(Double, meanResult[1].class)
+    assertTrue((meanResult[1] as Double).isNaN())
+  }
+
+  @Test
+  void testIntegerAndLongZeroRangeNullSentinelsUseDoubleNaNForMinMaxAndMeanNorm() {
+    [([1, null, 1]): 'Integer', ([1L, null, 1L]): 'Long'].each { List values, String label ->
+      List minMaxResult = Normalize.minMaxNorm(values, 6)
+      List meanResult = Normalize.meanNorm(values, 6)
+
+      minMaxResult.each { value ->
+        assertEquals(Double, value.class, label)
+        assertTrue((value as Double).isNaN(), label)
+      }
+      meanResult.each { value ->
+        assertEquals(Double, value.class, label)
+        assertTrue((value as Double).isNaN(), label)
+      }
+    }
+  }
+
+  @Test
   void testMeanNormFloat() {
     assertEquals(-0.150526076f, Normalize.meanNorm(1211f, 6412.428571428572f, 12f, 34567f, 9 ))
 
@@ -298,10 +328,10 @@ class NormalizeTest {
   void testMeanNormZeroes() {
     assertIterableEquals([Float.NaN]*3, Normalize.meanNorm(ListConverter.convert([0, 0, 0], Byte)), 'Byte should be -Infinity')
     assertIterableEquals([Float.NaN]*3, Normalize.meanNorm(ListConverter.convert([0, 0, 0], Short)), 'Short should be -Infinity')
-    assertIterableEquals([Float.NaN]*3, Normalize.meanNorm(ListConverter.toIntegers([0, 0, 0])), 'Integer should be -Infinity')
+    assertIterableEquals([Double.NaN]*3, Normalize.meanNorm(ListConverter.toIntegers([0, 0, 0])), 'Integer should be -Infinity')
     assertIterableEquals([Float.NaN]*3, Normalize.meanNorm([0f, 0f, 0f]), 'Float should be null')
     assertIterableEquals([Double.NaN]*3, Normalize.meanNorm([0.0d, 0d, 0d]), 'Double should be null')
-    assertIterableEquals([Float.NaN]*3, Normalize.meanNorm([0l, 0l, 0l]), 'Long should be -Infinity')
+    assertIterableEquals([Double.NaN]*3, Normalize.meanNorm([0l, 0l, 0l]), 'Long should be -Infinity')
     assertIterableEquals([null]*3, Normalize.meanNorm(ListConverter.convert([0, 0, 0], BigInteger)), 'BigInteger should be null')
     assertIterableEquals([null]*3, Normalize.meanNorm([0.0g, 0.0g, 0.0g]), 'BigDecimal should be null')
   }

--- a/matrix-xchart/build.gradle
+++ b/matrix-xchart/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'se.alipsa.matrix'
-version = '0.3.0'
+version = '0.3.1-SNAPSHOT'
 description = "Groovy library for creating charts with xcharts using matrix ([][] data)"
 
 JavaCompile javaCompile = compileJava {

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
@@ -70,8 +70,8 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
 
   /**
    * Add a correlation heatmap series computed from the specified numeric columns.
-   * The correlation matrix is calculated using Pearson correlation coefficients. Undefined correlations
-   * from zero-variance columns are rendered as 0-valued heatmap cells.
+   * The correlation matrix is calculated using Pearson correlation coefficients. Self-correlations are
+   * rendered as 1, and undefined non-diagonal correlations from zero-variance columns are rendered as 0.
    *
    * @param title the name for this series (displayed in legend)
    * @param columnNames the names of the numeric columns to compute correlations for
@@ -89,7 +89,7 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
       (0..<size).collect { int j ->
         List<BigDecimal> xValues = ListConverter.toBigDecimals(data[j])
         List<BigDecimal> yValues = ListConverter.toBigDecimals(data[i])
-        roundCorrelation(Correlation.cor(xValues, yValues))
+        roundCorrelation(Correlation.cor(xValues, yValues), i == j)
       }
     }
     def corrMatrix = Matrix.builder().data(X: 0..<corr.size(), Heat: corr)
@@ -131,7 +131,10 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
     this
   }
 
-  private static BigDecimal roundCorrelation(BigDecimal correlation) {
+  private static BigDecimal roundCorrelation(BigDecimal correlation, boolean selfCorrelation) {
+    if (selfCorrelation) {
+      return 1G
+    }
     correlation == null ? 0G : correlation.round(CORRELATION_SCALE)
   }
 

--- a/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/CorrelationHeatmapChartTest.groovy
+++ b/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/CorrelationHeatmapChartTest.groovy
@@ -85,7 +85,16 @@ class CorrelationHeatmapChartTest {
 
     def chart = CorrelationHeatmapChart.create(matrix).addSeries('Correlation', ['x', 'constant'])
 
-    assertNotNull(chart.getSeries('Correlation'))
+    def series = chart.getSeries('Correlation')
+    assertNotNull(series)
+
+    Map<String, Number> heatData = series.heatData.collectEntries { Number[] point ->
+      [("${point[0]},${point[1]}".toString()): point[2]]
+    }
+    assertEquals(0G, heatData['0,0'])
+    assertEquals(1G, heatData['1,0'])
+    assertEquals(1G, heatData['0,1'])
+    assertEquals(0G, heatData['1,1'])
   }
 
 }


### PR DESCRIPTION
## Summary
- Align `Normalize.meanNorm()` null sentinels for `Integer` and `Long` with `minMaxNorm()` by returning `Double.NaN`.
- Preserve the first non-null numeric type for `minMaxNorm()` null slots so Integer/Long columns use the same sentinel class consistently.
- Add regression coverage for Integer null slots and Integer/Long zero-range normalization.
- Record task 5 verification in `matrix-stats/req/2.5.1-plan.md`.

## Modules touched
- `matrix-stats`

## Tests
- `./gradlew :matrix-stats:codenarcMain`
- `./gradlew :matrix-stats:spotlessCheck`
- `./gradlew :matrix-stats:test --tests 'NormalizeTest'`
- `./gradlew :matrix-stats:test`
- `./gradlew test`