### PR TITLE
Fix stats edge cases

### DIFF
--- a/matrix-stats/release.md
+++ b/matrix-stats/release.md
@@ -2,6 +2,9 @@
 
 ## v2.5.2, in progress
 - Dependency update: org.ejml:ejml-simple 0.43.1 -> 0.46.0
+- Fix `Correlation.corKendall()` so zero-variance inputs return `null` instead of throwing.
+- Fix `Normalize` handling of `BigInteger` inputs so min-max, mean, and standard-score normalization preserve fractional results instead of truncating back to integers.
+- Fix `Student.tTest(..., equalVariance = null)` auto-detection to use the documented variance ratio rule instead of an absolute variance difference.
 
 ## v2.5.1, 2026-07-02
 - Add toString to GoalSeek.Result for easier debugging and logging.

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Correlation.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Correlation.groovy
@@ -140,7 +140,7 @@ class Correlation {
    * Kendall Tau can be used as a metric to compare similarities between search results.
    * @param numbersX the first list of Numbers
    * @param numbersY the second list of Numbers
-   * @return a value between -1 to +1 representing the correlation
+   * @return a value between -1 to +1 representing the correlation, or null if either input has zero variance
    * @throws IllegalArgumentException if inputs are null, empty, of different sizes, or have insufficient observations
    */
   static BigDecimal corKendall(List<? extends Number> numbersX, List<? extends Number> numbersY) {
@@ -213,6 +213,9 @@ class Correlation {
 
     final long concordantMinusDiscordant = numPairs - tiedXPairs - tiedYPairs + tiedXYPairs - 2 * swaps
     final BigDecimal nonTiedPairsMultiplied = (numPairs - tiedXPairs) * (numPairs - tiedYPairs)
+    if (nonTiedPairsMultiplied == 0) {
+      return null
+    }
     concordantMinusDiscordant / nonTiedPairsMultiplied.sqrt()
   }
 

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/Normalize.groovy
@@ -550,18 +550,15 @@ class Normalize {
       }
       return result as T
     }
-    if (sample instanceof BigInteger) {
-      return (value instanceof BigInteger ? value : BigInteger.valueOf(value.longValue())) as T
-    }
     if (sample instanceof Double) {
       return value.doubleValue() as T
     }
     if (sample instanceof Float) {
       return value.floatValue() as T
     }
-    // Integer types (Long, Integer, Short, Byte) are upgraded to Float
+    // Integer types (BigInteger, Long, Integer, Short, Byte) are upgraded to Float
     // because normalization operations produce non-integer results
-    if (sample instanceof Long || sample instanceof Integer ||
+    if (sample instanceof BigInteger || sample instanceof Long || sample instanceof Integer ||
         sample instanceof Short || sample instanceof Byte) {
       return value.floatValue() as T
     }

--- a/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Student.groovy
+++ b/matrix-stats/src/main/groovy/se/alipsa/matrix/stats/ttest/Student.groovy
@@ -120,7 +120,8 @@ class Student {
    * <ul>
    *   <li><b>true</b>: Performs Student's t-test with pooled variance (assumes equal variances)</li>
    *   <li><b>false</b>: Throws exception directing user to use {@link Welch#tTest}</li>
-   *   <li><b>null</b>: Auto-detect using rule of thumb |var1 - var2| < 4. If unequal variance detected, throws exception</li>
+   *   <li><b>null</b>: Auto-detect using rule of thumb max(var1, var2) / min(var1, var2) &lt; 4.
+   *       If unequal variance is detected, throws exception</li>
    * </ul>
    *
    * @param first the first sample
@@ -154,7 +155,7 @@ class Student {
     boolean isEqualVariance
     if (equalVariance == null) {
       // Auto-detect using rule of thumb: https://www.statology.org/equal-variance-assumption/
-      isEqualVariance = (var1 - var2).abs() < 4
+      isEqualVariance = hasEqualVariance(var1, var2)
       if (!isEqualVariance) {
         throw new IllegalArgumentException(
           "Student's t-test requires equal variances. Variances differ significantly (var1=${var1}, var2=${var2}). " +
@@ -252,6 +253,18 @@ class Student {
       df: degreesFreedom,
       pVal: p
     )
+  }
+
+  private static boolean hasEqualVariance(BigDecimal var1, BigDecimal var2) {
+    if (var1 == 0 && var2 == 0) {
+      return true
+    }
+    if (var1 == 0 || var2 == 0) {
+      return false
+    }
+    BigDecimal larger = var1 > var2 ? var1 : var2
+    BigDecimal smaller = var1 > var2 ? var2 : var1
+    larger.divide(smaller, SCALE, RoundingMode.HALF_EVEN) < 4
   }
 
   /**

--- a/matrix-stats/src/test/groovy/CorrelationTest.groovy
+++ b/matrix-stats/src/test/groovy/CorrelationTest.groovy
@@ -99,4 +99,19 @@ class CorrelationTest {
 
     assertEquals(apacheCor, corKendall(x, y) as double, 1e-14)
   }
+
+  @Test
+  void testKendallsCorrelationReturnsNullWhenXIsConstant() {
+    assertNull(corKendall([5, 5, 5, 5], [1, 2, 3, 4]))
+  }
+
+  @Test
+  void testKendallsCorrelationReturnsNullWhenYIsConstant() {
+    assertNull(corKendall([1, 2, 3, 4], [5, 5, 5, 5]))
+  }
+
+  @Test
+  void testKendallsCorrelationReturnsNullWhenBothInputsAreConstant() {
+    assertNull(corKendall([5, 5, 5, 5], [9, 9, 9, 9]))
+  }
 }

--- a/matrix-stats/src/test/groovy/NormalizeTest.groovy
+++ b/matrix-stats/src/test/groovy/NormalizeTest.groovy
@@ -170,6 +170,16 @@ class NormalizeTest {
   }
 
   @Test
+  void testMinMaxNormBigIntegerPreservesFractionalResults() {
+    List result = Normalize.minMaxNorm([0G, 1G, 2G, 3G, 4G])
+
+    assertIterableEquals([0.0f, 0.25f, 0.5f, 0.75f, 1.0f], result)
+    result.each { value ->
+      assertTrue(value instanceof Float, "value is not Float but ${value.getClass().simpleName}")
+    }
+  }
+
+  @Test
   void testStdScaleNormDouble() {
     assertEquals(-0.4175944d, Normalize.stdScaleNorm(1200d, 6412.428571428572d, 12482.037558790136d, 7 ))
 
@@ -216,6 +226,16 @@ class NormalizeTest {
 
     norm = Normalize.stdScaleNorm(obs, 7)
     assertIterableEquals(exp, norm)
+  }
+
+  @Test
+  void testStdScaleNormBigIntegerPreservesFractionalResults() {
+    List result = Normalize.stdScaleNorm([0G, 1G, 2G, 3G, 4G], 6)
+
+    assertIterableEquals([-1.264911f, -0.632456f, 0.0f, 0.632456f, 1.264911f], result)
+    result.each { value ->
+      assertTrue(value instanceof Float, "value is not Float but ${value.getClass().simpleName}")
+    }
   }
 
   @Test
@@ -329,6 +349,16 @@ class NormalizeTest {
 
     norm = Normalize.meanNorm(obs, 7)
     assertIterableEquals(exp, norm)
+  }
+
+  @Test
+  void testMeanNormBigIntegerPreservesFractionalResults() {
+    List result = Normalize.meanNorm([0G, 1G, 2G, 3G, 4G])
+
+    assertIterableEquals([-0.5f, -0.25f, 0.0f, 0.25f, 0.5f], result)
+    result.each { value ->
+      assertTrue(value instanceof Float, "value is not Float but ${value.getClass().simpleName}")
+    }
   }
 
   @Test

--- a/matrix-stats/src/test/groovy/ttest/StudentEqualVarianceTest.groovy
+++ b/matrix-stats/src/test/groovy/ttest/StudentEqualVarianceTest.groovy
@@ -124,7 +124,7 @@ class StudentEqualVarianceTest {
 
   /**
    * Test auto-detection of equal variance (null parameter).
-   * Should use rule of thumb: |var1 - var2| < 4
+   * Should use rule of thumb: max(var1, var2) / min(var1, var2) < 4
    */
   @Test
   void testAutoDetectEqualVariance() {
@@ -138,6 +138,16 @@ class StudentEqualVarianceTest {
     assertTrue(result.description.contains('equal variance') ||
                result.df == (group1.size() + group2.size() - 2),
                'Should auto-detect equal variance')
+  }
+
+  @Test
+  void testAutoDetectEqualVarianceUsesVarianceRatioNotAbsoluteDifference() {
+    def group1 = [0, 10, 20, 30, 40]
+    def group2 = [0, 11, 22, 33, 44]
+
+    def result = Student.tTest(group1, group2, null)
+
+    assertEquals("Student's two sample t-test", result.description)
   }
 
   /**
@@ -205,6 +215,21 @@ class StudentEqualVarianceTest {
     // Create samples with very different variances (> 4)
     def group1 = [1, 1, 1, 1, 1]      // var ≈ 0
     def group2 = [1, 10, 20, 30, 40]  // var ≈ 247
+
+    def exception = assertThrows(IllegalArgumentException) {
+      Student.tTest(group1, group2, null)
+    }
+
+    assertTrue(exception.message.contains('Welch.tTest()'),
+               'Exception should direct user to Welch.tTest()')
+    assertTrue(exception.message.contains('differ significantly'),
+               'Exception should mention variances differ')
+  }
+
+  @Test
+  void testStudentRejectsSmallScaleUnequalVarianceByRatio() {
+    def group1 = [0.0g, 0.1g, 0.2g]
+    def group2 = [0.0g, 0.3g, 0.6g]
 
     def exception = assertThrows(IllegalArgumentException) {
       Student.tTest(group1, group2, null)


### PR DESCRIPTION
## Summary

- Fix `Correlation.corKendall()` so zero-variance inputs return `null` instead of throwing on a zero denominator.
- Fix `Normalize` BigInteger handling so fractional normalization results are preserved instead of being truncated back to integers.
- Fix `Student.tTest(..., equalVariance = null)` to use the documented variance ratio rule for equal-variance auto-detection.
- Update `matrix-stats/release.md` for the `v2.5.2` release notes.

## Modules Touched

- `matrix-stats`

## Validation

- `./gradlew :matrix-stats:test --tests CorrelationTest --tests NormalizeTest --tests ttest.StudentEqualVarianceTest`
- `./gradlew :matrix-stats:codenarcMain :matrix-stats:spotlessCheck :matrix-stats:test`
- `./gradlew test`
- `./gradlew :matrix-stats:codenarcTest`
- `git diff --check`
