### PR TITLE
Matrix-tablesaw 0.3.2

### DIFF
--- a/matrix-bom/bom.xml
+++ b/matrix-bom/bom.xml
@@ -50,7 +50,7 @@
     <matrixSpreadsheetVersion>2.4.1-SNAPSHOT</matrixSpreadsheetVersion>
     <matrixSqlVersion>2.4.0</matrixSqlVersion>
     <matrixStatsVersion>2.5.2</matrixStatsVersion>
-    <matrixTablesawVersion>0.3.2-SNAPSHOT</matrixTablesawVersion>
+    <matrixTablesawVersion>0.3.2</matrixTablesawVersion>
     <matrixXChartVersion>0.3.2-SNAPSHOT</matrixXChartVersion>
   </properties>
   <dependencyManagement>

--- a/matrix-tablesaw/build.gradle
+++ b/matrix-tablesaw/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = 'se.alipsa.matrix'
-version = '0.3.2-SNAPSHOT'
+version = '0.3.2'
 description = 'Allows conversion between Matrix and Tablesaw'
 
 repositories {

--- a/matrix-tablesaw/release.md
+++ b/matrix-tablesaw/release.md
@@ -1,6 +1,6 @@
 # Matrix-Tablesaw Version history
 
-## v0.3.2, in progress
+## v0.3.2, 2026-07-06
 - matrix-tablesaw/src/main/java/tech/tablesaw/api/NumberAggregateFunction.java: BigDecimal aggregate functions now only declare compatibility with BigDecimalColumnType,
   preventing Tablesaw from dispatching them to DoubleColumn, IntColumn, etc.
 - matrix-tablesaw/src/main/java/tech/tablesaw/io/xlsx/XlsxWriter.java: BigDecimal values now export as numeric XLSX cells; null BigDecimal values remain blank.

--- a/matrix-tablesaw/release.md
+++ b/matrix-tablesaw/release.md
@@ -1,6 +1,10 @@
 # Matrix-Tablesaw Version history
 
 ## v0.3.2, in progress
+- matrix-tablesaw/src/main/java/tech/tablesaw/api/NumberAggregateFunction.java: BigDecimal aggregate functions now only declare compatibility with BigDecimalColumnType,
+  preventing Tablesaw from dispatching them to DoubleColumn, IntColumn, etc.
+- matrix-tablesaw/src/main/java/tech/tablesaw/io/xlsx/XlsxWriter.java: BigDecimal values now export as numeric XLSX cells; null BigDecimal values remain blank.
+- Added regression tests in matrix-tablesaw/src/test/java/tech/tablesaw/api/BigDecimalColumnTest.java and matrix-tablesaw/src/test/java/io/ExportDataTest.java.
 
 ### Dependency updates
 - com.github.miachm.sods:SODS 1.8.3 -> 1.10.1

--- a/matrix-tablesaw/src/main/java/tech/tablesaw/api/NumberAggregateFunction.java
+++ b/matrix-tablesaw/src/main/java/tech/tablesaw/api/NumberAggregateFunction.java
@@ -26,12 +26,7 @@ public abstract class NumberAggregateFunction extends AggregateFunction<BigDecim
    */
   @Override
   public boolean isCompatibleColumn(ColumnType type) {
-    return type.equals(ColumnType.DOUBLE)
-        || type.equals(ColumnType.FLOAT)
-        || type.equals(ColumnType.INTEGER)
-        || type.equals(ColumnType.SHORT)
-        || type.equals(ColumnType.LONG)
-        || type.equals(BigDecimalColumnType.instance());
+    return BigDecimalColumnType.instance().equals(type);
   }
 
   /**

--- a/matrix-tablesaw/src/main/java/tech/tablesaw/io/xlsx/XlsxWriter.java
+++ b/matrix-tablesaw/src/main/java/tech/tablesaw/io/xlsx/XlsxWriter.java
@@ -10,9 +10,11 @@ import tech.tablesaw.io.DataWriter;
 import tech.tablesaw.io.Destination;
 import tech.tablesaw.io.RuntimeIOException;
 import tech.tablesaw.io.WriterRegistry;
+import tech.tablesaw.column.numbers.BigDecimalColumnType;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -152,6 +154,11 @@ public class XlsxWriter implements DataWriter<XlsxWriteOptions> {
             cell.setCellValue(row.getFloat(colName));
           } else if (ColumnType.DOUBLE.equals(type)) {
             cell.setCellValue(row.getDouble(colName));
+          } else if (BigDecimalColumnType.instance().equals(type)) {
+            BigDecimal value = (BigDecimal) row.getObject(colName);
+            if (value != null) {
+              cell.setCellValue(value.doubleValue());
+            }
           } else if (ColumnType.BOOLEAN.equals(type)) {
             cell.setCellValue(row.getBoolean(colName));
           } else {

--- a/matrix-tablesaw/src/test/java/io/ExportDataTest.java
+++ b/matrix-tablesaw/src/test/java/io/ExportDataTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.api.ColumnType;
 import tech.tablesaw.api.DateTimeColumn;
+import tech.tablesaw.api.BigDecimalColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.io.ods.OdsWriteOptions;
 import tech.tablesaw.io.xml.XmlWriteOptions;
@@ -16,6 +17,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import org.apache.poi.ss.usermodel.Cell;
@@ -120,6 +122,33 @@ public class ExportDataTest {
       Row row2 = sheet.getRow(2);
       Cell cell2 = row2.getCell(0);
       assertEquals(CellType.BLANK, cell2.getCellType(), "Null DateTime should be blank");
+    }
+
+    destFile.deleteOnExit();
+  }
+
+  @Test
+  public void testXlsxExportBigDecimalAsNumericCell() throws IOException {
+    var table = Table.create("bigdecimal-test")
+        .addColumns(BigDecimalColumn.create("amount",
+            new BigDecimal[]{new BigDecimal("123.45"), null}));
+
+    File destFile = File.createTempFile("bigdecimal-test", ".xlsx");
+    try (FileOutputStream out = new FileOutputStream(destFile)) {
+      XlsxWriteOptions options = XlsxWriteOptions.builder(out).build();
+      table.write().usingOptions(options);
+    }
+
+    try (XSSFWorkbook workbook = new XSSFWorkbook(new FileInputStream(destFile))) {
+      XSSFSheet sheet = workbook.getSheetAt(0);
+      Row row1 = sheet.getRow(1);
+      Cell cell1 = row1.getCell(0);
+      assertEquals(CellType.NUMERIC, cell1.getCellType(), "BigDecimal should be numeric in Excel");
+      assertEquals(123.45d, cell1.getNumericCellValue());
+
+      Row row2 = sheet.getRow(2);
+      Cell cell2 = row2.getCell(0);
+      assertEquals(CellType.BLANK, cell2.getCellType(), "Null BigDecimal should be blank");
     }
 
     destFile.deleteOnExit();

--- a/matrix-tablesaw/src/test/java/tech/tablesaw/api/BigDecimalColumnTest.java
+++ b/matrix-tablesaw/src/test/java/tech/tablesaw/api/BigDecimalColumnTest.java
@@ -694,6 +694,18 @@ public class BigDecimalColumnTest {
   }
 
   @Test
+  public void testAggregateFunctionsOnlyAcceptBigDecimalColumns() {
+    assertTrue(BigDecimalAggregateFunctions.mean.isCompatibleColumn(BigDecimalColumnType.instance()));
+    assertFalse(BigDecimalAggregateFunctions.mean.isCompatibleColumn(ColumnType.DOUBLE));
+    assertFalse(BigDecimalAggregateFunctions.median.isCompatibleColumn(ColumnType.FLOAT));
+    assertFalse(BigDecimalAggregateFunctions.cv.isCompatibleColumn(ColumnType.INTEGER));
+    assertFalse(BigDecimalAggregateFunctions.sum.isCompatibleColumn(ColumnType.SHORT));
+    assertFalse(BigDecimalAggregateFunctions.range.isCompatibleColumn(ColumnType.LONG));
+    assertFalse(BigDecimalAggregateFunctions.min.isCompatibleColumn(ColumnType.DOUBLE));
+    assertFalse(BigDecimalAggregateFunctions.max.isCompatibleColumn(ColumnType.DOUBLE));
+  }
+
+  @Test
   public void testCvZeroMean() {
     var col = BigDecimalColumn.create("zero",
         new BigDecimal[]{new BigDecimal("-1"), new BigDecimal("1")});


### PR DESCRIPTION
  - matrix-tablesaw/src/main/java/tech/tablesaw/api/NumberAggregateFunction.java: BigDecimal aggregate functions now only declare compatibility with BigDecimalColumnType, preventing Tablesaw from dispatching them to DoubleColumn, IntColumn, etc.
  - matrix-tablesaw/src/main/java/tech/tablesaw/io/xlsx/XlsxWriter.java: BigDecimal values now export as numeric XLSX cells; null BigDecimal values remain blank.
  - Added regression tests in matrix-tablesaw/src/test/java/tech/tablesaw/api/BigDecimalColumnTest.java and matrix-tablesaw/src/test/java/io/ExportDataTest.java.