### PR TITLE
Upgrade matrix-json to Jackson 3.1.5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ v_groovy = "5.0.7"
 v_gsvg = "1.1.0"
 v_h2 = "2.4.240"
 v_hadoop = "3.5.0"
-v_jackson = "2.22.1"
+v_jackson = "3.1.5"
 v_jacoco = "0.8.14"
 v_javafx = "23.0.2"
 v_javaparser = "3.28.2"
@@ -87,9 +87,9 @@ opentest4j = { module = "org.opentest4j:opentest4j", version.ref = "v_opentest4j
 h2 = { module = "com.h2database:h2", version.ref = "v_h2" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "v_jsoup" }
 avro = { module = "org.apache.avro:avro", version.ref = "v_avro" }
-jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "v_jackson" }
-jackson-core = { module = "com.fasterxml.jackson.core:jackson-core" }
-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" }
+jackson-bom = { module = "tools.jackson:jackson-bom", version.ref = "v_jackson" }
+jackson-core = { module = "tools.jackson.core:jackson-core" }
+jackson-databind = { module = "tools.jackson.core:jackson-databind" }
 google-auth-library-bom = { module = "com.google.auth:google-auth-library-bom", version.ref = "v_google-auth-bom" }
 google-auth-library-oauth2-http = { module = "com.google.auth:google-auth-library-oauth2-http" }
 google-cloud-bigquery = { module = "com.google.cloud:google-cloud-bigquery", version.ref = "v_google-cloud-bigquery" }

--- a/matrix-json/release.md
+++ b/matrix-json/release.md
@@ -2,9 +2,11 @@
 
 ## v2.3.2, In progress
 - Upgrade dependencies:
-  - com.fasterxml.jackson:jackson-bom 2.22.0 -> 2.22.1
-  - com.fasterxml.jackson.core:jackson-core 2.22.0 -> 2.22.1
-  - com.fasterxml.jackson.core:jackson-databind 2.22.0 -> 2.22.1
+  - com.fasterxml.jackson:jackson-bom 2.22.1 -> tools.jackson:jackson-bom 3.1.5
+  - com.fasterxml.jackson.core:jackson-core 2.22.1 -> tools.jackson.core:jackson-core 3.1.5
+  - com.fasterxml.jackson.core:jackson-databind 2.22.1 -> tools.jackson.core:jackson-databind 3.1.5
+- Migrate matrix-json internals from Jackson 2 (`com.fasterxml.jackson.*`) to Jackson 3 (`tools.jackson.*`).
+  Production API (`JsonReader`/`JsonWriter`) is unchanged.
 
 ## v2.3.1, 2026-07-09
 - Dependency update: com.fasterxml.jackson:jackson-bom 2.21.2 -> 2.22.0

--- a/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonReader.groovy
+++ b/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonReader.groovy
@@ -2,11 +2,11 @@ package se.alipsa.matrix.json
 
 import groovy.transform.CompileStatic
 
-import com.fasterxml.jackson.core.JsonFactory
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.core.JsonToken
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.core.JsonParser
+import tools.jackson.core.JsonToken
+import tools.jackson.core.json.JsonFactory
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.json.JsonMapper
 
 import se.alipsa.matrix.core.Matrix
 
@@ -54,9 +54,11 @@ import java.nio.file.Path
 @CompileStatic
 class JsonReader {
 
-  private static final ObjectMapper MAPPER = new ObjectMapper()
+  private static final JsonFactory FACTORY = JsonFactory.builder().build()
+  private static final JsonMapper MAPPER = JsonMapper.builder(FACTORY)
       .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
-  private static final JsonFactory FACTORY = MAPPER.getFactory()
+      .disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+      .build()
   private static final String DOT = '.'
 
   private JsonReader() {

--- a/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonWriter.groovy
+++ b/matrix-json/src/main/groovy/se/alipsa/matrix/json/JsonWriter.groovy
@@ -2,8 +2,10 @@ package se.alipsa.matrix.json
 
 import groovy.transform.CompileStatic
 
-import com.fasterxml.jackson.core.JsonFactory
-import com.fasterxml.jackson.core.JsonGenerator
+import tools.jackson.core.JsonGenerator
+import tools.jackson.core.json.JsonFactory
+import tools.jackson.databind.ObjectWriter
+import tools.jackson.databind.json.JsonMapper
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.core.Row
@@ -32,7 +34,8 @@ import java.time.temporal.TemporalAccessor
 @CompileStatic
 class JsonWriter {
 
-  private static final JsonFactory FACTORY = new JsonFactory()
+  private static final JsonFactory FACTORY = JsonFactory.builder().build()
+  private static final JsonMapper MAPPER = JsonMapper.builder(FACTORY).build()
 
   private JsonWriter() {
   }
@@ -445,10 +448,10 @@ class JsonWriter {
       }
       DateTimeFormatter dtf = DateTimeFormatter.ofPattern(dateFormatValue)
 
-      JsonGenerator gen = FACTORY.createGenerator(writer)
-      if (indentValue) {
-        gen.useDefaultPrettyPrinter()
-      }
+      ObjectWriter objectWriter = indentValue
+          ? MAPPER.writer().withDefaultPrettyPrinter()
+          : MAPPER.writer()
+      JsonGenerator gen = objectWriter.createGenerator(writer)
       gen.withCloseable {
         gen.writeStartArray()
         List<String> colNames = t.columnNames()
@@ -466,7 +469,7 @@ class JsonWriter {
           for (Row row : t) {
             gen.writeStartObject()
             for (int i = 0; i < colCount; i++) {
-              gen.writeFieldName(colNames[i])
+              gen.writeName(colNames[i])
               writeValue(gen, row[i], dtf)
             }
             gen.writeEndObject()

--- a/matrix-json/src/test/groovy/JsonReaderTest.groovy
+++ b/matrix-json/src/test/groovy/JsonReaderTest.groovy
@@ -1,15 +1,15 @@
 import static org.junit.jupiter.api.Assertions.*
 import static se.alipsa.matrix.core.ListConverter.toLocalDates
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.node.ArrayNode
-import com.fasterxml.jackson.databind.node.BooleanNode
-import com.fasterxml.jackson.databind.node.NumericNode
-import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.databind.node.ValueNode
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.databind.node.ArrayNode
+import tools.jackson.databind.node.BooleanNode
+import tools.jackson.databind.node.NumericNode
+import tools.jackson.databind.node.ObjectNode
+import tools.jackson.databind.node.ValueNode
 
 import se.alipsa.matrix.core.Matrix
 import se.alipsa.matrix.json.JsonReader
@@ -315,7 +315,7 @@ class JsonReaderTest {
 
   @Test
   void testNestedPojoSerialization() {
-    ObjectMapper mapper = new ObjectMapper()
+    JsonMapper mapper = JsonMapper.builder().build()
 
     Family f1 = new Family('Nyfelt-Wersäll')
     f1.members.add(new Person('Per'))
@@ -346,13 +346,12 @@ class JsonReaderTest {
     }
     List rows = []
     for (int i = 0; i < flatMaps.size(); i++) {
-      def m = flatMaps.get(i)
-      keySet.each {
-        if (!m.containsKey(it)) {
-          m.put(it, null)
-        }
+      Map<String, Object> m = flatMaps.get(i)
+      List<Object> row = []
+      keySet.each { String key ->
+        row.add(m.containsKey(key) ? m.get(key) : null)
       }
-      rows << new ArrayList<>(m.values())
+      rows << row
     }
     Matrix.builder()
         .rows(rows)
@@ -363,11 +362,9 @@ class JsonReaderTest {
   def addKeys(String currentPath, JsonNode jsonNode, Map<String, Object> map) {
     if (jsonNode.isObject()) {
       ObjectNode objectNode = (ObjectNode) jsonNode
-      Iterator<Map.Entry<String, JsonNode>> iter = objectNode.fields()
       String pathPrefix = currentPath.isEmpty() ? '' : currentPath + '.'
 
-      while (iter.hasNext()) {
-        Map.Entry<String, JsonNode> entry = iter.next()
+      for (Map.Entry<String, JsonNode> entry : objectNode.properties()) {
         addKeys(pathPrefix + entry.getKey(), entry.getValue(), map)
       }
     } else if (jsonNode.isArray()) {


### PR DESCRIPTION
## Summary

Upgrade the `matrix-json` module from Jackson 2.22.1 (`com.fasterxml.jackson.*`) to Jackson 3.1.5 (`tools.jackson.*`). The public `JsonReader`/`JsonWriter` API is unchanged.

## Modules touched

- `matrix-json`
- `gradle/libs.versions.toml` (shared version catalog)

## Key changes

- Updated Jackson BOM, core, and databind coordinates to `tools.jackson.*`.
- Migrated `JsonReader` and `JsonWriter` to builder-based `JsonFactory`/`JsonMapper` construction (required by Jackson 3 immutability).
- Disabled `DeserializationFeature.FAIL_ON_TRAILING_TOKENS` so the streaming object-by-object reader keeps working under Jackson 3 defaults.
- Replaced removed `JsonGenerator.useDefaultPrettyPrinter()` / `writeFieldName()` with `ObjectWriter.withDefaultPrettyPrinter()` / `writeName()`.
- Updated tests for Jackson 3 package and API renames (`ObjectNode.properties()`, etc.) and fixed a latent row-ordering bug in the `toMatrix` test helper.

## Tests run

```bash
./gradlew :matrix-json:codenarcMain
./gradlew :matrix-json:spotlessCheck
./gradlew :matrix-json:test
./gradlew :matrix-json:build
```

Result: 77 tests passed, 0 failed.
