### PR TITLE
Add Pict-like XChart builders

### DIFF
--- a/docs/tutorial/8-matrix-xchart.md
+++ b/docs/tutorial/8-matrix-xchart.md
@@ -9,8 +9,8 @@ To use the matrix-xchart module, you need to add it as a dependency to your proj
 ### Gradle Configuration
 
 ```groovy
-implementation 'org.apache.groovy:groovy:5.0.5'
-implementation platform('se.alipsa.matrix:matrix-bom:2.5.1')
+implementation 'org.apache.groovy:groovy:5.0.6'
+implementation platform('se.alipsa.matrix:matrix-bom:2.5.2-SNAPSHOT')
 implementation 'se.alipsa.matrix:matrix-core'
 implementation 'se.alipsa.matrix:matrix-xchart'
 ```
@@ -24,7 +24,7 @@ implementation 'se.alipsa.matrix:matrix-xchart'
       <dependency>
         <groupId>se.alipsa.matrix</groupId>
         <artifactId>matrix-bom</artifactId>
-        <version>2.5.1</version>
+        <version>2.5.2-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -405,8 +405,8 @@ You can customize various aspects of the charts:
 ```groovy
 LineChart chart = LineChart.create(matrix, 600, 500)
     .setTitle("My Line Chart")
-    .setXAxisTitle("X Axis")
-    .setYAxisTitle("Y Axis")
+    .setXLabel("X Axis")
+    .setYLabel("Y Axis")
     .addSeries("Series 1", "X1", "Y1")
 ```
 

--- a/matrix-bom/bom.xml
+++ b/matrix-bom/bom.xml
@@ -51,7 +51,7 @@
     <matrixSqlVersion>2.4.0</matrixSqlVersion>
     <matrixStatsVersion>2.5.2</matrixStatsVersion>
     <matrixTablesawVersion>0.3.2</matrixTablesawVersion>
-    <matrixXChartVersion>0.3.3-SNAPSHOT</matrixXChartVersion>
+    <matrixXChartVersion>0.4.0-SNAPSHOT</matrixXChartVersion>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/matrix-xchart/build.gradle
+++ b/matrix-xchart/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'se.alipsa.matrix'
-version = '0.3.3-SNAPSHOT'
+version = '0.4.0-SNAPSHOT'
 description = "Groovy library for creating charts with xcharts using matrix ([][] data)"
 
 JavaCompile javaCompile = compileJava {

--- a/matrix-xchart/readme.md
+++ b/matrix-xchart/readme.md
@@ -8,10 +8,9 @@ The se.alipsa.matrix.xchart package contains factory classes for each chart type
 
 To use it add the following to your gradle build script (or equivalent for maven etc)
 ```groovy
-implementation 'org.apache.groovy:groovy:5.0.7'
-implementation 'se.alipsa.matrix:matrix-core:3.8.0'
-implementation 'se.alipsa.matrix:matrix-stats:2.5.2'
-implementation 'se.alipsa.matrix:matrix-xchart:0.3.2'
+implementation(platform('se.alipsa.matrix:matrix-bom:2.5.2-SNAPSHOT'))
+implementation 'org.apache.groovy:groovy:5.0.6'
+implementation 'se.alipsa.matrix:matrix-xchart:0.4.0-SNAPSHOT'
 ```
 Here is an example usage for a Line Chart:
 
@@ -44,6 +43,38 @@ try (FileOutputStream fos = new FileOutputStream("./build/testLineChart2.svg")) 
   chart.addSeries('Third', matrix.X1, matrix.Y2).exportSvg(fos)
 }
 ```
+
+## Convenience builders
+
+Builders provide the Pict-like quick-start API while returning native XChart-backed
+objects. Dimensions are fixed when `build()` is called and can be further customized
+through `getXChart()` or `style`.
+
+```groovy
+def chart = LineChart.builder(matrix)
+    .title('Lines')
+    .size(800, 600)
+    .x('X1')
+    .y('Y1', 'Y2')
+    .xAxisTitle('Time')
+    .yAxisTitle('Value')
+    .build()
+
+Plot.png(chart, new File('lines.png'))
+Plot.svg(chart, new File('lines.svg'))
+```
+
+Use the specialized mappings for non-XY data:
+
+```groovy
+RadarChart.builder(scores).label('player').values('speed', 'power').build()
+HeatmapChart.builder(data).values(['jan', 'feb', 'mar']).build()
+CorrelationHeatmapChart.builder(data).seriesName('Correlation').columns('x', 'y').build()
+OhlcChart.builder(prices).date('date').open('open').high('high').low('low').close('close').build()
+```
+
+For OHLC data, convert `LocalDate` values before building: `Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant())`.
+The legacy `create(...).addSeries(...)` APIs remain available for incremental or advanced configuration.
 See the [tests](https://github.com/Alipsa/matrix/tree/main/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart) for more examples.
 
 You can easily export to png, svg or swing using one of the exportXXX methods but if you need something else you can always get the underlying XChart and use one of the encoders. E.g:

--- a/matrix-xchart/release.md
+++ b/matrix-xchart/release.md
@@ -1,5 +1,10 @@
 # Matrix XChart release history
 
+## v0.4.0, In progress
+- Add deferred Pict-like `builder(Matrix)` convenience APIs for XChart chart types.
+- Add `Plot` PNG, SVG, PDF, Swing, and display export facade.
+- Keep existing `create`/`addSeries` APIs and native XChart customization available.
+
 ## v0.3.3, In progress
 - Dependency updates:
   - org.knowm.xchart:xchart 4.0.2 -> 4.0.3

--- a/matrix-xchart/release.md
+++ b/matrix-xchart/release.md
@@ -1,13 +1,14 @@
 # Matrix XChart release history
 
 ## v0.4.0, In progress
-- Add deferred Pict-like `builder(Matrix)` convenience APIs for XChart chart types.
-- Add `Plot` PNG, SVG, PDF, Swing, and display export facade.
-- Keep existing `create`/`addSeries` APIs and native XChart customization available.
-
-## v0.3.3, In progress
-- Dependency updates:
-  - org.knowm.xchart:xchart 4.0.2 -> 4.0.3
+- Add deferred Pict-like `builder(Matrix)` convenience APIs for Line, Area, Scatter, Bar, Stick, Box, Bubble, Histogram, Pie, Radar, Heatmap, CorrelationHeatmap, and OHLC charts.
+  - Common chart builders support title, dimensions, mappings, and axis labels where XChart supports axes.
+  - Specialized builders use explicit mappings for bubble sizes, histogram buckets, pie donuts, radar radii, heatmap values/labels, correlation columns, and OHLC fields.
+- Add the `Plot` facade for PNG, SVG, PDF, Swing, and display operations.
+- Preserve existing `create(...)`, `addSeries(...)`, per-chart export methods, and native XChart styling/customization through `getXChart()`.
+- Add early validation for missing mappings, unknown/non-numeric columns, incompatible chart options, incomplete heatmap labels, and invalid OHLC date columns.
+- Apply semi-transparent fills to builder-created area series so overlapping regions remain visible.
+- Upgrade org.knowm.xchart:xchart from 4.0.2 to 4.0.3.
 
 ## v0.3.2, 2026-07-10
 - Upgrade to xchart 4.0.2 (from 3.8.8)

--- a/matrix-xchart/req/v0.4.0-pict-like-api-compatibility.md
+++ b/matrix-xchart/req/v0.4.0-pict-like-api-compatibility.md
@@ -20,7 +20,7 @@ in the PR description.
 - Builder axis methods are `xAxisTitle(String)` and `yAxisTitle(String)`. At
   build time they delegate to the existing chart-level `setXLabel(String)` and
   `setYLabel(String)` APIs. Do not add chart-level aliases in this release.
-- Axis configuration is unsupported for PieChart, BoxChart, and RadarChart.
+- Axis configuration is unsupported for PieChart, BoxChart, RadarChart, HeatmapChart, and CorrelationHeatmapChart.
   Calling such a builder method throws `IllegalArgumentException` immediately;
   it is never silently ignored.
 - BoxChart accepts only `.y(String...)`; every selected column becomes one
@@ -44,9 +44,9 @@ in the PR description.
 
 ## Phase 1: Release Version and Compatibility Contract
 
-1.1 [ ] Change `version` in `matrix-xchart/build.gradle` from `0.3.3-SNAPSHOT` to `0.4.0-SNAPSHOT`.
+1.1 [x] Change `version` in `matrix-xchart/build.gradle` from `0.3.3-SNAPSHOT` to `0.4.0-SNAPSHOT`.
 
-1.2 [ ] Change `matrixXChartVersion` in `matrix-bom/bom.xml` from `0.3.3-SNAPSHOT` to `0.4.0-SNAPSHOT`.
+1.2 [x] Change `matrixXChartVersion` in `matrix-bom/bom.xml` from `0.3.3-SNAPSHOT` to `0.4.0-SNAPSHOT`.
 
 1.3 [ ] Define the public compatibility contract: `builder(Matrix)` is additive; existing `create(...)` and `addSeries(...)` entry points retain their behavior; advanced users continue to configure the result through `getXChart()` and `style`.
 

--- a/matrix-xchart/req/v0.4.0-pict-like-api-compatibility.md
+++ b/matrix-xchart/req/v0.4.0-pict-like-api-compatibility.md
@@ -1,0 +1,133 @@
+# matrix-xchart 0.4.0 Pict-like API Compatibility Plan
+
+## Scope
+
+Add an additive, chart-type-first convenience API to `matrix-xchart` that follows
+the familiar Matrix Pict builder style while preserving XChart's native chart and
+styler access. This is not an attempt to duplicate Charm's SVG grammar of graphics
+or the ggplot compatibility layer.
+
+Existing `create(...)`, `addSeries(...)`, direct `getXChart()`, and per-chart
+export APIs remain supported. A task is only complete when its checkbox is marked
+`[x]` and its exact successful verification command is recorded under that task or
+in the PR description.
+
+## Design Decisions
+
+- Builders are separate objects and are strictly deferred: they retain only the
+  Matrix, mappings, and configuration until `build()` invokes the existing chart
+  factory and adds series. No XChart instance is created by a builder constructor.
+- Builder axis methods are `xAxisTitle(String)` and `yAxisTitle(String)`. At
+  build time they delegate to the existing chart-level `setXLabel(String)` and
+  `setYLabel(String)` APIs. Do not add chart-level aliases in this release.
+- Axis configuration is unsupported for PieChart, BoxChart, and RadarChart.
+  Calling such a builder method throws `IllegalArgumentException` immediately;
+  it is never silently ignored.
+- BoxChart accepts only `.y(String...)`; every selected column becomes one
+  independent box series, matching its current `addSeries(String)` semantics.
+- A multi-series AreaChart built through the convenience API assigns the existing
+  Matrix theme colour to each series with alpha `185`, using
+  `makeFillTransparent`; the builder applies this consistently to one or more
+  series so its visual defaults are predictable. Users may still override the
+  returned XChart series styling.
+- `Plot` is compatibility sugar only. It accepts no width/height arguments:
+  dimensions are fixed by the chart builder and immediately reflected by
+  `getXChart()`, unlike matrix-pict where dimensions are export-time parameters.
+  Every Plot method validates a non-null chart and fails with
+  `IllegalArgumentException` before delegation.
+- Common builders must create charts exclusively through their existing
+  `create(Matrix, Integer, Integer)` factories so class-specific defaults—such
+  as ScatterChart's MatrixTheme markers—are preserved.
+- All new builder and validation code must compile under the repository's global
+  static-compilation configuration. Avoid dynamically typed closure delegation
+  in the builder implementation.
+
+## Phase 1: Release Version and Compatibility Contract
+
+1.1 [ ] Change `version` in `matrix-xchart/build.gradle` from `0.3.3-SNAPSHOT` to `0.4.0-SNAPSHOT`.
+
+1.2 [ ] Change `matrixXChartVersion` in `matrix-bom/bom.xml` from `0.3.3-SNAPSHOT` to `0.4.0-SNAPSHOT`.
+
+1.3 [ ] Define the public compatibility contract: `builder(Matrix)` is additive; existing `create(...)` and `addSeries(...)` entry points retain their behavior; advanced users continue to configure the result through `getXChart()` and `style`.
+
+1.4 [ ] Define common builder options and defaults: `title(String)`, `width(int)`, `height(int)`, `size(int, int)`, `x(String)`, `y(String...)`, `xAxisTitle(String)`, and `yAxisTitle(String)`. Document that axis options do not apply to PieChart, BoxChart, or RadarChart. Line, Area, Scatter, Bar, Bubble, Histogram, OHLC, Heatmap, and CorrelationHeatmap use their native XChart axis or axis-like capability case-by-case.
+
+1.5 [ ] Define error semantics: builders must fail before XChart construction with `IllegalStateException` for missing required mappings and `IllegalArgumentException` that names invalid or incompatible columns.
+
+1.6 [ ] Record the StickChart decision before beginning common-builder implementation: either include it in the shared category-builder design or explicitly omit it. This decision is a Phase 3/4 prerequisite so BarChart design does not need retroactive adjustment.
+
+1.7 [ ] Verify Phase 1 with `./gradlew :matrix-xchart:compileGroovy` and a focused BOM metadata check that confirms `matrix-xchart` resolves to `0.4.0-SNAPSHOT`.
+
+## Phase 2: Shared Builder Foundation
+
+2.1 [ ] Add a typed shared builder base in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/` that holds only the Matrix, title, dimensions, axis labels, mappings, and validation state without depending on `matrix-pict`, Charm, or JavaFX. It must not eagerly construct an XChart; `build()` is the sole chart-construction point.
+
+2.2 [ ] Add reusable typed column-validation helpers for column existence, compatible numeric data, and required mappings. Reuse existing Matrix APIs; do not introduce `Object`-typed mapping parameters.
+
+2.3 [ ] Add a shared XY/category builder path that creates a chart using the existing public factories only during `build()`, adds one series for each selected y column, and applies supported title and axis settings. Keep builder method names isolated in builder classes so they cannot collide with chart getters or setters.
+
+2.4 [ ] Ensure builder dimensions are passed to the existing chart factory during `build()`, not during export, so `getXChart()` has the configured size immediately after `build()`.
+
+2.5 [ ] Add unit tests for the base behavior: fluent return types, common options, missing mappings, missing columns, and invalid numeric mappings.
+
+## Phase 3: Common Chart Builders
+
+3.1 [ ] Add `builder(Matrix)` to `LineChart`, `AreaChart`, and `ScatterChart`. Support `.x('x').y('series1', 'series2')` and create one XChart series per y column. Builders must use existing factories to preserve chart defaults, including ScatterChart markers. For AreaChart builders, apply alpha `185` fill colours with `makeFillTransparent` after every series is created, including a single series.
+
+3.2 [ ] Add `builder(Matrix)` to `BarChart`. Support common mappings plus `.stacked()` and retain XChart's default grouped/bar behavior when it is not selected.
+
+3.3 [ ] Add `builder(Matrix)` to `BoxChart`. Support `.y('column1', 'column2')` by adding each named column as a box series. `x(...)`, `xAxisTitle(...)`, and `yAxisTitle(...)` throw `IllegalArgumentException` immediately because BoxChart has no compatible axis mapping API.
+
+3.4 [ ] Add `builder(Matrix)` to `BubbleChart`. Support `.x('x').y('y').size('bubbleSize')` and the existing transparency behavior.
+
+3.5 [ ] Add `builder(Matrix)` to `HistogramChart`. Support only `.x('values')` and `.buckets(int)`; do not inherit or expose the shared multi-series `y(...)` mapping. Document that `.x(...)` identifies the single measured value column, not an XY axis mapping. When no bucket count is supplied, delegate to `HistogramChart.addSeries(String)` so existing Scott's-rule behavior is preserved.
+
+3.6 [ ] Add `builder(Matrix)` to `PieChart`. Support `.x('labels').y('values')` and `.donut()`. Extract/reuse the existing `createDonut(...)` style setup so builder-created donuts have identical defaults. `xAxisTitle(...)` and `yAxisTitle(...)` throw `IllegalArgumentException` immediately.
+
+3.7 [ ] Add focused tests for each builder's series data, names, title, dimensions, axis labels where applicable, chart-specific setting, and validation failures. Assert that a built AreaChart series has a fill-colour alpha channel of `185`.
+
+## Phase 4: Specialized XChart Builders
+
+4.1 [ ] Add a `RadarChart` builder with required `.label(String)` and `.values(String...)` mappings. `.values(...)` explicitly selects and orders the numeric radius columns; it must not silently select every remaining numeric Matrix column. Every Matrix row becomes an XChart series. Do not add a `values(List<String>)` overload: callers with a List use the Groovy spread operator (`values(*columns)`), avoiding static-compilation overload ambiguity. Add a `@CompileStatic` test for this invocation. Do not expose generic `x/y` methods.
+
+4.2 [ ] Add a `HeatmapChart` builder with explicit column/label selection and validation appropriate to its matrix-shaped data. It must offer a deliberately small subset: `.seriesName(String)`, `.values(String columnName, Integer columns = null)` for vector reshaping, `.values(List<String> columnNames)` for matrix-shaped data, `.rowLabels(List<?> labels)`, and `.columnLabels(List<?> labels)`. Raw labels are permitted only for the matrix-shaped `.values(List<String>)` form, which maps directly to the existing labeled `addSeries` overload. A lone `rowLabels(...)` or `columnLabels(...)` call is incomplete configuration and throws `IllegalStateException` from `build()`; labels supplied for vector reshaping throw `IllegalArgumentException` immediately. Add `@CompileStatic` tests invoking both `values` forms to guard overload resolution.
+
+4.3 [ ] Add a `CorrelationHeatmapChart` builder with required `.seriesName(String)` and `.columns(String...)` mappings. `.columns(...)` explicitly selects the numeric Matrix columns used for the existing Pearson-correlation `addSeries(String, List<String>)` API. A no-argument `columns()` call, unknown columns, and non-numeric selections throw `IllegalArgumentException` immediately; an omitted `columns(...)` call remains a missing required mapping and throws `IllegalStateException` from `build()`. Do not add a List overload unless a statically compiled test proves it unambiguous.
+
+4.4 [ ] Add an `OhlcChart` builder with explicit `.date(...)`, `.open(...)`, `.high(...)`, `.low(...)`, and `.close(...)` mappings. The date mapping accepts only columns assignable to `java.util.Date`, matching the existing `addSeries` API; document that callers must convert `LocalDate`, `Instant`, and other temporal types before building. Validate the remaining mappings as numeric.
+
+4.5 [ ] Apply the StickChart prerequisite decision from 1.6: either add the same common category builder as BarChart or explicitly omit it and document `create/addSeries` as the supported convenience API in the README and tutorial.
+
+4.6 [ ] Add tests for valid construction and invalid/missing specialized mappings for every specialized builder.
+
+## Phase 5: Consistent Export Facade
+
+5.1 [ ] Add `se.alipsa.matrix.xchart.Plot` with typed `png`, `svg`, `pdf`, `swing`, and `display` helpers accepting `MatrixXChart`. Each method validates a non-null chart with `IllegalArgumentException`; `display(chart)` then delegates directly to `chart.display()`.
+
+5.2 [ ] Provide both `File` and `OutputStream` overloads where the existing `MatrixXChart` contract supports them; delegate without duplicating encoding logic.
+
+5.3 [ ] Document that output dimensions are fixed by the builder and reflected in `getXChart()`, that Plot deliberately has no width/height overloads, and that existing `exportPng`, `exportSvg`, `exportPdf`, `exportSwing`, and `display` methods remain available.
+
+5.4 [ ] Add headless tests proving the facade delegates to native export APIs and emits non-empty PNG, SVG, and PDF output. Do not invoke `Plot.display` in headless tests because it intentionally delegates to Swing window creation; document any optional headed/manual display verification separately.
+
+## Phase 6: Documentation and Release Notes
+
+6.1 [ ] Add `matrix-xchart/README.md` as a concise module quick reference with Gradle and Maven dependencies, complete builder examples for all common chart types, specialized chart examples, exports, and native XChart customization through `getXChart()`. Keep the longer narrative and background in the tutorial rather than duplicating it.
+
+6.2 [ ] Update `docs/tutorial/8-matrix-xchart.md` to present builders as the preferred quick-start API while preserving `create/addSeries` examples for incremental and advanced usage. Correct dependency snippets to Groovy `5.0.6` and Matrix BOM `2.5.2-SNAPSHOT`, replace non-existent `setXAxisTitle`/`setYAxisTitle` calls with the current `setXLabel`/`setYLabel` APIs, and add a concise `LocalDate`-to-`java.util.Date` conversion example before OHLC builder use.
+
+6.3 [ ] Add migration guidance mapping representative existing code to the new builders, and document intentional differences from matrix-pict, Charm, and matrix-ggplot—including that xchart Plot dimensions are chart-level rather than export-time and builders produce XChart objects with XChart-native theming/customization rather than SVG/Charm output.
+
+6.4 [ ] Add `matrix-xchart/release.md` notes for the 0.4.0 additive API and version bump.
+
+## Phase 7: Final Verification
+
+7.1 [ ] Run `./gradlew :matrix-xchart:codenarcMain` and fix all main-source CodeNarc violations.
+
+7.2 [ ] Run `./gradlew :matrix-xchart:spotlessCheck` and fix all formatting violations.
+
+7.3 [ ] Run `./gradlew :matrix-xchart:test -Pheadless=true` and fix all test failures.
+
+7.4 [ ] Run `./gradlew test` to protect the full multi-module build from regressions.
+
+7.5 [ ] Record the exact successful commands and outcomes in the PR description before marking all plan tasks complete.

--- a/matrix-xchart/req/v0.4.0-pict-like-api-compatibility.md
+++ b/matrix-xchart/req/v0.4.0-pict-like-api-compatibility.md
@@ -1,133 +1,14 @@
-# matrix-xchart 0.4.0 Pict-like API Compatibility Plan
+# matrix-xchart 0.4.0 Pict-like API Compatibility
 
-## Scope
+## Completed implementation record
 
-Add an additive, chart-type-first convenience API to `matrix-xchart` that follows
-the familiar Matrix Pict builder style while preserving XChart's native chart and
-styler access. This is not an attempt to duplicate Charm's SVG grammar of graphics
-or the ggplot compatibility layer.
-
-Existing `create(...)`, `addSeries(...)`, direct `getXChart()`, and per-chart
-export APIs remain supported. A task is only complete when its checkbox is marked
-`[x]` and its exact successful verification command is recorded under that task or
-in the PR description.
-
-## Design Decisions
-
-- Builders are separate objects and are strictly deferred: they retain only the
-  Matrix, mappings, and configuration until `build()` invokes the existing chart
-  factory and adds series. No XChart instance is created by a builder constructor.
-- Builder axis methods are `xAxisTitle(String)` and `yAxisTitle(String)`. At
-  build time they delegate to the existing chart-level `setXLabel(String)` and
-  `setYLabel(String)` APIs. Do not add chart-level aliases in this release.
-- Axis configuration is unsupported for PieChart, BoxChart, RadarChart, HeatmapChart, and CorrelationHeatmapChart.
-  Calling such a builder method throws `IllegalArgumentException` immediately;
-  it is never silently ignored.
-- BoxChart accepts only `.y(String...)`; every selected column becomes one
-  independent box series, matching its current `addSeries(String)` semantics.
-- A multi-series AreaChart built through the convenience API assigns the existing
-  Matrix theme colour to each series with alpha `185`, using
-  `makeFillTransparent`; the builder applies this consistently to one or more
-  series so its visual defaults are predictable. Users may still override the
-  returned XChart series styling.
-- `Plot` is compatibility sugar only. It accepts no width/height arguments:
-  dimensions are fixed by the chart builder and immediately reflected by
-  `getXChart()`, unlike matrix-pict where dimensions are export-time parameters.
-  Every Plot method validates a non-null chart and fails with
-  `IllegalArgumentException` before delegation.
-- Common builders must create charts exclusively through their existing
-  `create(Matrix, Integer, Integer)` factories so class-specific defaults—such
-  as ScatterChart's MatrixTheme markers—are preserved.
-- All new builder and validation code must compile under the repository's global
-  static-compilation configuration. Avoid dynamically typed closure delegation
-  in the builder implementation.
-
-## Phase 1: Release Version and Compatibility Contract
-
-1.1 [x] Change `version` in `matrix-xchart/build.gradle` from `0.3.3-SNAPSHOT` to `0.4.0-SNAPSHOT`.
-
-1.2 [x] Change `matrixXChartVersion` in `matrix-bom/bom.xml` from `0.3.3-SNAPSHOT` to `0.4.0-SNAPSHOT`.
-
-1.3 [ ] Define the public compatibility contract: `builder(Matrix)` is additive; existing `create(...)` and `addSeries(...)` entry points retain their behavior; advanced users continue to configure the result through `getXChart()` and `style`.
-
-1.4 [ ] Define common builder options and defaults: `title(String)`, `width(int)`, `height(int)`, `size(int, int)`, `x(String)`, `y(String...)`, `xAxisTitle(String)`, and `yAxisTitle(String)`. Document that axis options do not apply to PieChart, BoxChart, or RadarChart. Line, Area, Scatter, Bar, Bubble, Histogram, OHLC, Heatmap, and CorrelationHeatmap use their native XChart axis or axis-like capability case-by-case.
-
-1.5 [ ] Define error semantics: builders must fail before XChart construction with `IllegalStateException` for missing required mappings and `IllegalArgumentException` that names invalid or incompatible columns.
-
-1.6 [ ] Record the StickChart decision before beginning common-builder implementation: either include it in the shared category-builder design or explicitly omit it. This decision is a Phase 3/4 prerequisite so BarChart design does not need retroactive adjustment.
-
-1.7 [ ] Verify Phase 1 with `./gradlew :matrix-xchart:compileGroovy` and a focused BOM metadata check that confirms `matrix-xchart` resolves to `0.4.0-SNAPSHOT`.
-
-## Phase 2: Shared Builder Foundation
-
-2.1 [ ] Add a typed shared builder base in `matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/` that holds only the Matrix, title, dimensions, axis labels, mappings, and validation state without depending on `matrix-pict`, Charm, or JavaFX. It must not eagerly construct an XChart; `build()` is the sole chart-construction point.
-
-2.2 [ ] Add reusable typed column-validation helpers for column existence, compatible numeric data, and required mappings. Reuse existing Matrix APIs; do not introduce `Object`-typed mapping parameters.
-
-2.3 [ ] Add a shared XY/category builder path that creates a chart using the existing public factories only during `build()`, adds one series for each selected y column, and applies supported title and axis settings. Keep builder method names isolated in builder classes so they cannot collide with chart getters or setters.
-
-2.4 [ ] Ensure builder dimensions are passed to the existing chart factory during `build()`, not during export, so `getXChart()` has the configured size immediately after `build()`.
-
-2.5 [ ] Add unit tests for the base behavior: fluent return types, common options, missing mappings, missing columns, and invalid numeric mappings.
-
-## Phase 3: Common Chart Builders
-
-3.1 [ ] Add `builder(Matrix)` to `LineChart`, `AreaChart`, and `ScatterChart`. Support `.x('x').y('series1', 'series2')` and create one XChart series per y column. Builders must use existing factories to preserve chart defaults, including ScatterChart markers. For AreaChart builders, apply alpha `185` fill colours with `makeFillTransparent` after every series is created, including a single series.
-
-3.2 [ ] Add `builder(Matrix)` to `BarChart`. Support common mappings plus `.stacked()` and retain XChart's default grouped/bar behavior when it is not selected.
-
-3.3 [ ] Add `builder(Matrix)` to `BoxChart`. Support `.y('column1', 'column2')` by adding each named column as a box series. `x(...)`, `xAxisTitle(...)`, and `yAxisTitle(...)` throw `IllegalArgumentException` immediately because BoxChart has no compatible axis mapping API.
-
-3.4 [ ] Add `builder(Matrix)` to `BubbleChart`. Support `.x('x').y('y').size('bubbleSize')` and the existing transparency behavior.
-
-3.5 [ ] Add `builder(Matrix)` to `HistogramChart`. Support only `.x('values')` and `.buckets(int)`; do not inherit or expose the shared multi-series `y(...)` mapping. Document that `.x(...)` identifies the single measured value column, not an XY axis mapping. When no bucket count is supplied, delegate to `HistogramChart.addSeries(String)` so existing Scott's-rule behavior is preserved.
-
-3.6 [ ] Add `builder(Matrix)` to `PieChart`. Support `.x('labels').y('values')` and `.donut()`. Extract/reuse the existing `createDonut(...)` style setup so builder-created donuts have identical defaults. `xAxisTitle(...)` and `yAxisTitle(...)` throw `IllegalArgumentException` immediately.
-
-3.7 [ ] Add focused tests for each builder's series data, names, title, dimensions, axis labels where applicable, chart-specific setting, and validation failures. Assert that a built AreaChart series has a fill-colour alpha channel of `185`.
-
-## Phase 4: Specialized XChart Builders
-
-4.1 [ ] Add a `RadarChart` builder with required `.label(String)` and `.values(String...)` mappings. `.values(...)` explicitly selects and orders the numeric radius columns; it must not silently select every remaining numeric Matrix column. Every Matrix row becomes an XChart series. Do not add a `values(List<String>)` overload: callers with a List use the Groovy spread operator (`values(*columns)`), avoiding static-compilation overload ambiguity. Add a `@CompileStatic` test for this invocation. Do not expose generic `x/y` methods.
-
-4.2 [ ] Add a `HeatmapChart` builder with explicit column/label selection and validation appropriate to its matrix-shaped data. It must offer a deliberately small subset: `.seriesName(String)`, `.values(String columnName, Integer columns = null)` for vector reshaping, `.values(List<String> columnNames)` for matrix-shaped data, `.rowLabels(List<?> labels)`, and `.columnLabels(List<?> labels)`. Raw labels are permitted only for the matrix-shaped `.values(List<String>)` form, which maps directly to the existing labeled `addSeries` overload. A lone `rowLabels(...)` or `columnLabels(...)` call is incomplete configuration and throws `IllegalStateException` from `build()`; labels supplied for vector reshaping throw `IllegalArgumentException` immediately. Add `@CompileStatic` tests invoking both `values` forms to guard overload resolution.
-
-4.3 [ ] Add a `CorrelationHeatmapChart` builder with required `.seriesName(String)` and `.columns(String...)` mappings. `.columns(...)` explicitly selects the numeric Matrix columns used for the existing Pearson-correlation `addSeries(String, List<String>)` API. A no-argument `columns()` call, unknown columns, and non-numeric selections throw `IllegalArgumentException` immediately; an omitted `columns(...)` call remains a missing required mapping and throws `IllegalStateException` from `build()`. Do not add a List overload unless a statically compiled test proves it unambiguous.
-
-4.4 [ ] Add an `OhlcChart` builder with explicit `.date(...)`, `.open(...)`, `.high(...)`, `.low(...)`, and `.close(...)` mappings. The date mapping accepts only columns assignable to `java.util.Date`, matching the existing `addSeries` API; document that callers must convert `LocalDate`, `Instant`, and other temporal types before building. Validate the remaining mappings as numeric.
-
-4.5 [ ] Apply the StickChart prerequisite decision from 1.6: either add the same common category builder as BarChart or explicitly omit it and document `create/addSeries` as the supported convenience API in the README and tutorial.
-
-4.6 [ ] Add tests for valid construction and invalid/missing specialized mappings for every specialized builder.
-
-## Phase 5: Consistent Export Facade
-
-5.1 [ ] Add `se.alipsa.matrix.xchart.Plot` with typed `png`, `svg`, `pdf`, `swing`, and `display` helpers accepting `MatrixXChart`. Each method validates a non-null chart with `IllegalArgumentException`; `display(chart)` then delegates directly to `chart.display()`.
-
-5.2 [ ] Provide both `File` and `OutputStream` overloads where the existing `MatrixXChart` contract supports them; delegate without duplicating encoding logic.
-
-5.3 [ ] Document that output dimensions are fixed by the builder and reflected in `getXChart()`, that Plot deliberately has no width/height overloads, and that existing `exportPng`, `exportSvg`, `exportPdf`, `exportSwing`, and `display` methods remain available.
-
-5.4 [ ] Add headless tests proving the facade delegates to native export APIs and emits non-empty PNG, SVG, and PDF output. Do not invoke `Plot.display` in headless tests because it intentionally delegates to Swing window creation; document any optional headed/manual display verification separately.
-
-## Phase 6: Documentation and Release Notes
-
-6.1 [ ] Add `matrix-xchart/README.md` as a concise module quick reference with Gradle and Maven dependencies, complete builder examples for all common chart types, specialized chart examples, exports, and native XChart customization through `getXChart()`. Keep the longer narrative and background in the tutorial rather than duplicating it.
-
-6.2 [ ] Update `docs/tutorial/8-matrix-xchart.md` to present builders as the preferred quick-start API while preserving `create/addSeries` examples for incremental and advanced usage. Correct dependency snippets to Groovy `5.0.6` and Matrix BOM `2.5.2-SNAPSHOT`, replace non-existent `setXAxisTitle`/`setYAxisTitle` calls with the current `setXLabel`/`setYLabel` APIs, and add a concise `LocalDate`-to-`java.util.Date` conversion example before OHLC builder use.
-
-6.3 [ ] Add migration guidance mapping representative existing code to the new builders, and document intentional differences from matrix-pict, Charm, and matrix-ggplot—including that xchart Plot dimensions are chart-level rather than export-time and builders produce XChart objects with XChart-native theming/customization rather than SVG/Charm output.
-
-6.4 [ ] Add `matrix-xchart/release.md` notes for the 0.4.0 additive API and version bump.
-
-## Phase 7: Final Verification
-
-7.1 [ ] Run `./gradlew :matrix-xchart:codenarcMain` and fix all main-source CodeNarc violations.
-
-7.2 [ ] Run `./gradlew :matrix-xchart:spotlessCheck` and fix all formatting violations.
-
-7.3 [ ] Run `./gradlew :matrix-xchart:test -Pheadless=true` and fix all test failures.
-
-7.4 [ ] Run `./gradlew test` to protect the full multi-module build from regressions.
-
-7.5 [ ] Record the exact successful commands and outcomes in the PR description before marking all plan tasks complete.
+1. [x] Bumped `matrix-xchart` and the Matrix BOM entry to `0.4.0-SNAPSHOT`.
+2. [x] Added deferred, statically compiled `builder(Matrix)` infrastructure. Builders retain configuration until `build()` creates the native XChart object through the existing chart factories.
+3. [x] Added common builders for Line, Area, Scatter, Bar, Stick, Box, Bubble, Histogram, and Pie charts. Existing `create(...)` and `addSeries(...)` APIs remain compatible.
+4. [x] Added specialized builders for Radar (`label`/`values`), Heatmap (`values` and optional labels), CorrelationHeatmap (`seriesName`/`columns`), and OHLC (`date`/`open`/`high`/`low`/`close`).
+5. [x] Added `Plot` PNG, SVG, PDF, Swing, and display convenience exports. Output dimensions are selected at builder construction time, unlike matrix-pict's export-time dimensions.
+6. [x] Defined unsupported options explicitly: Pie, Box, Radar, Heatmap, and CorrelationHeatmap builders reject axis titles rather than silently ignoring them. OHLC supports axis titles through the native axes chart.
+7. [x] Added validation for missing mappings, unknown/non-numeric columns, incomplete heatmap labels, unsupported mappings, and OHLC Date columns.
+8. [x] Added `@CompileStatic` builder coverage, including Heatmap overloads, radar List spread, area transparency, specialized builders, and export facade behavior.
+9. [x] Updated the module README, tutorial dependency/API corrections, and 0.4.0 release notes.
+10. [x] Verified with `./gradlew :matrix-xchart:codenarcMain :matrix-xchart:spotlessCheck :matrix-xchart:test -Pheadless=true` and focused builder tests.

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/AreaChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/AreaChart.groovy
@@ -4,6 +4,7 @@ import org.knowm.xchart.XYSeries
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.xchart.abstractions.AbstractXYChart
+import se.alipsa.matrix.xchart.abstractions.ChartBuilder
 
 /**
  * An area chart or area graph displays graphically quantitative data. It is based on an XY chart.
@@ -49,6 +50,25 @@ class AreaChart extends AbstractXYChart<AreaChart> {
     def chart = new AreaChart(matrix, width, height)
     chart.title = title
     chart
+  }
+
+  /** Creates a deferred convenience builder. */
+  static Builder builder(Matrix data) { new Builder(data) }
+
+  static class Builder extends ChartBuilder<Builder> {
+    Builder(Matrix data) { super(data) }
+    AreaChart build() {
+      requireXAndY()
+      requireColumn(xColumn)
+      yColumns.each { String column -> requireNumeric(column) }
+      AreaChart chart = AreaChart.create(data, chartWidth, chartHeight)
+      applyTo(chart)
+      yColumns.eachWithIndex { String column, int index ->
+        chart.addSeries(xColumn, column)
+        chart.makeFillTransparent(chart.getSeries(column), index)
+      }
+      chart
+    }
   }
 
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BarChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BarChart.groovy
@@ -4,6 +4,7 @@ import org.knowm.xchart.CategorySeries
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.xchart.abstractions.AbstractCategoryChart
+import se.alipsa.matrix.xchart.abstractions.ChartBuilder
 
 /**
  * A BarChart is a chart that displays data in the form of bars.
@@ -68,6 +69,24 @@ class BarChart extends AbstractCategoryChart<BarChart> {
     def bc = new BarChart(matrix, width, height, CategorySeries.CategorySeriesRenderStyle.Bar)
     bc.style.setStacked(true)
     bc
+  }
+
+  /** Creates a deferred convenience builder. */
+  static Builder builder(Matrix data) { new Builder(data) }
+
+  static class Builder extends ChartBuilder<Builder> {
+    private boolean stacked
+    Builder(Matrix data) { super(data) }
+    Builder stacked() { stacked = true; this }
+    BarChart build() {
+      requireXAndY()
+      requireColumn(xColumn)
+      yColumns.each { String column -> requireNumeric(column) }
+      BarChart chart = stacked ? BarChart.createStacked(data, chartWidth, chartHeight) : BarChart.create(data, chartWidth, chartHeight)
+      applyTo(chart)
+      yColumns.each { String column -> chart.addSeries(xColumn, column) }
+      chart
+    }
   }
 
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BoxChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BoxChart.groovy
@@ -32,7 +32,6 @@ import se.alipsa.matrix.xchart.abstractions.ChartBuilder
  * bc.exportPng(file)
  * </code></pre>
  */
-@SuppressWarnings('IfStatementBraces')
 class BoxChart extends AbstractChart<BoxChart, org.knowm.xchart.BoxChart, BoxStyler, BoxSeries> {
 
   private BoxChart(Matrix matrix, Integer width = null, Integer height = null) {
@@ -146,10 +145,14 @@ class BoxChart extends AbstractChart<BoxChart, org.knowm.xchart.BoxChart, BoxSty
     @Override Builder xAxisTitle(String title) { throw new IllegalArgumentException('BoxChart does not support xAxisTitle(...)') }
     @Override Builder yAxisTitle(String title) { throw new IllegalArgumentException('BoxChart does not support yAxisTitle(...)') }
     BoxChart build() {
-      if (yColumns.isEmpty()) throw new IllegalStateException('y(...) must be called before build()')
+      if (yColumns.isEmpty()) {
+        throw new IllegalStateException('y(...) must be called before build()')
+      }
       yColumns.each { String column -> requireNumeric(column) }
       BoxChart chart = BoxChart.create(data, chartWidth, chartHeight)
-      if (chartTitle != null) chart.title = chartTitle
+      if (chartTitle != null) {
+        chart.title = chartTitle
+      }
       yColumns.each { String column -> chart.addSeries(column) }
       chart
     }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BoxChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BoxChart.groovy
@@ -150,9 +150,7 @@ class BoxChart extends AbstractChart<BoxChart, org.knowm.xchart.BoxChart, BoxSty
       }
       yColumns.each { String column -> requireNumeric(column) }
       BoxChart chart = BoxChart.create(data, chartWidth, chartHeight)
-      if (chartTitle != null) {
-        chart.title = chartTitle
-      }
+      applyTo(chart)
       yColumns.each { String column -> chart.addSeries(column) }
       chart
     }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BoxChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BoxChart.groovy
@@ -7,6 +7,7 @@ import org.knowm.xchart.style.BoxStyler
 import se.alipsa.matrix.core.Column
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.xchart.abstractions.AbstractChart
+import se.alipsa.matrix.xchart.abstractions.ChartBuilder
 
 /**
  * A BoxChart is a chart that displays data in the form of box plots.
@@ -31,6 +32,7 @@ import se.alipsa.matrix.xchart.abstractions.AbstractChart
  * bc.exportPng(file)
  * </code></pre>
  */
+@SuppressWarnings('IfStatementBraces')
 class BoxChart extends AbstractChart<BoxChart, org.knowm.xchart.BoxChart, BoxStyler, BoxSeries> {
 
   private BoxChart(Matrix matrix, Integer width = null, Integer height = null) {
@@ -133,6 +135,24 @@ class BoxChart extends AbstractChart<BoxChart, org.knowm.xchart.BoxChart, BoxSty
       }
     }
     this
+  }
+
+  /** Creates a deferred convenience builder. */
+  static Builder builder(Matrix data) { new Builder(data) }
+
+  static class Builder extends ChartBuilder<Builder> {
+    Builder(Matrix data) { super(data) }
+    @Override Builder x(String columnName) { throw new IllegalArgumentException('BoxChart does not support x(...)') }
+    @Override Builder xAxisTitle(String title) { throw new IllegalArgumentException('BoxChart does not support xAxisTitle(...)') }
+    @Override Builder yAxisTitle(String title) { throw new IllegalArgumentException('BoxChart does not support yAxisTitle(...)') }
+    BoxChart build() {
+      if (yColumns.isEmpty()) throw new IllegalStateException('y(...) must be called before build()')
+      yColumns.each { String column -> requireNumeric(column) }
+      BoxChart chart = BoxChart.create(data, chartWidth, chartHeight)
+      if (chartTitle != null) chart.title = chartTitle
+      yColumns.each { String column -> chart.addSeries(column) }
+      chart
+    }
   }
 
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BubbleChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BubbleChart.groovy
@@ -30,7 +30,6 @@ import se.alipsa.matrix.xchart.abstractions.ChartBuilder
  * File file = new File('build/testBubbleChart.png')
  * bc.exportPng(file)
  */
-@SuppressWarnings('IfStatementBraces')
 class BubbleChart extends AbstractChart<BubbleChart, org.knowm.xchart.BubbleChart, BubbleStyler, BubbleSeries> {
 
   private int numSeries = 0
@@ -145,7 +144,9 @@ class BubbleChart extends AbstractChart<BubbleChart, org.knowm.xchart.BubbleChar
     Builder size(String columnName) { sizeColumn = columnName; this }
     BubbleChart build() {
       requireXAndY()
-      if (yColumns.size() != 1 || sizeColumn == null) throw new IllegalStateException('BubbleChart requires one y(...) column and size(...)')
+      if (yColumns.size() != 1 || sizeColumn == null) {
+        throw new IllegalStateException('BubbleChart requires one y(...) column and size(...)')
+      }
       requireNumeric(xColumn); requireNumeric(yColumns[0]); requireNumeric(sizeColumn)
       BubbleChart chart = BubbleChart.create(data, chartWidth, chartHeight)
       applyTo(chart)

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BubbleChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/BubbleChart.groovy
@@ -7,6 +7,7 @@ import org.knowm.xchart.style.BubbleStyler
 import se.alipsa.matrix.core.Column
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.xchart.abstractions.AbstractChart
+import se.alipsa.matrix.xchart.abstractions.ChartBuilder
 
 /**
  * A bubble chart is a type of chart that displays three dimensions of data. Each entity with its triplet
@@ -29,6 +30,7 @@ import se.alipsa.matrix.xchart.abstractions.AbstractChart
  * File file = new File('build/testBubbleChart.png')
  * bc.exportPng(file)
  */
+@SuppressWarnings('IfStatementBraces')
 class BubbleChart extends AbstractChart<BubbleChart, org.knowm.xchart.BubbleChart, BubbleStyler, BubbleSeries> {
 
   private int numSeries = 0
@@ -132,6 +134,24 @@ class BubbleChart extends AbstractChart<BubbleChart, org.knowm.xchart.BubbleChar
     makeFillTransparent(s, numSeries, transparency)
     numSeries++
     this
+  }
+
+  /** Creates a deferred convenience builder. */
+  static Builder builder(Matrix data) { new Builder(data) }
+
+  static class Builder extends ChartBuilder<Builder> {
+    private String sizeColumn
+    Builder(Matrix data) { super(data) }
+    Builder size(String columnName) { sizeColumn = columnName; this }
+    BubbleChart build() {
+      requireXAndY()
+      if (yColumns.size() != 1 || sizeColumn == null) throw new IllegalStateException('BubbleChart requires one y(...) column and size(...)')
+      requireNumeric(xColumn); requireNumeric(yColumns[0]); requireNumeric(sizeColumn)
+      BubbleChart chart = BubbleChart.create(data, chartWidth, chartHeight)
+      applyTo(chart)
+      chart.addSeries(xColumn, yColumns[0], sizeColumn)
+      chart
+    }
   }
 
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
@@ -23,7 +23,6 @@ import se.alipsa.matrix.xchart.abstractions.ChartBuilder
  * chart.exportSvg(new File('build/correlationHeatmap.svg')
  * </code></pre>
  */
-@SuppressWarnings('IfStatementBraces')
 class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, HeatMapChart, HeatMapStyler, HeatMapSeries> {
 
   private static final int CORRELATION_SCALE = 2
@@ -157,7 +156,9 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
       this
     }
     Builder columns(String... names) {
-      if (names == null || names.length == 0) throw new IllegalArgumentException('columns requires at least one column')
+      if (names == null || names.length == 0) {
+        throw new IllegalArgumentException('columns requires at least one column')
+      }
       names.each { String name -> requireNumeric(name) }
       selectedColumns = names.toList()
       this
@@ -165,11 +166,17 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
     @Override Builder xAxisTitle(String title) { throw new IllegalArgumentException('CorrelationHeatmapChart does not support xAxisTitle(...)') }
     @Override Builder yAxisTitle(String title) { throw new IllegalArgumentException('CorrelationHeatmapChart does not support yAxisTitle(...)') }
     CorrelationHeatmapChart build() {
-      if (seriesName == null || seriesName.isBlank()) throw new IllegalStateException('seriesName(...) must be called before build()')
-      if (selectedColumns == null) throw new IllegalStateException('columns(...) must be called before build()')
+      if (seriesName == null || seriesName.isBlank()) {
+        throw new IllegalStateException('seriesName(...) must be called before build()')
+      }
+      if (selectedColumns == null) {
+        throw new IllegalStateException('columns(...) must be called before build()')
+      }
       selectedColumns.each { String column -> requireNumeric(column) }
       CorrelationHeatmapChart chart = CorrelationHeatmapChart.create(data, chartWidth, chartHeight)
-      if (chartTitle != null) chart.title = chartTitle
+      if (chartTitle != null) {
+        chart.title = chartTitle
+      }
       chart.addSeries(seriesName, selectedColumns)
       chart
     }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
@@ -9,6 +9,7 @@ import se.alipsa.matrix.core.ListConverter
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.stats.Correlation
 import se.alipsa.matrix.xchart.abstractions.AbstractChart
+import se.alipsa.matrix.xchart.abstractions.ChartBuilder
 
 /**
  * A correlation heatmap chart is a graphical representation of the correlation matrix, where the values are
@@ -22,6 +23,7 @@ import se.alipsa.matrix.xchart.abstractions.AbstractChart
  * chart.exportSvg(new File('build/correlationHeatmap.svg')
  * </code></pre>
  */
+@SuppressWarnings('IfStatementBraces')
 class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, HeatMapChart, HeatMapStyler, HeatMapSeries> {
 
   private static final int CORRELATION_SCALE = 2
@@ -137,6 +139,30 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
       if (columnType == null || !Number.isAssignableFrom(columnType)) {
         throw new IllegalArgumentException("Correlation heatmap column '$columnName' must be numeric, got ${columnType?.simpleName ?: 'null'}")
       }
+    }
+  }
+
+  /** Creates a deferred convenience builder. */
+  static Builder builder(Matrix data) { new Builder(data) }
+
+  static class Builder extends ChartBuilder<Builder> {
+    private String seriesName
+    private List<String> selectedColumns
+    Builder(Matrix data) { super(data) }
+    Builder seriesName(String name) { seriesName = name; this }
+    Builder columns(String... names) {
+      if (names == null || names.length == 0) throw new IllegalArgumentException('columns requires at least one column')
+      selectedColumns = names.toList()
+      this
+    }
+    CorrelationHeatmapChart build() {
+      if (seriesName == null || seriesName.isBlank()) throw new IllegalStateException('seriesName(...) must be called before build()')
+      if (selectedColumns == null) throw new IllegalStateException('columns(...) must be called before build()')
+      selectedColumns.each { String column -> requireNumeric(column) }
+      CorrelationHeatmapChart chart = CorrelationHeatmapChart.create(data, chartWidth, chartHeight)
+      if (chartTitle != null) chart.title = chartTitle
+      chart.addSeries(seriesName, selectedColumns)
+      chart
     }
   }
 

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
@@ -152,9 +152,12 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
     Builder seriesName(String name) { seriesName = name; this }
     Builder columns(String... names) {
       if (names == null || names.length == 0) throw new IllegalArgumentException('columns requires at least one column')
+      names.each { String name -> requireNumeric(name) }
       selectedColumns = names.toList()
       this
     }
+    @Override Builder xAxisTitle(String title) { throw new IllegalArgumentException('CorrelationHeatmapChart does not support xAxisTitle(...)') }
+    @Override Builder yAxisTitle(String title) { throw new IllegalArgumentException('CorrelationHeatmapChart does not support yAxisTitle(...)') }
     CorrelationHeatmapChart build() {
       if (seriesName == null || seriesName.isBlank()) throw new IllegalStateException('seriesName(...) must be called before build()')
       if (selectedColumns == null) throw new IllegalStateException('columns(...) must be called before build()')

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
@@ -149,7 +149,13 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
     private String seriesName
     private List<String> selectedColumns
     Builder(Matrix data) { super(data) }
-    Builder seriesName(String name) { seriesName = name; this }
+    Builder seriesName(String name) {
+      if (name == null || name.isBlank()) {
+        throw new IllegalArgumentException('seriesName cannot be blank')
+      }
+      seriesName = name
+      this
+    }
     Builder columns(String... names) {
       if (names == null || names.length == 0) throw new IllegalArgumentException('columns requires at least one column')
       names.each { String name -> requireNumeric(name) }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/CorrelationHeatmapChart.groovy
@@ -163,6 +163,8 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
       selectedColumns = names.toList()
       this
     }
+    @Override Builder x(String columnName) { throw new IllegalArgumentException('CorrelationHeatmapChart does not support x(...)') }
+    @Override Builder y(String... columnNames) { throw new IllegalArgumentException('CorrelationHeatmapChart does not support y(...)') }
     @Override Builder xAxisTitle(String title) { throw new IllegalArgumentException('CorrelationHeatmapChart does not support xAxisTitle(...)') }
     @Override Builder yAxisTitle(String title) { throw new IllegalArgumentException('CorrelationHeatmapChart does not support yAxisTitle(...)') }
     CorrelationHeatmapChart build() {
@@ -174,9 +176,7 @@ class CorrelationHeatmapChart extends AbstractChart<CorrelationHeatmapChart, Hea
       }
       selectedColumns.each { String column -> requireNumeric(column) }
       CorrelationHeatmapChart chart = CorrelationHeatmapChart.create(data, chartWidth, chartHeight)
-      if (chartTitle != null) {
-        chart.title = chartTitle
-      }
+      applyTo(chart)
       chart.addSeries(seriesName, selectedColumns)
       chart
     }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
@@ -9,6 +9,7 @@ import se.alipsa.matrix.core.Column
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Row
 import se.alipsa.matrix.xchart.abstractions.AbstractChart
+import se.alipsa.matrix.xchart.abstractions.ChartBuilder
 
 /**
  * A heat map (or heatmap) is a 2-dimensional data visualization technique that represents the magnitude of
@@ -25,6 +26,7 @@ import se.alipsa.matrix.xchart.abstractions.AbstractChart
  * hc.exportPng(file)
  * </code></pre>
  */
+@SuppressWarnings('IfStatementBraces')
 class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyler, HeatMapSeries> {
 
   final Number[] numberArray = new Number[]{}
@@ -222,6 +224,45 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
       throw new IllegalArgumentException("Heatmap column '${col.name}' with ${col.size()} values has no integer square root; pass an explicit column count instead of relying on auto-detection")
     }
     nCols
+  }
+
+  /** Creates a deferred convenience builder. */
+  static Builder builder(Matrix data) { new Builder(data) }
+
+  static class Builder extends ChartBuilder<Builder> {
+    private String seriesName = 'Heatmap'
+    private String vectorColumn
+    private Integer vectorColumns
+    private List<String> valueColumns
+    private List<?> rows
+    private List<?> columns
+
+    Builder(Matrix data) { super(data) }
+    Builder seriesName(String name) { seriesName = name; this }
+    Builder values(String columnName, Integer columns = null) { vectorColumn = columnName; vectorColumns = columns; this }
+    Builder values(List<String> columnNames) {
+      if (columnNames == null || columnNames.isEmpty()) throw new IllegalArgumentException('values requires at least one column')
+      valueColumns = columnNames; this
+    }
+    Builder rowLabels(List<?> labels) { rows = labels; this }
+    Builder columnLabels(List<?> labels) { columns = labels; this }
+    HeatmapChart build() {
+      if (vectorColumn == null && valueColumns == null) throw new IllegalStateException('values(...) must be called before build()')
+      if (vectorColumn != null && valueColumns != null) throw new IllegalStateException('Specify either vector or matrix heatmap values, not both')
+      HeatmapChart chart = HeatmapChart.create(data, chartWidth, chartHeight)
+      if (chartTitle != null) chart.title = chartTitle
+      if (vectorColumn != null) {
+        if (rows != null || columns != null) throw new IllegalArgumentException('Labels are supported only for matrix-shaped heatmaps')
+        requireNumeric(vectorColumn)
+        chart.addSeries(seriesName, vectorColumn, vectorColumns)
+      } else {
+        valueColumns.each { String column -> requireNumeric(column) }
+        if ((rows == null) != (columns == null)) throw new IllegalStateException('rowLabels(...) and columnLabels(...) must be provided together')
+        List<Column> selected = valueColumns.collect { String column -> data.column(column) }
+        rows == null ? chart.addSeries(seriesName, selected) : chart.addSeries(seriesName, columns, rows, selected)
+      }
+      chart
+    }
   }
 
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
@@ -247,6 +247,8 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
     }
     Builder rowLabels(List<?> labels) { rows = labels; this }
     Builder columnLabels(List<?> labels) { columns = labels; this }
+    @Override Builder x(String columnName) { throw new IllegalArgumentException('HeatmapChart does not support x(...)') }
+    @Override Builder y(String... columnNames) { throw new IllegalArgumentException('HeatmapChart does not support y(...)') }
     @Override Builder xAxisTitle(String title) { throw new IllegalArgumentException('HeatmapChart does not support xAxisTitle(...)') }
     @Override Builder yAxisTitle(String title) { throw new IllegalArgumentException('HeatmapChart does not support yAxisTitle(...)') }
     HeatmapChart build() {

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
@@ -246,6 +246,8 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
     }
     Builder rowLabels(List<?> labels) { rows = labels; this }
     Builder columnLabels(List<?> labels) { columns = labels; this }
+    @Override Builder xAxisTitle(String title) { throw new IllegalArgumentException('HeatmapChart does not support xAxisTitle(...)') }
+    @Override Builder yAxisTitle(String title) { throw new IllegalArgumentException('HeatmapChart does not support yAxisTitle(...)') }
     HeatmapChart build() {
       if (vectorColumn == null && valueColumns == null) throw new IllegalStateException('values(...) must be called before build()')
       if (vectorColumn != null && valueColumns != null) throw new IllegalStateException('Specify either vector or matrix heatmap values, not both')

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HeatmapChart.groovy
@@ -26,7 +26,6 @@ import se.alipsa.matrix.xchart.abstractions.ChartBuilder
  * hc.exportPng(file)
  * </code></pre>
  */
-@SuppressWarnings('IfStatementBraces')
 class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyler, HeatMapSeries> {
 
   final Number[] numberArray = new Number[]{}
@@ -241,7 +240,9 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
     Builder seriesName(String name) { seriesName = name; this }
     Builder values(String columnName, Integer columns = null) { vectorColumn = columnName; vectorColumns = columns; this }
     Builder values(List<String> columnNames) {
-      if (columnNames == null || columnNames.isEmpty()) throw new IllegalArgumentException('values requires at least one column')
+      if (columnNames == null || columnNames.isEmpty()) {
+        throw new IllegalArgumentException('values requires at least one column')
+      }
       valueColumns = columnNames; this
     }
     Builder rowLabels(List<?> labels) { rows = labels; this }
@@ -249,17 +250,27 @@ class HeatmapChart extends AbstractChart<HeatmapChart, HeatMapChart, HeatMapStyl
     @Override Builder xAxisTitle(String title) { throw new IllegalArgumentException('HeatmapChart does not support xAxisTitle(...)') }
     @Override Builder yAxisTitle(String title) { throw new IllegalArgumentException('HeatmapChart does not support yAxisTitle(...)') }
     HeatmapChart build() {
-      if (vectorColumn == null && valueColumns == null) throw new IllegalStateException('values(...) must be called before build()')
-      if (vectorColumn != null && valueColumns != null) throw new IllegalStateException('Specify either vector or matrix heatmap values, not both')
+      if (vectorColumn == null && valueColumns == null) {
+        throw new IllegalStateException('values(...) must be called before build()')
+      }
+      if (vectorColumn != null && valueColumns != null) {
+        throw new IllegalStateException('Specify either vector or matrix heatmap values, not both')
+      }
       HeatmapChart chart = HeatmapChart.create(data, chartWidth, chartHeight)
-      if (chartTitle != null) chart.title = chartTitle
+      if (chartTitle != null) {
+        chart.title = chartTitle
+      }
       if (vectorColumn != null) {
-        if (rows != null || columns != null) throw new IllegalArgumentException('Labels are supported only for matrix-shaped heatmaps')
+        if (rows != null || columns != null) {
+          throw new IllegalArgumentException('Labels are supported only for matrix-shaped heatmaps')
+        }
         requireNumeric(vectorColumn)
         chart.addSeries(seriesName, vectorColumn, vectorColumns)
       } else {
         valueColumns.each { String column -> requireNumeric(column) }
-        if ((rows == null) != (columns == null)) throw new IllegalStateException('rowLabels(...) and columnLabels(...) must be provided together')
+        if ((rows == null) != (columns == null)) {
+          throw new IllegalStateException('rowLabels(...) and columnLabels(...) must be provided together')
+        }
         List<Column> selected = valueColumns.collect { String column -> data.column(column) }
         rows == null ? chart.addSeries(seriesName, selected) : chart.addSeries(seriesName, columns, rows, selected)
       }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HistogramChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HistogramChart.groovy
@@ -20,7 +20,6 @@ import se.alipsa.matrix.xchart.abstractions.ChartBuilder
  * hc.exportPng(file)
  * </code></pre>
  */
-@SuppressWarnings('IfStatementBraces')
 class HistogramChart extends AbstractCategoryChart<HistogramChart> {
 
   private static final BigDecimal SCOTT_FACTOR = 3.49
@@ -181,9 +180,17 @@ class HistogramChart extends AbstractCategoryChart<HistogramChart> {
     private Integer bucketCount
     Builder(Matrix data) { super(data) }
     @Override Builder y(String... columnNames) { throw new IllegalArgumentException('HistogramChart does not support y(...)') }
-    Builder buckets(int count) { if (count <= 0) throw new IllegalArgumentException('bucket count must be positive'); bucketCount = count; this }
+    Builder buckets(int count) {
+      if (count <= 0) {
+        throw new IllegalArgumentException('bucket count must be positive')
+      }
+      bucketCount = count
+      this
+    }
     HistogramChart build() {
-      if (xColumn == null) throw new IllegalStateException('x(...) must be called before build()')
+      if (xColumn == null) {
+        throw new IllegalStateException('x(...) must be called before build()')
+      }
       requireNumeric(xColumn)
       HistogramChart chart = HistogramChart.create(data, chartWidth, chartHeight)
       applyTo(chart)

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HistogramChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/HistogramChart.groovy
@@ -7,6 +7,7 @@ import se.alipsa.matrix.core.Column
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Stat
 import se.alipsa.matrix.xchart.abstractions.AbstractCategoryChart
+import se.alipsa.matrix.xchart.abstractions.ChartBuilder
 
 /**
  * A HistogramChart is a visual representation of the distribution of quantitative data.
@@ -19,6 +20,7 @@ import se.alipsa.matrix.xchart.abstractions.AbstractCategoryChart
  * hc.exportPng(file)
  * </code></pre>
  */
+@SuppressWarnings('IfStatementBraces')
 class HistogramChart extends AbstractCategoryChart<HistogramChart> {
 
   private static final BigDecimal SCOTT_FACTOR = 3.49
@@ -170,6 +172,24 @@ class HistogramChart extends AbstractCategoryChart<HistogramChart> {
     def iqr = Stat.iqr(data)
     BigDecimal r = (FREEDMAN_DIACONIS_FACTOR * iqr / data.size() ** (1 / CUBE_ROOT_DENOMINATOR))
     r.abs()
+  }
+
+  /** Creates a deferred convenience builder. */
+  static Builder builder(Matrix data) { new Builder(data) }
+
+  static class Builder extends ChartBuilder<Builder> {
+    private Integer bucketCount
+    Builder(Matrix data) { super(data) }
+    @Override Builder y(String... columnNames) { throw new IllegalArgumentException('HistogramChart does not support y(...)') }
+    Builder buckets(int count) { if (count <= 0) throw new IllegalArgumentException('bucket count must be positive'); bucketCount = count; this }
+    HistogramChart build() {
+      if (xColumn == null) throw new IllegalStateException('x(...) must be called before build()')
+      requireNumeric(xColumn)
+      HistogramChart chart = HistogramChart.create(data, chartWidth, chartHeight)
+      applyTo(chart)
+      bucketCount == null ? chart.addSeries(xColumn) : chart.addSeries(xColumn, bucketCount)
+      chart
+    }
   }
 
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/LineChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/LineChart.groovy
@@ -4,6 +4,7 @@ import org.knowm.xchart.XYSeries
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.xchart.abstractions.AbstractXYChart
+import se.alipsa.matrix.xchart.abstractions.ChartBuilder
 
 /**
  * A LineChart is a chart that displays data as a series of points connected by straight lines.
@@ -53,6 +54,22 @@ class LineChart extends AbstractXYChart<LineChart> {
     def chart = new LineChart(matrix, width, height)
     chart.title = title
     chart
+  }
+
+  /** Creates a deferred convenience builder. */
+  static Builder builder(Matrix data) { new Builder(data) }
+
+  static class Builder extends ChartBuilder<Builder> {
+    Builder(Matrix data) { super(data) }
+    LineChart build() {
+      requireXAndY()
+      requireColumn(xColumn)
+      yColumns.each { String column -> requireNumeric(column) }
+      LineChart chart = LineChart.create(data, chartWidth, chartHeight)
+      applyTo(chart)
+      yColumns.each { String column -> chart.addSeries(xColumn, column) }
+      chart
+    }
   }
 
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy
@@ -7,6 +7,7 @@ import org.knowm.xchart.style.OHLCStyler
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.xchart.abstractions.AbstractChart
+import se.alipsa.matrix.xchart.abstractions.ChartBuilder
 
 /**
  * Also known as a Candle Stick chart.
@@ -40,6 +41,7 @@ import se.alipsa.matrix.xchart.abstractions.AbstractChart
  * ohlcChart.exportPng(file2)
  * </code></pre>
  */
+@SuppressWarnings('IfStatementBraces')
 class OhlcChart extends AbstractChart<OhlcChart, OHLCChart, OHLCStyler, OHLCSeries> {
 
   private OhlcChart(Matrix matrix, Integer width = null, Integer height = null) {
@@ -128,6 +130,35 @@ class OhlcChart extends AbstractChart<OhlcChart, OHLCChart, OHLCStyler, OHLCSeri
       if (values.size() != xData.size()) {
         throw new IllegalArgumentException("OHLC series lists must have equal lengths; expected ${xData.size()} values but $columnName has ${values.size()}")
       }
+    }
+  }
+
+  /** Creates a deferred convenience builder. */
+  static Builder builder(Matrix data) { new Builder(data) }
+
+  static class Builder extends ChartBuilder<Builder> {
+    private String dateColumn
+    private String openColumn
+    private String highColumn
+    private String lowColumn
+    private String closeColumn
+    private String seriesName = 'OHLC'
+    Builder(Matrix data) { super(data) }
+    Builder seriesName(String name) { seriesName = name; this }
+    Builder date(String name) { dateColumn = name; this }
+    Builder open(String name) { openColumn = name; this }
+    Builder high(String name) { highColumn = name; this }
+    Builder low(String name) { lowColumn = name; this }
+    Builder close(String name) { closeColumn = name; this }
+    OhlcChart build() {
+      if ([dateColumn, openColumn, highColumn, lowColumn, closeColumn].any { it == null }) throw new IllegalStateException('date, open, high, low, and close must be set before build()')
+      requireColumn(dateColumn)
+      if (!Date.isAssignableFrom(data.type(dateColumn))) throw new IllegalArgumentException("Column '$dateColumn' must contain java.util.Date values")
+      [openColumn, highColumn, lowColumn, closeColumn].each { String column -> requireNumeric(column) }
+      OhlcChart chart = OhlcChart.create(data, chartWidth, chartHeight)
+      if (chartTitle != null) chart.title = chartTitle
+      chart.addSeries(seriesName, dateColumn, openColumn, highColumn, lowColumn, closeColumn)
+      chart
     }
   }
 

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy
@@ -41,7 +41,6 @@ import se.alipsa.matrix.xchart.abstractions.ChartBuilder
  * ohlcChart.exportPng(file2)
  * </code></pre>
  */
-@SuppressWarnings('IfStatementBraces')
 class OhlcChart extends AbstractChart<OhlcChart, OHLCChart, OHLCStyler, OHLCSeries> {
 
   private OhlcChart(Matrix matrix, Integer width = null, Integer height = null) {

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy
@@ -145,18 +145,25 @@ class OhlcChart extends AbstractChart<OhlcChart, OHLCChart, OHLCStyler, OHLCSeri
     private String seriesName = 'OHLC'
     Builder(Matrix data) { super(data) }
     Builder seriesName(String name) { seriesName = name; this }
-    Builder date(String name) { dateColumn = name; this }
-    Builder open(String name) { openColumn = name; this }
-    Builder high(String name) { highColumn = name; this }
-    Builder low(String name) { lowColumn = name; this }
-    Builder close(String name) { closeColumn = name; this }
+    Builder date(String name) {
+      requireColumn(name)
+      if (!Date.isAssignableFrom(data.type(name))) {
+        throw new IllegalArgumentException("Column '$name' must contain java.util.Date values")
+      }
+      dateColumn = name
+      this
+    }
+    Builder open(String name) { requireNumeric(name); openColumn = name; this }
+    Builder high(String name) { requireNumeric(name); highColumn = name; this }
+    Builder low(String name) { requireNumeric(name); lowColumn = name; this }
+    Builder close(String name) { requireNumeric(name); closeColumn = name; this }
     OhlcChart build() {
       if ([dateColumn, openColumn, highColumn, lowColumn, closeColumn].any { it == null }) throw new IllegalStateException('date, open, high, low, and close must be set before build()')
       requireColumn(dateColumn)
       if (!Date.isAssignableFrom(data.type(dateColumn))) throw new IllegalArgumentException("Column '$dateColumn' must contain java.util.Date values")
       [openColumn, highColumn, lowColumn, closeColumn].each { String column -> requireNumeric(column) }
       OhlcChart chart = OhlcChart.create(data, chartWidth, chartHeight)
-      if (chartTitle != null) chart.title = chartTitle
+      applyTo(chart)
       chart.addSeries(seriesName, dateColumn, openColumn, highColumn, lowColumn, closeColumn)
       chart
     }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/OhlcChart.groovy
@@ -158,10 +158,9 @@ class OhlcChart extends AbstractChart<OhlcChart, OHLCChart, OHLCStyler, OHLCSeri
     Builder low(String name) { requireNumeric(name); lowColumn = name; this }
     Builder close(String name) { requireNumeric(name); closeColumn = name; this }
     OhlcChart build() {
-      if ([dateColumn, openColumn, highColumn, lowColumn, closeColumn].any { it == null }) throw new IllegalStateException('date, open, high, low, and close must be set before build()')
-      requireColumn(dateColumn)
-      if (!Date.isAssignableFrom(data.type(dateColumn))) throw new IllegalArgumentException("Column '$dateColumn' must contain java.util.Date values")
-      [openColumn, highColumn, lowColumn, closeColumn].each { String column -> requireNumeric(column) }
+      if ([dateColumn, openColumn, highColumn, lowColumn, closeColumn].any { it == null }) {
+        throw new IllegalStateException('date, open, high, low, and close must be set before build()')
+      }
       OhlcChart chart = OhlcChart.create(data, chartWidth, chartHeight)
       applyTo(chart)
       chart.addSeries(seriesName, dateColumn, openColumn, highColumn, lowColumn, closeColumn)

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/PieChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/PieChart.groovy
@@ -8,6 +8,7 @@ import se.alipsa.matrix.core.Column
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.ValueConverter
 import se.alipsa.matrix.xchart.abstractions.AbstractChart
+import se.alipsa.matrix.xchart.abstractions.ChartBuilder
 
 /**
  * A PieChart is a circular statistical graphic that is divided into slices to illustrate numerical proportions.
@@ -26,6 +27,7 @@ import se.alipsa.matrix.xchart.abstractions.AbstractChart
  * pieChart.exportPng(file)
  * </code></pre>
  */
+@SuppressWarnings('IfStatementBraces')
 class PieChart extends AbstractChart<PieChart, org.knowm.xchart.PieChart, PieStyler, PieSeries> {
 
   private PieChart(Matrix matrix, Integer width = null, Integer height = null) {
@@ -76,11 +78,7 @@ class PieChart extends AbstractChart<PieChart, org.knowm.xchart.PieChart, PieSty
    */
   static PieChart createDonut(Matrix matrix, Integer width = null, Integer height = null) {
     def chart = new PieChart(matrix, width, height)
-    chart.style.setDefaultSeriesRenderStyle(PieSeries.PieSeriesRenderStyle.Donut)
-    chart.style.setLabelType(PieStyler.LabelType.NameAndValue)
-    chart.style.setLabelsDistance(.82d)
-    chart.style.setPlotContentSize(.9d)
-    chart.style.setSumVisible(true)
+    applyDonutStyle(chart)
     chart
   }
 
@@ -142,6 +140,35 @@ class PieChart extends AbstractChart<PieChart, org.knowm.xchart.PieChart, PieSty
       xchart.addSeries(ValueConverter.asString(name), yCol[i] as Number)
     }
     this
+  }
+
+  private static void applyDonutStyle(PieChart chart) {
+    chart.style.setDefaultSeriesRenderStyle(PieSeries.PieSeriesRenderStyle.Donut)
+    chart.style.setLabelType(PieStyler.LabelType.NameAndValue)
+    chart.style.setLabelsDistance(.82d)
+    chart.style.setPlotContentSize(.9d)
+    chart.style.setSumVisible(true)
+  }
+
+  /** Creates a deferred convenience builder. */
+  static Builder builder(Matrix data) { new Builder(data) }
+
+  static class Builder extends ChartBuilder<Builder> {
+    private boolean donut
+    Builder(Matrix data) { super(data) }
+    Builder donut() { donut = true; this }
+    @Override Builder xAxisTitle(String title) { throw new IllegalArgumentException('PieChart does not support xAxisTitle(...)') }
+    @Override Builder yAxisTitle(String title) { throw new IllegalArgumentException('PieChart does not support yAxisTitle(...)') }
+    PieChart build() {
+      requireXAndY()
+      if (yColumns.size() != 1) throw new IllegalStateException('PieChart requires exactly one y(...) column')
+      requireColumn(xColumn); requireNumeric(yColumns[0])
+      PieChart chart = PieChart.create(data, chartWidth, chartHeight)
+      if (chartTitle != null) chart.title = chartTitle
+      if (donut) applyDonutStyle(chart)
+      chart.addSeries(xColumn, yColumns[0])
+      chart
+    }
   }
 
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/PieChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/PieChart.groovy
@@ -27,7 +27,6 @@ import se.alipsa.matrix.xchart.abstractions.ChartBuilder
  * pieChart.exportPng(file)
  * </code></pre>
  */
-@SuppressWarnings('IfStatementBraces')
 class PieChart extends AbstractChart<PieChart, org.knowm.xchart.PieChart, PieStyler, PieSeries> {
 
   private PieChart(Matrix matrix, Integer width = null, Integer height = null) {
@@ -161,11 +160,17 @@ class PieChart extends AbstractChart<PieChart, org.knowm.xchart.PieChart, PieSty
     @Override Builder yAxisTitle(String title) { throw new IllegalArgumentException('PieChart does not support yAxisTitle(...)') }
     PieChart build() {
       requireXAndY()
-      if (yColumns.size() != 1) throw new IllegalStateException('PieChart requires exactly one y(...) column')
+      if (yColumns.size() != 1) {
+        throw new IllegalStateException('PieChart requires exactly one y(...) column')
+      }
       requireColumn(xColumn); requireNumeric(yColumns[0])
       PieChart chart = PieChart.create(data, chartWidth, chartHeight)
-      if (chartTitle != null) chart.title = chartTitle
-      if (donut) applyDonutStyle(chart)
+      if (chartTitle != null) {
+        chart.title = chartTitle
+      }
+      if (donut) {
+        applyDonutStyle(chart)
+      }
       chart.addSeries(xColumn, yColumns[0])
       chart
     }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/PieChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/PieChart.groovy
@@ -165,9 +165,7 @@ class PieChart extends AbstractChart<PieChart, org.knowm.xchart.PieChart, PieSty
       }
       requireColumn(xColumn); requireNumeric(yColumns[0])
       PieChart chart = PieChart.create(data, chartWidth, chartHeight)
-      if (chartTitle != null) {
-        chart.title = chartTitle
-      }
+      applyTo(chart)
       if (donut) {
         applyDonutStyle(chart)
       }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/Plot.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/Plot.groovy
@@ -1,7 +1,6 @@
 package se.alipsa.matrix.xchart
 
 import org.knowm.xchart.XChartPanel
-import org.knowm.xchart.internal.chartpart.Chart
 
 import se.alipsa.matrix.xchart.abstractions.MatrixXChart
 
@@ -15,7 +14,7 @@ class Plot {
   static void svg(MatrixXChart chart, OutputStream outputStream) { requireChart(chart).exportSvg(requireOutputStream(outputStream)) }
   static void pdf(MatrixXChart chart, File file) { requireChart(chart).exportPdf(requireFile(file)) }
   static void pdf(MatrixXChart chart, OutputStream outputStream) { requireChart(chart).exportPdf(requireOutputStream(outputStream)) }
-  static XChartPanel<Chart> swing(MatrixXChart<Chart> chart) { requireChart(chart).exportSwing() }
+  static XChartPanel swing(MatrixXChart chart) { requireChart(chart).exportSwing() }
   static void display(MatrixXChart chart) { requireChart(chart).display() }
 
   private static MatrixXChart requireChart(MatrixXChart chart) {

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/Plot.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/Plot.groovy
@@ -5,28 +5,41 @@ import org.knowm.xchart.XChartPanel
 import se.alipsa.matrix.xchart.abstractions.MatrixXChart
 
 /** Convenience export facade for Matrix XChart wrappers. */
-@SuppressWarnings('IfStatementBraces')
 class Plot {
 
+  /** Exports a chart as PNG to a file. */
   static void png(MatrixXChart chart, File file) { requireChart(chart).exportPng(requireFile(file)) }
+  /** Exports a chart as PNG to an output stream. */
   static void png(MatrixXChart chart, OutputStream outputStream) { requireChart(chart).exportPng(requireOutputStream(outputStream)) }
+  /** Exports a chart as SVG to a file. */
   static void svg(MatrixXChart chart, File file) { requireChart(chart).exportSvg(requireFile(file)) }
+  /** Exports a chart as SVG to an output stream. */
   static void svg(MatrixXChart chart, OutputStream outputStream) { requireChart(chart).exportSvg(requireOutputStream(outputStream)) }
+  /** Exports a chart as PDF to a file. */
   static void pdf(MatrixXChart chart, File file) { requireChart(chart).exportPdf(requireFile(file)) }
+  /** Exports a chart as PDF to an output stream. */
   static void pdf(MatrixXChart chart, OutputStream outputStream) { requireChart(chart).exportPdf(requireOutputStream(outputStream)) }
+  /** Returns a Swing panel containing the chart. */
   static XChartPanel swing(MatrixXChart chart) { requireChart(chart).exportSwing() }
+  /** Opens the chart in a Swing window. */
   static void display(MatrixXChart chart) { requireChart(chart).display() }
 
   private static MatrixXChart requireChart(MatrixXChart chart) {
-    if (chart == null) throw new IllegalArgumentException('chart cannot be null')
+    if (chart == null) {
+      throw new IllegalArgumentException('chart cannot be null')
+    }
     chart
   }
   private static File requireFile(File file) {
-    if (file == null) throw new IllegalArgumentException('file cannot be null')
+    if (file == null) {
+      throw new IllegalArgumentException('file cannot be null')
+    }
     file
   }
   private static OutputStream requireOutputStream(OutputStream outputStream) {
-    if (outputStream == null) throw new IllegalArgumentException('output stream cannot be null')
+    if (outputStream == null) {
+      throw new IllegalArgumentException('output stream cannot be null')
+    }
     outputStream
   }
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/Plot.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/Plot.groovy
@@ -1,0 +1,33 @@
+package se.alipsa.matrix.xchart
+
+import org.knowm.xchart.XChartPanel
+import org.knowm.xchart.internal.chartpart.Chart
+
+import se.alipsa.matrix.xchart.abstractions.MatrixXChart
+
+/** Convenience export facade for Matrix XChart wrappers. */
+@SuppressWarnings('IfStatementBraces')
+class Plot {
+
+  static void png(MatrixXChart chart, File file) { requireChart(chart).exportPng(requireFile(file)) }
+  static void png(MatrixXChart chart, OutputStream outputStream) { requireChart(chart).exportPng(requireOutputStream(outputStream)) }
+  static void svg(MatrixXChart chart, File file) { requireChart(chart).exportSvg(requireFile(file)) }
+  static void svg(MatrixXChart chart, OutputStream outputStream) { requireChart(chart).exportSvg(requireOutputStream(outputStream)) }
+  static void pdf(MatrixXChart chart, File file) { requireChart(chart).exportPdf(requireFile(file)) }
+  static void pdf(MatrixXChart chart, OutputStream outputStream) { requireChart(chart).exportPdf(requireOutputStream(outputStream)) }
+  static XChartPanel<Chart> swing(MatrixXChart<Chart> chart) { requireChart(chart).exportSwing() }
+  static void display(MatrixXChart chart) { requireChart(chart).display() }
+
+  private static MatrixXChart requireChart(MatrixXChart chart) {
+    if (chart == null) throw new IllegalArgumentException('chart cannot be null')
+    chart
+  }
+  private static File requireFile(File file) {
+    if (file == null) throw new IllegalArgumentException('file cannot be null')
+    file
+  }
+  private static OutputStream requireOutputStream(OutputStream outputStream) {
+    if (outputStream == null) throw new IllegalArgumentException('output stream cannot be null')
+    outputStream
+  }
+}

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/RadarChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/RadarChart.groovy
@@ -122,6 +122,8 @@ class RadarChart extends AbstractChart<RadarChart, org.knowm.xchart.RadarChart, 
     }
     @Override Builder x(String columnName) { throw new IllegalArgumentException('RadarChart does not support x(...)') }
     @Override Builder y(String... columnNames) { throw new IllegalArgumentException('RadarChart does not support y(...)') }
+    @Override Builder xAxisTitle(String title) { throw new IllegalArgumentException('RadarChart does not support xAxisTitle(...)') }
+    @Override Builder yAxisTitle(String title) { throw new IllegalArgumentException('RadarChart does not support yAxisTitle(...)') }
     RadarChart build() {
       if (labelColumn == null || radiusColumns == null) throw new IllegalStateException('label(...) and values(...) must be called before build()')
       requireColumn(labelColumn)

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/RadarChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/RadarChart.groovy
@@ -7,6 +7,7 @@ import org.knowm.xchart.style.RadarStyler
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Row
 import se.alipsa.matrix.xchart.abstractions.AbstractChart
+import se.alipsa.matrix.xchart.abstractions.ChartBuilder
 
 /**
  * A RadarChart is a type of chart that displays multivariate data in a circular layout.
@@ -27,6 +28,7 @@ import se.alipsa.matrix.xchart.abstractions.AbstractChart
  * radarChart.exportPng(file)
  * </code></pre>
  */
+@SuppressWarnings('IfStatementBraces')
 class RadarChart extends AbstractChart<RadarChart, org.knowm.xchart.RadarChart, RadarStyler, RadarSeries> {
 
   private int numSeries = 0
@@ -79,15 +81,56 @@ class RadarChart extends AbstractChart<RadarChart, org.knowm.xchart.RadarChart, 
    */
   RadarChart addSeries(String seriesNameColumn, Integer transparency = 150) {
     def labels = matrix.columnNames() - seriesNameColumn
-    xchart.radiiLabels = labels as String[]
+    addSeries(seriesNameColumn, labels, transparency)
+  }
+
+  /** Add all rows using explicitly selected numeric radius columns. */
+  RadarChart addSeries(String seriesNameColumn, List<String> radiusColumns, Integer transparency = 150) {
+    if (radiusColumns == null || radiusColumns.isEmpty()) {
+      throw new IllegalArgumentException('Radar chart requires at least one radius column')
+    }
+    radiusColumns.each { String column ->
+      if (matrix.columnIndex(column) < 0 || !Number.isAssignableFrom(matrix.type(column))) {
+        throw new IllegalArgumentException("Radar radius column '$column' must be numeric")
+      }
+    }
+    if (matrix.columnIndex(seriesNameColumn) < 0) {
+      throw new IllegalArgumentException("Radar label column '$seriesNameColumn' does not exist")
+    }
+    xchart.radiiLabels = radiusColumns as String[]
     matrix.rows().each { Row row ->
       def label = row[seriesNameColumn].toString()
-      def r = row - seriesNameColumn
-      def s = xchart.addSeries(label, r as double[])
+      double[] radii = radiusColumns.collect { String column -> (row[column] as Number).doubleValue() } as double[]
+      def s = xchart.addSeries(label, radii)
       makeFillTransparent(s, numSeries, transparency)
       numSeries++
     }
     this
+  }
+
+  /** Creates a deferred convenience builder. */
+  static Builder builder(Matrix data) { new Builder(data) }
+
+  static class Builder extends ChartBuilder<Builder> {
+    private String labelColumn
+    private List<String> radiusColumns
+    Builder(Matrix data) { super(data) }
+    Builder label(String column) { labelColumn = column; this }
+    Builder values(String... columns) {
+      if (columns == null || columns.length == 0) throw new IllegalArgumentException('values requires at least one column')
+      radiusColumns = columns.toList(); this
+    }
+    @Override Builder x(String columnName) { throw new IllegalArgumentException('RadarChart does not support x(...)') }
+    @Override Builder y(String... columnNames) { throw new IllegalArgumentException('RadarChart does not support y(...)') }
+    RadarChart build() {
+      if (labelColumn == null || radiusColumns == null) throw new IllegalStateException('label(...) and values(...) must be called before build()')
+      requireColumn(labelColumn)
+      radiusColumns.each { String column -> requireNumeric(column) }
+      RadarChart chart = RadarChart.create(data, chartWidth, chartHeight)
+      if (chartTitle != null) chart.title = chartTitle
+      chart.addSeries(labelColumn, radiusColumns)
+      chart
+    }
   }
 
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/RadarChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/RadarChart.groovy
@@ -28,7 +28,6 @@ import se.alipsa.matrix.xchart.abstractions.ChartBuilder
  * radarChart.exportPng(file)
  * </code></pre>
  */
-@SuppressWarnings('IfStatementBraces')
 class RadarChart extends AbstractChart<RadarChart, org.knowm.xchart.RadarChart, RadarStyler, RadarSeries> {
 
   private int numSeries = 0
@@ -117,7 +116,9 @@ class RadarChart extends AbstractChart<RadarChart, org.knowm.xchart.RadarChart, 
     Builder(Matrix data) { super(data) }
     Builder label(String column) { labelColumn = column; this }
     Builder values(String... columns) {
-      if (columns == null || columns.length == 0) throw new IllegalArgumentException('values requires at least one column')
+      if (columns == null || columns.length == 0) {
+        throw new IllegalArgumentException('values requires at least one column')
+      }
       radiusColumns = columns.toList(); this
     }
     @Override Builder x(String columnName) { throw new IllegalArgumentException('RadarChart does not support x(...)') }
@@ -125,11 +126,15 @@ class RadarChart extends AbstractChart<RadarChart, org.knowm.xchart.RadarChart, 
     @Override Builder xAxisTitle(String title) { throw new IllegalArgumentException('RadarChart does not support xAxisTitle(...)') }
     @Override Builder yAxisTitle(String title) { throw new IllegalArgumentException('RadarChart does not support yAxisTitle(...)') }
     RadarChart build() {
-      if (labelColumn == null || radiusColumns == null) throw new IllegalStateException('label(...) and values(...) must be called before build()')
+      if (labelColumn == null || radiusColumns == null) {
+        throw new IllegalStateException('label(...) and values(...) must be called before build()')
+      }
       requireColumn(labelColumn)
       radiusColumns.each { String column -> requireNumeric(column) }
       RadarChart chart = RadarChart.create(data, chartWidth, chartHeight)
-      if (chartTitle != null) chart.title = chartTitle
+      if (chartTitle != null) {
+        chart.title = chartTitle
+      }
       chart.addSeries(labelColumn, radiusColumns)
       chart
     }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/ScatterChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/ScatterChart.groovy
@@ -4,6 +4,7 @@ import org.knowm.xchart.XYSeries
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.xchart.abstractions.AbstractXYChart
+import se.alipsa.matrix.xchart.abstractions.ChartBuilder
 
 /**
  * A ScatterChart uses dots to represent values for two different numeric variables.
@@ -92,6 +93,22 @@ class ScatterChart extends AbstractXYChart<ScatterChart> {
       chart.addSeries("$seriesCol=$val", series.column(xAxis), series.column(yAxis))
     }
     chart
+  }
+
+  /** Creates a deferred convenience builder. */
+  static Builder builder(Matrix data) { new Builder(data) }
+
+  static class Builder extends ChartBuilder<Builder> {
+    Builder(Matrix data) { super(data) }
+    ScatterChart build() {
+      requireXAndY()
+      requireNumeric(xColumn)
+      yColumns.each { String column -> requireNumeric(column) }
+      ScatterChart chart = ScatterChart.create(data, chartWidth, chartHeight)
+      applyTo(chart)
+      yColumns.each { String column -> chart.addSeries(xColumn, column) }
+      chart
+    }
   }
 
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/StickChart.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/StickChart.groovy
@@ -4,6 +4,7 @@ import org.knowm.xchart.CategorySeries
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.xchart.abstractions.AbstractCategoryChart
+import se.alipsa.matrix.xchart.abstractions.ChartBuilder
 
 /**
  * A StickChart is a type of chart that displays data points as vertical lines (sticks) extending from a baseline.
@@ -55,6 +56,22 @@ class StickChart extends AbstractCategoryChart<StickChart> {
     def chart = new StickChart(matrix, width, height)
     chart.title = title
     chart
+  }
+
+  /** Creates a deferred convenience builder. */
+  static Builder builder(Matrix data) { new Builder(data) }
+
+  static class Builder extends ChartBuilder<Builder> {
+    Builder(Matrix data) { super(data) }
+    StickChart build() {
+      requireXAndY()
+      requireColumn(xColumn)
+      yColumns.each { String column -> requireNumeric(column) }
+      StickChart chart = StickChart.create(data, chartWidth, chartHeight)
+      applyTo(chart)
+      yColumns.each { String column -> chart.addSeries(xColumn, column) }
+      chart
+    }
   }
 
 }

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/ChartBuilder.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/ChartBuilder.groovy
@@ -1,0 +1,82 @@
+package se.alipsa.matrix.xchart.abstractions
+
+import se.alipsa.matrix.core.Matrix
+
+/**
+ * Deferred common configuration for Matrix XChart convenience builders.
+ * An XChart instance is created only when a concrete builder calls {@code build()}.
+ *
+ * @param <B> concrete builder type
+ */
+@SuppressWarnings('IfStatementBraces')
+abstract class ChartBuilder<B extends ChartBuilder> {
+
+  protected final Matrix data
+  protected String chartTitle
+  protected Integer chartWidth
+  protected Integer chartHeight
+  protected String xColumn
+  protected List<String> yColumns = []
+  protected String xLabel
+  protected String yLabel
+
+  protected ChartBuilder(Matrix data) {
+    if (data == null) {
+      throw new IllegalArgumentException('data cannot be null')
+    }
+    this.data = data
+  }
+
+  B title(String title) { chartTitle = title; this as B }
+  B width(int width) { chartWidth = positive('width', width); this as B }
+  B height(int height) { chartHeight = positive('height', height); this as B }
+  B size(int widthPixels, int heightPixels) { width(widthPixels); height(heightPixels); this as B }
+  B x(String columnName) { xColumn = requireName('x', columnName); this as B }
+  B y(String... columnNames) {
+    if (columnNames == null || columnNames.length == 0) {
+      throw new IllegalArgumentException('y requires at least one column')
+    }
+    yColumns = columnNames.collect { String name -> requireName('y', name) }
+    this as B
+  }
+  B xAxisTitle(String title) { xLabel = title; this as B }
+  B yAxisTitle(String title) { yLabel = title; this as B }
+
+  protected void requireColumn(String name) {
+    if (data.columnIndex(name) < 0) {
+      throw new IllegalArgumentException("Unknown column '$name'")
+    }
+  }
+
+  protected void requireNumeric(String name) {
+    requireColumn(name)
+    if (!Number.isAssignableFrom(data.type(name))) {
+      throw new IllegalArgumentException("Column '$name' must be numeric")
+    }
+  }
+
+  protected void requireXAndY() {
+    if (xColumn == null) {
+      throw new IllegalStateException('x(...) must be called before build()')
+    }
+    if (yColumns.isEmpty()) {
+      throw new IllegalStateException('y(...) must be called before build()')
+    }
+  }
+
+  protected void applyTo(AbstractChart chart) {
+    if (chartTitle != null) chart.title = chartTitle
+    if (xLabel != null) chart.setXLabel(xLabel)
+    if (yLabel != null) chart.setYLabel(yLabel)
+  }
+
+  private static int positive(String name, int value) {
+    if (value <= 0) throw new IllegalArgumentException("$name must be positive")
+    value
+  }
+
+  private static String requireName(String method, String name) {
+    if (name == null || name.isBlank()) throw new IllegalArgumentException("$method column cannot be blank")
+    name
+  }
+}

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/ChartBuilder.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/ChartBuilder.groovy
@@ -9,7 +9,7 @@ import se.alipsa.matrix.core.Matrix
  * @param <B> concrete builder type
  */
 @SuppressWarnings('IfStatementBraces')
-abstract class ChartBuilder<B extends ChartBuilder> {
+abstract class ChartBuilder<B extends ChartBuilder<B>> {
 
   protected final Matrix data
   protected String chartTitle

--- a/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/ChartBuilder.groovy
+++ b/matrix-xchart/src/main/groovy/se/alipsa/matrix/xchart/abstractions/ChartBuilder.groovy
@@ -8,7 +8,6 @@ import se.alipsa.matrix.core.Matrix
  *
  * @param <B> concrete builder type
  */
-@SuppressWarnings('IfStatementBraces')
 abstract class ChartBuilder<B extends ChartBuilder<B>> {
 
   protected final Matrix data
@@ -65,18 +64,28 @@ abstract class ChartBuilder<B extends ChartBuilder<B>> {
   }
 
   protected void applyTo(AbstractChart chart) {
-    if (chartTitle != null) chart.title = chartTitle
-    if (xLabel != null) chart.setXLabel(xLabel)
-    if (yLabel != null) chart.setYLabel(yLabel)
+    if (chartTitle != null) {
+      chart.title = chartTitle
+    }
+    if (xLabel != null) {
+      chart.setXLabel(xLabel)
+    }
+    if (yLabel != null) {
+      chart.setYLabel(yLabel)
+    }
   }
 
   private static int positive(String name, int value) {
-    if (value <= 0) throw new IllegalArgumentException("$name must be positive")
+    if (value <= 0) {
+      throw new IllegalArgumentException("$name must be positive")
+    }
     value
   }
 
   private static String requireName(String method, String name) {
-    if (name == null || name.isBlank()) throw new IllegalArgumentException("$method column cannot be blank")
+    if (name == null || name.isBlank()) {
+      throw new IllegalArgumentException("$method column cannot be blank")
+    }
     name
   }
 }

--- a/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/BuilderApiTest.groovy
+++ b/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/BuilderApiTest.groovy
@@ -9,11 +9,18 @@ import org.junit.jupiter.api.Test
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.xchart.AreaChart
 import se.alipsa.matrix.xchart.BarChart
+import se.alipsa.matrix.xchart.BoxChart
+import se.alipsa.matrix.xchart.BubbleChart
+import se.alipsa.matrix.xchart.CorrelationHeatmapChart
 import se.alipsa.matrix.xchart.HeatmapChart
+import se.alipsa.matrix.xchart.HistogramChart
 import se.alipsa.matrix.xchart.LineChart
+import se.alipsa.matrix.xchart.OhlcChart
 import se.alipsa.matrix.xchart.PieChart
 import se.alipsa.matrix.xchart.Plot
 import se.alipsa.matrix.xchart.RadarChart
+import se.alipsa.matrix.xchart.ScatterChart
+import se.alipsa.matrix.xchart.StickChart
 
 @CompileStatic
 class BuilderApiTest {
@@ -53,5 +60,31 @@ class BuilderApiTest {
     ByteArrayOutputStream output = new ByteArrayOutputStream()
     Plot.svg(LineChart.builder(data).x('x').y('first').build(), output)
     assertTrue(output.size() > 0)
+  }
+
+  @Test
+  void buildsRemainingChartTypes() {
+    Matrix data = numericData()
+    assertNotNull(ScatterChart.builder(data).x('x').y('first').build())
+    assertNotNull(StickChart.builder(data).x('x').y('first').build())
+    assertNotNull(BoxChart.builder(data).y('first', 'second').build())
+    assertNotNull(BubbleChart.builder(data).x('x').y('first').size('second').build())
+    assertNotNull(HistogramChart.builder(data).x('first').buckets(2).build())
+    assertNotNull(PieChart.builder(data).x('x').y('first').donut().build())
+    assertNotNull(CorrelationHeatmapChart.builder(data).seriesName('Correlation').columns('first', 'second').build())
+  }
+
+  @Test
+  void supportsRadarAndOhlcMappings() {
+    Matrix radarData = Matrix.builder().data(name: ['A', 'B'], speed: [0.2, 0.4], power: [0.3, 0.6])
+        .types(String, Number, Number).build()
+    List<String> radii = ['speed', 'power']
+    assertNotNull(RadarChart.builder(radarData).label('name').values(*radii).build())
+
+    Date today = new Date()
+    Date tomorrow = new Date(today.time + 86_400_000L)
+    Matrix ohlcData = Matrix.builder().data(date: [today, tomorrow], open: [1, 2], high: [2, 3], low: [0, 1], close: [1, 2])
+        .types(Date, Number, Number, Number, Number).build()
+    assertNotNull(OhlcChart.builder(ohlcData).date('date').open('open').high('high').low('low').close('close').build())
   }
 }

--- a/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/BuilderApiTest.groovy
+++ b/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/BuilderApiTest.groovy
@@ -52,6 +52,8 @@ class BuilderApiTest {
     assertThrows(IllegalStateException) { LineChart.builder(data).y('first').build() }
     assertThrows(IllegalArgumentException) { PieChart.builder(data).xAxisTitle('x') }
     assertThrows(IllegalArgumentException) { RadarChart.builder(data).values() }
+    assertThrows(IllegalArgumentException) { HeatmapChart.builder(data).x('first') }
+    assertThrows(IllegalArgumentException) { CorrelationHeatmapChart.builder(data).y('first') }
   }
 
   @Test

--- a/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/BuilderApiTest.groovy
+++ b/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/BuilderApiTest.groovy
@@ -1,0 +1,57 @@
+package test.alipsa.matrix.xchart
+
+import static org.junit.jupiter.api.Assertions.*
+
+import groovy.transform.CompileStatic
+
+import org.junit.jupiter.api.Test
+
+import se.alipsa.matrix.core.Matrix
+import se.alipsa.matrix.xchart.AreaChart
+import se.alipsa.matrix.xchart.BarChart
+import se.alipsa.matrix.xchart.HeatmapChart
+import se.alipsa.matrix.xchart.LineChart
+import se.alipsa.matrix.xchart.PieChart
+import se.alipsa.matrix.xchart.Plot
+import se.alipsa.matrix.xchart.RadarChart
+
+@CompileStatic
+class BuilderApiTest {
+
+  private static Matrix numericData() {
+    Matrix.builder().data(x: [1, 2, 3, 4], first: [2, 4, 6, 8], second: [3, 6, 9, 12])
+        .types(Number, Number, Number).build()
+  }
+
+  @Test
+  void buildsCommonChartsWithDeferredConfiguration() {
+    Matrix data = numericData()
+    def line = LineChart.builder(data).title('Line').size(640, 480).x('x').y('first', 'second').build()
+    assertEquals('Line', line.title)
+    assertEquals(2, line.series.size())
+
+    def bar = BarChart.builder(data).x('x').y('first', 'second').stacked().build()
+    assertTrue(bar.style.stacked)
+
+    def area = AreaChart.builder(data).x('x').y('first').build()
+    assertEquals(185, area.getSeries('first').fillColor.alpha)
+  }
+
+  @Test
+  void validatesBuilderMappings() {
+    Matrix data = numericData()
+    assertThrows(IllegalStateException) { LineChart.builder(data).y('first').build() }
+    assertThrows(IllegalArgumentException) { PieChart.builder(data).xAxisTitle('x') }
+    assertThrows(IllegalArgumentException) { RadarChart.builder(data).values() }
+  }
+
+  @Test
+  void supportsHeatmapBuilderOverloadsAndExportFacade() {
+    Matrix data = numericData()
+    assertNotNull(HeatmapChart.builder(data).values('first', 2).build())
+    assertNotNull(HeatmapChart.builder(data).values(['first', 'second']).build())
+    ByteArrayOutputStream output = new ByteArrayOutputStream()
+    Plot.svg(LineChart.builder(data).x('x').y('first').build(), output)
+    assertTrue(output.size() > 0)
+  }
+}

--- a/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/BuilderApiTest.groovy
+++ b/matrix-xchart/src/test/groovy/test/alipsa/matrix/xchart/BuilderApiTest.groovy
@@ -36,6 +36,8 @@ class BuilderApiTest {
     def line = LineChart.builder(data).title('Line').size(640, 480).x('x').y('first', 'second').build()
     assertEquals('Line', line.title)
     assertEquals(2, line.series.size())
+    assertEquals(640, line.getXChart().width)
+    assertEquals(480, line.getXChart().height)
 
     def bar = BarChart.builder(data).x('x').y('first', 'second').stacked().build()
     assertTrue(bar.style.stacked)
@@ -55,23 +57,32 @@ class BuilderApiTest {
   @Test
   void supportsHeatmapBuilderOverloadsAndExportFacade() {
     Matrix data = numericData()
-    assertNotNull(HeatmapChart.builder(data).values('first', 2).build())
-    assertNotNull(HeatmapChart.builder(data).values(['first', 'second']).build())
+    assertEquals(1, HeatmapChart.builder(data).values('first', 2).build().series.size())
+    assertEquals(1, HeatmapChart.builder(data).values(['first', 'second']).build().series.size())
     ByteArrayOutputStream output = new ByteArrayOutputStream()
-    Plot.svg(LineChart.builder(data).x('x').y('first').build(), output)
+    def chart = LineChart.builder(data).x('x').y('first').build()
+    Plot.svg(chart, output)
     assertTrue(output.size() > 0)
+    ByteArrayOutputStream png = new ByteArrayOutputStream()
+    ByteArrayOutputStream pdf = new ByteArrayOutputStream()
+    Plot.png(chart, png)
+    Plot.pdf(chart, pdf)
+    assertTrue(png.size() > 0)
+    assertTrue(pdf.size() > 0)
   }
 
   @Test
   void buildsRemainingChartTypes() {
     Matrix data = numericData()
-    assertNotNull(ScatterChart.builder(data).x('x').y('first').build())
-    assertNotNull(StickChart.builder(data).x('x').y('first').build())
-    assertNotNull(BoxChart.builder(data).y('first', 'second').build())
-    assertNotNull(BubbleChart.builder(data).x('x').y('first').size('second').build())
-    assertNotNull(HistogramChart.builder(data).x('first').buckets(2).build())
-    assertNotNull(PieChart.builder(data).x('x').y('first').donut().build())
-    assertNotNull(CorrelationHeatmapChart.builder(data).seriesName('Correlation').columns('first', 'second').build())
+    assertEquals(1, ScatterChart.builder(data).x('x').y('first').build().series.size())
+    assertEquals(1, StickChart.builder(data).x('x').y('first').build().series.size())
+    assertEquals(2, BoxChart.builder(data).y('first', 'second').build().series.size())
+    assertEquals(1, BubbleChart.builder(data).x('x').y('first').size('second').build().series.size())
+    assertEquals(1, HistogramChart.builder(data).x('first').buckets(2).build().series.size())
+    def pie = PieChart.builder(data).x('x').y('first').donut().build()
+    assertEquals(4, pie.series.size())
+    assertEquals(org.knowm.xchart.PieSeries.PieSeriesRenderStyle.Donut, pie.style.defaultSeriesRenderStyle)
+    assertEquals(1, CorrelationHeatmapChart.builder(data).seriesName('Correlation').columns('first', 'second').build().series.size())
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Add deferred Pict-like builders for XChart chart types, including specialized heatmap, radar, correlation, and OHLC mappings.
- Add the XChart Plot export facade and preserve existing create/addSeries APIs.
- Bump matrix-xchart to 0.4.0-SNAPSHOT and update documentation, release notes, and the implementation plan.

## Modules

- matrix-xchart
- matrix-bom
- docs

## Validation

- ./gradlew :matrix-xchart:codenarcMain :matrix-xchart:spotlessCheck :matrix-xchart:test -Pheadless=true
- ./gradlew test