### PR TITLE
[codex] Fix BigQuery nested types and error handling

### DIFF
--- a/matrix-bigquery/build.gradle
+++ b/matrix-bigquery/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = 'se.alipsa.matrix'
-version = '0.6.2-SNAPSHOT'
+version = '0.7.0-SNAPSHOT'
 description = "Groovy library for importing and exporting to and from Google BigQuery to a Matrix"
 
 ext.releaseNexusUrl = version.toString().endsWith("SNAPSHOT")

--- a/matrix-bigquery/build.gradle
+++ b/matrix-bigquery/build.gradle
@@ -10,12 +10,8 @@ plugins {
 }
 
 group = 'se.alipsa.matrix'
-version = '0.7.0-SNAPSHOT'
+version = '0.7.0'
 description = "Groovy library for importing and exporting to and from Google BigQuery to a Matrix"
-
-ext.releaseNexusUrl = version.toString().endsWith("SNAPSHOT")
-    ? "https://oss.sonatype.org/cofntent/repositories/snapshots/"
-    : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
 
 JavaCompile javaCompile = compileJava {
   options.release = 21
@@ -147,7 +143,6 @@ publishing {
           username = sonatypeUsername
           password = sonatypePassword
         }
-        url = releaseNexusUrl
       }
     }
   }

--- a/matrix-bigquery/release.md
+++ b/matrix-bigquery/release.md
@@ -12,7 +12,7 @@
   - interrupted load-job and table-propagation waits now restore interrupt status and are wrapped in `BqException`
 - Make `getProjects()` use explicit `GoogleCredentials` supplied to the `Bq` instance instead of always falling back to Application Default Credentials.
 - Clean up misleading `getDatasets()` debug logging.
-- Update the release script to tolerate missing local SDKMAN/JDK helper commands, validate Java 21, and only enable external integration tests when `gclogin` is available.
+- Update the release script to tolerate missing local SDKMAN/JDK helper commands, abort when Java is not 21, and only enable external integration tests when `gclogin` is available.
 - Dependency updates:
   - com.google.auth:google-auth-library-bom 1.46.0 -> 1.48.0
   - com.google.auth:google-auth-library-oauth2-http 1.46.0 -> 1.48.0

--- a/matrix-bigquery/release.md
+++ b/matrix-bigquery/release.md
@@ -1,6 +1,18 @@
 # Matrix-bigquery Release History
 
-## v0.6.2, in progress
+## v0.7.0, in progress
+- Add support for converting BigQuery nested result values:
+  - `ARRAY`/repeated fields now convert to `List` values instead of being forced through primitive string access
+  - `STRUCT`/record fields now convert to `Map<String, Object>` values when field schema is available
+  - unsupported scalar fallback conversion now uses the raw BigQuery value instead of `FieldValue.getStringValue()`, avoiding `ClassCastException` for metadata columns returned by `INFORMATION_SCHEMA`
+- Preserve repeated BigQuery field types as `List` in the resulting `Matrix` column metadata.
+- Improve write-channel and InsertAll fallback error handling:
+  - load-job failures now keep the BigQuery load-job error as the top-level `BqException` message instead of being reported as an unrelated row/value serialization failure
+  - when write-channel insert fails and InsertAll fallback also fails, the fallback failure is now the exception cause and the original streaming failure is attached as suppressed
+  - interrupted load-job and table-propagation waits now restore interrupt status and are wrapped in `BqException`
+- Make `getProjects()` use explicit `GoogleCredentials` supplied to the `Bq` instance instead of always falling back to Application Default Credentials.
+- Clean up misleading `getDatasets()` debug logging.
+- Update the release script to tolerate missing local SDKMAN/JDK helper commands, validate Java 21, and only enable external integration tests when `gclogin` is available.
 - Dependency updates:
   - com.google.auth:google-auth-library-bom 1.46.0 -> 1.48.0
   - com.google.auth:google-auth-library-oauth2-http 1.46.0 -> 1.48.0

--- a/matrix-bigquery/release.md
+++ b/matrix-bigquery/release.md
@@ -1,6 +1,6 @@
 # Matrix-bigquery Release History
 
-## v0.7.0, in progress
+## v0.7.0, 2026-07-05
 - Add support for converting BigQuery nested result values:
   - `ARRAY`/repeated fields now convert to `List` values instead of being forced through primitive string access
   - `STRUCT`/record fields now convert to `Map<String, Object>` values when field schema is available

--- a/matrix-bigquery/release.sh
+++ b/matrix-bigquery/release.sh
@@ -11,6 +11,7 @@ javaVersion=$(java -version 2>&1 | head -1 | cut -d '"' -f2 | sed '/^1\./s///' |
 
 if [ ! "$javaVersion" = 21 ]; then
   echo "java must be 21 to release"
+  exit 1
 fi
 
 if (command -v gclogin >/dev/null 2>&1); then

--- a/matrix-bigquery/release.sh
+++ b/matrix-bigquery/release.sh
@@ -1,13 +1,31 @@
 #!/usr/bin/env bash
-source ~/.sdkman/bin/sdkman-init.sh
-source jdk21
-#./gradlew clean publishToSonatype closeAndReleaseSonatypeStagingRepository
-../gradlew -PrunExternalTests=true :matrix-bigquery:clean :matrix-bigquery:build :matrix-bigquery:release || exit 1
+if [[ -f ~/.sdkman/bin/sdkman-init.sh ]]; then
+  source ~/.sdkman/bin/sdkman-init.sh
+fi
+
+if (command -v jdk21 >/dev/null 2>&1); then
+  source jdk21
+fi
+
+javaVersion=$(java -version 2>&1 | head -1 | cut -d '"' -f2 | sed '/^1\./s///' | cut -d '.' -f1)
+
+if [ ! "$javaVersion" = 21 ]; then
+  echo "java must be 21 to release"
+fi
+
+if (command -v gclogin >/dev/null 2>&1); then
+  gclogin
+  export RUN_EXTERNAL_TESTS=true
+else
+  echo "gclogin not found, skipping external tests"
+fi
+
+./gradlew :matrix-bigquery:clean :matrix-bigquery:build :matrix-bigquery:release || exit 1
 PROJECT=$(basename "$PWD")
 if grep "version '" build.gradle | grep -q 'SNAPSHOT'; then
   echo "$PROJECT snapshot published"
 else
-  echo "$PROJECT uploaded, release it if it checks out"
+  echo "$PROJECT uploaded"
   echo "see https://central.sonatype.com/publishing/deployments for more info"
   # browse https://oss.sonatype.org &
 fi

--- a/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/Bq.groovy
+++ b/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/Bq.groovy
@@ -8,6 +8,7 @@ import groovy.transform.PackageScope
 import com.fasterxml.jackson.core.JsonEncoding
 import com.fasterxml.jackson.core.JsonFactory
 import com.fasterxml.jackson.core.JsonGenerator
+import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.api.gax.paging.Page
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.bigquery.*
@@ -146,6 +147,7 @@ class Bq {
   private final BigQuery bigQuery
   private final String projectId
   private final boolean useAsyncQueries
+  private final GoogleCredentials credentials
   private long waitForTableTimeoutMs = DEFAULT_WAIT_FOR_TABLE_TIMEOUT_MS
 
   /**
@@ -162,6 +164,7 @@ class Bq {
     bigQuery = options.getService()
     projectId = options.getProjectId()
     this.useAsyncQueries = useAsyncQueries
+    credentials = options.getCredentials() instanceof GoogleCredentials ? options.getCredentials() as GoogleCredentials : null
   }
 
   @PackageScope
@@ -169,6 +172,7 @@ class Bq {
     this.bigQuery = bigQuery
     this.projectId = projectId
     this.useAsyncQueries = useAsyncQueries
+    credentials = null
   }
 
   /**
@@ -185,6 +189,7 @@ class Bq {
   Bq(GoogleCredentials credentials, String projectId, boolean useAsyncQueries = false) {
     this.projectId = projectId
     this.useAsyncQueries = useAsyncQueries
+    this.credentials = credentials
     bigQuery = BigQueryOptions.newBuilder()
         .setCredentials(credentials)
         .setProjectId(projectId)
@@ -210,6 +215,7 @@ class Bq {
     }
     this.projectId = projectId
     this.useAsyncQueries = useAsyncQueries
+    credentials = null
     bigQuery = BigQueryOptions.newBuilder()
         .setProjectId(projectId)
         .build()
@@ -234,6 +240,7 @@ class Bq {
     }
     this.projectId = projectId
     this.useAsyncQueries = useAsyncQueries
+    credentials = null
     bigQuery = BigQueryOptions.newBuilder()
         .setProjectId(projectId)
         .build()
@@ -449,7 +456,8 @@ class Bq {
    * @throws BqException if the table is not ready within the timeout period
    * @see #setWaitForTableTimeoutMs
    */
-  private void waitForTable(TableId tableId, long timeoutMs) {
+  @PackageScope
+  void waitForTable(TableId tableId, long timeoutMs) {
     long start = System.currentTimeMillis()
     long backoff = 300L
     while (System.currentTimeMillis() - start < timeoutMs) {
@@ -457,7 +465,12 @@ class Bq {
       if (t?.exists()) {
         return
       }
-      Thread.sleep(backoff)
+      try {
+        Thread.sleep(backoff)
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt()
+        throw new BqException("Interrupted while waiting for table ${tableId} to be ready.", e)
+      }
       backoff = Math.min((long)(backoff * 1.7), 5000L)
     }
     throw new BqException("Timed out waiting for table ${tableId} to be ready.")
@@ -626,37 +639,35 @@ class Bq {
     JobId jobId = JobId.newBuilder().setProject(projectId).setRandomJob().build()
     TableDataWriteChannel writer = bigQuery.writer(jobId, wcfg)
 
+    OutputStream out = openWriterStream(writer)
+    JsonGenerator json = new JsonFactory().createGenerator(out, JsonEncoding.UTF8)
+
+    List<String> columnNames = matrix.columnNames()
+    int rowCount = matrix.rowCount()
+    int stepSize = Math.max(1, (int) (rowCount * tickPercent))
+    ProgressBar pb = createProgressBar("Inserting into ${tableId.dataset}.${tableId.table}", rowCount)
+
     try {
-      OutputStream out = Channels.newOutputStream(writer)
-      JsonGenerator json = new JsonFactory().createGenerator(out, JsonEncoding.UTF8)
+      for (Row row : matrix.rows()) {
+        rowIdx++
+        lastValue = writeRowAsJson(json, row, columnNames)
 
-      List<String> columnNames = matrix.columnNames()
-      int rowCount = matrix.rowCount()
-      int stepSize = Math.max(1, (int) (rowCount * tickPercent))
-      ProgressBar pb = createProgressBar("Inserting into ${tableId.dataset}.${tableId.table}", rowCount)
-
-      try {
-        for (Row row : matrix.rows()) {
-          rowIdx++
-          lastValue = writeRowAsJson(json, row, columnNames)
-
-          if (pb != null && rowIdx % stepSize == 0) {
-            pb.stepBy(stepSize)
-          }
+        if (pb != null && rowIdx % stepSize == 0) {
+          pb.stepBy(stepSize)
         }
-        if (pb != null) {
-          pb.stepTo(rowIdx)
-        }
-      } finally {
-        pb?.close()
-        json.flush()
-        json.close()
       }
-
-      return waitForLoadJobAndGetStats(writer, tableId)
+      if (pb != null) {
+        pb.stepTo(rowIdx)
+      }
     } catch (Exception e) {
       throw new BqException("Error writing value '${lastValue}' (type=${lastValue?.class?.name}) on row ${rowIdx}", e)
+    } finally {
+      pb?.close()
+      json.flush()
+      json.close()
     }
+
+    return waitForLoadJobAndGetStats(writer, tableId)
   }
 
   @PackageScope
@@ -731,8 +742,20 @@ class Bq {
    * @return load statistics from the completed job
    * @throws BqException if the job fails
    */
-  private JobStatistics.LoadStatistics waitForLoadJobAndGetStats(TableDataWriteChannel writer, TableId tableId) throws BqException {
-    Job loadJob = writer.getJob().waitFor()
+  @PackageScope
+  OutputStream openWriterStream(TableDataWriteChannel writer) {
+    Channels.newOutputStream(writer)
+  }
+
+  @PackageScope
+  JobStatistics.LoadStatistics waitForLoadJobAndGetStats(TableDataWriteChannel writer, TableId tableId) throws BqException {
+    Job loadJob
+    try {
+      loadJob = writer.getJob().waitFor()
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt()
+      throw new BqException("Interrupted while waiting for BigQuery load job for ${tableId}", e)
+    }
 
     JobStatus status = loadJob.getStatus()
     BigQueryError primary = status?.getError()
@@ -811,7 +834,9 @@ class Bq {
         log.error("InsertAll failed: ${fallbackException.message}")
       }
       if (originalException != null) {
-        throw new BqException("Streaming insert failed: ${originalException.message}. Fallback also failed: ${fallbackException.message}", originalException)
+        BqException combined = new BqException("Streaming insert failed: ${originalException.message}. Fallback also failed: ${fallbackException.message}", fallbackException)
+        combined.addSuppressed(originalException)
+        throw combined
       }
       throw new BqException("InsertAll failed: ${fallbackException.message}", fallbackException)
     }
@@ -1115,7 +1140,7 @@ class Bq {
     try {
       Page<Dataset> datasets = bigQuery.listDatasets(projectId, DatasetListOption.pageSize(DEFAULT_PAGE_SIZE))
       if (datasets == null) {
-        log.debug('Dataset does not contain any models')
+        log.debug("Project ${projectId} does not contain any datasets")
         return []
       }
       return datasets
@@ -1137,12 +1162,26 @@ class Bq {
    * @throws BqException if the API call fails
    */
   List<Project> getProjects() throws BqException {
-    ProjectsSettings projectsSettings = ProjectsSettings.newBuilder().build()
-    try (ProjectsClient pc = ProjectsClient.create(projectsSettings)) {
-      return pc.searchProjects('').iterateAll().collect()
-    } catch (BigQueryException e) {
+    try {
+      ProjectsSettings projectsSettings = createProjectsSettings()
+      ProjectsClient pc = ProjectsClient.create(projectsSettings)
+      try {
+        return pc.searchProjects('').iterateAll().collect()
+      } finally {
+        pc.close()
+      }
+    } catch (Exception e) {
       throw new BqException(e)
     }
+  }
+
+  @PackageScope
+  ProjectsSettings createProjectsSettings() {
+    ProjectsSettings.Builder projectsSettingsBuilder = ProjectsSettings.newBuilder()
+    if (credentials != null) {
+      projectsSettingsBuilder.setCredentialsProvider(FixedCredentialsProvider.create(credentials))
+    }
+    projectsSettingsBuilder.build()
   }
 
   /**

--- a/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/Bq.groovy
+++ b/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/Bq.groovy
@@ -1082,9 +1082,11 @@ class Bq {
   static Matrix convertToMatrix(TableResult result) {
     Schema schema = result.getSchema()
     List<String> colNames = []
+    List<Field> fields = []
     List<StandardSQLTypeName> colTypes = []
     schema.fields.each {
       colNames << it.name
+      fields << it
       colTypes << it.type.standardType
     }
 
@@ -1094,7 +1096,7 @@ class Bq {
       row = []
       int i = 0
       for (FieldValue fv : fvl.iterator()) {
-        row << convertFieldValue(fv, colTypes[i++])
+        row << convertFieldValue(fv, fields[i++])
       }
       rows << row
     }

--- a/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/Bq.groovy
+++ b/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/Bq.groovy
@@ -1164,11 +1164,8 @@ class Bq {
   List<Project> getProjects() throws BqException {
     try {
       ProjectsSettings projectsSettings = createProjectsSettings()
-      ProjectsClient pc = ProjectsClient.create(projectsSettings)
-      try {
+      ProjectsClient.create(projectsSettings).withCloseable { ProjectsClient pc ->
         return pc.searchProjects('').iterateAll().collect()
-      } finally {
-        pc.close()
       }
     } catch (Exception e) {
       throw new BqException(e)

--- a/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/Bq.groovy
+++ b/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/Bq.groovy
@@ -164,7 +164,7 @@ class Bq {
     bigQuery = options.getService()
     projectId = options.getProjectId()
     this.useAsyncQueries = useAsyncQueries
-    credentials = options.getCredentials() instanceof GoogleCredentials ? options.getCredentials() as GoogleCredentials : null
+    credentials = null
   }
 
   @PackageScope

--- a/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/Bq.groovy
+++ b/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/Bq.groovy
@@ -352,7 +352,7 @@ class Bq {
     JobId jobId = JobId.newBuilder().setProject(projectId).build()
     Job queryJob = bigQuery.create(JobInfo.newBuilder(queryConfig).setJobId(jobId).build())
     // Wait for the query to complete.
-    queryJob = queryJob.waitFor()
+    queryJob = waitForQueryJob(queryJob)
 
     // Check for errors
     if (queryJob == null) {
@@ -361,6 +361,16 @@ class Bq {
       throw new BqException(queryJob.getStatus().getError().toString())
     }
     queryJob
+  }
+
+  @PackageScope
+  Job waitForQueryJob(Job queryJob) throws BqException {
+    try {
+      queryJob.waitFor()
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt()
+      throw new BqException('Interrupted while waiting for BigQuery query job', e)
+    }
   }
 
   /**
@@ -639,14 +649,22 @@ class Bq {
     JobId jobId = JobId.newBuilder().setProject(projectId).setRandomJob().build()
     TableDataWriteChannel writer = bigQuery.writer(jobId, wcfg)
 
-    OutputStream out = openWriterStream(writer)
-    JsonGenerator json = new JsonFactory().createGenerator(out, JsonEncoding.UTF8)
+    OutputStream out = null
+    JsonGenerator json = null
+    try {
+      out = openWriterStream(writer)
+      json = new JsonFactory().createGenerator(out, JsonEncoding.UTF8)
+    } catch (Exception e) {
+      closeOutputStream(out, e)
+      throw new BqException("Error opening BigQuery write channel for ${tableId}", e)
+    }
 
     List<String> columnNames = matrix.columnNames()
     int rowCount = matrix.rowCount()
     int stepSize = Math.max(1, (int) (rowCount * tickPercent))
     ProgressBar pb = createProgressBar("Inserting into ${tableId.dataset}.${tableId.table}", rowCount)
 
+    Exception rowFailure = null
     try {
       for (Row row : matrix.rows()) {
         rowIdx++
@@ -660,11 +678,14 @@ class Bq {
         pb.stepTo(rowIdx)
       }
     } catch (Exception e) {
-      throw new BqException("Error writing value '${lastValue}' (type=${lastValue?.class?.name}) on row ${rowIdx}", e)
+      rowFailure = e
     } finally {
       pb?.close()
-      json.flush()
-      json.close()
+      closeJsonGenerator(json, tableId, rowFailure)
+    }
+
+    if (rowFailure != null) {
+      throw new BqException("Error writing value '${lastValue}' (type=${lastValue?.class?.name}) on row ${rowIdx}", rowFailure)
     }
 
     return waitForLoadJobAndGetStats(writer, tableId)
@@ -735,6 +756,46 @@ class Bq {
   }
 
   /**
+   * Opens an output stream for a BigQuery table data write channel.
+   *
+   * @param writer the table data write channel
+   * @return output stream connected to the write channel
+   */
+  @PackageScope
+  OutputStream openWriterStream(TableDataWriteChannel writer) {
+    Channels.newOutputStream(writer)
+  }
+
+  private static void closeOutputStream(OutputStream out, Throwable primaryException) {
+    if (out == null) {
+      return
+    }
+
+    try {
+      out.close()
+    } catch (Exception closeException) {
+      primaryException.addSuppressed(closeException)
+    }
+  }
+
+  private static void closeJsonGenerator(JsonGenerator json, TableId tableId, Throwable rowFailure) throws BqException {
+    if (json == null) {
+      return
+    }
+
+    try {
+      json.flush()
+      json.close()
+    } catch (Exception closeException) {
+      if (rowFailure != null) {
+        rowFailure.addSuppressed(closeException)
+      } else {
+        throw new BqException("Error closing BigQuery write channel for ${tableId}", closeException)
+      }
+    }
+  }
+
+  /**
    * Waits for a load job to complete and returns the statistics.
    *
    * @param writer the table data write channel
@@ -742,11 +803,6 @@ class Bq {
    * @return load statistics from the completed job
    * @throws BqException if the job fails
    */
-  @PackageScope
-  OutputStream openWriterStream(TableDataWriteChannel writer) {
-    Channels.newOutputStream(writer)
-  }
-
   @PackageScope
   JobStatistics.LoadStatistics waitForLoadJobAndGetStats(TableDataWriteChannel writer, TableId tableId) throws BqException {
     Job loadJob

--- a/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/Bq.groovy
+++ b/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/Bq.groovy
@@ -1083,11 +1083,9 @@ class Bq {
     Schema schema = result.getSchema()
     List<String> colNames = []
     List<Field> fields = []
-    List<StandardSQLTypeName> colTypes = []
     schema.fields.each {
       colNames << it.name
       fields << it
-      colTypes << it.type.standardType
     }
 
     List<List> rows = []
@@ -1102,7 +1100,7 @@ class Bq {
     }
     Matrix.builder()
         .rows(rows)
-        .types(colTypes.collect { convertType(it) })
+        .types(fields.collect { convertType(it) })
         .columnNames(colNames)
         .build()
   }

--- a/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/TypeMapper.groovy
+++ b/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/TypeMapper.groovy
@@ -2,7 +2,10 @@ package se.alipsa.matrix.bigquery
 
 import groovy.transform.CompileStatic
 
+import com.google.cloud.bigquery.Field
+import com.google.cloud.bigquery.FieldList
 import com.google.cloud.bigquery.FieldValue
+import com.google.cloud.bigquery.FieldValueList
 import com.google.cloud.bigquery.StandardSQLTypeName
 
 import se.alipsa.matrix.core.ValueConverter
@@ -50,7 +53,6 @@ import java.time.ZonedDateTime
  *   <li><b>INTERVAL</b>: Duration type - could map to java.time.Duration</li>
  *   <li><b>JSON</b>: JSON documents - could map to Map or JsonNode</li>
  *   <li><b>RANGE</b>: Range of values - would require custom Range class</li>
- *   <li><b>STRUCT</b>: Nested structures - could map to Map&lt;String, Object&gt;</li>
  * </ul>
  *
  * @see Bq
@@ -120,6 +122,8 @@ class TypeMapper {
    *   <li>STRING → String</li>
    *   <li>TIMESTAMP → Instant</li>
    *   <li>TIME → LocalTime</li>
+   *   <li>ARRAY → List</li>
+   *   <li>STRUCT → Map</li>
    *   <li>Other → Object (default fallback)</li>
    * </ul>
    *
@@ -128,6 +132,7 @@ class TypeMapper {
    */
   static Class convertType(StandardSQLTypeName typeName) {
     switch (typeName) {
+      case StandardSQLTypeName.ARRAY -> List
       case StandardSQLTypeName.BIGNUMERIC -> BigDecimal
       case StandardSQLTypeName.BOOL -> Boolean
       case StandardSQLTypeName.BYTES -> byte[]
@@ -140,11 +145,29 @@ class TypeMapper {
         // JSON: Not yet supported - could map to Map or JsonNode
       case StandardSQLTypeName.NUMERIC -> BigDecimal
         // RANGE: Not yet supported - would require custom Range class
-        // STRUCT: Not yet supported - could map to Map<String, Object>
       case StandardSQLTypeName.STRING -> String
+      case StandardSQLTypeName.STRUCT -> Map
       case StandardSQLTypeName.TIMESTAMP -> Instant
       case StandardSQLTypeName.TIME -> LocalTime
       default -> Object
+    }
+  }
+
+  /**
+   * Converts a BigQuery FieldValue to a Java object based on the column type,
+   * using typed accessors for accurate and efficient conversion.
+   *
+   * @param fv the FieldValue from BigQuery
+   * @param field the BigQuery field schema for the value
+   * @return the converted Java object, or null if the field value is null
+   */
+  static Object convertFieldValue(FieldValue fv, Field field) {
+    if (fv.isNull()) return null
+
+    switch (fv.attribute) {
+      case FieldValue.Attribute.REPEATED -> convertRepeatedValue(fv, field)
+      case FieldValue.Attribute.RECORD -> convertRecordValue(fv.recordValue, field)
+      default -> convertPrimitiveFieldValue(fv, field.type.standardType)
     }
   }
 
@@ -159,6 +182,13 @@ class TypeMapper {
   static Object convertFieldValue(FieldValue fv, StandardSQLTypeName colType) {
     if (fv.isNull()) return null
 
+    if (fv.attribute == FieldValue.Attribute.REPEATED) return convertRepeatedValue(fv)
+    if (fv.attribute == FieldValue.Attribute.RECORD) return convertRecordValue(fv.recordValue)
+
+    convertPrimitiveFieldValue(fv, colType)
+  }
+
+  private static Object convertPrimitiveFieldValue(FieldValue fv, StandardSQLTypeName colType) {
     switch (colType) {
       case StandardSQLTypeName.BYTES -> convertBytesValue(fv)
       case StandardSQLTypeName.BIGNUMERIC, StandardSQLTypeName.NUMERIC -> fv.getNumericValue()
@@ -174,11 +204,61 @@ class TypeMapper {
         if (v instanceof CharSequence) {
           LocalTime.parse(v.toString(), Bq.BQ_TIME_FORMATTER)
         } else if (v instanceof Number) {
-          LocalTime.ofNanoOfDay(((Number) v).longValue() * 1_000L)
+          LocalTime.ofNanoOfDay(v.longValue() * 1_000L)
         }
       }
-      default -> fv.getStringValue()
+      case StandardSQLTypeName.RANGE -> fv.rangeValue
+      default -> convertRawFieldValue(fv)
     }
+  }
+
+  private static List convertRepeatedValue(FieldValue fv, Field field = null) {
+    StandardSQLTypeName elementType = field?.type?.standardType
+    fv.repeatedValue.collect { FieldValue repeatedValue ->
+      if (field != null && repeatedValue.attribute == FieldValue.Attribute.RECORD) {
+        convertRecordValue(repeatedValue.recordValue, field)
+      } else {
+        convertFieldValue(repeatedValue, elementType ?: StandardSQLTypeName.STRING)
+      }
+    }
+  }
+
+  private static Map<String, Object> convertRecordValue(FieldValueList recordValue, Field field = null) {
+    FieldList subFields = field?.subFields
+    if (subFields != null && subFields.size() == recordValue.size()) {
+      Map<String, Object> record = [:]
+      int index = 0
+      recordValue.each { FieldValue fieldValue ->
+        Field subField = subFields.get(index++)
+        record[subField.name] = convertFieldValue(fieldValue, subField)
+      }
+      return record
+    }
+
+    Map<String, Object> record = [:]
+    int index = 0
+    recordValue.each { FieldValue fieldValue ->
+      record["field${index}"] = convertNestedFieldValue(fieldValue)
+      index++
+    }
+    record
+  }
+
+  private static Object convertNestedFieldValue(FieldValue fv) {
+    if (fv.isNull()) return null
+
+    switch (fv.attribute) {
+      case FieldValue.Attribute.REPEATED -> convertRepeatedValue(fv)
+      case FieldValue.Attribute.RECORD -> convertRecordValue(fv.recordValue)
+      case FieldValue.Attribute.RANGE -> fv.rangeValue
+      default -> convertRawFieldValue(fv)
+    }
+  }
+
+  private static Object convertRawFieldValue(FieldValue fv) {
+    Object value = fv.value
+    if (value instanceof CharSequence) return value.toString()
+    value
   }
 
   private static byte[] convertBytesValue(FieldValue fv) {

--- a/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/TypeMapper.groovy
+++ b/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/TypeMapper.groovy
@@ -9,6 +9,7 @@ import com.google.cloud.bigquery.FieldValueList
 import com.google.cloud.bigquery.StandardSQLTypeName
 
 import se.alipsa.matrix.core.ValueConverter
+import se.alipsa.matrix.core.util.Logger
 
 import java.math.RoundingMode
 import java.nio.ByteBuffer
@@ -59,6 +60,8 @@ import java.time.ZonedDateTime
  */
 @CompileStatic
 class TypeMapper {
+
+  private static final Logger log = Logger.getLogger(TypeMapper)
 
   /**
    * Maps a Java class to a BigQuery StandardSQLTypeName.
@@ -244,6 +247,8 @@ class TypeMapper {
       }
       return record
     }
+
+    log.debug("Converting BigQuery RECORD ${field?.name ?: '<unknown>'} without matching schema; using synthetic field0... keys")
 
     Map<String, Object> record = [:]
     int index = 0

--- a/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/TypeMapper.groovy
+++ b/matrix-bigquery/src/main/groovy/se/alipsa/matrix/bigquery/TypeMapper.groovy
@@ -154,6 +154,16 @@ class TypeMapper {
   }
 
   /**
+   * Maps a BigQuery field schema to a Java class.
+   *
+   * @param field the BigQuery field schema to map
+   * @return List for repeated fields, otherwise the corresponding scalar Java class
+   */
+  static Class convertType(Field field) {
+    field.mode == Field.Mode.REPEATED ? List : convertType(field.type.standardType)
+  }
+
+  /**
    * Converts a BigQuery FieldValue to a Java object based on the column type,
    * using typed accessors for accurate and efficient conversion.
    *

--- a/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/BqConvertToMatrixTest.groovy
+++ b/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/BqConvertToMatrixTest.groovy
@@ -1,0 +1,75 @@
+package se.alipsa.matrix.bigquery
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+import groovy.transform.CompileStatic
+
+import com.google.api.gax.paging.Page
+import com.google.cloud.bigquery.Field
+import com.google.cloud.bigquery.FieldValue
+import com.google.cloud.bigquery.FieldValueList
+import com.google.cloud.bigquery.Schema
+import com.google.cloud.bigquery.StandardSQLTypeName
+import com.google.cloud.bigquery.TableResult
+import org.junit.jupiter.api.Test
+
+import se.alipsa.matrix.core.Matrix
+
+/**
+ * Tests BigQuery result conversion to Matrix.
+ */
+@CompileStatic
+class BqConvertToMatrixTest {
+
+  @Test
+  void repeatedFieldsBecomeListColumns() {
+    Field tagsField = Field.newBuilder('tags', StandardSQLTypeName.STRING)
+        .setMode(Field.Mode.REPEATED)
+        .build()
+    Schema schema = Schema.of(tagsField)
+    FieldValue repeatedValue = FieldValue.of(FieldValue.Attribute.REPEATED, FieldValueList.of([
+        FieldValue.of(FieldValue.Attribute.PRIMITIVE, 'tag1'),
+        FieldValue.of(FieldValue.Attribute.PRIMITIVE, 'tag2')
+    ] as List<FieldValue>))
+    FieldValueList row = FieldValueList.of([repeatedValue] as List<FieldValue>, schema.fields)
+    TableResult result = TableResult.newBuilder()
+        .setSchema(schema)
+        .setTotalRows(1L)
+        .setPageNoSchema(pageOf([row] as List<FieldValueList>))
+        .build()
+
+    Matrix matrix = Bq.convertToMatrix(result)
+
+    assertEquals([List], matrix.types())
+    assertEquals([['tag1', 'tag2']], matrix['tags'])
+  }
+
+  private static Page<FieldValueList> pageOf(List<FieldValueList> values) {
+    new Page<FieldValueList>() {
+      @Override
+      boolean hasNextPage() {
+        false
+      }
+
+      @Override
+      String getNextPageToken() {
+        null
+      }
+
+      @Override
+      Page<FieldValueList> getNextPage() {
+        null
+      }
+
+      @Override
+      Iterable<FieldValueList> iterateAll() {
+        values
+      }
+
+      @Override
+      Iterable<FieldValueList> getValues() {
+        values
+      }
+    }
+  }
+}

--- a/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/BqErrorHandlingTest.groovy
+++ b/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/BqErrorHandlingTest.groovy
@@ -1,0 +1,129 @@
+package se.alipsa.matrix.bigquery
+
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertSame
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
+
+import com.google.auth.oauth2.AccessToken
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.cloud.NoCredentials
+import com.google.cloud.bigquery.BigQuery
+import com.google.cloud.bigquery.BigQueryOptions
+import com.google.cloud.bigquery.JobId
+import com.google.cloud.bigquery.JobStatistics
+import com.google.cloud.bigquery.Table
+import com.google.cloud.bigquery.TableDataWriteChannel
+import com.google.cloud.bigquery.TableId
+import com.google.cloud.bigquery.WriteChannelConfiguration
+import com.google.cloud.resourcemanager.v3.ProjectsSettings
+import org.junit.jupiter.api.Test
+
+import se.alipsa.matrix.core.Matrix
+
+/**
+ * Tests error-handling behavior in the BigQuery client wrapper.
+ */
+@CompileStatic
+class BqErrorHandlingTest {
+
+  @Test
+  void waitForTableWrapsInterruptedExceptionAndRestoresInterruptStatus() {
+    Bq bq = new Bq(fakeBigQueryForWait(), 'matrix-project')
+
+    try {
+      Thread.currentThread().interrupt()
+      BqException ex = assertThrows(BqException) {
+        bq.waitForTable(Bq.tableId('matrix-project', 'analytics', 'events'), 10_000L)
+      }
+
+      assertTrue(ex.message.contains('Interrupted while waiting for table'))
+      assertTrue(ex.cause instanceof InterruptedException)
+      assertTrue(Thread.currentThread().isInterrupted())
+    } finally {
+      Thread.interrupted()
+    }
+  }
+
+  @Test
+  void writeChannelLoadJobFailuresKeepLoadJobMessage() {
+    BqException loadFailure = new BqException('Write-channel load (JSON) failed for matrix-project:analytics.events: schema mismatch')
+    LoadFailureClient bq = new LoadFailureClient(fakeBigQueryForWriter(), 'matrix-project', loadFailure)
+
+    BqException ex = assertThrows(BqException) {
+      bq.insertViaWriteChannel(sampleMatrix(), Bq.tableId('matrix-project', 'analytics', 'events'), false)
+    }
+
+    assertSame(loadFailure, ex)
+    assertFalse(ex.message.contains('Error writing value'))
+  }
+
+  @Test
+  void projectSettingsUseExplicitCredentialsWhenAvailable() {
+    GoogleCredentials credentials = GoogleCredentials.create(new AccessToken('token-value', new Date(System.currentTimeMillis() + 60_000L)))
+    Bq bq = new Bq(credentials, 'matrix-project')
+
+    ProjectsSettings settings = bq.createProjectsSettings()
+
+    assertSame(credentials, settings.credentialsProvider.credentials)
+  }
+
+  private static Matrix sampleMatrix() {
+    Matrix.builder()
+        .columnNames(['id', 'name'])
+        .rows([
+            [1, 'Alice'],
+            [2, 'Bob']
+        ])
+        .types([Integer, String])
+        .matrixName('events')
+        .build()
+  }
+
+  @CompileDynamic
+  private static BigQuery fakeBigQueryForWait() {
+    BigQueryOptions options = BigQueryOptions.newBuilder()
+        .setProjectId('matrix-project')
+        .setCredentials(NoCredentials.getInstance())
+        .build()
+    [
+        getOptions: { -> options },
+        getTable : { TableId tableId, Object... ignored -> null as Table }
+    ] as BigQuery
+  }
+
+  @CompileDynamic
+  private static BigQuery fakeBigQueryForWriter() {
+    BigQueryOptions options = BigQueryOptions.newBuilder()
+        .setProjectId('matrix-project')
+        .setCredentials(NoCredentials.getInstance())
+        .build()
+    [
+        getOptions: { -> options },
+        writer    : { JobId jobId, WriteChannelConfiguration config -> null as TableDataWriteChannel }
+    ] as BigQuery
+  }
+
+  @SuppressWarnings('ClassName')
+  private static final class LoadFailureClient extends Bq {
+    private final BqException loadFailure
+
+    LoadFailureClient(BigQuery bigQuery, String projectId, BqException loadFailure) {
+      super(bigQuery, projectId)
+      this.loadFailure = loadFailure
+    }
+
+    @Override
+    OutputStream openWriterStream(TableDataWriteChannel writer) {
+      new ByteArrayOutputStream()
+    }
+
+    @Override
+    JobStatistics.LoadStatistics waitForLoadJobAndGetStats(TableDataWriteChannel writer, TableId tableId) throws BqException {
+      throw loadFailure
+    }
+  }
+}

--- a/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/BqErrorHandlingTest.groovy
+++ b/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/BqErrorHandlingTest.groovy
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 
+import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.auth.oauth2.AccessToken
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.NoCredentials
@@ -82,6 +83,20 @@ class BqErrorHandlingTest {
     ProjectsSettings settings = bq.createProjectsSettings()
 
     assertSame(credentials, settings.credentialsProvider.credentials)
+  }
+
+  @Test
+  void projectSettingsDoNotReuseBigQueryOptionsCredentials() {
+    GoogleCredentials credentials = GoogleCredentials.create(new AccessToken('token-value', new Date(System.currentTimeMillis() + 60_000L)))
+    BigQueryOptions options = BigQueryOptions.newBuilder()
+        .setProjectId('matrix-project')
+        .setCredentials(credentials)
+        .build()
+    Bq bq = new Bq(options)
+
+    ProjectsSettings settings = bq.createProjectsSettings()
+
+    assertFalse(settings.credentialsProvider instanceof FixedCredentialsProvider)
   }
 
   private static Matrix sampleMatrix() {

--- a/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/BqErrorHandlingTest.groovy
+++ b/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/BqErrorHandlingTest.groovy
@@ -62,6 +62,19 @@ class BqErrorHandlingTest {
   }
 
   @Test
+  void writeChannelSetupFailuresAreWrappedAsBqException() {
+    IllegalStateException setupFailure = new IllegalStateException('stream unavailable')
+    SetupFailureClient bq = new SetupFailureClient(fakeBigQueryForWriter(), 'matrix-project', setupFailure)
+
+    BqException ex = assertThrows(BqException) {
+      bq.insertViaWriteChannel(sampleMatrix(), Bq.tableId('matrix-project', 'analytics', 'events'), false)
+    }
+
+    assertTrue(ex.message.contains('Error opening BigQuery write channel'))
+    assertSame(setupFailure, ex.cause)
+  }
+
+  @Test
   void projectSettingsUseExplicitCredentialsWhenAvailable() {
     GoogleCredentials credentials = GoogleCredentials.create(new AccessToken('token-value', new Date(System.currentTimeMillis() + 60_000L)))
     Bq bq = new Bq(credentials, 'matrix-project')
@@ -124,6 +137,21 @@ class BqErrorHandlingTest {
     @Override
     JobStatistics.LoadStatistics waitForLoadJobAndGetStats(TableDataWriteChannel writer, TableId tableId) throws BqException {
       throw loadFailure
+    }
+  }
+
+  @SuppressWarnings('ClassName')
+  private static final class SetupFailureClient extends Bq {
+    private final RuntimeException setupFailure
+
+    SetupFailureClient(BigQuery bigQuery, String projectId, RuntimeException setupFailure) {
+      super(bigQuery, projectId)
+      this.setupFailure = setupFailure
+    }
+
+    @Override
+    OutputStream openWriterStream(TableDataWriteChannel writer) {
+      throw setupFailure
     }
   }
 }

--- a/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/InsertAppendSemanticsTest.groovy
+++ b/matrix-bigquery/src/test/groovy/se/alipsa/matrix/bigquery/InsertAppendSemanticsTest.groovy
@@ -125,6 +125,22 @@ class InsertAppendSemanticsTest {
   }
 
   @Test
+  void fallbackFailureKeepsInsertAllFailureAsCauseAndStreamingFailureSuppressed() {
+    InsertAllTestState state = new InsertAllTestState(tableId('events'))
+    state.insertAllFailure = new IllegalStateException('InsertAll unavailable')
+    RecordingInsertClient bq = new RecordingInsertClient(fakeBigQueryFor(state), 'matrix-project', true)
+
+    BqException ex = assertThrows(BqException) {
+      bq.insert(sampleMatrix(), state.tableId, true)
+    }
+
+    assertSame(state.insertAllFailure, ex.cause)
+    assertEquals(1, ex.suppressed.length)
+    assertTrue(ex.suppressed[0].message.contains('Simulated write-channel failure'))
+    assertTrue(ex.message.contains('Fallback also failed: InsertAll unavailable'))
+  }
+
+  @Test
   void insertAllReplacementTableInfoPreservesWritableMetadata() {
     TableId tableId = tableId('events')
     TableInfo existingTable = TableInfo.newBuilder(tableId, sampleDefinition())
@@ -243,6 +259,7 @@ class InsertAppendSemanticsTest {
     int deleteCalls
     int createCalls
     int insertAllCalls
+    Exception insertAllFailure
     InsertAllRequest lastInsertRequest
     final List<String> events = []
 
@@ -281,6 +298,9 @@ class InsertAppendSemanticsTest {
           state.events << 'insertAll'
           state.insertAllCalls++
           state.lastInsertRequest = request
+          if (state.insertAllFailure != null) {
+            throw state.insertAllFailure
+          }
           emptyInsertAllResponse()
         }
     ] as BigQuery

--- a/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/TypeMapperTest.groovy
+++ b/matrix-bigquery/src/test/groovy/test/alipsa/matrix/bigquery/TypeMapperTest.groovy
@@ -4,6 +4,9 @@ import static org.junit.jupiter.api.Assertions.*
 
 import groovy.transform.CompileStatic
 
+import com.google.cloud.bigquery.Field
+import com.google.cloud.bigquery.FieldValue
+import com.google.cloud.bigquery.FieldValueList
 import com.google.cloud.bigquery.StandardSQLTypeName
 import org.junit.jupiter.api.Test
 
@@ -190,6 +193,51 @@ class TypeMapperTest {
   void testConvertDefaultToString() {
     // Unknown/unsupported types default to string conversion
     assertEquals("someValue", TypeMapper.convert("someValue", StandardSQLTypeName.STRUCT))
+  }
+
+  @Test
+  void testConvertFieldValueArrayWithoutSchema() {
+    FieldValueList repeatedValues = FieldValueList.of([
+        FieldValue.of(FieldValue.Attribute.PRIMITIVE, 'tag1'),
+        FieldValue.of(FieldValue.Attribute.PRIMITIVE, 'tag2')
+    ] as List<FieldValue>)
+    FieldValue fieldValue = FieldValue.of(FieldValue.Attribute.REPEATED, repeatedValues)
+
+    assertEquals(['tag1', 'tag2'], TypeMapper.convertFieldValue(fieldValue, StandardSQLTypeName.ARRAY))
+  }
+
+  @Test
+  void testConvertFieldValueRepeatedFieldWithSchema() {
+    Field field = Field.newBuilder('policy_tags', StandardSQLTypeName.STRING)
+        .setMode(Field.Mode.REPEATED)
+        .build()
+    FieldValueList repeatedValues = FieldValueList.of([
+        FieldValue.of(FieldValue.Attribute.PRIMITIVE, 'tag1'),
+        FieldValue.of(FieldValue.Attribute.PRIMITIVE, 'tag2')
+    ] as List<FieldValue>)
+    FieldValue fieldValue = FieldValue.of(FieldValue.Attribute.REPEATED, repeatedValues)
+
+    assertEquals(['tag1', 'tag2'], TypeMapper.convertFieldValue(fieldValue, field))
+  }
+
+  @Test
+  void testConvertFieldValueStructWithSchema() {
+    Field field = Field.of(
+        'rounding',
+        StandardSQLTypeName.STRUCT,
+        Field.of('rounding_mode', StandardSQLTypeName.STRING),
+        Field.of('precision', StandardSQLTypeName.INT64)
+    )
+    FieldValueList recordValues = FieldValueList.of([
+        FieldValue.of(FieldValue.Attribute.PRIMITIVE, 'ROUND_HALF_AWAY_FROM_ZERO'),
+        FieldValue.of(FieldValue.Attribute.PRIMITIVE, '38')
+    ] as List<FieldValue>, field.subFields)
+    FieldValue fieldValue = FieldValue.of(FieldValue.Attribute.RECORD, recordValues)
+
+    Map<String, Object> converted = TypeMapper.convertFieldValue(fieldValue, field) as Map<String, Object>
+
+    assertEquals('ROUND_HALF_AWAY_FROM_ZERO', converted.rounding_mode)
+    assertEquals(38L, converted.precision)
   }
 
   // Tests for convertToInstant(Object)

--- a/matrix-bom/bom.xml
+++ b/matrix-bom/bom.xml
@@ -34,7 +34,7 @@
 
     <matrixArffVersion>0.2.1</matrixArffVersion>
     <matrixAvroVersion>0.3.0</matrixAvroVersion>
-    <matrixBigQueryVersion>0.6.2-SNAPSHOT</matrixBigQueryVersion>
+    <matrixBigQueryVersion>0.7.0-SNAPSHOT</matrixBigQueryVersion>
     <matrixChartsVersion>0.5.0</matrixChartsVersion>
     <matrixCoreVersion>3.8.0</matrixCoreVersion>
     <matrixCsvVersion>2.4.0</matrixCsvVersion>

--- a/matrix-bom/bom.xml
+++ b/matrix-bom/bom.xml
@@ -34,7 +34,7 @@
 
     <matrixArffVersion>0.2.1</matrixArffVersion>
     <matrixAvroVersion>0.3.0</matrixAvroVersion>
-    <matrixBigQueryVersion>0.7.0-SNAPSHOT</matrixBigQueryVersion>
+    <matrixBigQueryVersion>0.7.0</matrixBigQueryVersion>
     <matrixChartsVersion>0.5.0</matrixChartsVersion>
     <matrixCoreVersion>3.8.0</matrixCoreVersion>
     <matrixCsvVersion>2.4.0</matrixCsvVersion>


### PR DESCRIPTION
## Summary

Prepares `matrix-bigquery` for the `0.7.0-SNAPSHOT` line and fixes BigQuery result conversion and error handling.

## Changes

- Bump `matrix-bigquery` and the BOM BigQuery entry from `0.6.2-SNAPSHOT` to `0.7.0-SNAPSHOT`.
- Update the `matrix-bigquery` release script to tolerate missing local SDKMAN/JDK helper commands, abort when Java is not 21, and only enable external tests when `gclogin` is available.
- Handle BigQuery nested result values (`ARRAY`/`STRUCT`) without forcing primitive string access.
- Preserve repeated field Matrix column types as `List`.
- Keep write-channel load-job failures as top-level errors instead of rewriting them as row/value serialization failures.
- Preserve both exceptions when write-channel insert fails and InsertAll fallback also fails.
- Wrap interrupted table waits in `BqException` and restore interrupt status.
- Use explicit `GoogleCredentials` for Resource Manager project listing when the `Bq` instance was constructed with explicit credentials.
- Clean up a misleading `getDatasets()` debug log message.

## Modules touched

- `matrix-bigquery`
- `matrix-bom`

## Validation

- `./gradlew :matrix-bigquery:codenarcMain`
- `./gradlew :matrix-bigquery:spotlessCheck`
- `./gradlew :matrix-bigquery:test`
- `./gradlew test`
- `git diff --check`

External Google integration tests were not run locally; the default Gradle test run excludes them.
