### PR TITLE
Wrap Gtable fluent joins

### DIFF
--- a/matrix-tablesaw/req/v0.3.1-plan.md
+++ b/matrix-tablesaw/req/v0.3.1-plan.md
@@ -57,23 +57,25 @@ Tablesaw 0.44.4 exposes these public CSV overloads: `csv(String)`, `csv(String, 
 
 **File:** `matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/gtable/GdataFrameJoiner.groovy`
 
-3.1 [ ] Add tests that use the fluent joiner path from `Gtable.joinOn(...)`, for example `left.joinOn('id').type(JoinType.INNER).with(right).join()`, and assert the final result is a `Gtable`.
+3.1 [x] Add tests that use the fluent joiner path from `Gtable.joinOn(...)`, for example `left.joinOn('id').type(JoinType.INNER).with(right).join()`, and assert the final result is a `Gtable`.
 
-3.2 [ ] Add tests for at least one fluent option before `with(...)`, such as `keepAllJoinKeyColumns(boolean)`, `allowDuplicateColumnNames(boolean)`, or `rightJoinColumns(String...)`, proving the method returns `GdataFrameJoiner` and the final `join()` still returns `Gtable`.
+3.2 [x] Add tests for at least one fluent option before `with(...)`, such as `keepAllJoinKeyColumns(boolean)`, `allowDuplicateColumnNames(boolean)`, or `rightJoinColumns(String...)`, proving the method returns `GdataFrameJoiner` and the final `join()` still returns `Gtable`.
 
-3.3 [ ] Inspect `tech.tablesaw.joining.DataFrameJoiner` in the resolved Tablesaw dependency and list the public fluent methods and terminal methods to override. Confirm exact return types and signatures before implementation.
+3.3 [x] Inspect `tech.tablesaw.joining.DataFrameJoiner` in the resolved Tablesaw dependency and list the public fluent methods and terminal methods to override. Confirm exact return types and signatures before implementation.
 
-3.4 [ ] Override fluent builder methods such as `type(JoinType)`, `keepAllJoinKeyColumns(boolean)`, `allowDuplicateColumnNames(boolean)`, `rightJoinColumns(String...)`, and `with(Table...)` so they call `super`, preserve the underlying builder state, and return `this` as `GdataFrameJoiner`.
+Tablesaw 0.44.4 exposes these public fluent/terminal methods: `type(JoinType)`, `keepAllJoinKeyColumns(boolean)`, `allowDuplicateColumnNames(boolean)`, `rightJoinColumns(String...)`, `with(Table...)`, and `join()`.
 
-3.5 [ ] Override terminal `join()` so it wraps `super.join()` with `Gtable.create(...)`.
+3.4 [x] Override fluent builder methods such as `type(JoinType)`, `keepAllJoinKeyColumns(boolean)`, `allowDuplicateColumnNames(boolean)`, `rightJoinColumns(String...)`, and `with(Table...)` so they call `super`, preserve the underlying builder state, and return `this` as `GdataFrameJoiner`.
 
-3.6 [ ] Keep existing direct convenience join methods (`inner`, `leftOuter`, `rightOuter`, `fullOuter`) unchanged except for any shared helper extraction that reduces duplication without changing behavior.
+3.5 [x] Override terminal `join()` so it wraps `super.join()` with `Gtable.create(...)`.
 
-3.7 [ ] Run and record verification:
-- [ ] `./gradlew :matrix-tablesaw:codenarcMain`
-- [ ] `./gradlew :matrix-tablesaw:spotlessCheck`
-- [ ] `./gradlew :matrix-tablesaw:test --tests 'test.alipsa.groovy.matrix.tablesaw.GtableTest'`
-- [ ] `./gradlew :matrix-tablesaw:test`
+3.6 [x] Keep existing direct convenience join methods (`inner`, `leftOuter`, `rightOuter`, `fullOuter`) unchanged except for any shared helper extraction that reduces duplication without changing behavior.
+
+3.7 [x] Run and record verification:
+- [x] `./gradlew :matrix-tablesaw:codenarcMain` — passed
+- [x] `./gradlew :matrix-tablesaw:spotlessCheck` — passed
+- [x] `./gradlew :matrix-tablesaw:test --tests 'test.alipsa.groovy.matrix.tablesaw.GtableTest'` — passed (21 tests)
+- [x] `./gradlew :matrix-tablesaw:test` — passed (123 tests)
 
 ## 4. Render Missing Values Explicitly in Frequency Tables
 

--- a/matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/gtable/GdataFrameJoiner.groovy
+++ b/matrix-tablesaw/src/main/groovy/se/alipsa/matrix/tablesaw/gtable/GdataFrameJoiner.groovy
@@ -2,6 +2,7 @@ package se.alipsa.matrix.tablesaw.gtable
 
 import tech.tablesaw.api.Table
 import tech.tablesaw.joining.DataFrameJoiner
+import tech.tablesaw.joining.JoinType
 
 /**
  * Groovy-friendly wrapper for Tablesaw's DataFrameJoiner that returns Gtable instances.
@@ -40,6 +41,76 @@ class GdataFrameJoiner extends DataFrameJoiner {
    */
   GdataFrameJoiner(Table table, String... joinColumnNames) {
     super(table, joinColumnNames)
+  }
+
+  /**
+   * Sets the join type for fluent join construction.
+   *
+   * @param joinType the type of join to perform
+   * @return this joiner for method chaining
+   */
+  @Override
+  GdataFrameJoiner type(JoinType joinType) {
+    super.type(joinType)
+    this
+  }
+
+  /**
+   * Configures whether all join-key columns should be retained.
+   *
+   * @param keep true to keep join-key columns from right tables
+   * @return this joiner for method chaining
+   */
+  @Override
+  GdataFrameJoiner keepAllJoinKeyColumns(boolean keep) {
+    super.keepAllJoinKeyColumns(keep)
+    this
+  }
+
+  /**
+   * Configures whether duplicate non-join column names are allowed.
+   *
+   * @param allow true to allow duplicate column names
+   * @return this joiner for method chaining
+   */
+  @Override
+  GdataFrameJoiner allowDuplicateColumnNames(boolean allow) {
+    super.allowDuplicateColumnNames(allow)
+    this
+  }
+
+  /**
+   * Sets the join columns for the right-side tables.
+   *
+   * @param rightJoinColumnNames the right-side join column names
+   * @return this joiner for method chaining
+   */
+  @Override
+  GdataFrameJoiner rightJoinColumns(String... rightJoinColumnNames) {
+    super.rightJoinColumns(rightJoinColumnNames)
+    this
+  }
+
+  /**
+   * Sets the right-side tables for fluent join construction.
+   *
+   * @param tables the right-side tables
+   * @return this joiner for method chaining
+   */
+  @Override
+  GdataFrameJoiner with(Table... tables) {
+    super.with(tables)
+    this
+  }
+
+  /**
+   * Performs a fluent join and returns a Gtable.
+   *
+   * @return a Gtable containing the join result
+   */
+  @Override
+  Gtable join() {
+    Gtable.create(super.join())
   }
 
   /**

--- a/matrix-tablesaw/src/test/groovy/test/alipsa/groovy/matrix/tablesaw/GtableTest.groovy
+++ b/matrix-tablesaw/src/test/groovy/test/alipsa/groovy/matrix/tablesaw/GtableTest.groovy
@@ -11,10 +11,12 @@ import tech.tablesaw.api.BigDecimalColumn
 import tech.tablesaw.api.ColumnType
 import tech.tablesaw.column.numbers.BigDecimalColumnType
 import tech.tablesaw.io.csv.CsvReadOptions
+import tech.tablesaw.joining.JoinType
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.tablesaw.Normalizer
 import se.alipsa.matrix.tablesaw.TableUtil
+import se.alipsa.matrix.tablesaw.gtable.GdataFrameJoiner
 import se.alipsa.matrix.tablesaw.gtable.Gtable
 
 class GtableTest {
@@ -162,6 +164,53 @@ class GtableTest {
     table.concat(table2)
     assertEquals(5, table.rowCount(), 'concat rowcount')
     assertEquals(6, table.columnCount(), 'concat columnCount')
+  }
+
+  @Test
+  void testFluentJoinReturnsGtable() {
+    Gtable employees = Gtable.create([
+        id: [1, 2, 3],
+        name: ['Rick', 'Dan', 'Michelle']
+    ])
+    Gtable performance = Gtable.create([
+        id: [1, 3, 4],
+        score: [0.76, 0.68, 0.91]
+    ])
+
+    def joined = employees.joinOn('id')
+        .type(JoinType.INNER)
+        .with(performance)
+        .join()
+
+    assertTrue(joined instanceof Gtable)
+    assertEquals(2, joined.rowCount())
+    assertEquals(['id', 'name', 'score'], joined.columnNames())
+  }
+
+  @Test
+  void testFluentJoinOptionsReturnGdataFrameJoiner() {
+    Gtable employees = Gtable.create([
+        emp_id: [1, 2, 3],
+        name: ['Rick', 'Dan', 'Michelle']
+    ])
+    Gtable performance = Gtable.create([
+        employee_id: [1, 3, 4],
+        score: [0.76, 0.68, 0.91]
+    ])
+
+    def joiner = employees.joinOn('emp_id')
+    assertTrue(joiner.type(JoinType.LEFT_OUTER) instanceof GdataFrameJoiner)
+    assertTrue(joiner.keepAllJoinKeyColumns(true) instanceof GdataFrameJoiner)
+    assertTrue(joiner.allowDuplicateColumnNames(true) instanceof GdataFrameJoiner)
+    assertTrue(joiner.rightJoinColumns('employee_id') instanceof GdataFrameJoiner)
+    assertTrue(joiner.with(performance) instanceof GdataFrameJoiner)
+
+    def joined = joiner.join()
+
+    assertTrue(joined instanceof Gtable)
+    assertEquals(3, joined.rowCount())
+    assertTrue(joined.columnNames().contains('employee_id'))
+    assertTrue(joined.columnNames().contains('score'))
   }
 
   @Test


### PR DESCRIPTION
## Summary

Implements phase 3 from `matrix-tablesaw/req/v0.3.1-plan.md`.

- Overrides `GdataFrameJoiner` fluent builder methods so chaining preserves `GdataFrameJoiner`.
- Wraps fluent `join()` results as `Gtable`.
- Adds tests for `joinOn(...).type(...).with(...).join()` and option chaining with right-side join columns.
- Records the resolved Tablesaw 0.44.4 fluent joiner API and verification in the plan.

## Modules Touched

- `matrix-tablesaw`

## Verification

- `./gradlew :matrix-tablesaw:codenarcMain`
- `./gradlew :matrix-tablesaw:spotlessCheck`
- `./gradlew :matrix-tablesaw:test --tests 'test.alipsa.groovy.matrix.tablesaw.GtableTest'`
- `./gradlew :matrix-tablesaw:test`
