### PR TITLE
Add release.sh for matrix-logging

### DIFF
--- a/matrix-logging/release.sh
+++ b/matrix-logging/release.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+echo "Releasing project in $SCRIPT_DIR"
+cd "$SCRIPT_DIR" || exit 1
+
+# shellcheck disable=SC1090
+source ~/.sdkman/bin/sdkman-init.sh
+source jdk21
+
+PROJECT=$(basename "$PWD")
+
+../gradlew :"$PROJECT":clean :"$PROJECT":build :"$PROJECT":release || exit 1
+
+if grep "^version" build.gradle | grep -q 'SNAPSHOT'; then
+  echo "$PROJECT snapshot published"
+else
+  echo "$PROJECT uploaded and released"
+  echo "see https://central.sonatype.com/publishing/deployments for more info"
+  # browse https://oss.sonatype.org &
+fi


### PR DESCRIPTION
## Summary
- matrix-logging was the only published module missing a `release.sh`. Added one following the current template (matrix-ggplot/release.sh: resolves its own script dir, sources jdk21, runs the module-scoped `clean build release` Gradle tasks).
- Fixed the SNAPSHOT-detection check while adding it: the copied `grep "version '" build.gradle` pattern never matches this repo's actual `version = '...'` syntax in any module's build.gradle, so it silently always falls into the "released" branch. Changed to `grep "^version" build.gradle`, verified it correctly reports "released" for matrix-logging's current `0.1.1`.

## Test plan
- [x] Verified `grep "^version" build.gradle | grep -q 'SNAPSHOT'` correctly evaluates to false for the current non-SNAPSHOT `0.1.1` version
- [x] Confirmed script is executable and matches the structure of other modules' release scripts (`../gradlew :$PROJECT:clean :$PROJECT:build :$PROJECT:release`)
- Not run end-to-end (requires Sonatype credentials / actual publish, out of scope for this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)