### PR TITLE
Add explicit normalize missing value sentinel

### DIFF
--- a/matrix-bom/bom.xml
+++ b/matrix-bom/bom.xml
@@ -50,7 +50,7 @@
     <matrixSpreadsheetVersion>2.4.0</matrixSpreadsheetVersion>
     <matrixSqlVersion>2.4.0</matrixSqlVersion>
     <matrixStatsVersion>2.5.1</matrixStatsVersion>
-    <matrixTablesawVersion>0.3.0</matrixTablesawVersion>
+    <matrixTablesawVersion>0.3.1-SNAPSHOT</matrixTablesawVersion>
     <matrixXChartVersion>0.3.1-SNAPSHOT</matrixXChartVersion>
   </properties>
   <dependencyManagement>

--- a/matrix-stats/req/2.5.1-plan.md
+++ b/matrix-stats/req/2.5.1-plan.md
@@ -160,7 +160,7 @@ Float.NaN as T
 
 Task 5 made `minMaxNormNullValue()` and `meanNormNullValue()` agree with each other, but both still return type-dependent sentinels (`null` for BigDecimal/BigInteger, `Float.NaN` for Byte/Short/Float, `Double.NaN` for Double/Integer/Long). Every other undefined-result path in this module — `stdScaleNorm`, `logNorm` (task 2), `Correlation.corPearson()`/`corSpearman()` (task 4) — returns plain `null` regardless of `T`. Instead of hardcoding a single implicit convention, add an explicit, optional parameter so any caller can choose the sentinel it needs, defaulting to `null` everywhere for consistency with the rest of the module.
 
-6.1 [ ] Add a `MissingValueType` enum nested in `Normalize` with values `NULL`, `FLOAT_NAN`, `DOUBLE_NAN`. Thread an optional `MissingValueType missingValueType = MissingValueType.NULL` parameter through the `minMaxNorm` and `meanNorm` overloads (`T`, `T[]`, `List`, `Matrix` column, `Matrix`), inserted **before** the trailing `int... decimals` varargs, e.g.:
+6.1 [x] Add a `MissingValueType` enum nested in `Normalize` with values `NULL`, `FLOAT_NAN`, `DOUBLE_NAN`. Thread an optional `MissingValueType missingValueType = MissingValueType.NULL` parameter through the `minMaxNorm` and `meanNorm` overloads (`T`, `T[]`, `List`, `Matrix` column, `Matrix`), inserted **before** the trailing `int... decimals` varargs, e.g.:
 
 ```groovy
 static <T extends Number> T minMaxNorm(T x, Number min, Number max,
@@ -170,19 +170,19 @@ static <T extends Number> T minMaxNorm(T x, Number min, Number max,
 
 Confirmed during review: this ordering is backward-compatible. An enum-typed parameter cannot bind to a bare `int` literal, so existing calls like `minMaxNorm(list, 2)` keep resolving `2` to `decimals`, not the new parameter — verified with a standalone `@CompileStatic` reproduction. **Do not** type the new parameter as a plain `Number` (or anything else `int`-assignable) — that overlaps with `decimals` and silently rebinds existing positional calls, e.g. `minMaxNorm(list, 2)` would reinterpret `2` as the sentinel instead of the decimals count.
 
-6.2 [ ] Replace the private `minMaxNormNullValue()`/`meanNormNullValue()` per-type branching with a single lookup keyed on `missingValueType`: `NULL` → `null`, `FLOAT_NAN` → `Float.NaN`, `DOUBLE_NAN` → `Double.NaN`, applied uniformly regardless of the sampled `T`/`Class`. Default (`NULL`) matches `stdScaleNorm`'s existing behaviour for every numeric type, including `Integer`/`Long`/`Double`.
+6.2 [x] Replace the private `minMaxNormNullValue()`/`meanNormNullValue()` per-type branching with a single lookup keyed on `missingValueType`: `NULL` → `null`, `FLOAT_NAN` → `Float.NaN`, `DOUBLE_NAN` → `Double.NaN`, applied uniformly regardless of the sampled `T`/`Class`. Default (`NULL`) matches `stdScaleNorm`'s existing behaviour for every numeric type, including `Integer`/`Long`/`Double`.
 
-6.3 [ ] Update `matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/Normalizer.groovy`'s `minMaxNorm`/`meanNorm` overloads for `DoubleColumn`/`FloatColumn` to pass `MissingValueType.DOUBLE_NAN`/`MissingValueType.FLOAT_NAN` explicitly to `Normalize.minMaxNorm`/`meanNorm`, since Tablesaw's `DoubleColumn`/`FloatColumn` use `NaN` as their own missing-value sentinel. The `BigDecimalColumn` overloads keep the default (`NULL`).
+6.3 [x] Update `matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/Normalizer.groovy`'s `minMaxNorm`/`meanNorm` overloads for `DoubleColumn`/`FloatColumn` to pass `MissingValueType.DOUBLE_NAN`/`MissingValueType.FLOAT_NAN` explicitly to `Normalize.minMaxNorm`/`meanNorm`, since Tablesaw's `DoubleColumn`/`FloatColumn` use `NaN` as their own missing-value sentinel. The `BigDecimalColumn` overloads keep the default (`NULL`).
 
-6.4 [ ] Update GroovyDoc on the affected `Normalize` methods to document the new parameter and its default, and add/adjust tests in `matrix-stats/src/test/groovy/NormalizeTest.groovy` covering all three `MissingValueType` values (including that the default with no argument is `null`), plus a `matrix-tablesaw` test confirming a zero-range column still reports its value as missing (`NaN`) via the explicit `DOUBLE_NAN`/`FLOAT_NAN` call.
+6.4 [x] Update GroovyDoc on the affected `Normalize` methods to document the new parameter and its default, and add/adjust tests in `matrix-stats/src/test/groovy/NormalizeTest.groovy` covering all three `MissingValueType` values (including that the default with no argument is `null`), plus a `matrix-tablesaw` test confirming a zero-range column still reports its value as missing (`NaN`) via the explicit `DOUBLE_NAN`/`FLOAT_NAN` call.
 
-6.5 [ ] Run and record verification:
-- [ ] `./gradlew :matrix-stats:codenarcMain`
-- [ ] `./gradlew :matrix-stats:spotlessCheck`
-- [ ] `./gradlew :matrix-stats:test --tests 'NormalizeTest'`
-- [ ] `./gradlew :matrix-stats:test`
-- [ ] `./gradlew :matrix-tablesaw:test`
-- [ ] `./gradlew test`
+6.5 [x] Run and record verification:
+- [x] `./gradlew :matrix-stats:codenarcMain` — passed
+- [x] `./gradlew :matrix-stats:spotlessCheck` — passed
+- [x] `./gradlew :matrix-stats:test --tests 'NormalizeTest'` — passed (28 tests)
+- [x] `./gradlew :matrix-stats:test` — passed (1014 tests)
+- [x] `./gradlew :matrix-tablesaw:test` — passed (117 tests)
+- [x] `./gradlew test` — passed
 
 ---
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
@@ -110,12 +110,15 @@ class Normalize {
    * @param x the value to normalize
    * @param min the minimum value in the dataset
    * @param max the maximum value in the dataset
+   * @param missingValueType sentinel to return for null or undefined results; defaults to {@link MissingValueType#NULL}
    * @param decimals optional number of decimal places to round to
-   * @return the normalized value in [0, 1] range, or null/NaN for invalid input
+   * @return the normalized value in [0, 1] range, or the requested missing-value sentinel for invalid input
    */
-  static <T extends Number> T minMaxNorm(T x, Number min, Number max, int... decimals) {
+  static <T extends Number> T minMaxNorm(T x, Number min, Number max,
+                                         MissingValueType missingValueType = MissingValueType.NULL,
+                                         int... decimals) {
     if (x == null) {
-      return minMaxNormNullValue(x)
+      return nullSentinel(missingValueType) as T
     }
 
     double xVal = x.doubleValue()
@@ -124,7 +127,7 @@ class Normalize {
     double range = maxVal - minVal
 
     if (range == 0) {
-      return minMaxNormNullValue(x)
+      return nullSentinel(missingValueType) as T
     }
 
     double result = (xVal - minVal) / range
@@ -139,24 +142,38 @@ class Normalize {
 
   /**
    * Apply min-max normalization to an array of values.
+   *
+   * @param values the values to normalize
+   * @param missingValueType sentinel to return for null or undefined results; defaults to {@link MissingValueType#NULL}
+   * @param decimals optional number of decimal places to round to
+   * @return the normalized values
    */
-  static <T extends Number> List<T> minMaxNorm(T[] values, int... decimals) {
+  static <T extends Number> List<T> minMaxNorm(T[] values,
+                                               MissingValueType missingValueType = MissingValueType.NULL,
+                                               int... decimals) {
     if (values.length == 0) {
       return []
     }
 
-    T min = values.min()
-    T max = values.max()
+    List<T> numbers = values.findAll { it != null } as List<T>
+    if (numbers.isEmpty()) {
+      return values.collect { nullSentinel(missingValueType) as T }
+    }
+    T min = numbers.min()
+    T max = numbers.max()
 
-    values.collect { minMaxNorm(it, min, max, decimals) }
+    values.collect { minMaxNorm(it, min, max, missingValueType, decimals) }
   }
 
   /**
    * Apply min-max normalization to a list of values.
-   * For lists containing nulls, the null sentinel is inferred from the first non-null numeric value,
-   * assuming the list represents one homogeneous numeric column.
+   *
+   * @param values the values to normalize
+   * @param missingValueType sentinel to return for null or undefined results; defaults to {@link MissingValueType#NULL}
+   * @param decimals optional number of decimal places to round to
+   * @return the normalized values, or the original list if it contains non-numeric values
    */
-  static List minMaxNorm(List values, int... decimals) {
+  static List minMaxNorm(List values, MissingValueType missingValueType = MissingValueType.NULL, int... decimals) {
     if (values.isEmpty()) {
       return []
     }
@@ -167,23 +184,35 @@ class Normalize {
     List<Number> numbers = numericValues(values)
     Number min = numbers.min()
     Number max = numbers.max()
-    Class nullValueType = numbers.first().class
 
-    values.collect { it == null ? minMaxNormNullValue(nullValueType) : minMaxNorm(it as Number, min, max, decimals) }
+    values.collect { minMaxNorm(it as Number, min, max, missingValueType, decimals) }
   }
 
   /**
    * Apply min-max normalization to a specific column in a Matrix.
+   *
+   * @param table the Matrix containing the column
+   * @param columnName the column to normalize
+   * @param missingValueType sentinel to return for null or undefined results; defaults to {@link MissingValueType#NULL}
+   * @param decimals optional number of decimal places to round to
+   * @return the normalized column values
    */
-  static List<? extends Number> minMaxNorm(Matrix table, String columnName, int... decimals) {
-    minMaxNorm(table.column(columnName) as List, decimals)
+  static List<? extends Number> minMaxNorm(Matrix table, String columnName,
+                                           MissingValueType missingValueType = MissingValueType.NULL,
+                                           int... decimals) {
+    minMaxNorm(table.column(columnName) as List, missingValueType, decimals)
   }
 
   /**
    * Apply min-max normalization to all numeric columns in a Matrix.
+   *
+   * @param table the Matrix to normalize
+   * @param missingValueType sentinel to return for null or undefined results; defaults to {@link MissingValueType#NULL}
+   * @param decimals optional number of decimal places to round to
+   * @return a new Matrix with normalized numeric columns
    */
-  static Matrix minMaxNorm(Matrix table, int... decimals) {
-    normalizeMatrix(table, Normalization.MIN_MAX, decimals)
+  static Matrix minMaxNorm(Matrix table, MissingValueType missingValueType = MissingValueType.NULL, int... decimals) {
+    normalizeMatrix(table, Normalization.MIN_MAX, missingValueType, decimals)
   }
 
   // ===== MEAN NORMALIZATION =====
@@ -196,12 +225,15 @@ class Normalize {
    * @param mean the mean of the dataset
    * @param min the minimum value in the dataset
    * @param max the maximum value in the dataset
+   * @param missingValueType sentinel to return for null or undefined results; defaults to {@link MissingValueType#NULL}
    * @param decimals optional number of decimal places to round to
-   * @return the normalized value, or null/NaN for invalid input
+   * @return the normalized value, or the requested missing-value sentinel for invalid input
    */
-  static <T extends Number> T meanNorm(T x, Number mean, Number min, Number max, int... decimals) {
+  static <T extends Number> T meanNorm(T x, Number mean, Number min, Number max,
+                                       MissingValueType missingValueType = MissingValueType.NULL,
+                                       int... decimals) {
     if (x == null) {
-      return meanNormNullValue(x)
+      return nullSentinel(missingValueType) as T
     }
 
     double xVal = x.doubleValue()
@@ -211,7 +243,7 @@ class Normalize {
     double range = maxVal - minVal
 
     if (range == 0) {
-      return meanNormNullValue(x)
+      return nullSentinel(missingValueType) as T
     }
 
     double result = (xVal - meanVal) / range
@@ -226,31 +258,39 @@ class Normalize {
 
   /**
    * Apply mean normalization to an array of values.
+   *
+   * @param values the values to normalize
+   * @param missingValueType sentinel to return for null or undefined results; defaults to {@link MissingValueType#NULL}
+   * @param decimals optional number of decimal places to round to
+   * @return the normalized values
    */
-  static <T extends Number> List<T> meanNorm(T[] values, int... decimals) {
+  static <T extends Number> List<T> meanNorm(T[] values,
+                                             MissingValueType missingValueType = MissingValueType.NULL,
+                                             int... decimals) {
     if (values.length == 0) {
       return []
     }
 
     List<T> numbers = values.findAll { it != null } as List<T>
-    Class arrayComponentType = values.getClass().getComponentType()
     if (numbers.isEmpty()) {
-      return values.collect { meanNormNullValue(arrayComponentType) as T }
+      return values.collect { nullSentinel(missingValueType) as T }
     }
     BigDecimal mean = Stat.mean(numbers)
     T min = numbers.min()
     T max = numbers.max()
-    Class nullValueType = numbers.first().class
 
-    values.collect { it == null ? meanNormNullValue(nullValueType) as T : meanNorm(it, mean, min, max, decimals) }
+    values.collect { meanNorm(it, mean, min, max, missingValueType, decimals) }
   }
 
   /**
    * Apply mean normalization to a list of values.
-   * For lists containing nulls, the null sentinel is inferred from the first non-null numeric value,
-   * assuming the list represents one homogeneous numeric column.
+   *
+   * @param values the values to normalize
+   * @param missingValueType sentinel to return for null or undefined results; defaults to {@link MissingValueType#NULL}
+   * @param decimals optional number of decimal places to round to
+   * @return the normalized values, or the original list if it contains non-numeric values
    */
-  static List meanNorm(List values, int... decimals) {
+  static List meanNorm(List values, MissingValueType missingValueType = MissingValueType.NULL, int... decimals) {
     if (values.isEmpty()) {
       return []
     }
@@ -258,28 +298,39 @@ class Normalize {
       return values
     }
 
-    // nulls are excluded from stats and yield NaN/null according to the non-null value type
     List<Number> numbers = numericValues(values)
     BigDecimal mean = Stat.mean(numbers)
     Number min = numbers.min()
     Number max = numbers.max()
-    Class nullValueType = numbers.first().class
 
-    values.collect { it == null ? meanNormNullValue(nullValueType) : meanNorm(it as Number, mean, min, max, decimals) }
+    values.collect { meanNorm(it as Number, mean, min, max, missingValueType, decimals) }
   }
 
   /**
    * Apply mean normalization to a specific column in a Matrix.
+   *
+   * @param table the Matrix containing the column
+   * @param columnName the column to normalize
+   * @param missingValueType sentinel to return for null or undefined results; defaults to {@link MissingValueType#NULL}
+   * @param decimals optional number of decimal places to round to
+   * @return the normalized column values
    */
-  static List<? extends Number> meanNorm(Matrix table, String columnName, int... decimals) {
-    meanNorm(table.column(columnName) as List, decimals)
+  static List<? extends Number> meanNorm(Matrix table, String columnName,
+                                         MissingValueType missingValueType = MissingValueType.NULL,
+                                         int... decimals) {
+    meanNorm(table.column(columnName) as List, missingValueType, decimals)
   }
 
   /**
    * Apply mean normalization to all numeric columns in a Matrix.
+   *
+   * @param table the Matrix to normalize
+   * @param missingValueType sentinel to return for null or undefined results; defaults to {@link MissingValueType#NULL}
+   * @param decimals optional number of decimal places to round to
+   * @return a new Matrix with normalized numeric columns
    */
-  static Matrix meanNorm(Matrix table, int... decimals) {
-    normalizeMatrix(table, Normalization.MEAN, decimals)
+  static Matrix meanNorm(Matrix table, MissingValueType missingValueType = MissingValueType.NULL, int... decimals) {
+    normalizeMatrix(table, Normalization.MEAN, missingValueType, decimals)
   }
 
   // ===== STANDARD DEVIATION NORMALIZATION (Z-SCORE) =====
@@ -374,10 +425,13 @@ class Normalize {
     STD_SCALE
   }
 
-  private enum MissingValueType {
+  /**
+   * Missing-value sentinel options for normalization methods that can produce undefined results.
+   */
+  enum MissingValueType {
     NULL(null),
-    DOUBLE_NAN(Double.NaN),
-    FLOAT_NAN(Float.NaN)
+    FLOAT_NAN(Float.NaN),
+    DOUBLE_NAN(Double.NaN)
 
     final Number sentinel
 
@@ -387,11 +441,16 @@ class Normalize {
   }
 
   private static Matrix normalizeMatrix(Matrix table, Normalization normalization, int... decimals) {
+    normalizeMatrix(table, normalization, MissingValueType.NULL, decimals)
+  }
+
+  private static Matrix normalizeMatrix(Matrix table, Normalization normalization,
+                                        MissingValueType missingValueType, int... decimals) {
     List<List> columns = []
     List<Class> types = []
     for (Column col in table.columns()) {
       if (isNumericColumn(col)) {
-        List normalized = normalizeList(col as List, normalization, decimals)
+        List normalized = normalizeList(col as List, normalization, missingValueType, decimals)
         columns << normalized
         types << transformedType(normalized, col.type)
       } else {
@@ -407,10 +466,15 @@ class Normalize {
   }
 
   private static List normalizeList(List values, Normalization normalization, int... decimals) {
+    normalizeList(values, normalization, MissingValueType.NULL, decimals)
+  }
+
+  private static List normalizeList(List values, Normalization normalization,
+                                    MissingValueType missingValueType, int... decimals) {
     switch (normalization) {
       case LOG -> logNorm(values, decimals)
-      case MIN_MAX -> minMaxNorm(values, decimals)
-      case MEAN -> meanNorm(values, decimals)
+      case MIN_MAX -> minMaxNorm(values, missingValueType, decimals)
+      case MEAN -> meanNorm(values, missingValueType, decimals)
       case STD_SCALE -> stdScaleNorm(values, decimals)
       default -> throw new IllegalArgumentException("Unsupported normalization: $normalization")
     }
@@ -459,40 +523,8 @@ class Normalize {
     transformedValue == null ? fallbackType : transformedValue.class
   }
 
-  /**
-   * Returns null/NaN for minMaxNorm: Float.NaN for Byte/Short/Float, Double.NaN for Integer/Long/Double, null for BigInteger/BigDecimal
-   */
-  private static <T extends Number> T minMaxNormNullValue(T sample) {
-    nullSentinel(sample == null ? null : sample.class) as T
-  }
-
-  /**
-   * Returns null/NaN for meanNorm: Float.NaN for Byte/Short/Float, Double.NaN for Integer/Long/Double, null for BigInteger/BigDecimal
-   */
-  private static <T extends Number> T meanNormNullValue(T sample) {
-    nullSentinel(sample == null ? null : sample.class) as T
-  }
-
-  private static Number minMaxNormNullValue(Class sampleType) {
-    nullSentinel(sampleType)
-  }
-
-  private static Number meanNormNullValue(Class sampleType) {
-    nullSentinel(sampleType)
-  }
-
-  private static Number nullSentinel(Class sampleType) {
-    missingValueType(sampleType).sentinel
-  }
-
-  private static MissingValueType missingValueType(Class sampleType) {
-    if (sampleType == BigDecimal || sampleType == BigInteger) {
-      return MissingValueType.NULL
-    }
-    if (sampleType == Double || sampleType == Integer || sampleType == Long) {
-      return MissingValueType.DOUBLE_NAN
-    }
-    MissingValueType.FLOAT_NAN
+  private static Number nullSentinel(MissingValueType missingValueType) {
+    missingValueType.sentinel
   }
 
   /**

--- a/matrix-stats/src/test/groovy/NormalizeTest.groovy
+++ b/matrix-stats/src/test/groovy/NormalizeTest.groovy
@@ -9,6 +9,7 @@ import se.alipsa.matrix.core.ListConverter
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.datasets.Dataset
 import se.alipsa.matrix.stats.Normalize
+import se.alipsa.matrix.stats.Normalize.MissingValueType
 
 class NormalizeTest {
 
@@ -139,12 +140,12 @@ class NormalizeTest {
 
   @Test
   void testMinMaxNormZeroes() {
-    assert [Float.NaN]*3 == Normalize.minMaxNorm(ListConverter.convert([0, 0, 0], Byte)) : 'Byte should be NaN'
-    assert [Float.NaN]*3 == Normalize.minMaxNorm(ListConverter.convert([0, 0, 0], Short)) : 'Short should be NaN'
-    assert [Double.NaN]*3 == Normalize.minMaxNorm([0i, 0i, 0i]) : 'Integer should be NaN'
-    assert [Float.NaN]*3 == Normalize.minMaxNorm([0f, 0f, 0f]) : 'Float should be NaN'
-    assert [Double.NaN]*3 == Normalize.minMaxNorm([0d, 0d, 0d]) : 'Double should be NaN'
-    assert [Double.NaN]*3 == Normalize.minMaxNorm([0l, 0l, 0l]) : 'Long should be NaN'
+    assert [null]*3 == Normalize.minMaxNorm(ListConverter.convert([0, 0, 0], Byte)) : 'Byte should be null'
+    assert [null]*3 == Normalize.minMaxNorm(ListConverter.convert([0, 0, 0], Short)) : 'Short should be null'
+    assert [null]*3 == Normalize.minMaxNorm([0i, 0i, 0i]) : 'Integer should be null'
+    assert [null]*3 == Normalize.minMaxNorm([0f, 0f, 0f]) : 'Float should be null'
+    assert [null]*3 == Normalize.minMaxNorm([0d, 0d, 0d]) : 'Double should be null'
+    assert [null]*3 == Normalize.minMaxNorm([0l, 0l, 0l]) : 'Long should be null'
     assert [null]*3 == Normalize.minMaxNorm([0G, 0G, 0G]) : 'BigInteger should be null'
     assert [null]*3 == Normalize.minMaxNorm([0.0g, 0.0g, 0.0g]) : 'BigDecimal should be null'
   }
@@ -249,10 +250,8 @@ class NormalizeTest {
     List<Double> meanResult = Normalize.meanNorm(values, 6)
 
     assertEquals(5, meanResult.size())
-    assertTrue(meanResult[0] instanceof Double)
-    assertTrue(meanResult[0].isNaN())
-    assertTrue(meanResult[3] instanceof Double)
-    assertTrue(meanResult[3].isNaN())
+    assertNull(meanResult[0])
+    assertNull(meanResult[3])
     assertEquals(-0.5d, meanResult[1], 1e-6d)
     assertEquals(0.0d, meanResult[2], 1e-6d)
     assertEquals(0.5d, meanResult[4], 1e-6d)
@@ -265,37 +264,45 @@ class NormalizeTest {
     List<Double> meanResult = Normalize.meanNorm(values, 6)
 
     assertEquals(3, meanResult.size())
-    assertTrue(meanResult.every { it instanceof Double && it.isNaN() })
+    assertEquals([null, null, null], meanResult)
   }
 
   @Test
-  void testIntegerNullSentinelTypeMatchesForMinMaxAndMeanNorm() {
+  void testDefaultNullSentinelMatchesForMinMaxAndMeanNorm() {
     List<Integer> values = [1, null, 3]
 
     List minMaxResult = Normalize.minMaxNorm(values, 6)
     List meanResult = Normalize.meanNorm(values, 6)
 
-    assertEquals(Double, minMaxResult[1].class)
-    assertTrue((minMaxResult[1] as Double).isNaN())
-    assertEquals(Double, meanResult[1].class)
-    assertTrue((meanResult[1] as Double).isNaN())
+    assertNull(minMaxResult[1])
+    assertNull(meanResult[1])
   }
 
   @Test
-  void testIntegerAndLongZeroRangeNullSentinelsUseDoubleNaNForMinMaxAndMeanNorm() {
+  void testIntegerAndLongZeroRangeUseDefaultNullForMinMaxAndMeanNorm() {
     [([1, null, 1]): 'Integer', ([1L, null, 1L]): 'Long'].each { List values, String label ->
       List minMaxResult = Normalize.minMaxNorm(values, 6)
       List meanResult = Normalize.meanNorm(values, 6)
 
       minMaxResult.each { value ->
-        assertEquals(Double, value.class, label)
-        assertTrue((value as Double).isNaN(), label)
+        assertNull(value, label)
       }
       meanResult.each { value ->
-        assertEquals(Double, value.class, label)
-        assertTrue((value as Double).isNaN(), label)
+        assertNull(value, label)
       }
     }
+  }
+
+  @Test
+  void testMissingValueTypeControlsMinMaxAndMeanNormSentinels() {
+    List<Integer> values = [1, null, 1]
+
+    assertEquals([null, null, null], Normalize.minMaxNorm(values))
+    assertEquals([null, null, null], Normalize.meanNorm(values))
+    assertEquals([Float.NaN, Float.NaN, Float.NaN], Normalize.minMaxNorm(values, MissingValueType.FLOAT_NAN))
+    assertEquals([Float.NaN, Float.NaN, Float.NaN], Normalize.meanNorm(values, MissingValueType.FLOAT_NAN))
+    assertEquals([Double.NaN, Double.NaN, Double.NaN], Normalize.minMaxNorm(values, MissingValueType.DOUBLE_NAN))
+    assertEquals([Double.NaN, Double.NaN, Double.NaN], Normalize.meanNorm(values, MissingValueType.DOUBLE_NAN))
   }
 
   @Test
@@ -326,12 +333,12 @@ class NormalizeTest {
 
   @Test
   void testMeanNormZeroes() {
-    assertIterableEquals([Float.NaN]*3, Normalize.meanNorm(ListConverter.convert([0, 0, 0], Byte)), 'Byte should be -Infinity')
-    assertIterableEquals([Float.NaN]*3, Normalize.meanNorm(ListConverter.convert([0, 0, 0], Short)), 'Short should be -Infinity')
-    assertIterableEquals([Double.NaN]*3, Normalize.meanNorm(ListConverter.toIntegers([0, 0, 0])), 'Integer should be -Infinity')
-    assertIterableEquals([Float.NaN]*3, Normalize.meanNorm([0f, 0f, 0f]), 'Float should be null')
-    assertIterableEquals([Double.NaN]*3, Normalize.meanNorm([0.0d, 0d, 0d]), 'Double should be null')
-    assertIterableEquals([Double.NaN]*3, Normalize.meanNorm([0l, 0l, 0l]), 'Long should be -Infinity')
+    assertIterableEquals([null]*3, Normalize.meanNorm(ListConverter.convert([0, 0, 0], Byte)), 'Byte should be null')
+    assertIterableEquals([null]*3, Normalize.meanNorm(ListConverter.convert([0, 0, 0], Short)), 'Short should be null')
+    assertIterableEquals([null]*3, Normalize.meanNorm(ListConverter.toIntegers([0, 0, 0])), 'Integer should be null')
+    assertIterableEquals([null]*3, Normalize.meanNorm([0f, 0f, 0f]), 'Float should be null')
+    assertIterableEquals([null]*3, Normalize.meanNorm([0.0d, 0d, 0d]), 'Double should be null')
+    assertIterableEquals([null]*3, Normalize.meanNorm([0l, 0l, 0l]), 'Long should be null')
     assertIterableEquals([null]*3, Normalize.meanNorm(ListConverter.convert([0, 0, 0], BigInteger)), 'BigInteger should be null')
     assertIterableEquals([null]*3, Normalize.meanNorm([0.0g, 0.0g, 0.0g]), 'BigDecimal should be null')
   }
@@ -425,10 +432,8 @@ class NormalizeTest {
 
     List meanResult = Normalize.meanNorm(values, 6)
     assertEquals(5, meanResult.size())
-    assertTrue(meanResult[0] instanceof Double)
-    assertTrue((meanResult[0] as Double).isNaN())
-    assertTrue(meanResult[3] instanceof Double)
-    assertTrue((meanResult[3] as Double).isNaN())
+    assertNull(meanResult[0])
+    assertNull(meanResult[3])
     // mean=20, min=10, max=30: (x-20)/(30-10)
     assertEquals(-0.5d, meanResult[1] as Double, 1e-6d)
     assertEquals(0.0d, meanResult[2] as Double, 1e-6d)

--- a/matrix-tablesaw/build.gradle
+++ b/matrix-tablesaw/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = 'se.alipsa.matrix'
-version = '0.3.0'
+version = '0.3.1-SNAPSHOT'
 description = 'Allows conversion between Matrix and Tablesaw'
 
 repositories {

--- a/matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/Normalizer.groovy
+++ b/matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/Normalizer.groovy
@@ -5,6 +5,7 @@ import tech.tablesaw.api.DoubleColumn
 import tech.tablesaw.api.FloatColumn
 
 import se.alipsa.matrix.stats.Normalize
+import se.alipsa.matrix.stats.Normalize.MissingValueType
 
 /**
  * This class provides various ways to normalize a Tablesaw column.
@@ -74,7 +75,7 @@ class Normalizer {
 
     List<Double> vals = []
     for (def x : column) {
-      vals.add(Normalize.minMaxNorm(x, min, max, decimals))
+      vals.add(Normalize.minMaxNorm(x, min, max, MissingValueType.DOUBLE_NAN, decimals))
     }
     DoubleColumn.create(NORM_PREFIX + column.name(), vals as Double[])
   }
@@ -92,7 +93,7 @@ class Normalizer {
 
     List<Float> vals = []
     for (def x : column) {
-      vals.add(Normalize.minMaxNorm(x, min, max, decimals))
+      vals.add(Normalize.minMaxNorm(x, min, max, MissingValueType.FLOAT_NAN, decimals))
     }
     FloatColumn.create(NORM_PREFIX + column.name(), vals as Float[])
   }
@@ -129,7 +130,7 @@ class Normalizer {
 
     List<Double> vals = []
     for (def x : column) {
-      vals.add(Normalize.meanNorm(x, mean, min, max, decimals))
+      vals.add(Normalize.meanNorm(x, mean, min, max, MissingValueType.DOUBLE_NAN, decimals))
     }
     DoubleColumn.create(NORM_PREFIX + column.name(), vals as Double[])
   }
@@ -148,7 +149,7 @@ class Normalizer {
 
     List<Float> vals = []
     for (def x : column) {
-      vals.add(Normalize.meanNorm(x, mean, min, max, decimals))
+      vals.add(Normalize.meanNorm(x, mean, min, max, MissingValueType.FLOAT_NAN, decimals))
     }
     FloatColumn.create(NORM_PREFIX + column.name(), vals as Float[])
   }

--- a/matrix-tablesaw/src/test/groovy/test/alipsa/groovy/matrix/tablesaw/NormalizeTest.groovy
+++ b/matrix-tablesaw/src/test/groovy/test/alipsa/groovy/matrix/tablesaw/NormalizeTest.groovy
@@ -45,6 +45,17 @@ class NormalizeTest {
   }
 
   @Test
+  void testMinMaxNormZeroRangeFloatColumnsUseMissingValues() {
+    def doubleNorm = Normalizer.minMaxNorm(DoubleColumn.create('doubleValues', [7d, 7d, 7d] as double[]))
+    def floatNorm = Normalizer.minMaxNorm(FloatColumn.create('floatValues', [7f, 7f, 7f] as float[]))
+
+    (0..<3).each { int row ->
+      Assertions.assertTrue(doubleNorm.isMissing(row))
+      Assertions.assertTrue(floatNorm.isMissing(row))
+    }
+  }
+
+  @Test
   void testMinMaxNormBigDecimal() {
     def obs = BigDecimalColumn.create('values', [1200, 34567, 3456, 12, 3456, 985, 1211] as BigDecimal[])
     def norm = Normalizer.minMaxNorm(obs, 8)
@@ -90,6 +101,17 @@ class NormalizeTest {
     def norm = Normalizer.meanNorm(obs, 7)
     def exp = [ -0.1508444, 0.8147756, -0.0855572, -0.1852244, -0.0855572, -0.1570664, -0.1505261 ] as Float[]
     Assertions.assertArrayEquals(exp, norm.asFloatArray())
+  }
+
+  @Test
+  void testMeanNormZeroRangeFloatColumnsUseMissingValues() {
+    def doubleNorm = Normalizer.meanNorm(DoubleColumn.create('doubleValues', [7d, 7d, 7d] as double[]))
+    def floatNorm = Normalizer.meanNorm(FloatColumn.create('floatValues', [7f, 7f, 7f] as float[]))
+
+    (0..<3).each { int row ->
+      Assertions.assertTrue(doubleNorm.isMissing(row))
+      Assertions.assertTrue(floatNorm.isMissing(row))
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

Implements task 6 from `matrix-stats/req/2.5.1-plan.md`.

- Adds `Normalize.MissingValueType` with `NULL`, `FLOAT_NAN`, and `DOUBLE_NAN`.
- Threads the optional missing-value sentinel through `minMaxNorm` and `meanNorm` scalar, array, list, column, and matrix overloads.
- Defaults undefined min-max and mean-normalization results to `null`, matching the other undefined-result paths in `matrix-stats`.
- Updates `matrix-tablesaw` normalization to opt into `DOUBLE_NAN` and `FLOAT_NAN` for Tablesaw floating columns.
- Bumps `matrix-tablesaw` and the BOM-managed Tablesaw version to `0.3.1-SNAPSHOT`.

## Modules Touched

- `matrix-stats`
- `matrix-tablesaw`
- `matrix-bom`

## Verification

- `./gradlew :matrix-stats:codenarcMain`
- `./gradlew :matrix-stats:spotlessCheck`
- `./gradlew :matrix-stats:test --tests 'NormalizeTest'`
- `./gradlew :matrix-stats:test`
- `./gradlew :matrix-tablesaw:codenarcMain`
- `./gradlew :matrix-tablesaw:spotlessCheck`
- `./gradlew :matrix-tablesaw:test`
- `mvn -f matrix-bom/bom.xml validate`
- `./gradlew test`
