### PR TITLE
matrix-xchart: fix BigDecimal literals and correlation heatmap label mismatch

### DIFF
--- a/matrix-bom/bom.xml
+++ b/matrix-bom/bom.xml
@@ -51,7 +51,7 @@
     <matrixSqlVersion>2.4.0</matrixSqlVersion>
     <matrixStatsVersion>2.5.1</matrixStatsVersion>
     <matrixTablesawVersion>0.3.1</matrixTablesawVersion>
-    <matrixXChartVersion>0.3.1-SNAPSHOT</matrixXChartVersion>
+    <matrixXChartVersion>0.3.1</matrixXChartVersion>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/matrix-xchart/build.gradle
+++ b/matrix-xchart/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'se.alipsa.matrix'
-version = '0.3.1-SNAPSHOT'
+version = '0.3.1'
 description = "Groovy library for creating charts with xcharts using matrix ([][] data)"
 
 JavaCompile javaCompile = compileJava {

--- a/matrix-xchart/readme.md
+++ b/matrix-xchart/readme.md
@@ -10,8 +10,8 @@ To use it add the following to your gradle build script (or equivalent for maven
 ```groovy
 implementation 'org.apache.groovy:groovy:5.0.6'
 implementation 'se.alipsa.matrix:matrix-core:3.8.0'
-implementation 'se.alipsa.matrix:matrix-stats:2.4.0'
-implementation 'se.alipsa.matrix:matrix-xchart:0.3.0'
+implementation 'se.alipsa.matrix:matrix-stats:2.5.1'
+implementation 'se.alipsa.matrix:matrix-xchart:0.3.1'
 ```
 Here is an example usage for a Line Chart:
 

--- a/matrix-xchart/release.md
+++ b/matrix-xchart/release.md
@@ -1,5 +1,10 @@
 # Matrix XChart release history
 
+## v0.3.1, in progress
+- Fix xchart correlation heatmap diagonal
+- Handle undefined heatmap correlations
+- Use BigDecimal.ONE and ZERO instead of 1G and 0G which must be coerced to BigDecimal.
+
 ## v0.3.0, 2026-05-25
 - fix histogram default bin calculation so Scott's rule is treated as a bin width and converted to a bucket count from the data range
 - add clear validation for invalid histogram input and invalid heatmap shapes

--- a/matrix-xchart/release.md
+++ b/matrix-xchart/release.md
@@ -4,6 +4,7 @@
 - Fix xchart correlation heatmap diagonal
 - Handle undefined heatmap correlations
 - Use BigDecimal.ONE and ZERO instead of 1G and 0G which must be coerced to BigDecimal.
+- Fix CorrelationHeatmapChart auto-series so heatmap cells are labeled with the correct row/column pair for 3+ columns (previously off-diagonal cells showed the correlation of a different, mirrored column pair)
 
 ## v0.3.0, 2026-05-25
 - fix histogram default bin calculation so Scott's rule is treated as a bin width and converted to a bucket count from the data range

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
@@ -133,9 +133,9 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
 
   private static BigDecimal roundCorrelation(BigDecimal correlation, boolean selfCorrelation) {
     if (selfCorrelation) {
-      return 1G
+      return BigDecimal.ONE
     }
-    correlation == null ? 0G : correlation.round(CORRELATION_SCALE)
+    correlation == null ? BigDecimal.ZERO : correlation.round(CORRELATION_SCALE)
   }
 
   private void validateColumns(List<String> columnNames) {

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
@@ -25,7 +25,6 @@ import se.alipsa.matrix.xchart.abstractions.AbstractChart
 class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, HeatMapChart, HeatMapStyler, HeatMapSeries> {
 
   private static final int CORRELATION_SCALE = 2
-  private static final int CORR_MATRIX_COLUMNS = 2
   final Number[] numberArray = new Number[]{}
 
   private CorrelationHeatmapChart(Matrix matrix, Integer width = null, Integer height = null) {
@@ -85,23 +84,14 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
     validateColumns(columnNames)
     Matrix data = matrix.select(columnNames)
     int size = columnNames.size()
-    List<BigDecimal> corr = ((size - 1)..0).collectMany { int i ->
-      (0..<size).collect { int j ->
-        List<BigDecimal> xValues = ListConverter.toBigDecimals(data[j])
-        List<BigDecimal> yValues = ListConverter.toBigDecimals(data[i])
-        roundCorrelation(Correlation.cor(xValues, yValues), i == j)
+    List<List<Number>> corr = (0..<size).collect { int c ->
+      (0..<size).collect { int r ->
+        List<BigDecimal> xValues = ListConverter.toBigDecimals(data[c])
+        List<BigDecimal> yValues = ListConverter.toBigDecimals(data[r])
+        roundCorrelation(Correlation.cor(xValues, yValues), c == r) as Number
       }
     }
-    def corrMatrix = Matrix.builder().data(X: 0..<corr.size(), Heat: corr)
-        .types([Number] * CORR_MATRIX_COLUMNS)
-        .matrixName('Heatmap')
-        .build()
-    addSeries(
-        title,
-        columnNames.reverse(),
-        columnNames,
-        corrMatrix['Heat'].collate(size)
-    )
+    addSeries(title, columnNames, columnNames, corr)
   }
 
   /**
@@ -127,7 +117,7 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
       }
       tmpRows << tmpRow
     }
-    xchart.addSeries(seriesName, rowLabels, columnLabels, heatData)
+    xchart.addSeries(seriesName, columnLabels, rowLabels, heatData)
     this
   }
 

--- a/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/CorrelationHeatmapChartTest.groovy
+++ b/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/CorrelationHeatmapChartTest.groovy
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
 import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.stats.Correlation
 import se.alipsa.matrix.xchart.CorrelationHeatmapChart
 
 class CorrelationHeatmapChartTest {
@@ -91,10 +92,45 @@ class CorrelationHeatmapChartTest {
     Map<String, Number> heatData = series.heatData.collectEntries { Number[] point ->
       [("${point[0]},${point[1]}".toString()): point[2]]
     }
-    assertEquals(0G, heatData['0,0'])
-    assertEquals(1G, heatData['1,0'])
-    assertEquals(1G, heatData['0,1'])
-    assertEquals(0G, heatData['1,1'])
+    // (0,0) = x vs x (self), (1,1) = constant vs constant (self)
+    assertEquals(1G, heatData['0,0'])
+    assertEquals(0G, heatData['1,0'])
+    assertEquals(0G, heatData['0,1'])
+    assertEquals(1G, heatData['1,1'])
+  }
+
+  @Test
+  void testCorrelationHeatmapCellsMatchColumnLabelsForThreeColumns() {
+    Matrix matrix = Matrix.builder().data(
+        A: [1, 2, 3, 4, 5],
+        B: [5, 3, 4, 1, 2],
+        C: [2, 1, 5, 3, 4]
+    ).types([Number] * 3).build()
+
+    def chart = CorrelationHeatmapChart.create(matrix).addSeries('Correlation', ['A', 'B', 'C'])
+    def series = chart.getSeries('Correlation')
+
+    BigDecimal corrAB = Correlation.cor(matrix['A'] as List, matrix['B'] as List).round(2)
+    BigDecimal corrAC = Correlation.cor(matrix['A'] as List, matrix['C'] as List).round(2)
+    BigDecimal corrBC = Correlation.cor(matrix['B'] as List, matrix['C'] as List).round(2)
+
+    List<?> xData = series.xData
+    List<?> yData = series.yData
+    Map<String, Number> cellByLabels = series.heatData.collectEntries { Number[] point ->
+      String x = xData[point[0].intValue()]
+      String y = yData[point[1].intValue()]
+      [("$x,$y".toString()): point[2]]
+    }
+
+    assertEquals(corrAB, cellByLabels['A,B'])
+    assertEquals(corrAB, cellByLabels['B,A'])
+    assertEquals(corrAC, cellByLabels['A,C'])
+    assertEquals(corrAC, cellByLabels['C,A'])
+    assertEquals(corrBC, cellByLabels['B,C'])
+    assertEquals(corrBC, cellByLabels['C,B'])
+    assertEquals(1G, cellByLabels['A,A'])
+    assertEquals(1G, cellByLabels['B,B'])
+    assertEquals(1G, cellByLabels['C,C'])
   }
 
 }


### PR DESCRIPTION
## Summary
- Replace `1G`/`0G` (BigInteger literals implicitly coerced to BigDecimal) with `BigDecimal.ONE`/`BigDecimal.ZERO` in `CorrelationHeatmapChart.roundCorrelation()`.
- Fix a correctness bug in `CorrelationHeatmapChart.addSeries(title, columnNames)`: for 3+ columns, off-diagonal heatmap cells showed the correlation of a different, mirrored column pair instead of the labeled pair. Caused by a reversed-index loop combined with an xData/yData argument swap in the internal `addSeries(seriesName, columnLabels, rowLabels, columns)` helper that contradicted its own GroovyDoc. For exactly 2 columns the two reversals canceled out, which is why it went unnoticed.
- Updated the existing whitebox test that had encoded the old (buggy) tuple layout, and added a new regression test that verifies heatmap cells match column labels by value for a 3-column case.

## Modules touched
- matrix-xchart

## Test plan
- [x] `./gradlew :matrix-xchart:test -Pheadless=true` — 62/62 tests pass
- [x] `./gradlew :matrix-xchart:codenarcMain :matrix-xchart:codenarcTest`
- [x] `./gradlew :matrix-xchart:spotlessCheck`
- [x] Manually verified via a throwaway probe test (not included) that the fix produces `cell(A,B)==corr(A,B)`, `cell(A,C)==corr(A,C)`, `cell(B,C)==corr(B,C)` for a 3-column dataset, matching directly-computed correlations

🤖 Generated with [Claude Code](https://claude.com/claude-code)