### PR TITLE
Fix gsheets empty reads and serial conversion

### DIFF
--- a/matrix-bom/bom.xml
+++ b/matrix-bom/bom.xml
@@ -41,7 +41,7 @@
     <matrixDatasetsVersion>2.2.0</matrixDatasetsVersion>
     <matrixGgplotVersion>0.5.0</matrixGgplotVersion>
     <matrixGroovyExtVersion>0.3.0</matrixGroovyExtVersion>
-    <matrixGsheetsVersion>0.2.1-SNAPSHOT</matrixGsheetsVersion>
+    <matrixGsheetsVersion>0.2.1</matrixGsheetsVersion>
     <matrixJsonVersion>2.3.1-SNAPSHOT</matrixJsonVersion>
     <matrixLoggingVersion>0.1.1-SNAPSHOT</matrixLoggingVersion>
     <matrixParquetVersion>0.6.0</matrixParquetVersion>

--- a/matrix-gsheets/build.gradle
+++ b/matrix-gsheets/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = 'se.alipsa.matrix'
-version = '0.2.1-SNAPSHOT'
+version = '0.2.1'
 description = 'Google Sheets import/export'
 
 JavaCompile javaCompile = compileJava {

--- a/matrix-gsheets/release.md
+++ b/matrix-gsheets/release.md
@@ -1,6 +1,11 @@
 # Release history
 
-## 0.2.1, in progress
+## 0.2.1, 2026-07-08
+
+### Bug Fixes
+- Fix `GsConverter.toSerials(List<Object>)` throwing for `java.util.Date` values by dispatching `Date` through `GsConverter.asSerial(Object)`
+- Fix `GsUtil.columnCountForRange` rejecting single-cell A1 ranges such as `Sheet1!A1`
+- Fix `GsheetsReader.readAsObject`/`readAsStrings` throwing `NullPointerException` on genuinely empty ranges; they now return an empty `Matrix` with generated headers
 
 ### Dependency updates
 - com.google.apis:google-api-services-drive v3-rev20260428-2.0.0 -> v3-rev20260624-2.0.0

--- a/matrix-gsheets/src/main/groovy/se/alipsa/matrix/gsheets/GsConverter.groovy
+++ b/matrix-gsheets/src/main/groovy/se/alipsa/matrix/gsheets/GsConverter.groovy
@@ -212,6 +212,9 @@ class GsConverter {
     if (o in LocalTime) {
       return asSerial((LocalTime) o)
     }
+    if (o in Date) {
+      return asSerial((Date) o)
+    }
     throw new IllegalArgumentException("Cannot convert object of type ${o?.getClass()} to serial number")
   }
 

--- a/matrix-gsheets/src/main/groovy/se/alipsa/matrix/gsheets/GsUtil.groovy
+++ b/matrix-gsheets/src/main/groovy/se/alipsa/matrix/gsheets/GsUtil.groovy
@@ -27,6 +27,7 @@ class GsUtil {
   private static final String RANGE_ERROR = 'range must not be null or empty'
   private static final String COLON = ':'
   private static final String COLUMN_PATTERN = '^([A-Z]+)'
+  private static final String SINGLE_CELL_PATTERN = '^[A-Z]+\\d+$'
   private static final int MAX_SHEET_NAME_LENGTH = 100
 
   static void deleteSheet(String spreadsheetId) {
@@ -88,8 +89,7 @@ class GsUtil {
 
     String[] cellParts = cellRange.split(COLON)
     if (cellParts.size() == 1) {
-      def singleCellMatcher = cellParts[0] =~ COLUMN_PATTERN
-      if (!singleCellMatcher) {
+      if (!cellParts[0].matches(SINGLE_CELL_PATTERN)) {
         throw new IllegalArgumentException(
           "Invalid range format: '${range}'. Expected A1 notation like 'Sheet1!A1:D10', 'A1:D10', or 'Sheet1!A1'"
         )

--- a/matrix-gsheets/src/main/groovy/se/alipsa/matrix/gsheets/GsUtil.groovy
+++ b/matrix-gsheets/src/main/groovy/se/alipsa/matrix/gsheets/GsUtil.groovy
@@ -86,11 +86,19 @@ class GsUtil {
     String[] parts = range.split('!')
     String cellRange = parts.size() > 1 ? parts[1] : parts[0]
 
-    // Split the range into start and end cells
     String[] cellParts = cellRange.split(COLON)
+    if (cellParts.size() == 1) {
+      def singleCellMatcher = cellParts[0] =~ COLUMN_PATTERN
+      if (!singleCellMatcher) {
+        throw new IllegalArgumentException(
+          "Invalid range format: '${range}'. Expected A1 notation like 'Sheet1!A1:D10', 'A1:D10', or 'Sheet1!A1'"
+        )
+      }
+      return 1
+    }
     if (cellParts.size() != 2) {
       throw new IllegalArgumentException(
-        "Invalid range format: '${range}'. Expected A1 notation with a range like 'Sheet1!A1:D10' or 'A1:D10'"
+        "Invalid range format: '${range}'. Expected A1 notation like 'Sheet1!A1:D10', 'A1:D10', or 'Sheet1!A1'"
       )
     }
 

--- a/matrix-gsheets/src/main/groovy/se/alipsa/matrix/gsheets/GsheetsReader.groovy
+++ b/matrix-gsheets/src/main/groovy/se/alipsa/matrix/gsheets/GsheetsReader.groovy
@@ -50,6 +50,7 @@ class GsheetsReader {
 
   private static final String APP_NAME = 'Groovy Sheets Reader'
   private static final String SHEET_NAME_SEPARATOR = '!'
+  private static final String SHEETS_SERVICE_ERROR = 'sheetsService must not be null'
   private static final int RANGE_SPLIT_LIMIT = 2
 
   /**
@@ -125,21 +126,41 @@ class GsheetsReader {
   static Matrix readAsObject(String spreadsheetId, String range, boolean firstRowAsColumnNames, GoogleCredentials credentials = null, boolean convertEmptyToNull = false) {
     GsUtil.validateSheetId(spreadsheetId)
     GsUtil.validateRange(range)
+    Sheets sheetsService = buildSheetsService(credentials)
+    readAsObjectWithService(spreadsheetId, range, firstRowAsColumnNames, sheetsService, convertEmptyToNull)
+  }
 
-    def sheetsService = buildSheetsService(credentials)
-
+  /**
+   * Reads unformatted object values using a provided Sheets service.
+   * This overload is useful for tests and callers that manage their own Sheets service.
+   *
+   * @param spreadsheetId The Google Sheets spreadsheet ID
+   * @param range The range in A1 notation
+   * @param firstRowAsColumnNames If true, uses first row as column names
+   * @param sheetsService The Sheets service to use
+   * @param convertEmptyToNull If true, converts empty string cells to null
+   * @return A Matrix containing the unformatted values
+   * @throws IllegalArgumentException if spreadsheetId, range, or sheetsService is null/empty or malformed
+   * @throws IOException if the Google Sheets API call fails
+   */
+  static Matrix readAsObjectWithService(String spreadsheetId, String range, boolean firstRowAsColumnNames, Sheets sheetsService, boolean convertEmptyToNull = false) {
+    GsUtil.validateSheetId(spreadsheetId)
+    GsUtil.validateRange(range)
+    if (sheetsService == null) {
+      throw new IllegalArgumentException(SHEETS_SERVICE_ERROR)
+    }
     def response = sheetsService
         .spreadsheets()
         .values()
         .get(spreadsheetId, range)
         .setValueRenderOption('UNFORMATTED_VALUE')
         .execute()
-    List<List<Object>> values = response.getValues()
+    List<List<Object>> values = copyRows(response.getValues())
     int ncol = GsUtil.columnCountForRange(range)
 
     List<String> headers
     if (firstRowAsColumnNames) {
-      List<Object> firstRow = values.remove(0)
+      List<Object> firstRow = values.isEmpty() ? [] : values.remove(0)
       headers = GsUtil.buildHeader(ncol, firstRow)
     } else {
       headers = Matrix.anonymousHeader(ncol)
@@ -178,9 +199,28 @@ class GsheetsReader {
   static Matrix readAsStrings(String spreadsheetId, String range, boolean firstRowAsColumnNames, GoogleCredentials credentials = null) {
     GsUtil.validateSheetId(spreadsheetId)
     GsUtil.validateRange(range)
+    Sheets sheetsService = buildSheetsService(credentials)
+    readAsStringsWithService(spreadsheetId, range, firstRowAsColumnNames, sheetsService)
+  }
 
-    def sheetsService = buildSheetsService(credentials)
-
+  /**
+   * Reads formatted string values using a provided Sheets service.
+   * This overload is useful for tests and callers that manage their own Sheets service.
+   *
+   * @param spreadsheetId The Google Sheets spreadsheet ID
+   * @param range The range in A1 notation
+   * @param firstRowAsColumnNames If true, uses first row as column names
+   * @param sheetsService The Sheets service to use
+   * @return A Matrix containing the data as strings
+   * @throws IllegalArgumentException if spreadsheetId, range, or sheetsService is null/empty or malformed
+   * @throws IOException if the Google Sheets API call fails
+   */
+  static Matrix readAsStringsWithService(String spreadsheetId, String range, boolean firstRowAsColumnNames, Sheets sheetsService) {
+    GsUtil.validateSheetId(spreadsheetId)
+    GsUtil.validateRange(range)
+    if (sheetsService == null) {
+      throw new IllegalArgumentException(SHEETS_SERVICE_ERROR)
+    }
     def request = sheetsService
         .spreadsheets()
         .values()
@@ -188,12 +228,12 @@ class GsheetsReader {
         .setValueRenderOption('FORMATTED_VALUE')
 
     def response = request.execute()
-    List<List<Object>> values = response.getValues()
+    List<List<Object>> values = copyRows(response.getValues())
     int ncol = GsUtil.columnCountForRange(range)
 
     List<String> headers
     if (firstRowAsColumnNames) {
-      List<Object> firstRow = values.remove(0)
+      List<Object> firstRow = values.isEmpty() ? [] : values.remove(0)
       headers = GsUtil.buildHeader(ncol, firstRow)
     } else {
       headers = Matrix.anonymousHeader(ncol)
@@ -224,6 +264,17 @@ class GsheetsReader {
         .columnNames(headers)
         .types([String] * ncol)
         .build()
+  }
+
+  private static List<List<Object>> copyRows(List<List<Object>> values) {
+    if (values == null) {
+      return []
+    }
+    List<List<Object>> rows = []
+    values.each { List<Object> row ->
+      rows << new ArrayList<Object>(row)
+    }
+    rows
   }
 
   private static Sheets buildSheetsService(GoogleCredentials credentials) {

--- a/matrix-gsheets/src/main/groovy/se/alipsa/matrix/gsheets/GsheetsReader.groovy
+++ b/matrix-gsheets/src/main/groovy/se/alipsa/matrix/gsheets/GsheetsReader.groovy
@@ -127,7 +127,7 @@ class GsheetsReader {
     GsUtil.validateSheetId(spreadsheetId)
     GsUtil.validateRange(range)
     Sheets sheetsService = buildSheetsService(credentials)
-    readAsObjectWithService(spreadsheetId, range, firstRowAsColumnNames, sheetsService, convertEmptyToNull)
+    readAsObjectValues(spreadsheetId, range, firstRowAsColumnNames, sheetsService, convertEmptyToNull)
   }
 
   /**
@@ -149,6 +149,10 @@ class GsheetsReader {
     if (sheetsService == null) {
       throw new IllegalArgumentException(SHEETS_SERVICE_ERROR)
     }
+    readAsObjectValues(spreadsheetId, range, firstRowAsColumnNames, sheetsService, convertEmptyToNull)
+  }
+
+  private static Matrix readAsObjectValues(String spreadsheetId, String range, boolean firstRowAsColumnNames, Sheets sheetsService, boolean convertEmptyToNull) {
     def response = sheetsService
         .spreadsheets()
         .values()
@@ -200,7 +204,7 @@ class GsheetsReader {
     GsUtil.validateSheetId(spreadsheetId)
     GsUtil.validateRange(range)
     Sheets sheetsService = buildSheetsService(credentials)
-    readAsStringsWithService(spreadsheetId, range, firstRowAsColumnNames, sheetsService)
+    readAsStringValues(spreadsheetId, range, firstRowAsColumnNames, sheetsService)
   }
 
   /**
@@ -221,6 +225,10 @@ class GsheetsReader {
     if (sheetsService == null) {
       throw new IllegalArgumentException(SHEETS_SERVICE_ERROR)
     }
+    readAsStringValues(spreadsheetId, range, firstRowAsColumnNames, sheetsService)
+  }
+
+  private static Matrix readAsStringValues(String spreadsheetId, String range, boolean firstRowAsColumnNames, Sheets sheetsService) {
     def request = sheetsService
         .spreadsheets()
         .values()

--- a/matrix-gsheets/src/test/groovy/test/alipsa/matrix/gsheets/GsConverterTest.groovy
+++ b/matrix-gsheets/src/test/groovy/test/alipsa/matrix/gsheets/GsConverterTest.groovy
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import se.alipsa.matrix.core.*
 import se.alipsa.matrix.gsheets.GsConverter
 
+import java.sql.Timestamp
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -263,12 +264,22 @@ class GsConverterTest {
   }
 
   @Test
+  void testToSerialsWithDates() {
+    Date date = Timestamp.valueOf(LocalDateTime.parse('2022-01-14T12:33:20'))
+    def serials = GsConverter.toSerials([date])
+    assertEquals(1, serials.size())
+    assertEquals(asSerial(date), serials[0])
+  }
+
+  @Test
   void testToSerialsWithMixedDateTypes() {
-    def mixed = [LocalDate.parse('2024-06-24'), LocalDateTime.parse('2022-01-14T12:33:20')]
+    Date date = Timestamp.valueOf(LocalDateTime.parse('2022-01-14T12:33:20'))
+    def mixed = [LocalDate.parse('2024-06-24'), LocalDateTime.parse('2022-01-14T12:33:20'), date]
     def serials = GsConverter.toSerials(mixed)
-    assertEquals(2, serials.size())
+    assertEquals(3, serials.size())
     assertEquals(new BigDecimal(45467), serials[0])
     assertEquals(44575.5231481481, serials[1])
+    assertEquals(asSerial(date), serials[2])
   }
 
   @Test

--- a/matrix-gsheets/src/test/groovy/test/alipsa/matrix/gsheets/GsUtilTest.groovy
+++ b/matrix-gsheets/src/test/groovy/test/alipsa/matrix/gsheets/GsUtilTest.groovy
@@ -41,6 +41,9 @@ class GsUtilTest {
     columns = columnCountForRange(range)
     //println "The number of columns in the range is: ${columns}"
     assertEquals(12, columns)
+
+    assertEquals(1, columnCountForRange('A1'))
+    assertEquals(1, columnCountForRange('Sheet1!A1'))
   }
 
   @Test
@@ -126,10 +129,6 @@ class GsUtilTest {
 
   @Test
   void testColumnCountForRangeWithInvalidFormat() {
-    // Missing colon
-    assertThrows(IllegalArgumentException, () -> columnCountForRange('A1'))
-    assertThrows(IllegalArgumentException, () -> columnCountForRange('Sheet1!A1'))
-
     // Invalid format - too many colons
     assertThrows(IllegalArgumentException, () -> columnCountForRange('A1:B2:C3'))
   }

--- a/matrix-gsheets/src/test/groovy/test/alipsa/matrix/gsheets/GsUtilTest.groovy
+++ b/matrix-gsheets/src/test/groovy/test/alipsa/matrix/gsheets/GsUtilTest.groovy
@@ -129,6 +129,10 @@ class GsUtilTest {
 
   @Test
   void testColumnCountForRangeWithInvalidFormat() {
+    // Missing row number
+    assertThrows(IllegalArgumentException, () -> columnCountForRange('A'))
+    assertThrows(IllegalArgumentException, () -> columnCountForRange('Sheet1!A'))
+
     // Invalid format - too many colons
     assertThrows(IllegalArgumentException, () -> columnCountForRange('A1:B2:C3'))
   }

--- a/matrix-gsheets/src/test/groovy/test/alipsa/matrix/gsheets/GsheetsReaderTest.groovy
+++ b/matrix-gsheets/src/test/groovy/test/alipsa/matrix/gsheets/GsheetsReaderTest.groovy
@@ -1,9 +1,14 @@
 package test.alipsa.matrix.gsheets
 
 import static org.junit.jupiter.api.Assertions.*
+import static org.mockito.ArgumentMatchers.anyString
+import static org.mockito.Mockito.*
 
+import com.google.api.services.sheets.v4.Sheets
+import com.google.api.services.sheets.v4.model.ValueRange
 import org.junit.jupiter.api.Test
 
+import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.gsheets.GsheetsReader
 
 /**
@@ -62,6 +67,49 @@ class GsheetsReaderTest {
     assertThrows(IllegalArgumentException, () -> {
       GsheetsReader.readAsStrings('some-id', null, true)
     }, 'Should throw on null range')
+  }
+
+  @Test
+  void testReadAsObjectHandlesEmptyRange() {
+    Matrix matrix = GsheetsReader.readAsObjectWithService(
+        'some-id',
+        'Sheet1!A1:D10',
+        true,
+        sheetsServiceReturning(new ValueRange(), 'UNFORMATTED_VALUE')
+    )
+
+    assertEquals(0, matrix.rowCount())
+    assertEquals(4, matrix.columnCount())
+    assertEquals(['c1', 'c2', 'c3', 'c4'], matrix.columnNames())
+  }
+
+  @Test
+  void testReadAsStringsHandlesEmptySingleCellRange() {
+    Matrix matrix = GsheetsReader.readAsStringsWithService(
+        'some-id',
+        'Sheet1!A1',
+        false,
+        sheetsServiceReturning(new ValueRange(), 'FORMATTED_VALUE')
+    )
+
+    assertEquals(0, matrix.rowCount())
+    assertEquals(1, matrix.columnCount())
+    assertEquals(['c1'], matrix.columnNames())
+  }
+
+  private static Sheets sheetsServiceReturning(ValueRange response, String renderOption) {
+    def sheetsService = mock(Sheets)
+    def spreadsheets = mock(Sheets.Spreadsheets)
+    def values = mock(Sheets.Spreadsheets.Values)
+    def getRequest = mock(Sheets.Spreadsheets.Values.Get)
+
+    when(sheetsService.spreadsheets()).thenReturn(spreadsheets)
+    when(spreadsheets.values()).thenReturn(values)
+    when(values.get(anyString(), anyString())).thenReturn(getRequest)
+    when(getRequest.setValueRenderOption(renderOption)).thenReturn(getRequest)
+    when(getRequest.execute()).thenReturn(response)
+
+    sheetsService
   }
 
 }

--- a/matrix-gsheets/src/test/groovy/test/alipsa/matrix/gsheets/GsheetsReaderTest.groovy
+++ b/matrix-gsheets/src/test/groovy/test/alipsa/matrix/gsheets/GsheetsReaderTest.groovy
@@ -14,8 +14,8 @@ import se.alipsa.matrix.gsheets.GsheetsReader
 /**
  * Tests for GsheetsReader class.
  *
- * These tests verify input validation and method existence.
- * Actual read operations are tested via external/integration tests.
+ * These tests verify input validation and mocked read behavior.
+ * External integration tests cover reads against the Google Sheets API.
  */
 class GsheetsReaderTest {
 


### PR DESCRIPTION
## Summary

Fixes three matrix-gsheets edge cases found during review:

- dispatch `java.util.Date` through `GsConverter.asSerial(Object)` so `toSerials(List<Object>)` handles every supported date/time overload
- allow single-cell A1 ranges such as `Sheet1!A1` in `GsUtil.columnCountForRange`
- handle Google Sheets empty-range responses where `ValueRange.values` is unset by returning an empty `Matrix` with generated headers

## Impact

`GsheetsReader.readAsObject` and `readAsStrings` no longer throw NPEs for genuinely empty ranges, and single-cell reads now behave consistently with `validateRange`. Date serial conversion also works for `Date` values passed through statically resolved `Object` paths.

## Validation

- `./gradlew :matrix-gsheets:codenarcMain`
- `./gradlew :matrix-gsheets:spotlessCheck`
- `./gradlew :matrix-gsheets:test` (123 passed)
- `./gradlew test`