### PR TITLE
Wrap Gtable CSV reads

### DIFF
--- a/matrix-tablesaw/req/v0.3.1-plan.md
+++ b/matrix-tablesaw/req/v0.3.1-plan.md
@@ -37,18 +37,21 @@ Each numbered section is intended to be implementable and reviewable as a separa
 
 **File:** `matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/gtable/GdataFrameReader.groovy`
 
-2.1 [ ] Add tests for common `Gtable.read().csv(...)` paths proving each returns `Gtable`, not plain `Table`. Cover at least `csv(String)` and `csv(File)` because they are the most common user-facing overloads.
+2.1 [x] Add tests for common `Gtable.read().csv(...)` paths proving each returns `Gtable`, not plain `Table`. Cover at least `csv(String)` and `csv(File)` because they are the most common user-facing overloads.
 
-2.2 [ ] Inspect `tech.tablesaw.io.DataFrameReader` in the resolved Tablesaw dependency and list every public `csv(...)` overload available in the version used by this module. Do not rely on memory here; use `javap` or source JAR inspection.
+2.2 [x] Inspect `tech.tablesaw.io.DataFrameReader` in the resolved Tablesaw dependency and list every public `csv(...)` overload available in the version used by this module. Do not rely on memory here; use `javap` or source JAR inspection.
 
-2.3 [ ] Override every public `csv(...)` overload in `GdataFrameReader` with a covariant `Gtable` return type, wrapping `super.csv(...)` via `Gtable.create(...)`. Expected candidates include overloads for path strings, `File`, `InputStream`, `URL`, and CSV read options/builders; confirm exact signatures from step 2.2.
+Tablesaw 0.44.4 exposes these public CSV overloads: `csv(String)`, `csv(String, String)`, `csv(File)`, `csv(InputStream)`, `csv(URL)`, `csv(InputStream, String)`, `csv(Reader)`, `csv(CsvReadOptions.Builder)`, and `csv(CsvReadOptions)`.
 
-2.4 [ ] Add or update GroovyDoc for the CSV overloads so the class-level "all read operations return Gtable" promise is true for CSV as well as `url`, `file`, `string`, `usingOptions`, and `db`.
+2.3 [x] Override every public `csv(...)` overload in `GdataFrameReader` with a covariant `Gtable` return type, wrapping `super.csv(...)` via `Gtable.create(...)`. Expected candidates include overloads for path strings, `File`, `InputStream`, `URL`, and CSV read options/builders; confirm exact signatures from step 2.2.
 
-2.5 [ ] Run and record verification:
-- [ ] `./gradlew :matrix-tablesaw:codenarcMain`
-- [ ] `./gradlew :matrix-tablesaw:spotlessCheck`
-- [ ] `./gradlew :matrix-tablesaw:test --tests 'test.alipsa.groovy.matrix.tablesaw.*'`
+2.4 [x] Add or update GroovyDoc for the CSV overloads so the class-level "all read operations return Gtable" promise is true for CSV as well as `url`, `file`, `string`, `usingOptions`, and `db`.
+
+2.5 [x] Run and record verification:
+- [x] `./gradlew :matrix-tablesaw:codenarcMain` — passed
+- [x] `./gradlew :matrix-tablesaw:spotlessCheck` — passed
+- [x] `./gradlew :matrix-tablesaw:test --tests 'test.alipsa.groovy.matrix.tablesaw.*'` — passed (45 tests)
+- [x] `./gradlew :matrix-tablesaw:test` — passed (121 tests)
 
 ## 3. Preserve Gtable Through GdataFrameJoiner Fluent Builder API
 

--- a/matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/gtable/GdataFrameReader.groovy
+++ b/matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/gtable/GdataFrameReader.groovy
@@ -3,6 +3,7 @@ package se.alipsa.matrix.tablesaw.gtable
 import tech.tablesaw.io.DataFrameReader
 import tech.tablesaw.io.ReadOptions
 import tech.tablesaw.io.ReaderRegistry
+import tech.tablesaw.io.csv.CsvReadOptions
 
 import java.sql.ResultSet
 import java.sql.SQLException
@@ -25,6 +26,107 @@ class GdataFrameReader extends DataFrameReader {
    */
   GdataFrameReader(ReaderRegistry registry) {
     super(registry)
+  }
+
+  /**
+   * Read a CSV file from a path.
+   *
+   * @param file the file path to read from
+   * @return a Gtable containing the CSV data
+   */
+  @Override
+  Gtable csv(String file) {
+    Gtable.create(super.csv(file))
+  }
+
+  /**
+   * Read CSV data from a string and assign the given table name.
+   *
+   * @param contents the CSV contents
+   * @param tableName the table name
+   * @return a Gtable containing the CSV data
+   */
+  @Override
+  Gtable csv(String contents, String tableName) {
+    Gtable.create(super.csv(contents, tableName))
+  }
+
+  /**
+   * Read a CSV file.
+   *
+   * @param file the file to read from
+   * @return a Gtable containing the CSV data
+   */
+  @Override
+  Gtable csv(File file) {
+    Gtable.create(super.csv(file))
+  }
+
+  /**
+   * Read CSV data from an input stream.
+   *
+   * @param stream the input stream to read from
+   * @return a Gtable containing the CSV data
+   */
+  @Override
+  Gtable csv(InputStream stream) {
+    Gtable.create(super.csv(stream))
+  }
+
+  /**
+   * Read CSV data from a URL.
+   *
+   * @param url the URL to read from
+   * @return a Gtable containing the CSV data
+   */
+  @Override
+  Gtable csv(URL url) {
+    Gtable.create(super.csv(url))
+  }
+
+  /**
+   * Read CSV data from an input stream and assign the given table name.
+   *
+   * @param stream the input stream to read from
+   * @param name the table name
+   * @return a Gtable containing the CSV data
+   */
+  @Override
+  Gtable csv(InputStream stream, String name) {
+    Gtable.create(super.csv(stream, name))
+  }
+
+  /**
+   * Read CSV data from a reader.
+   *
+   * @param reader the reader to read from
+   * @return a Gtable containing the CSV data
+   */
+  @Override
+  Gtable csv(Reader reader) {
+    Gtable.create(super.csv(reader))
+  }
+
+  /**
+   * Read CSV data using a CSV read options builder.
+   *
+   * @param options the CSV read options builder
+   * @return a Gtable containing the CSV data
+   */
+  @Override
+  Gtable csv(CsvReadOptions.Builder options) {
+    Gtable.create(super.csv(options))
+  }
+
+  /**
+   * Read CSV data using CSV read options.
+   *
+   * @param options the CSV read options
+   * @return a Gtable containing the CSV data
+   */
+  @Override
+  Gtable csv(CsvReadOptions options) {
+    Gtable.create(super.csv(options))
   }
 
   /**

--- a/matrix-tablesaw/src/test/groovy/test/alipsa/groovy/matrix/tablesaw/GtableTest.groovy
+++ b/matrix-tablesaw/src/test/groovy/test/alipsa/groovy/matrix/tablesaw/GtableTest.groovy
@@ -90,6 +90,36 @@ class GtableTest {
   }
 
   @Test
+  void testCsvReaderReturnsGtableForPathAndFile() {
+    File csv = new File(getClass().getResource('/glaciers.csv').toURI())
+
+    def fromPath = Gtable.read().csv(csv.absolutePath)
+    def fromFile = Gtable.read().csv(csv)
+
+    assertTrue(fromPath instanceof Gtable)
+    assertTrue(fromFile instanceof Gtable)
+    assertEquals(70, fromPath.rowCount())
+    assertEquals(70, fromFile.rowCount())
+  }
+
+  @Test
+  void testCsvReaderReturnsGtableForOptions() {
+    def csv = getClass().getResource('/glaciers.csv')
+    CsvReadOptions options = CsvReadOptions.builder(csv)
+        .separator(',' as Character)
+        .columnTypes([INTEGER, BigDecimalColumnType.instance(), INTEGER] as ColumnType[])
+        .build()
+
+    def fromOptions = Gtable.read().csv(options)
+    def fromBuilder = Gtable.read().csv(CsvReadOptions.builder(csv))
+
+    assertTrue(fromOptions instanceof Gtable)
+    assertTrue(fromBuilder instanceof Gtable)
+    assertEquals(1946, fromOptions[1, 0])
+    assertEquals(70, fromBuilder.rowCount())
+  }
+
+  @Test
   void testExportToCsv() {
     def empData = [
         emp_id: 1..5,


### PR DESCRIPTION
## Summary

Implements phase 2 from `matrix-tablesaw/req/v0.3.1-plan.md`.

- Overrides every public `DataFrameReader.csv(...)` overload in `GdataFrameReader` so CSV reads return `Gtable`.
- Adds coverage for `Gtable.read().csv(...)` using path, `File`, `CsvReadOptions`, and `CsvReadOptions.Builder`.
- Records the resolved Tablesaw 0.44.4 CSV overload list and phase verification in the plan.

## Modules Touched

- `matrix-tablesaw`

## Verification

- `./gradlew :matrix-tablesaw:codenarcMain`
- `./gradlew :matrix-tablesaw:spotlessCheck`
- `./gradlew :matrix-tablesaw:test --tests 'test.alipsa.groovy.matrix.tablesaw.*'`
- `./gradlew :matrix-tablesaw:test`
