### PR TITLE
Update matrix-stats 2.5.1 release notes

### DIFF
--- a/matrix-stats/release.md
+++ b/matrix-stats/release.md
@@ -3,6 +3,11 @@
 ## v2.5.1, 2026-06-30
 - Add toString to GoalSeek.Result for easier debugging and logging.
 - Fix `LinearRegression.summary()` matrix orientation so coefficient labels, estimates, and standard errors align with their column names.
+- Fix `Normalize.logNorm()` so negative values return `null` instead of throwing, matching the documented invalid-input behavior.
+- Fix confidence ellipses with `type = 't'` to use the finite-sample F-distribution scale instead of the normal chi-squared scale.
+- Fix Pearson and Spearman correlation for zero-variance inputs by returning `null` for undefined correlations instead of `0`.
+- Fix `Normalize.meanNorm()` null-sentinel handling so Integer and Long inputs match `minMaxNorm()`.
+- Add explicit `Normalize.MissingValueType` support for min-max and mean normalization, defaulting undefined results to `null` while allowing callers such as `matrix-tablesaw` to opt into `Float.NaN` or `Double.NaN`.
 
 ## v2.5.0, 2026-06-14
 - `GoalSeek.solve()` now returns a typed `GoalSeek.Result` with BigDecimal accessors for the computed value, result, and difference. Existing callers that need the previous map-shaped value can use `GoalSeek.solve(...) as Map`.

--- a/matrix-stats/req/2.5.1-plan.md
+++ b/matrix-stats/req/2.5.1-plan.md
@@ -188,16 +188,16 @@ Confirmed during review: this ordering is backward-compatible. An enum-typed par
 
 ## 7. Final Verification and Release Notes
 
-7.1 [ ] Run module verification in the repository-required order:
-- [ ] `./gradlew :matrix-stats:codenarcMain`
-- [ ] `./gradlew :matrix-stats:spotlessCheck`
-- [ ] `./gradlew :matrix-stats:test`
+7.1 [x] Run module verification in the repository-required order:
+- [x] `./gradlew :matrix-stats:codenarcMain` — passed
+- [x] `./gradlew :matrix-stats:spotlessCheck` — passed
+- [x] `./gradlew :matrix-stats:test` — passed (1014 tests)
 
-7.2 [ ] Run full regression verification before release/merge:
-- [ ] `./gradlew test`
+7.2 [x] Run full regression verification before release/merge:
+- [x] `./gradlew test` — passed
 
-7.3 [ ] Record all exact passing commands in this plan or in the PR description before marking any implementation section complete.
+7.3 [x] Record all exact passing commands in this plan or in the PR description before marking any implementation section complete.
 
-7.4 [ ] Update `matrix-stats/release.md` with a v2.5.1 section documenting the six bug fixes.
+7.4 [x] Update `matrix-stats/release.md` with a v2.5.1 section documenting the six bug fixes.
 
-7.5 [ ] Confirm no unrelated generated artifacts or local build outputs are included in the PR.
+7.5 [x] Confirm no unrelated generated artifacts or local build outputs are included in the PR.


### PR DESCRIPTION
## Summary

Implements task 7 from `matrix-stats/req/2.5.1-plan.md`.

- Updates `matrix-stats/release.md` so the `v2.5.1` section documents all six bug fixes from the plan.
- Records final module and full regression verification in the task plan.
- Confirms the PR contains no generated artifacts or local build outputs.

## Modules Touched

- `matrix-stats`

## Verification

- `./gradlew :matrix-stats:codenarcMain`
- `./gradlew :matrix-stats:spotlessCheck`
- `./gradlew :matrix-stats:test`
- `./gradlew test`
