### PR TITLE
Implemented phase 1.

### DIFF
--- a/matrix-tablesaw/req/v0.3.1-plan.md
+++ b/matrix-tablesaw/req/v0.3.1-plan.md
@@ -1,0 +1,110 @@
+# matrix-tablesaw v0.3.1 Correctness Plan
+
+## Scope
+
+This plan covers four correctness and API-wrapper gaps in `matrix-tablesaw` v0.3.1:
+
+- `TableUtil.round(NumberColumn, int)` fails when `DoubleColumn` or `FloatColumn` contains missing values.
+- `GdataFrameReader.csv(...)` overloads return plain Tablesaw `Table` instances instead of `Gtable`.
+- `GdataFrameJoiner` fluent builder methods return plain `DataFrameJoiner`/`Table` results instead of preserving `GdataFrameJoiner`/`Gtable`.
+- `TableUtil.frequency(Column<?>)` renders missing values with ambiguous real-looking strings such as `"null"`.
+
+Each numbered section is intended to be implementable and reviewable as a separate commit if useful. A task is only complete when its tests have passed and the exact test command has been recorded in this file or the PR description.
+
+## 1. Preserve Missing Values When Rounding Floating Columns
+
+**File:** `matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/TableUtil.groovy`
+
+1.1 [x] Add regression tests in `matrix-tablesaw/src/test/groovy/test/alipsa/groovy/matrix/tablesaw/TableUtilTest.groovy` for `DoubleColumn` and `FloatColumn` containing at least one missing value and at least one non-missing decimal value.
+
+1.2 [x] Assert the tests prove both behaviors:
+- missing values remain missing after `TableUtil.round(column, numDecimals)`;
+- non-missing values are rounded to the requested precision.
+
+1.3 [x] Update the `DoubleColumn` branch in `TableUtil.round(NumberColumn, int)` to skip missing rows before calling `round(double, int)`. Prefer `dc.isMissing(i)` because it uses Tablesaw's column-level missing-value semantics.
+
+1.4 [x] Update the `FloatColumn` branch the same way, using `fc.isMissing(i)` before calling `round(float, int)`.
+
+1.5 [x] Keep `round(double, int)` and `round(float, int)` strict for direct scalar calls; do not special-case `NaN` there unless a separate public scalar contract is intentionally added.
+
+1.6 [x] Run and record verification:
+- [x] `./gradlew :matrix-tablesaw:codenarcMain` — passed
+- [x] `./gradlew :matrix-tablesaw:spotlessCheck` — passed
+- [x] `./gradlew :matrix-tablesaw:test --tests 'test.alipsa.groovy.matrix.tablesaw.TableUtilTest'` — passed (14 tests)
+- [x] `./gradlew :matrix-tablesaw:test` — passed (119 tests)
+
+## 2. Wrap CSV Reads in GdataFrameReader
+
+**File:** `matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/gtable/GdataFrameReader.groovy`
+
+2.1 [ ] Add tests for common `Gtable.read().csv(...)` paths proving each returns `Gtable`, not plain `Table`. Cover at least `csv(String)` and `csv(File)` because they are the most common user-facing overloads.
+
+2.2 [ ] Inspect `tech.tablesaw.io.DataFrameReader` in the resolved Tablesaw dependency and list every public `csv(...)` overload available in the version used by this module. Do not rely on memory here; use `javap` or source JAR inspection.
+
+2.3 [ ] Override every public `csv(...)` overload in `GdataFrameReader` with a covariant `Gtable` return type, wrapping `super.csv(...)` via `Gtable.create(...)`. Expected candidates include overloads for path strings, `File`, `InputStream`, `URL`, and CSV read options/builders; confirm exact signatures from step 2.2.
+
+2.4 [ ] Add or update GroovyDoc for the CSV overloads so the class-level "all read operations return Gtable" promise is true for CSV as well as `url`, `file`, `string`, `usingOptions`, and `db`.
+
+2.5 [ ] Run and record verification:
+- [ ] `./gradlew :matrix-tablesaw:codenarcMain`
+- [ ] `./gradlew :matrix-tablesaw:spotlessCheck`
+- [ ] `./gradlew :matrix-tablesaw:test --tests 'test.alipsa.groovy.matrix.tablesaw.*'`
+
+## 3. Preserve Gtable Through GdataFrameJoiner Fluent Builder API
+
+**File:** `matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/gtable/GdataFrameJoiner.groovy`
+
+3.1 [ ] Add tests that use the fluent joiner path from `Gtable.joinOn(...)`, for example `left.joinOn('id').type(JoinType.INNER).with(right).join()`, and assert the final result is a `Gtable`.
+
+3.2 [ ] Add tests for at least one fluent option before `with(...)`, such as `keepAllJoinKeyColumns(boolean)`, `allowDuplicateColumnNames(boolean)`, or `rightJoinColumns(String...)`, proving the method returns `GdataFrameJoiner` and the final `join()` still returns `Gtable`.
+
+3.3 [ ] Inspect `tech.tablesaw.joining.DataFrameJoiner` in the resolved Tablesaw dependency and list the public fluent methods and terminal methods to override. Confirm exact return types and signatures before implementation.
+
+3.4 [ ] Override fluent builder methods such as `type(JoinType)`, `keepAllJoinKeyColumns(boolean)`, `allowDuplicateColumnNames(boolean)`, `rightJoinColumns(String...)`, and `with(Table...)` so they call `super`, preserve the underlying builder state, and return `this` as `GdataFrameJoiner`.
+
+3.5 [ ] Override terminal `join()` so it wraps `super.join()` with `Gtable.create(...)`.
+
+3.6 [ ] Keep existing direct convenience join methods (`inner`, `leftOuter`, `rightOuter`, `fullOuter`) unchanged except for any shared helper extraction that reduces duplication without changing behavior.
+
+3.7 [ ] Run and record verification:
+- [ ] `./gradlew :matrix-tablesaw:codenarcMain`
+- [ ] `./gradlew :matrix-tablesaw:spotlessCheck`
+- [ ] `./gradlew :matrix-tablesaw:test --tests 'test.alipsa.groovy.matrix.tablesaw.GtableTest'`
+- [ ] `./gradlew :matrix-tablesaw:test`
+
+## 4. Render Missing Values Explicitly in Frequency Tables
+
+**File:** `matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/TableUtil.groovy`
+
+4.1 [ ] Add tests in `TableUtilTest.groovy` for `TableUtil.frequency(Column<?>)` on a column type whose iterator returns Java `null` for missing values, such as `BooleanColumn`, `DateColumn`, `DateTimeColumn`, `InstantColumn`, or `TimeColumn`.
+
+4.2 [ ] Include a regression case where a real string value could be confused with the missing marker, for example a `StringColumn` containing a literal `"null"` alongside missing values if Tablesaw exposes those distinctly enough to assert.
+
+4.3 [ ] Decide and document the display convention for missing values in frequency output. Prefer a clear reserved marker such as `"<missing>"` over `String.valueOf(null)`, because it is visibly not a real data value.
+
+4.4 [ ] Update `TableUtil.frequency(Column<?>)` so missing entries are detected with column-level semantics where possible. Prefer using row indexes and `column.isMissing(i)` instead of only `forEach`, because iterator values do not reliably encode missingness across Tablesaw column types.
+
+4.5 [ ] Ensure the frequency counts still include missing values as their own bucket and that percentages are still calculated over the full column size.
+
+4.6 [ ] Add/update GroovyDoc for `frequency(Column<?>)` to document that missing values are grouped under the chosen missing-value marker.
+
+4.7 [ ] Run and record verification:
+- [ ] `./gradlew :matrix-tablesaw:codenarcMain`
+- [ ] `./gradlew :matrix-tablesaw:spotlessCheck`
+- [ ] `./gradlew :matrix-tablesaw:test --tests 'test.alipsa.groovy.matrix.tablesaw.TableUtilTest'`
+
+## 5. Final Verification and Release Notes
+
+5.1 [ ] Run module verification in repository-required order:
+- [ ] `./gradlew :matrix-tablesaw:codenarcMain`
+- [ ] `./gradlew :matrix-tablesaw:spotlessCheck`
+- [ ] `./gradlew :matrix-tablesaw:test`
+
+5.2 [ ] Run full regression verification before merge:
+- [ ] `./gradlew test`
+
+5.3 [ ] Update `matrix-tablesaw/release.md` with a v0.3.1 section documenting the four fixes.
+
+5.4 [ ] Record all exact passing commands in this plan or in the PR description before marking implementation tasks complete.
+
+5.5 [ ] Confirm no unrelated generated artifacts or local build outputs are included in the PR.

--- a/matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/TableUtil.groovy
+++ b/matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/TableUtil.groovy
@@ -165,6 +165,9 @@ class TableUtil {
     if (column in DoubleColumn) {
       def dc = column as DoubleColumn
       for (int i = 0; i < dc.size(); i++) {
+        if (dc.isMissing(i)) {
+          continue
+        }
         double val = dc.getDouble(i)
         dc.set(i, round(val, numDecimals))
       }
@@ -173,6 +176,9 @@ class TableUtil {
     if (column in FloatColumn) {
       def fc = column as FloatColumn
       for (int i = 0; i < fc.size(); i++) {
+        if (fc.isMissing(i)) {
+          continue
+        }
         float val = fc.getFloat(i)
         fc.set(i, round(val, numDecimals))
       }

--- a/matrix-tablesaw/src/test/groovy/test/alipsa/groovy/matrix/tablesaw/TableUtilTest.groovy
+++ b/matrix-tablesaw/src/test/groovy/test/alipsa/groovy/matrix/tablesaw/TableUtilTest.groovy
@@ -191,6 +191,28 @@ class TableUtilTest {
   }
 
   @Test
+  void testRoundDoubleColumnPreservesMissingValues() {
+    DoubleColumn col = DoubleColumn.create('values', [1.234d, Double.NaN, 5.678d] as double[])
+
+    TableUtil.round(col, 2)
+
+    assertEquals(1.23d, col.getDouble(0), 1e-9)
+    assertTrue(col.isMissing(1))
+    assertEquals(5.68d, col.getDouble(2), 1e-9)
+  }
+
+  @Test
+  void testRoundFloatColumnPreservesMissingValues() {
+    FloatColumn col = FloatColumn.create('values', [1.234f, Float.NaN, 5.678f] as float[])
+
+    TableUtil.round(col, 2)
+
+    assertEquals(1.23f, col.getFloat(0), 1e-6f)
+    assertTrue(col.isMissing(1))
+    assertEquals(5.68f, col.getFloat(2), 1e-6f)
+  }
+
+  @Test
   void testRoundRejectsNegativeDecimals() {
     assertThrows(IllegalArgumentException) { -> TableUtil.round(1.0d, -1) }
     assertThrows(IllegalArgumentException) { -> TableUtil.round(1.0f, -1) }


### PR DESCRIPTION
  Changed matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/TableUtil.groovy:165 so DoubleColumn and FloatColumn rounding skips rows where isMissing(i) is true,
  preserving missing values instead of passing NaN into BigDecimal.valueOf.

  Added regression coverage in matrix-tablesaw/src/test/groovy/test/alipsa/groovy/matrix/tablesaw/TableUtilTest.groovy:193 for missing-preserving rounding on both column
  types. Updated the phase 1 checklist in matrix-tablesaw/req/v0.3.1-plan.md.

  Verification passed:

  - ./gradlew :matrix-tablesaw:codenarcMain
  - ./gradlew :matrix-tablesaw:spotlessCheck
  - ./gradlew :matrix-tablesaw:test --tests 'test.alipsa.groovy.matrix.tablesaw.TableUtilTest'
  - ./gradlew :matrix-tablesaw:test