### PR TITLE
[codex] Finalize matrix-tablesaw 0.3.1 notes

### DIFF
--- a/matrix-tablesaw/release.md
+++ b/matrix-tablesaw/release.md
@@ -1,5 +1,25 @@
 # Matrix-Tablesaw Version history
 
+## v0.3.1, 2026-07-03
+
+### Bug Fixes
+- **Preserve missing floating values during rounding**
+  - `TableUtil.round(NumberColumn, int)` now skips missing rows for `DoubleColumn` and `FloatColumn` before rounding non-missing values.
+  - Direct scalar rounding remains strict and does not special-case `NaN`.
+- **Return Gtable from CSV reader overloads**
+  - `GdataFrameReader.csv(...)` now wraps all public Tablesaw CSV read overloads in `Gtable`, including path, file, stream, URL, reader, and `CsvReadOptions` variants.
+- **Preserve Gtable through fluent joins**
+  - `GdataFrameJoiner` fluent builder methods now return `GdataFrameJoiner`, and terminal `join()` returns `Gtable`.
+  - Existing direct convenience joins continue to return `Gtable`.
+- **Render frequency-table missing values explicitly**
+  - `TableUtil.frequency(Column<?>)` now detects missing entries with `column.isMissing(i)` and groups them under the reserved `"<missing>"` marker.
+  - Literal string values such as `"null"` remain distinct from true missing values.
+  - A real non-missing value that would display as `"<missing>"` now fails with a clear `IllegalArgumentException` instead of silently merging with missing values.
+
+### Testing
+- Final matrix-tablesaw verification passed in repository-required order.
+- Full repository test suite passed.
+
 ## v0.3.0, 2026-05-05
 
 ### Breaking Changes

--- a/matrix-tablesaw/req/v0.3.1-plan.md
+++ b/matrix-tablesaw/req/v0.3.1-plan.md
@@ -101,16 +101,16 @@ Tablesaw 0.44.4 exposes these public fluent/terminal methods: `type(JoinType)`, 
 
 ## 5. Final Verification and Release Notes
 
-5.1 [ ] Run module verification in repository-required order:
-- [ ] `./gradlew :matrix-tablesaw:codenarcMain`
-- [ ] `./gradlew :matrix-tablesaw:spotlessCheck`
-- [ ] `./gradlew :matrix-tablesaw:test`
+5.1 [x] Run module verification in repository-required order:
+- [x] `./gradlew :matrix-tablesaw:codenarcMain` — passed
+- [x] `./gradlew :matrix-tablesaw:spotlessCheck` — passed
+- [x] `./gradlew :matrix-tablesaw:test` — passed (126 tests)
 
-5.2 [ ] Run full regression verification before merge:
-- [ ] `./gradlew test`
+5.2 [x] Run full regression verification before merge:
+- [x] `./gradlew test` — passed
 
-5.3 [ ] Update `matrix-tablesaw/release.md` with a v0.3.1 section documenting the four fixes.
+5.3 [x] Update `matrix-tablesaw/release.md` with a v0.3.1 section documenting the four fixes.
 
-5.4 [ ] Record all exact passing commands in this plan or in the PR description before marking implementation tasks complete.
+5.4 [x] Record all exact passing commands in this plan or in the PR description before marking implementation tasks complete.
 
-5.5 [ ] Confirm no unrelated generated artifacts or local build outputs are included in the PR.
+5.5 [x] Confirm no unrelated generated artifacts or local build outputs are included in the PR.


### PR DESCRIPTION
## Summary
- Add v0.3.1 release notes for the four matrix-tablesaw correctness/API fixes.
- Mark phase 5 final verification tasks complete in the v0.3.1 plan.

## Modules touched
- matrix-tablesaw

## Validation
- `./gradlew :matrix-tablesaw:codenarcMain`
- `./gradlew :matrix-tablesaw:spotlessCheck`
- `./gradlew :matrix-tablesaw:test` (126 tests)
- `./gradlew test`

## Scope
- Documentation/checklist-only phase 5 update.
- No generated artifacts or local build outputs included.